### PR TITLE
Corrige problemas na formatação do label de notas de autores

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -104,6 +104,7 @@
     
     <xsl:template match="contrib/xref" mode="contrib-dropdown-menu">
         <xsl:variable name="rid" select="@rid"/>
+        <xsl:apply-templates select="$article//author-notes/corresp[@id=$rid]" mode="contrib-dropdown-menu"/>
         <xsl:apply-templates select="$article//aff[@id=$rid]" mode="contrib-dropdown-menu"/>
         <xsl:apply-templates select="$article//fn[@id=$rid]" mode="xref"/>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
@@ -59,6 +59,9 @@
     <xsl:template match="contrib" mode="modal-contrib">
         <div class="tutors">
             <strong><xsl:apply-templates select="name|collab|on-behalf-of"/></strong>
+            <xsl:if test="xref[@ref-type='corresp']">
+                <xsl:apply-templates select="xref[@ref-type='corresp']" />
+            </xsl:if>
             <br/>
             <xsl:apply-templates select="role"/>
             <xsl:apply-templates select="xref" mode="modal-contrib"/>
@@ -101,7 +104,14 @@
     </xsl:template>
     
     <xsl:template match="author-notes//label">
-        <h3><xsl:apply-templates select="*|text()"></xsl:apply-templates></h3>        
+        <xsl:choose>
+            <xsl:when test="string-length(normalize-space(text())) = 1">
+                <xsl:apply-templates select="*|text()"></xsl:apply-templates>
+            </xsl:when>
+            <xsl:otherwise>
+                <h3><xsl:apply-templates select="*|text()"></xsl:apply-templates></h3>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
     <!--xsl:template match="author-notes//fn" mode="modal-contrib">
@@ -112,4 +122,11 @@
             </div>
         </xsl:if>
     </xsl:template-->
+
+    <xsl:template match="author-notes/corresp" mode="contrib-dropdown-menu">
+      <div class="corresp">
+        <xsl:apply-templates/>
+      </div>
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige apresentação de label de correspondência de autores nos artigos.

#### Onde a revisão poderia começar?
- Em `catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl`, verificar inclusão de correspondência no dropdown-menu.
- Em `catalogs/htmlgenerator/v2.0/html-modals-contrib.xsl`, verificar:
  - Tratamento diferente para o valor do label de correspondência com tamanho 1
  - Identificação do autor correspondente às notas

#### Como este poderia ser testado manualmente?
- O arquivo `data/xml/tema/v18n3/2179-8451-tema-18-03-385.xml` possui um autor com notas de correspondência e deve ser relacionado com as notas. Gerar o HTML e verificar o dropdown do autor e o modal sobre os autores
- O arquivo `data/xml/acb/v33n11/1678-2674-acb-33-11-00975.xml` possui notas de correspondência apresentadas de forma diferente e sua formatação não deve ser afetada pela alteração deste PR.

#### Algum cenário de contexto que queira dar?
N/A

#### Quais são tickets relevantes?
scieloorg/opac/issues/992

#### Screenshots (se aplicável)
N/A

#### Perguntas:
N/A
