### PR TITLE
Corrige falha na renderização de tabelas sem label ou caption

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+#### O que esse PR faz?
+Fale sobre o propósito do pull request como por exemplo: quais problemas ele soluciona ou quais features ele adiciona.
+
+#### Onde a revisão poderia começar?
+Indique o caminho do arquivo e o arquivo onde o revisor deve iniciar a leitura do código.
+
+#### Como este poderia ser testado manualmente?
+Estabeleça os passos necessários para que a funcionalidade seja testada manualmente pelo revisor.
+
+#### Algum cenário de contexto que queira dar?
+Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
+o revisor a fim de facilitar o entendimento da funcionalidade.
+
+### Screenshots
+Quando aplicável e se fizer possível adicione screenshots que remetem a situação gráfica do problema que o pull request resolve.
+
+#### Quais são tickets relevantes?
+Indique uma issue ao qual o pull request faz relacionamento.
+
+### Referências
+Indique as referências utilizadas para a elaboração do pull request.
+

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xsl
@@ -126,14 +126,19 @@
         <xsl:if test="label and caption"> &#160; </xsl:if>
         <xsl:apply-templates select="caption"/>
     </xsl:template>
-    
-    <xsl:template match="*[label or caption]" mode="label-caption-thumb">
-        <strong><xsl:apply-templates select="label" mode="label-caption-thumb"/></strong><br/>
-        <xsl:apply-templates select="caption" mode="label-caption-thumb"/>
+    <xsl:template match="*" mode="label-caption-thumb">
     </xsl:template>
     
-    <xsl:template match="label|caption| *" mode="label-caption-thumb">
-        <xsl:apply-templates select="*|text()" mode="label-caption-thumb"></xsl:apply-templates>
+    <xsl:template match="*[label or caption]" mode="label-caption-thumb">
+        <strong><xsl:apply-templates select="label"/></strong><br/>
+        <xsl:apply-templates select="caption"/>
+    </xsl:template>
+
+    <xsl:template match="label|caption" mode="label-caption-thumb">
+        <xsl:apply-templates select="*|text()"></xsl:apply-templates>
+    </xsl:template>
+    <xsl:template match="label//*|caption//*" mode="label-caption-thumb">
+        <xsl:apply-templates select="*|text()"></xsl:apply-templates>
     </xsl:template>
     <xsl:template match="xref" mode="label-caption-thumb">
     </xsl:template>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige falha na renderização de tabelas sem label ou caption. O que ocorre sem esta correção é a inclusão do conteúdo da tabela em texto no lugar do label ou caption.
Também inclui o template para os próximos PRs.

#### Onde a revisão poderia começar?
Em `packtools/catalogs/htmlgenerator/v2.0/config-labels.xsl`.

#### Como este poderia ser testado manualmente?
XML exemplo com problema: https://ssm.scielo.br/media/assets/abc/v111n3/0066-782X-abc-111-03-0436.xml
Transformá-lo em html: `htmlgenerator 0066-782X-abc-111-03-0436.xml`.

#### Algum cenário de contexto que queira dar?
Verificar issue aberta: scieloorg/opac/issues/1276.

### Screenshots
![Screen Shot 2019-04-16 at 17 41 42](https://user-images.githubusercontent.com/18053487/56242593-026f5d80-606f-11e9-9d54-cefc3c3c16e5.png)

---

![Screen Shot 2019-04-16 at 17 42 06](https://user-images.githubusercontent.com/18053487/56242601-056a4e00-606f-11e9-9cf8-a2639ea2c7cc.png)

#### Quais são tickets relevantes?
scieloorg/opac/issues/1276.

### Referências
Nenhuma.
