### PR TITLE
Fixes #5 - `article/front/article-meta/article-categories` é obrigatório

### DIFF
--- a/packtools/sps/sps.sch
+++ b/packtools/sps/sps.sch
@@ -36,6 +36,10 @@
     <active pattern="publisher"/>
   </phase>
 
+  <phase id="phase.article-categories">
+    <active pattern="article_categories"/>
+  </phase>
+
 
   <!--
    Patterns - sets of rules.
@@ -77,6 +81,14 @@
     <rule context="article/front/journal-meta">
       <assert test="publisher">
         Element 'journal-meta': Missing element publisher.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article_categories">
+    <rule context="article/front/article-meta">
+      <assert test="article-categories">
+        Element 'article-meta': Missing element article-categories.
       </assert>
     </rule>
   </pattern>

--- a/tests/test_schematron.py
+++ b/tests/test_schematron.py
@@ -278,3 +278,43 @@ class PublisherTests(unittest.TestCase):
 
         self.assertFalse(self._run_validation(sample))
 
+
+class ArticleCategoriesTests(unittest.TestCase):
+    """Tests for article/front/article-meta/article-categories elements.
+    """
+    def _run_validation(self, sample):
+        schematron = isoschematron.Schematron(SCH, phase='phase.article-categories')
+        return schematron.validate(etree.parse(sample))
+
+    def test_article_categories_is_present(self):
+        sample = """<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group>
+                              <subject>ISO/TC 108</subject>
+                              <subject>
+                                SC 2, Measurement and evaluation of...
+                              </subject>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = StringIO(sample)
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_article_categories_is_absent(self):
+        sample = """<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = StringIO(sample)
+
+        self.assertFalse(self._run_validation(sample))
+


### PR DESCRIPTION
Criado novo padrão do schematron para garantir a existência do elemento.
