### PR TITLE
Correção para não ocorrer duplicação da div 'contribGroup'

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -14,7 +14,10 @@
     </xsl:template>
     
     <xsl:template match="article" mode="contrib-group">
-        <xsl:apply-templates select="front/article-meta//contrib-group"/>
+        <div>
+            <xsl:attribute name="class">contribGroup</xsl:attribute>
+            <xsl:apply-templates select="front/article-meta//contrib-group"/>
+        </div>
     </xsl:template>
     
     <xsl:template match="sub-article" mode="contrib-group">
@@ -25,23 +28,19 @@
     </xsl:template>
     
     <xsl:template match="front/contrib-group | front-stub/contrib-group" mode="modal-id"><xsl:value-of select="../../@id"/></xsl:template>
-    <xsl:template match="article-meta/contrib-group | sub-article[@article-type='translation']//contrib-group" mode="modal-id">    
-    </xsl:template>
+    <xsl:template match="article-meta/contrib-group | sub-article[@article-type='translation']//contrib-group" mode="modal-id"></xsl:template>
     
     <xsl:template match="article-meta/contrib-group | front/contrib-group | front-stub/contrib-group">
         <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
-        <div>
-            <xsl:attribute name="class">contribGroup</xsl:attribute>
-            <xsl:apply-templates select="contrib" mode="article-meta-contrib"/>
-            <xsl:if test="contrib/*[name()!='name' and name()!='collab']">
-                <a href="" class="outlineFadeLink" data-toggle="modal"
-                    data-target="#ModalTutors{$id}">
-                    <xsl:apply-templates select="." mode="interface">
-                        <xsl:with-param name="text">About the author<xsl:if test="count(contrib)&gt;1">s</xsl:if></xsl:with-param>
-                    </xsl:apply-templates>
-                </a>
-            </xsl:if>
-        </div>
+        <xsl:apply-templates select="contrib" mode="article-meta-contrib"/>
+        <xsl:if test="contrib/*[name()!='name' and name()!='collab']">
+            <a href="" class="outlineFadeLink" data-toggle="modal"
+                data-target="#ModalTutors{$id}">
+                <xsl:apply-templates select="." mode="interface">
+                    <xsl:with-param name="text">About the author<xsl:if test="count(contrib)&gt;1">s</xsl:if></xsl:with-param>
+                </xsl:apply-templates>
+            </a>
+        </xsl:if>
     </xsl:template>
    
     <xsl:template match="contrib" mode="article-meta-contrib">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -21,10 +21,13 @@
     </xsl:template>
     
     <xsl:template match="sub-article" mode="contrib-group">
-        <xsl:apply-templates select=".//front-stub//contrib-group | .//front//contrib-group"></xsl:apply-templates>
-        <xsl:if test="not(.//contrib) and ../@article-type='translation'">
-            <xsl:apply-templates select="$article//article-meta//contrib"></xsl:apply-templates>
-        </xsl:if>
+        <div>
+            <xsl:attribute name="class">contribGroup</xsl:attribute>
+            <xsl:apply-templates select=".//front-stub//contrib-group | .//front//contrib-group"></xsl:apply-templates>
+            <xsl:if test="not(.//contrib) and ../@article-type='translation'">
+                <xsl:apply-templates select="$article//article-meta//contrib"></xsl:apply-templates>
+            </xsl:if>
+        </div>
     </xsl:template>
     
     <xsl:template match="front/contrib-group | front-stub/contrib-group" mode="modal-id"><xsl:value-of select="../../@id"/></xsl:template>


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR corrige a duplicação da div `contribGroup` assim evitando a duplicação de autores na visualização do artigo 

#### Onde a revisão poderia começar?
Pelo arquivo 
* `packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl`

#### Como este poderia ser testado manualmente?
Apos atualizar o packtools e o ambinete local do opac, tente acessar alguns artigos e em especial o 
`http://0.0.0.0:5000/article/abc/2018.v111n3/436-539/` que ocasionou todo o problema


#### Algum cenário de contexto que queira dar?
Quando o Artigo possui mais de 10 autores aparece um collapse `[...]` que em alguns casos estava seno duplicado

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/opac#1311

### Referências
https://github.com/scieloorg/opac/issues/1311#issuecomment-508259339

