### PR TITLE
Corrige apresentação de mais de uma afiliação para um único autor

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -104,7 +104,9 @@
     
     <xsl:template match="contrib/xref" mode="contrib-dropdown-menu">
         <xsl:variable name="rid" select="@rid"/>
-        <xsl:apply-templates select="$article//aff[@id=$rid]" mode="contrib-dropdown-menu"/>
+        <xsl:if test="* or normalize-space(text()) != ''">
+            <xsl:apply-templates select="$article//aff[@id=$rid]" mode="contrib-dropdown-menu"/>
+        </xsl:if>
         <xsl:apply-templates select="$article//fn[@id=$rid]" mode="xref"/>
     </xsl:template>
     

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
@@ -74,7 +74,9 @@
     
     <xsl:template match="contrib/xref" mode="modal-contrib">
         <xsl:variable name="rid" select="@rid"/>
-        <xsl:apply-templates select="$article//aff[@id=$rid]" mode="modal-contrib"/>
+        <xsl:if test="* or normalize-space(text()) != ''">
+            <xsl:apply-templates select="$article//aff[@id=$rid]" mode="modal-contrib"/>
+        </xsl:if>
         <xsl:apply-templates select="$article//fn[@id=$rid]" mode="xref"/>
     </xsl:template>
     


### PR DESCRIPTION
#### O que esse PR faz?
Corrige apresentação de mais de uma afiliação para um único autor.

#### Onde a revisão poderia começar?
- Em `catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl`, verificar tratamento no dropdown-menu.
- Em `catalogs/htmlgenerator/v2.0/html-modals-contrib.xsl`, verificar tratamento no modal.

#### Como este poderia ser testado manualmente?
O arquivo `data/xml/tema/v18n3/2179-8451-tema-18-03-385.xml` possui um autor com 2 afiliações. Gerar o HTML e verificar o dropdown do autor e o modal sobre os autores

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
scieloorg/opac/issues/993

#### Screenshots (se aplicável)

Como estava:

<img width="883" alt="screen shot 2019-01-08 at 16 30 35" src="https://user-images.githubusercontent.com/18053487/50851105-f59de800-1362-11e9-9168-e9ec99ea8d49.png">

<img width="597" alt="screen shot 2019-01-08 at 16 31 02" src="https://user-images.githubusercontent.com/18053487/50851138-0f3f2f80-1363-11e9-8c10-28d951bab1df.png">


Como ficará:

<img width="869" alt="screen shot 2019-01-08 at 16 33 29" src="https://user-images.githubusercontent.com/18053487/50851193-372e9300-1363-11e9-9406-f1ddd2374b11.png">

<img width="597" alt="screen shot 2019-01-08 at 16 33 42" src="https://user-images.githubusercontent.com/18053487/50851199-3d247400-1363-11e9-95f1-4cc85a0ed46f.png">


#### Perguntas:
N/A
