### PR TITLE
Stylechecker

### DIFF
--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -52,3 +52,13 @@ def checksum_file(filepath, callable):
 
     return hash.hexdigest()
 
+
+def setdefault(object, attribute, producer):
+    """
+    Like dict().setdefault but for object attributes.
+    """
+    if not hasattr(object, attribute):
+        setattr(object, attribute, producer())
+
+    return getattr(object, attribute)
+

--- a/tests/test_stylechecker.py
+++ b/tests/test_stylechecker.py
@@ -1,0 +1,144 @@
+#coding: utf-8
+import unittest
+from StringIO import StringIO
+from tempfile import NamedTemporaryFile
+
+from lxml import etree
+
+from packtools import stylechecker
+
+
+# valid: <a><b></b></a>
+# invalid: anything else
+sample_xsd = StringIO('''\
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<xsd:element name="a" type="AType"/>
+<xsd:complexType name="AType">
+  <xsd:sequence>
+    <xsd:element name="b" type="xsd:string" />
+  </xsd:sequence>
+</xsd:complexType>
+</xsd:schema>
+''')
+
+
+def setup_tmpfile(method):
+    def wrapper(self):
+        valid_tmpfile = NamedTemporaryFile()
+        valid_tmpfile.write(b'<a><b>bar</b></a>')
+        valid_tmpfile.seek(0)
+        self.valid_tmpfile = valid_tmpfile
+
+        method(self)
+
+        self.valid_tmpfile.close()
+    return wrapper
+
+
+class XMLTests(unittest.TestCase):
+
+    @setup_tmpfile
+    def test_initializes_with_filepath(self):
+        self.assertTrue(stylechecker.XML(self.valid_tmpfile.name))
+
+    def test_initializes_with_etree(self):
+        fp = StringIO(b'<a><b>bar</b></a>')
+        et = etree.parse(fp)
+
+        self.assertTrue(stylechecker.XML(et))
+
+    def test_validation(self):
+        fp = etree.parse(StringIO(b'<a><b>bar</b></a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        result, errors = xml.validate()
+        self.assertTrue(result)
+        self.assertFalse(errors)
+
+    def test_invalid(self):
+        fp = etree.parse(StringIO(b'<a><c>bar</c></a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        result, _ = xml.validate()
+        self.assertFalse(result)
+
+    def test_invalid_errors(self):
+        # Default lxml error log.
+        fp = etree.parse(StringIO(b'<a><c>bar</c></a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        _, errors = xml.validate()
+        self.assertIsInstance(errors, etree._ListErrorLog)
+
+    def test_find(self):
+        fp = etree.parse(StringIO(b'<a>\n<b>bar</b>\n</a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        elem = xml.find('b', 2)
+        self.assertEqual(elem.tag, 'b')
+        self.assertEqual(elem.sourceline, 2)
+
+    def test_find_root_element(self):
+        fp = etree.parse(StringIO(b'<a>\n<b>bar</b>\n</a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        elem = xml.find('a', 1)
+        self.assertEqual(elem.tag, 'a')
+        self.assertEqual(elem.sourceline, 1)
+
+    def test_find_missing(self):
+        fp = etree.parse(StringIO(b'<a>\n<b>bar</b>\n</a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        self.assertIsNone(xml.find('c', 2))
+
+    def test_annotate_errors(self):
+        fp = etree.parse(StringIO(b'<a><c>bar</c></a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        xml.annotate_errors()
+        self.assertIn("<SPS-ERROR>Element 'c': This element is not expected. Expected is ( b ).</SPS-ERROR>", str(xml))
+
+    def test_annotate_errors(self):
+        fp = etree.parse(StringIO(b'<a><c>bar</c></a>'))
+        xml = stylechecker.XML(fp)
+        xml.xmlschema = etree.XMLSchema(etree.parse(sample_xsd))
+
+        xml.annotate_errors()
+        xml_text = xml.read()
+
+        self.assertIn("<SPS-ERROR>Element 'c': This element is not expected. Expected is ( b ).</SPS-ERROR>", xml_text)
+        self.assertTrue(isinstance(xml_text, unicode))
+
+
+class ElementNamePatternTests(unittest.TestCase):
+    pattern = stylechecker.EXPOSE_ELEMENTNAME_PATTERN
+
+    def test_case1(self):
+        message = "Element 'article', attribute 'dtd-version': [facet 'enumeration'] The value '3.0' is not an element of the set {'1.0'}."
+        self.assertEqual(self.pattern.search(message).group(0), "'article'")
+
+
+    def test_case2(self):
+        message = "Element 'article', attribute 'dtd-version': '3.0' is not a valid value of the local atomic type."
+        self.assertEqual(self.pattern.search(message).group(0), "'article'")
+
+    def test_case3(self):
+        message = "Element 'author-notes': This element is not expected. Expected is one of ( label, title, ack, app-group, bio, fn-group, glossary, ref-list, notes, sec )."
+        self.assertEqual(self.pattern.search(message).group(0), "'author-notes'")
+
+    def test_case4(self):
+        message = "Element 'journal-title-group': This element is not expected. Expected is ( journal-id )."
+        self.assertEqual(self.pattern.search(message).group(0), "'journal-title-group'")
+
+    def test_case5(self):
+        message = "Element 'contrib-group': This element is not expected. Expected is one of ( article-id, article-categories, title-group )."
+        self.assertEqual(self.pattern.search(message).group(0), "'contrib-group'")
+

--- a/tests/test_xray.py
+++ b/tests/test_xray.py
@@ -1,23 +1,25 @@
 #coding: utf-8
+import unittest
 import zipfile
 from tempfile import NamedTemporaryFile
-from lxml import etree
 
+from lxml import etree
 import mocker
-import unittest
 
 from packtools import xray as x_ray
 
 
+def make_test_archive(arch_data):
+    fp = NamedTemporaryFile()
+    with zipfile.ZipFile(fp, 'w') as zipfp:
+        for archive, data in arch_data:
+            zipfp.writestr(archive, data)
+
+    return fp
+
+
 class SPSMixinTests(mocker.MockerTestCase):
 
-    def _make_test_archive(self, arch_data):
-        fp = NamedTemporaryFile()
-        with zipfile.ZipFile(fp, 'w') as zipfp:
-            for archive, data in arch_data:
-                zipfp.writestr(archive, data)
-
-        return fp
 
     def _makeOne(self, fname):
         class Foo(x_ray.SPSMixin, x_ray.Xray):
@@ -27,7 +29,7 @@ class SPSMixinTests(mocker.MockerTestCase):
 
     def test_xmls_yields_etree_instances(self):
         data = [('bar.xml', b'<root><name>bar</name></root>')]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         xmls = pkg.xmls
@@ -35,7 +37,7 @@ class SPSMixinTests(mocker.MockerTestCase):
 
     def test_xml_returns_etree_instance(self):
         data = [('bar.xml', b'<root><name>bar</name></root>')]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsInstance(pkg.xml, etree._ElementTree)
@@ -45,7 +47,7 @@ class SPSMixinTests(mocker.MockerTestCase):
             ('bar.xml', b'<root><name>bar</name></root>'),
             ('baz.xml', b'<root><name>baz</name></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertRaises(AttributeError, lambda: pkg.xml)
@@ -54,7 +56,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><journal-meta><journal-title-group><journal-title>foo</journal-title></journal-title-group></journal-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['journal_title'], 'foo')
@@ -63,7 +65,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['journal_title'])
@@ -72,7 +74,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><journal-meta><issn pub-type="epub">1234-1234</issn></journal-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['journal_eissn'], '1234-1234')
@@ -81,7 +83,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['journal_eissn'])
@@ -90,7 +92,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><journal-meta><issn pub-type="ppub">1234-1234</issn></journal-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['journal_pissn'], '1234-1234')
@@ -99,7 +101,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['journal_pissn'])
@@ -108,7 +110,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><article-meta><title-group><article-title>bar</article-title></title-group></article-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['article_title'], 'bar')
@@ -117,7 +119,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['article_title'])
@@ -126,7 +128,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><article-meta><pub-date><year>2013</year></pub-date></article-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['issue_year'], '2013')
@@ -135,7 +137,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['issue_year'])
@@ -144,7 +146,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><article-meta><volume>2</volume></article-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['issue_volume'], '2')
@@ -153,7 +155,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['issue_volume'])
@@ -162,7 +164,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><article-meta><issue>2</issue></article-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertEqual(pkg.meta['issue_number'], '2')
@@ -171,7 +173,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertIsNone(pkg.meta['issue_number'])
@@ -180,7 +182,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertFalse(pkg.is_valid_meta())
@@ -189,7 +191,7 @@ class SPSMixinTests(mocker.MockerTestCase):
         data = [
             ('bar.xml', b'<root><journal-meta><issn pub-type="ppub">12-34</issn></journal-meta><article-meta><issue>3</issue><title-group><article-title>Titulo de artigo</article-title></title-group></article-meta></root>'),
         ]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertTrue(pkg.is_valid_meta())
@@ -243,7 +245,7 @@ class SPSMixinTests(mocker.MockerTestCase):
                 </body>
             </article>
             ''')]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertTrue(pkg.is_valid_schema())
@@ -296,7 +298,7 @@ class SPSMixinTests(mocker.MockerTestCase):
                 </body>
             </article>
             ''')]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertFalse(pkg.is_valid_schema())
@@ -350,7 +352,7 @@ class SPSMixinTests(mocker.MockerTestCase):
                 </body>
             </article>
             ''')]
-        arch = self._make_test_archive(data)
+        arch = make_test_archive(data)
         pkg = self._makeOne(arch.name)
 
         self.assertFalse(pkg.is_valid_schema())
@@ -371,7 +373,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertRaises(ValueError, lambda: x_ray.Xray(fp.name))
 
     def test_get_ext_returns_member_names(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>')])
 
         xray = x_ray.Xray(arch.name)
@@ -379,7 +381,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_ext('xml'), ['bar.xml'])
 
     def test_get_ext_returns_empty_when_ext_doesnot_exist(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>')])
 
         xray = x_ray.Xray(arch.name)
@@ -387,7 +389,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_ext('jpeg'), [])
 
     def test_get_fps_returns_an_iterable(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>')])
 
         xray = x_ray.Xray(arch.name)
@@ -396,7 +398,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertTrue(hasattr(fps, 'next'))
 
     def test_get_fpd_yields_ZipExtFile_instances(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>')])
 
         xray = x_ray.Xray(arch.name)
@@ -405,7 +407,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertIsInstance(fps.next(), zipfile.ZipExtFile)
 
     def test_get_fps_swallow_exceptions_when_ext_doesnot_exist(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>')])
 
         xray = x_ray.Xray(arch.name)
@@ -415,8 +417,8 @@ class XrayTests(mocker.MockerTestCase):
 
     def test_package_checksum_is_calculated(self):
         data = [('bar.xml', b'<root><name>bar</name></root>')]
-        arch1 = self._make_test_archive(data)
-        arch2 = self._make_test_archive(data)
+        arch1 = make_test_archive(data)
+        arch2 = make_test_archive(data)
 
         self.assertEquals(
             x_ray.Xray(arch1.name).checksum,
@@ -424,7 +426,7 @@ class XrayTests(mocker.MockerTestCase):
         )
 
     def test_get_members(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.xml', b'<root><name>bar</name></root>')])
 
@@ -433,14 +435,14 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_members(), ['bar.xml', 'jar.xml'])
 
     def test_get_members_returns_empty(self):
-        arch = self._make_test_archive([])
+        arch = make_test_archive([])
 
         xray = x_ray.Xray(arch.name)
 
         self.assertEquals(xray.get_members(), [])
 
     def test_get_fp(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.xml', b'<root><name>bar</name></root>')])
 
@@ -450,7 +452,7 @@ class XrayTests(mocker.MockerTestCase):
             zipfile.ZipExtFile)
 
     def test_get_fp_nonexisting_members(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.xml', b'<root><name>bar</name></root>')])
 
@@ -459,7 +461,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertRaises(ValueError, lambda: xray.get_fp('foo.xml'))
 
     def test_get_classified_members(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.xml', b'<root><name>bar</name></root>')])
 
@@ -468,7 +470,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_classified_members(), {'xml': ['bar.xml', 'jar.xml']})
 
     def test_get_ext_is_caseinsensitive(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.XML', b'<root><name>bar</name></root>')])
 
@@ -477,7 +479,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_ext('xml'), ['bar.xml', 'jar.XML'])
 
     def test_get_ext_arg_is_caseinsensitive(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.XML', b'<root><name>bar</name></root>')])
 
@@ -486,7 +488,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_ext('XML'), ['bar.xml', 'jar.XML'])
 
     def test_get_classified_members_is_caseinsensitive(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.XML', b'<root><name>bar</name></root>')])
 
@@ -495,7 +497,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEquals(xray.get_classified_members(), {'xml': ['bar.xml', 'jar.XML']})
 
     def test_get_fps_is_caseinsensitive(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.XML', b'<root><name>bar</name></root>')])
 
@@ -505,7 +507,7 @@ class XrayTests(mocker.MockerTestCase):
         self.assertEqual([fp.name for fp in fps], ['bar.xml', 'jar.XML'])
 
     def test_get_fps_arg_is_caseinsensitive(self):
-        arch = self._make_test_archive(
+        arch = make_test_archive(
             [('bar.xml', b'<root><name>bar</name></root>'),
              ('jar.XML', b'<root><name>bar</name></root>')])
 
@@ -513,4 +515,5 @@ class XrayTests(mocker.MockerTestCase):
         fps = xray.get_fps('XML')
 
         self.assertEqual([fp.name for fp in fps], ['bar.xml', 'jar.XML'])
+
 


### PR DESCRIPTION
Módulo `stylechecker` para realizar validação do XML contra a XSD SciELO Publishing Schema.

O módulo pode ser usado também como utilitário de linha de comando:

``` bash
python stylechecker.py -h
usage: stylechecker.py [-h] [--annotated] xmlpath

stylechecker cli utility.

positional arguments:
  xmlpath      Absolute or relative path to the XML file.

optional arguments:
  -h, --help   show this help message and exit
  --annotated
```
