### PR TITLE
[Opac tk903] Apresentação das data de histórico

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -85,6 +85,36 @@
         <name lang="en">Reviewed</name>
     </term>
     <term>
+        <name>corrected</name>
+        <name lang="en">Corrected</name>
+        <name lang="pt">Corrigido</name>
+        <name lang="es">Corregido</name>
+    </term>
+    <term>
+        <name>pub</name>
+        <name lang="pt">Publicação</name>
+        <name lang="es">Publicación</name>
+        <name lang="en">Publication</name>
+    </term>
+    <term>
+        <name>preprint</name>
+        <name lang="pt">Preprint</name>
+        <name lang="es">Preprint</name>
+        <name lang="en">Preprint</name>
+    </term>
+    <term>
+        <name>retracted</name>
+        <name lang="pt">Retratado</name>
+        <name lang="es">Retractado</name>
+        <name lang="en">Retracted</name>
+    </term>
+    <term>
+        <name>rev-requested</name>
+        <name lang="pt">Solicitud de Revisión</name>
+        <name lang="es">Revisado</name>
+        <name lang="en">Requested Revision</name>
+    </term>
+    <term>
         <name>About the authors</name>
         <name lang="pt">Sobre os autores</name>
         <name lang="es">Acerca de los autores</name>        

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -92,9 +92,9 @@
     </term>
     <term>
         <name>pub</name>
-        <name lang="pt">Publicação</name>
-        <name lang="es">Publicación</name>
-        <name lang="en">Publication</name>
+        <name lang="pt">Publicado</name>
+        <name lang="es">Publicado</name>
+        <name lang="en">Published</name>
     </term>
     <term>
         <name>preprint</name>


### PR DESCRIPTION
#### What's this PR do?
Apresentar todos os possíveis tipos de datas do histórico, além de received, accepted e pub.

#### Where should the reviewer start?


#### How should this be manually tested?
Ter o packtools instalado e executar o htmlgenerator para um arquivo XML que contenha 
```xml
<history>
       <date date-type="received">
           <day>15</day>
           <month>03</month>
           <year>2013</year>
       </date>
       <date date-type="rev-recd">
           <day>06</day>
           <month>11</month>
           <year>2013</year>
       </date>
       <date date-type="accepted">
           <day>12</day>
           <month>05</month>
           <year>2014</year>
       </date>
<date date-type="corrected">
           <day>15</day>
           <month>03</month>
           <year>2013</year>
       </date>
       <date date-type="retracted">
           <day>06</day>
           <month>11</month>
           <year>2013</year>
       </date>
       <date date-type="preprint">
           <day>12</day>
           <month>05</month>
           <year>2014</year>
       </date>
<date date-type="rev-requested">
           <day>15</day>
           <month>03</month>
           <year>2013</year>
       </date>
<date date-type="pub">
           <day>15</day>
           <month>03</month>
           <year>2013</year>
       </date>
      
   </history>
```

#### Any background context you want to provide?
https://new.scielo.br/scielo.php?script=sci_arttext&pid=S0102-76382018000500435&lng=en&nrm=iso&tlng=en
Todas as datas de histórico poderiam ser apresentadas na página do artigo, no entanto, nem todas teriam o "rótulo" traduzido. Somente accepted e reviewed eram traduzidos.
 
#### What are the relevant tickets?
https://github.com/scieloorg/opac/issues/903
