### PR TITLE
Ajustes no label das traduções scieloorg/opac#1180

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -373,4 +373,10 @@
         <name lang="pt">Publicação</name>
         <name lang="es">Publicación</name>
     </term>
+    <term>
+        <name>Publication in this collection</name>
+        <name lang="en">Publication in this collection</name>
+        <name lang="pt">Publicação nesta coleção</name>
+        <name lang="es">Publicación en esta colección</name>
+    </term>
 </labels>

--- a/packtools/catalogs/htmlgenerator/v2.0/generic-pub-date.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/generic-pub-date.xsl
@@ -27,7 +27,7 @@
         <xsl:if test="pub-date[@pub-type='epub-ppub'] or pub-date[@date-type='pub'] or pub-date[@pub-type='epub']">
                 <li><strong>
                     <xsl:apply-templates select="." mode="text-labels">
-                        <xsl:with-param name="text">Publication</xsl:with-param>
+                        <xsl:with-param name="text">Publication in this collection</xsl:with-param>
                     </xsl:apply-templates>
                     </strong><br/>
                     <xsl:choose>


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR Ajustar os termos utilizados no bloco de visualização para as datas de publicação como descrito no ticket scieloorg/opac#1180 e incorporado pelo PR #194 

#### Onde a revisão poderia começar?
Pelos arquivos
* `packtools/catalogs/htmlgenerator/v2.0/config-labels.xml`
* `packtools/catalogs/htmlgenerator/v2.0/generic-pub-date.xsl`

#### Como este poderia ser testado manualmente?
Apos atualizar o pacote e gerar o html de um xml, verifique se o html produzido condiz com o esperado

#### Quais são tickets relevantes?
scieloorg/opac#1180
