### PR TITLE
Modifica a XSL para comportar funcionalidades legadas do site vintage

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
@@ -14,7 +14,11 @@
             </div>
         </div>
     </xsl:template>
-    
+
+	<xsl:template match="disp-formula/label">
+		<span class="label"><xsl:value-of select="."/></span>
+	</xsl:template>
+
     <xsl:template match="tex-math">
         <span>
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
@@ -10,7 +10,9 @@
         <div class="row formula" id="e{@id}">
             <a name="{@id}"></a>
             <div class="col-md-12">
-                <xsl:apply-templates select="*|text()"></xsl:apply-templates>
+                <div class="formula-container">
+                    <xsl:apply-templates select="*|text()"></xsl:apply-templates>
+                </div>
             </div>
         </div>
     </xsl:template>
@@ -20,8 +22,15 @@
 	</xsl:template>
 
     <xsl:template match="tex-math">
-        <span>
-            <xsl:apply-templates select="*|text()"></xsl:apply-templates>
+        <span class="formula-body">
+            <xsl:choose>
+                <xsl:when test="contains(.,'\begin{document}') and contains(.,'\end{document}')">
+                    <xsl:value-of select="substring-after(substring-before(.,'\end{document}'),'\begin{document}')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="."/>
+                </xsl:otherwise>
+            </xsl:choose>
         </span>
     </xsl:template>
     


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request  modifica a XLS das `disp-formula` com match em `tex-math` e:
- Encapsula os `labels` em uma tag HTML com um identificador para posterior tratamento via CSS
- Remove o preâmbulo de fórmulas matemáticas do tipo LaTeX e assim prover a compatibilidade com o site antigo.

#### Onde a revisão poderia começar?
Este PR pode ser revisado a partir do arquivo:
- `packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl`

#### Como este poderia ser testado manualmente?
- Rodando os testes com `python setup.py test`
- ```htmlgenerator 1980-5381-neco-28-02-385.xml```  - [XML](https://new.scielo.br/article/ssm/content/raw/\?resource_ssm_path\=/media/assets/neco/v28n2/1980-5381-neco-28-02-385.xml)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#168
#169

### Referências
N/A
