### PR TITLE
Corrige as datas na página do artigo, considerando a SPS 1.9

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -85,6 +85,9 @@
     <xsl:template match="article" mode="issue-meta-pub-dates">
 
         <xsl:choose>
+            <xsl:when test="front/article-meta/pub-date[@date-type='collection']">
+                <xsl:apply-templates  select="front/article-meta/pub-date[@date-type='collection']"></xsl:apply-templates>
+            </xsl:when>
             <xsl:when test="front/article-meta/pub-date[@pub-type='collection']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='collection']"></xsl:apply-templates>
             </xsl:when>
@@ -97,9 +100,9 @@
             <xsl:when test="front/article-meta/pub-date[@pub-type='epub-ppub']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='epub-ppub']"></xsl:apply-templates>
             </xsl:when>
-            <xsl:otherwise>
+            <!--xsl:otherwise>
                 <xsl:apply-templates  select="front/article-meta/pub-date"></xsl:apply-templates>
-            </xsl:otherwise>
+            </xsl:otherwise-->
         </xsl:choose>
     </xsl:template>
 
@@ -107,6 +110,9 @@
         <xsl:apply-templates select="front/article-meta/pub-date[1]" mode="generated-label"></xsl:apply-templates>&#160;
 
         <xsl:choose>
+            <xsl:when test="front/article-meta/pub-date[@date-type='epub']">
+                <xsl:apply-templates  select="front/article-meta/pub-date[@date-type='epub']"></xsl:apply-templates>
+            </xsl:when>
             <xsl:when test="front/article-meta/pub-date[@pub-type='epub']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='epub']"></xsl:apply-templates>
             </xsl:when>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -88,6 +88,9 @@
             <xsl:when test="front/article-meta/pub-date[@date-type='collection']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@date-type='collection']"></xsl:apply-templates>
             </xsl:when>
+            <xsl:when test="front/article-meta/pub-date[@date-type='pub']">
+                <xsl:apply-templates select="front/article-meta/pub-date[@date-type='pub']"/>
+            </xsl:when>
             <xsl:when test="front/article-meta/pub-date[@pub-type='collection']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='collection']"></xsl:apply-templates>
             </xsl:when>
@@ -100,9 +103,6 @@
             <xsl:when test="front/article-meta/pub-date[@pub-type='epub-ppub']">
                 <xsl:apply-templates  select="front/article-meta/pub-date[@pub-type='epub-ppub']"></xsl:apply-templates>
             </xsl:when>
-            <!--xsl:otherwise>
-                <xsl:apply-templates  select="front/article-meta/pub-date"></xsl:apply-templates>
-            </xsl:otherwise-->
         </xsl:choose>
     </xsl:template>
 

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -185,6 +185,7 @@
                             <xsl:apply-templates select="." mode="journal-meta-bibstrip-title"/>
                             <xsl:text> </xsl:text>
                             <xsl:apply-templates select="." mode="journal-meta-bibstrip-issue"/>
+                            <span class="_separator"> • </span>
                             <xsl:apply-templates select="." mode="issue-meta-pub-dates"/>
                         </span>
                         <span class="_separator"> • </span>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-how2cite.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-how2cite.xsl
@@ -158,6 +158,9 @@
 
     <xsl:template match="*" mode="how2cite-issue-info">
         <xsl:choose>
+            <xsl:when test=".//pub-date[@date-type='collection']">
+                <xsl:apply-templates select=".//pub-date[@date-type='collection']/year"/><xsl:if test=".//volume or .//issue">, </xsl:if>
+            </xsl:when>
             <xsl:when test=".//pub-date[@pub-type='epub-ppub']">
                 <xsl:apply-templates select=".//pub-date[@pub-type='epub-ppub']/year"/><xsl:if test=".//volume or .//issue">, </xsl:if>
             </xsl:when>
@@ -166,6 +169,9 @@
             </xsl:when>
             <xsl:when test=".//pub-date[@pub-type='ppub']">
                 <xsl:apply-templates select=".//pub-date[@pub-type='ppub']/year"/><xsl:if test=".//volume or .//issue">, </xsl:if>
+            </xsl:when>
+            <xsl:when test=".//pub-date[@date-type='pub']">
+                <xsl:apply-templates select=".//pub-date[@date-type='pub']/year"/><xsl:if test=".//volume or .//issue">, </xsl:if>
             </xsl:when>
             <xsl:when test=".//pub-date[@pub-type='epub']">
                 <xsl:apply-templates select=".//pub-date[@pub-type='epub']/year"/><xsl:if test=".//volume or .//issue">, </xsl:if>
@@ -212,9 +218,14 @@
     </xsl:template>
 
     <xsl:template match="*" mode="how2cite-epub-date">
-        <xsl:if test=".//pub-date[@pub-type='epub']">
-            Epub <xsl:apply-templates select=".//pub-date[@pub-type='epub']"/>.
-        </xsl:if>
+        <xsl:choose>
+            <xsl:when test=".//pub-date[@date-type='pub' and @publication-format='electronic']">
+                Epub <xsl:apply-templates select=".//pub-date[@date-type='pub']"/>.
+            </xsl:when>
+            <xsl:when test=".//pub-date[@pub-type='epub']">
+                Epub <xsl:apply-templates select=".//pub-date[@pub-type='epub']"/>.
+            </xsl:when>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="*" mode="how2cite-issn">


### PR DESCRIPTION
#### O que esse PR faz?
Corrige as datas na página do artigo, considerando a SPS 1.9.
A partir da SPS 1.9 (2019) as datas são representadas com
`pub-date[@date-type]` no lugar de `pub-date[@pub-type]`

Os valores para @date-type são pub e collection que são correpondentes
respectivamente a

`pub-date/@pub-type == epub-ppub, collection, ppub` equivalem a
`@date-type='collection'`

`pub-date/@pub-type == epub` equivalem a @date-type='pub' conjuntamente
com `@publication-format='electronic'`

#### Onde a revisão poderia começar?
packtools/catalogs/htmlgenerator/v2.0/article.xsl:187

#### Como este poderia ser testado manualmente?

[1807-5762-icse-23-e170521-com-collection.zip](https://github.com/scieloorg/packtools/files/3154300/1807-5762-icse-23-e170521-com-collection.zip)
```xml
<pub-date pub-type="epub">
				<day>14</day>
				<month>02</month>
				<year>2019</year>
			</pub-date>
			<pub-date pub-type="collection"><year>2019</year></pub-date>
```

[1807-5762-icse-23-e170521-sps-1.9.zip](https://github.com/scieloorg/packtools/files/3154308/1807-5762-icse-23-e170521-sps-1.9.zip)
```xml
<pub-date date-type="pub" publication-format="electronic">
				<day>14</day>
				<month>02</month>
				<year>2019</year>
			</pub-date>
			<pub-date date-type="collection"><year>2019</year></pub-date>
```

`python htmlgenerator.py 1807-5762-icse-23-e170521.xml --nochecks`

Para AOP, apresentar a data "pub", completa:
(simulando aop, comentando a outra data)
```
<pub-date date-type="pub" publication-format="electronic">
				<day>28</day>
				<month>09</month>
				<year>2020</year>
			</pub-date>
			<!--pub-date date-type="collection" publication-format="electronic">
				<season>Sep-Oct</season>
				<year>2020</year>
			</pub-date-->
```

<img width="630" alt="Captura de Tela 2020-11-27 às 14 07 48" src="https://user-images.githubusercontent.com/505143/100472125-661a9300-30ba-11eb-86d6-11d57ab613fc.png">

Se existe a data `collection`, fica:
<img width="534" alt="Captura de Tela 2020-11-27 às 14 12 38" src="https://user-images.githubusercontent.com/505143/100472336-d5908280-30ba-11eb-999d-5b750b91a1b2.png">


#### Algum cenário de contexto que queira dar?
**Os XML que são "publicação contínua" anteriores a SPS 1.9 não possuem "collection", mas deveriam ter. E por conta disso, após packtools ser atualizado e se os XML não forem compatibilizados, nenhuma data será apresentada. Isso pode ser um problema.**

### Screenshots
<img width="493" alt="Captura de Tela 2019-05-07 às 16 56 18" src="https://user-images.githubusercontent.com/505143/57328913-17c52e00-70e9-11e9-8044-3cf3ad8effc3.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1274

### Referências
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/1.9-branch/tagset/elemento-pub-date.html

