### PR TITLE
Makes stylechecker more reusable.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+1.3
+---
+
+* Added functions ``stylechecker.summarize`` and ``stylechecker.annotate``.
+
+
 1.2 (2016-04-04)
 ----------------
 


### PR DESCRIPTION
Now the summary and annotation features can be used by calling
``stylechecker.summarize`` and ``stylechecker.annotate`` functions.