### PR TITLE
Fixes bdist_wheel builds.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [egg_info]
 tag_build = dev
 tag_date = true
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #coding:utf-8
 from __future__ import unicode_literals
 from setuptools import setup, find_packages
+import setuptools
 import codecs
 import sys
 
@@ -11,24 +12,37 @@ if sys.version_info[0:2] < (2, 7):
 
 
 # adds version to the local namespace
-version = {}
+VERSION = {}
 with open('packtools/version.py') as fp:
-    exec(fp.read(), version)
+    exec(fp.read(), VERSION)
 
 
-install_requires = [
+INSTALL_REQUIRES = [
     'lxml>=3.4.0',
     'picles.plumber>=0.11',
-    'pathlib>=1.0.1;python_version<"3.4"',
 ]
 
 
-tests_require = []
+EXTRAS_REQUIRE = {} 
+
+
+TESTS_REQUIRE = []
+
+
+# from https://hynek.me/articles/conditional-python-dependencies/
+# basically, binary wheels built using setuptools version < 18 do not support
+# the syntax for conditional dependencies used below.
+if int(setuptools.__version__.split('.', 1)[0]) < 18:
+    assert "bdist_wheel" not in sys.argv, "setuptools 18 required for wheels."
+    if sys.version_info[0:2] < (3, 4):
+        INSTALL_REQUIRES.append('pathlib>=1.0.1')
+else:
+    EXTRAS_REQUIRE[':python_version<"3.4"'] = ['pathlib>=1.0.1']
 
 
 setup(
     name="packtools",
-    version=version['__version__'],
+    version=VERSION['__version__'],
     description="Handle SPS packages like a breeze.",
     long_description=codecs.open('README.rst', mode='r', encoding='utf-8').read() + '\n\n' +
                      codecs.open('HISTORY.rst', mode='r', encoding='utf-8').read(),
@@ -50,9 +64,10 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    tests_require=tests_require,
+    tests_require=TESTS_REQUIRE,
     test_suite='tests',
-    install_requires=install_requires,
+    install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     entry_points="""
     [console_scripts]
     stylechecker = packtools.stylechecker:main


### PR DESCRIPTION
Binary wheels built using setuptools < 18 do not support the syntax for conditional dependencies based on the `extras_require` param, e.g.: `dict(':python_version<"3.4"'=['pathlib>=1.0.1'])`.