### PR TITLE
Make built-in schematron schemas available via stylechecker.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,10 +1,15 @@
 History
 =======
 
+1.4
+---
+
 * XML catalog to resolve system ids of type URL
   [https://github.com/scieloorg/packtools/issues/110].
 * Remove the use license restrictions from the Brazil instance
   [https://github.com/scieloorg/packtools/issues/112].
+* Make built-in schematron schemas available through the prefix `@`:
+  @scielo-br, @sps-1.1, @sps-1.2, @sps-1.3, @sps-1.4, @sps-1.5.
 
 
 1.3.3 (2017-02-16)

--- a/packtools/catalogs/__init__.py
+++ b/packtools/catalogs/__init__.py
@@ -6,7 +6,7 @@ import os
 _CWD = os.path.dirname(os.path.abspath(__file__))
 
 # Validation schemas: XSD or DTD files.
-SCHEMAS = {
+SCH_SCHEMAS = {
     'sps-1.1': os.path.join(_CWD, 'scielo-style-1.1.sch'),
     'sps-1.2': os.path.join(_CWD, 'scielo-style-1.2.sch'),
     'sps-1.3': os.path.join(_CWD, 'scielo-style-1.3.sch'),
@@ -15,13 +15,19 @@ SCHEMAS = {
 
     # Collection-specific schema
     'scielo-br': os.path.join(_CWD, 'scielo-br.sch'),
+}
 
-    # DTD
+DTDS = {
     'JATS-journalpublishing1.dtd': os.path.join(
         _CWD, 'jats-publishing-dtd-1.0/JATS-journalpublishing1.dtd'),
     'journalpublishing3.dtd': os.path.join(
         _CWD, 'pmc-publishing-dtd-3.0/journalpublishing3.dtd'),
 }
+
+# Python>=3.5 is possible to use the syntax: SCHEMAS = {**SCH_SCHEMAS, **DTDS}
+# https://docs.python.org/dev/whatsnew/3.5.html#pep-448-additional-unpacking-generalizations
+SCHEMAS = dict(SCH_SCHEMAS)
+SCHEMAS.update(DTDS)
 
 # XML Catalog - OASIS Standard.
 XML_CATALOG = os.path.join(_CWD, 'scielo-publishing-schema.xml')

--- a/packtools/stylechecker.py
+++ b/packtools/stylechecker.py
@@ -33,9 +33,19 @@ code for more information.
 ERR_MESSAGE = "Something went wrong while working on {filename}: {details}."
 
 
+AVAILABLE_SCHEMAS = ', '.join(sorted(['@'+key 
+    for key in packtools.catalogs.SCH_SCHEMAS.keys()]))
+
+
 def get_xmlvalidator(xmlpath, no_network, extra_sch):
     parsed_xml = packtools.XML(xmlpath, no_network=no_network)
-    return packtools.XMLValidator.parse(parsed_xml, extra_schematron=extra_sch)
+    if extra_sch:
+        path_to_extra_sch = packtools.utils.resolve_schematron_filepath(extra_sch)
+    else:
+        path_to_extra_sch = None
+
+    return packtools.XMLValidator.parse(parsed_xml, 
+            extra_schematron=path_to_extra_sch)
 
 
 def annotate(validator, buff, encoding=None):
@@ -155,7 +165,7 @@ def _main():
     parser.add_argument('--nocolors', action='store_false',
                         help='prevents the output from being colorized by ANSI escape sequences')
     parser.add_argument('--extrasch', default=None,
-                        help='runs an extra validation using an external schematron schema.')
+                        help='runs an extra validation using an external schematron schema. built-in schemas are available through the prefix `@`: %s.' % AVAILABLE_SCHEMAS)
     parser.add_argument('--sysinfo', action='store_true',
                         help='show program\'s installation info and exit.')
     parser.add_argument('XML', nargs='*',

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -232,3 +232,28 @@ class Xray(object):
         """
         self._zipfile.close()
 
+
+def resolve_schematron_filepath(value):
+    """Determine the filepath for ``value``.
+
+    The lookup is run against all known schemas from
+    ``packtools.catalogs.SCH_SCHEMAS``. If ``value`` is already a filepath,
+    than it is returned as it is.
+    """
+    try:
+        lookup_builtin = value.startswith('@')
+    except AttributeError as exc:
+        # the `from` clause cannot be used due to compatibility with python 2.
+        raise TypeError('This function only handles text strings.')
+
+    if lookup_builtin:
+        path = catalogs.SCH_SCHEMAS.get(value[1:])
+        if path:
+            return path
+        else:
+            raise ValueError('Could not resolve schematron "%s".' % value)
+    elif os.path.lexists(value):
+        return value
+    else:
+        raise ValueError('File not found.')
+         

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,3 +112,30 @@ class XrayTests(unittest.TestCase):
             self.assertEqual(xray.show_sorted_members(),
                     {'xml': ['bar.xml', 'jar.XML']})
 
+
+class ResolveSchematronFilepathTests(unittest.TestCase):
+    def setUp(self):
+        from packtools import catalogs
+        self.sch_schemas = catalogs.SCH_SCHEMAS
+
+    def test_builtin_lookup(self):
+        for name, path in self.sch_schemas.items():
+            self.assertEqual(utils.resolve_schematron_filepath('@'+name), path)
+
+    def test_resolve_unsupported_types(self):
+        self.assertRaises(TypeError,
+                lambda: utils.resolve_schematron_filepath(None))
+
+    def test_non_existing_builtin(self):
+        self.assertRaises(ValueError, 
+                lambda: utils.resolve_schematron_filepath('@notexists'))
+
+    def test_existing_filepath(self):
+        path = list(self.sch_schemas.values())[0]  # get the first item
+        self.assertEqual(utils.resolve_schematron_filepath(path), path)
+
+    def test_non_existing_filepath(self):
+        path = list(self.sch_schemas.values())[0] + '.notexists'
+        self.assertRaises(ValueError, 
+                lambda: utils.resolve_schematron_filepath(path))
+


### PR DESCRIPTION
Make built-in schematron schemas available through the prefix `@`:
@scielo-br, @sps-1.1, @sps-1.2, @sps-1.3, @sps-1.4, @sps-1.5.