### PR TITLE
Corrige problema de truncamento do financiador (fn-label)

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
@@ -28,7 +28,14 @@
     </xsl:template>
     
     <xsl:template match="fn/label">
-        <span class="xref big"><xsl:apply-templates select="*|text()"></xsl:apply-templates></span>
+        <xsl:choose>
+            <xsl:when test="string-length(normalize-space(text())) &gt; 3">
+                <h3><span class="xref big"><xsl:apply-templates select="*|text()"></xsl:apply-templates></span></h3>
+            </xsl:when>
+            <xsl:otherwise>
+                <span class="xref big"><xsl:apply-templates select="*|text()"></xsl:apply-templates></span>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
     <xsl:template match="fn/p">


### PR DESCRIPTION
#### O que esse PR faz?
Corrige apresentação de label de financiador, que está sendo sobreposto com o valor, conforme exemplos dados no ticket scieloorg/opac/issues/827.

#### Onde a revisão poderia começar?
- Em `catalogs/htmlgenerator/v2.0/article-text-fn.xsl`, verificar tratamento para textos maiores que 3 caracteres.

#### Como este poderia ser testado manualmente?
- O arquivo `data/xml/gs/v31n3/0213-9111-gs-31-03-00253.xml` possui a seguinte tag:
```xml
<fn-group>
    <fn fn-type="financial-disclosure" id="fn2">
        <label>Financiación</label>
        <p>Ninguna.</p>
    </fn>
</fn-group>
```
Ao gerar o HTML deste XML, o valor da tag `label` deve ser exibida sem que o valor de `p` seja sobreposto, assim como um valor de label com tamanho menor deve continuar sendo exibido sem problema de sobreposição.

#### Algum cenário de contexto que queira dar?
Existem outros casos que este PR não resolve, por se tratarem de um problema no layout de exibição que o problema foi detectado. É necessário que, ainda assim, o problema seja corrigido na interface.

#### Quais são tickets relevantes?
scieloorg/opac/issues/827

#### Screenshots (se aplicável)
Resultado deste PR:

![screen shot 2019-01-10 at 08 37 40](https://user-images.githubusercontent.com/18053487/50963238-52101d00-14b3-11e9-937b-4c5a0a69c95c.png)

#### Perguntas:
N/A
