### PR TITLE
Stylechecker utility output overhaul.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,17 @@
 History
 =======
 
+0.6.3 (2015-02-02)
+------------------
+
+* stylechecker CLI utility overhaul:
+  * The basic output is now presented as JSON structure. 
+  * The option *--assetsdir* lookups, in the given dir, for each asset referenced in
+      XML. The *--annotated* option now writes the output to a file. The
+      utility now takes more than one XML a time.
+  * *pygments*, if installed, will be used to display pretty JSON outputs.
+
+
 0.6.2 (2015-01-23)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -56,30 +56,52 @@ cópia do XML em validação, por meio do argumento opcional `--annotated`.
 O utilitário `stylechecker` tenta carregar a DTD externa, especificada na declaração DOCTYPE do 
 XML. Para evitar esse comportamento, utilize a opção `--nonetwork`.
 
+A função *ajuda* pode ser utilizada com a opção `-h`, conforme o exemplo:
+
 ```bash
 $ stylechecker -h
-usage: stylechecker [-h] [--annotated] [--nonetwork] [--version] xmlpath
+usage: stylechecker [-h] [--annotated] [--nonetwork] [--assetsdir ASSETSDIR]
+                    [--version]
+                    XML [XML ...]
 
-stylechecker cli utility.
+stylechecker cli utility
 
 positional arguments:
-  xmlpath      Filesystem path or URL to the XML file.
+  XML                   filesystem path or URL to the XML
 
 optional arguments:
-  -h, --help   show this help message and exit
-  --annotated
-  --nonetwork
-  --version    show program's version number and exit
+  -h, --help            show this help message and exit
+  --annotated           reproduces the XML with notes at elements that have
+                        errors
+  --nonetwork           prevents the retrieval of the DTD through the network
+  --assetsdir ASSETSDIR
+                        lookup, at the given directory, for each asset
+                        referenced by the XML
+  --version             show program's version number and exit
 ```
 
-Obs.: Para validar XMLs disponíveis via http, é necessário delimitar a URL com aspas ou apóstrofo. e.g.: 
+
+Exemplo do resultado da validação:
 
 ```bash
-$ stylechecker "http://192.168.1.162:7000/api/v1/article?code=S1516-635X2014000100012&format=xmlrsps"
-Valid XML! ;)
-Invalid SPS Style! Found 3 errors:
-Element 'journal-meta': Missing element journal-id of type "nlm-ta" or "publisher-id".
-Element 'journal-title-group': Missing element abbrev-journal-title of type "publisher".
-Element 'journal-meta': Missing element issn of type "epub".
+$ stylechecker 0034-8910-rsp-48-2-0206.xml
+[
+  {
+    "_xml": "0034-8910-rsp-48-2-0206.xml",
+    "dtd_errors": [
+      "Value \"foo\" for attribute ref-type of xref is not among the enumerated set"
+    ],
+    "is_valid": false,
+    "sps_errors": [
+      "Element 'abstract': Unexpected attribute xml:lang.",
+      "Element 'article-title': Unexpected attribute xml:lang.",
+      "Element 'counts': Missing element or wrong value in equation-count.",
+      "Element 'xref', attribute ref-type: Invalid value \"foo\".",
+      "Element 'person-group': Missing attribute person-group-type.",
+      "Element 'fn': Missing attribute fn-type.",
+      "Element 'article': Missing SPS version at the attribute specific-use."
+    ]
+  }
+]
 ```
 

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 


### PR DESCRIPTION
The basic output is now presented as JSON structure. The option
*--assetsdir* lookups, in the given dir, for each asset referenced in
XML. The *--annotated* option now writes the output to a file. The
utility now takes more than one XML a time.