### PR TITLE
 scieloorg/opac#1123 Apresentação de Subseção dos artigos

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -10,14 +10,24 @@
         -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//subject" mode="display"></xsl:apply-templates>
+                <xsl:for-each select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//subject">
+                    <xsl:value-of select="text()"/>
+                    <xsl:choose>
+                        <xsl:when test="position() != last()">, </xsl:when>
+                    </xsl:choose>
+                </xsl:for-each>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="front/article-meta//subject"></xsl:apply-templates>
+                <xsl:for-each select="front/article-meta//subject">
+                    <xsl:value-of select="text()"/>
+                    <xsl:choose>
+                        <xsl:when test="position() != last()">, </xsl:when>
+                    </xsl:choose>
+                </xsl:for-each>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xsl:template match="article" mode="article-meta-title">
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -31,7 +41,7 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xsl:template match="article" mode="article-meta-trans-title">
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -47,25 +57,25 @@
     <xsl:template match="trans-title" mode="translation">
         <h2 class="article-title"><xsl:apply-templates select="*|text()"></xsl:apply-templates></h2>
     </xsl:template>
-    
+
     <xsl:template match="*" mode="article-meta-doi">
-        <xsl:apply-templates select="front/article-meta//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>        
+        <xsl:apply-templates select="front/article-meta//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
     </xsl:template>
-   
+
     <xsl:template match="article-id[@pub-id-type='doi']" mode="display">
         <xsl:variable name="link">https://doi.org/<xsl:value-of select="."/></xsl:variable>
         <span class="_doi"><xsl:value-of select="$link"/></span>
         &#160;
         <a class="copyLink" data-clipboard-text="{$link}">
-            <span class="sci-ico-link"/> 
+            <span class="sci-ico-link"/>
             <xsl:apply-templates select="." mode="interface">
                 <xsl:with-param name="text">copy</xsl:with-param>
             </xsl:apply-templates>
         </a>
     </xsl:template>
-    
+
     <xsl:template match="article" mode="issue-meta-pub-dates">
-        
+
         <xsl:choose>
             <xsl:when test="front/article-meta/pub-date[@pub-type='collection']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='collection']"></xsl:apply-templates>
@@ -84,10 +94,10 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xsl:template match="article" mode="article-meta-pub-dates">
         <xsl:apply-templates select="front/article-meta/pub-date[1]" mode="generated-label"></xsl:apply-templates>&#160;
-        
+
         <xsl:choose>
             <xsl:when test="front/article-meta/pub-date[@pub-type='epub']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='epub']"></xsl:apply-templates>


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR adiciona uma `,` entre as subseção do artigo, essa correção foi pedida atreves do Ticket do projeto do OPAC descrito abaixo, 

#### Onde a revisão poderia começar?

Pode ser revisado a estrutura de condição da xsl que foi alterada para tratar esse caso 

#### Como este poderia ser testado manualmente?
baixar um xml do ssm que possua subj-group e rodar o comando de gerar o HTML do artigo

**xml de exemplo**
```bach
curl https://ssm.scielo.br/media/assets/prc/v31/1678-7153-prc-31-12.xml -o /tmp/1678-7153-prc-31-12.xml
```

**geração do HTML**
```bach
htmlgenerator /tmp/1678-7153-prc-31-12.xml
```

#### Algum cenário de contexto que queira dar?
O proplema acontecia quando havia um `subj-group` de categoria no xml do arquivo

#### Quais são tickets relevantes?
scieloorg/opac#1123

### Screenshots
![image](https://user-images.githubusercontent.com/16937218/49595567-6797a180-f95f-11e8-9eb0-8ef011533406.png)