### PR TITLE
Adds zip-file validation capabilities.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
 script: python setup.py test -q
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 ---
 
 * Added functions ``stylechecker.summarize`` and ``stylechecker.annotate``.
+* Added zip-file validation capabilities.
 
 
 1.2 (2016-04-04)

--- a/packtools/domain.py
+++ b/packtools/domain.py
@@ -373,14 +373,14 @@ class XMLValidator(object):
         """
         return utils.get_static_assets(self.lxml)
 
-    def lookup_assets(self, base_dir):
-        """Look for each asset in `base_dir`, and returns a list of tuples
+    def lookup_assets(self, base):
+        """Look for each asset in `base`, and returns a list of tuples
         with the asset name and its presence status.
 
-        :param base_dir: path to the directory where the lookup will be based on.
+        :param base: any container that implements membership tests, i.e.
+                     it must support the ``in`` operator.
         """
-        is_available = utils.make_file_checker(base_dir)
-        return [(asset, is_available(asset)) for asset in self.assets]
+        return [(asset, asset in base) for asset in self.assets]
 
 
 class HTMLGenerator(object):

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ install_requires = [
 ]
 
 
+if sys.version_info[0] == 2:
+    install_requires.append('pathlib2 >= 2.1.0')
+
+
 tests_require = []
 
 
@@ -45,6 +49,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     tests_require=tests_require,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 #coding: utf-8
 from __future__ import unicode_literals
 import unittest
+import zipfile
+from tempfile import NamedTemporaryFile
 
 from packtools import utils
 
@@ -48,4 +50,65 @@ class CachedMethodTests(unittest.TestCase):
 
         self.assertEqual(a.sum(2, 2), 4)
         self.assertEqual(a.counter, 2)
+
+
+class XrayTests(unittest.TestCase):
+
+    def _make_test_archive(self, arch_data):
+        fp = NamedTemporaryFile()
+        with zipfile.ZipFile(fp, 'w') as zipfp:
+            for archive, data in arch_data:
+                zipfp.writestr(archive, data)
+
+        return fp
+
+    def test_members_are_shown(self):
+        arch = self._make_test_archive(
+            [('bar.xml', u'<root><name>bar</name></root>'),
+             ('jar.xml', u'<root><name>bar</name></root>')])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            self.assertEqual(sorted(xray.show_members()),
+                    sorted(['bar.xml', 'jar.xml']))
+
+    def test_get_members_returns_empty(self):
+        arch = self._make_test_archive([])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            self.assertEqual(xray.show_members(), [])
+
+    def test_get_file(self):
+        arch = self._make_test_archive(
+            [('bar.xml', u'<root><name>bar</name></root>'),
+             ('jar.xml', u'<root><name>bar</name></root>')])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            member = xray.get_file('bar.xml')
+            self.assertEqual(member.read(), b'<root><name>bar</name></root>')
+
+    def test_get_file_for_nonexisting_member(self):
+        arch = self._make_test_archive(
+            [('bar.xml', u'<root><name>bar</name></root>'),
+             ('jar.xml', u'<root><name>bar</name></root>')])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            self.assertRaises(ValueError, lambda: xray.get_file('foo.xml'))
+
+    def test_show_sorted_members(self):
+        arch = self._make_test_archive(
+            [('bar.xml', u'<root><name>bar</name></root>'),
+             ('jar.xml', u'<root><name>bar</name></root>')])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            self.assertEqual(xray.show_sorted_members(),
+                    {'xml': ['bar.xml', 'jar.xml']})
+
+    def test_show_sorted_members_is_caseinsensitive(self):
+        arch = self._make_test_archive(
+            [('bar.xml', u'<root><name>bar</name></root>'),
+             ('jar.XML', u'<root><name>bar</name></root>')])
+
+        with utils.Xray.fromfile(arch.name) as xray:
+            self.assertEqual(xray.show_sorted_members(),
+                    {'xml': ['bar.xml', 'jar.XML']})
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,py35
 
 [testenv]
 commands=python setup.py test -q


### PR DESCRIPTION
The new function ``stylechecker.validate_zip_package`` can perform full validations on zip packages, including assets lookup.

The method ``XMLValidation.lookup_assets`` now receives any object that supports the ``in`` operator.