### PR TITLE
Adiciona suporte para visual abstract na página do artigo

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet 
+<xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     exclude-result-prefixes="xlink mml"
     version="1.0">
-    
+
     <xsl:template match="fig-group">
         <xsl:choose>
             <xsl:when test="fig[@xml:lang=$TEXT_LANG]">
@@ -33,11 +33,26 @@
             </div>
         </div>
     </xsl:template>
-    
+
+    <xsl:template match="abstract[@abstract-type='graphical']//fig[graphic]">
+        <xsl:variable name="location">
+            <xsl:apply-templates select="." mode="file-location"></xsl:apply-templates>
+        </xsl:variable>
+        <div>
+            <span><xsl:apply-templates select="caption"/></span>
+           <img>
+                <xsl:attribute name="style">max-width:100%</xsl:attribute>
+                <xsl:attribute name="src">
+                    <xsl:value-of select="$location"/>
+                </xsl:attribute>
+            </img>
+        </div>
+    </xsl:template>
+
     <xsl:template match="fig-group" mode="file-location">
         <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
     </xsl:template>
-    
+
     <xsl:template match="fig[disp-formula and not(graphic)]">
         <div class="row fig" id="{@id}">
             <a name="{@id}"></a>
@@ -49,11 +64,11 @@
             </div>
         </div>
     </xsl:template>
-    
+
     <xsl:template match="*[graphic]" mode="file-location"><xsl:apply-templates select="graphic/@xlink:href"/></xsl:template>
-    
+
     <xsl:template match="fig-group" mode="label-caption">
         <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="label-caption"></xsl:apply-templates>
     </xsl:template>
-      
+
 </xsl:stylesheet>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -131,3 +131,142 @@ class HTMLGeneratorTests(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: gen.generate('ru'))
 
+    def test_if_visual_abstract_image_present_in_html(self):
+        sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <abstract abstract-type="graphical">
+                              <title>Visual Abstract</title>
+                              <p>
+                                  <fig id="vf01">
+                                      <caption>
+                                          <title>Caption em Inglês</title>
+                                      </caption>
+                                      <graphic xlink:href="2175-8239-jbn-2018-0058-vf01.jpg"/>
+                                  </fig>
+                              </p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertIn('<img style="max-width:100%" src="2175-8239-jbn-2018-0058-vf01.jpg">', html_string)
+
+    def test_if_visual_abstract_caption_present_in_html(self):
+        sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <front>
+                        <article-meta>
+                          <abstract abstract-type="graphical">
+                              <title>Resumo Visual</title>
+                              <p>
+                                  <fig id="vf01">
+                                      <caption>
+                                          <title>Caption em Português</title>
+                                      </caption>
+                                      <graphic xlink:href="2175-8239-jbn-2018-0058-vf01.jpg"/>
+                                  </fig>
+                              </p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertIn('Caption em Português', html_string)
+
+    def test_if_visual_abstract_anchor_section_present_in_html(self):
+        sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <front>
+                        <article-meta>
+                          <abstract abstract-type="graphical">
+                              <title>Resumo Visual</title>
+                              <p>
+                                  <fig id="vf01">
+                                      <caption>
+                                          <title>Caption em Português</title>
+                                      </caption>
+                                      <graphic xlink:href="2175-8239-jbn-2018-0058-vf01.jpg"/>
+                                  </fig>
+                              </p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertIn('<div class="articleSection" data-anchor="Resumo Visual">', html_string)
+
+    def test_if_visual_abstract_section_present_in_html(self):
+        sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <front>
+                        <article-meta>
+                          <abstract abstract-type="graphical">
+                              <title>Resumo Visual</title>
+                              <p>
+                                  <fig id="vf01">
+                                      <caption>
+                                          <title>Caption em Português</title>
+                                      </caption>
+                                      <graphic xlink:href="2175-8239-jbn-2018-0058-vf01.jpg"/>
+                                  </fig>
+                              </p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertIn('Resumo Visual', html_string)
+
+    def test_if_visual_abstract_image_from_another_language_is_present_in_html(self):
+        sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <sub-article article-type="translation" id="s1" xml:lang="en">
+                        <front-stub>
+                          <abstract abstract-type="graphical">
+                              <title>Visual Abstract EN</title>
+                              <p>
+                                  <fig id="vf01">
+                                      <caption>
+                                          <title>Caption em Inglês</title>
+                                      </caption>
+                                      <graphic xlink:href="2175-8239-jbn-2018-0058-vf01-EN.jpg"/>
+                                  </fig>
+                              </p>
+                          </abstract>
+                        </front-stub>
+                      </sub-article>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertIn('<img style="max-width:100%" src="2175-8239-jbn-2018-0058-vf01-EN.jpg">', html_string)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a capacidade de obter imagens e caption de visual abstract.

#### Onde a revisão poderia começar?

Nos módulos: 
```python
packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
tests/test_htmlgenerator.py
```

#### Como este poderia ser testado manualmente?

Executando o comando: 

```python
python setup.py test
```

#### Algum cenário de contexto que queira dar?

Não há.

### Screenshots

![Screen Shot 2019-08-12 at 14 25 42](https://user-images.githubusercontent.com/373745/62884506-1d946600-bd0d-11e9-9a37-0559f5f3c9bd.png)

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1363

### Referências

Não há .

### Um pouco sobre a solução: 


Como foi resolvido essa demanda:


    No XML a tag que representa o "Visual Abstract" é a tag abstract com um atributo abstract-type="graphical", exemplo:

```xml
        <abstract abstract-type="graphical">
            <title>qualquer coisa</title>
            <p>
                <fig id="vf01">
                    <caption>
                        <title>Texto em inglês<italic>propensity-score
                            matching</italic></title>
                    </caption>
                    <graphic xlink:href="2175-8239-jbn-2018-0058-vf01.jpg"/>
                </fig>
            </p>
        </abstract>
```

    Na XSL adicionamos as seguintes linhas de código:

```xml
        <xsl:template match="abstract[@abstract-type='graphical']//fig[graphic]">
            <xsl:variable name="location">
                <xsl:apply-templates select="." mode="file-location"></xsl:apply-templates>
            </xsl:variable>
            <div>
                <span><xsl:apply-templates select="caption"/></span>
               <img>
                    <xsl:attribute name="style">max-width:100%</xsl:attribute>
                    <xsl:attribute name="src">
                        <xsl:value-of select="$location"/>
                    </xsl:attribute>
                </img>
            </div>
        </xsl:template>
```

Traduzindo: Navegamos por todos as tags em que o match é "abstract" com atributo 'graphical' e filho como tag fig e filho graphic.

    Reparem que obtemos a localização da imagem utilizando um template chamado "file-location", atribuimos para uma variável chamado location.

    Obtemos o caminho para a figura da seguinte forma:
```xml
        <xsl:template match="*[graphic]" mode="file-location">
            <xsl:apply-templates select="graphic/@xlink:href"/>
        </xsl:template>
```




