### PR TITLE
Exibição do DOI de tradução na página do artigo scieloorg/opac#1391

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -59,7 +59,15 @@
     </xsl:template>
 
     <xsl:template match="*" mode="article-meta-doi">
-        <xsl:apply-templates select="front/article-meta//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
+        <xsl:choose>
+            <xsl:when test=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//front-stub/article-meta//article-id[@pub-id-type='doi']">
+                <xsl:apply-templates select=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
+            </xsl:when>
+
+            <xsl:otherwise>
+                <xsl:apply-templates select="front/article-meta//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="article-id[@pub-id-type='doi']" mode="display">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -60,8 +60,8 @@
 
     <xsl:template match="*" mode="article-meta-doi">
         <xsl:choose>
-            <xsl:when test=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//front-stub/article-meta//article-id[@pub-id-type='doi']">
-                <xsl:apply-templates select=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
+            <xsl:when test=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//front-stub//article-id[@pub-id-type='doi']">
+                <xsl:apply-templates select=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//front-stub//article-id[@pub-id-type='doi']" mode="display"></xsl:apply-templates>
             </xsl:when>
 
             <xsl:otherwise>


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR implementa a visualização do **DOI** do idioma corrente e não somente o DOI do idioma principal, como descrito no TK scieloorg/opac#1391

#### Onde a revisão poderia começar?
Pelo Arquivo
`packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl`


#### Como este poderia ser testado manualmente?
Vc pode editar um xml mult-language SPS e adicionar dentro da tag `<front-stub>` as tags abaixo

```xml
    <article-meta>
        <article-id pub-id-type="doi">10.1590/NUMERO DO DOI</article-id>
    </article-meta>
```

#### Algum cenário de contexto que queira dar?
Arquivo xml e html utilizado para o teste
[packtools_tk_opac_1391.zip](https://github.com/scieloorg/packtools/files/3531357/packtools_tk_opac_1391.zip)

### Screenshots
PT-BR
<img width="1024" alt="PT" src="https://user-images.githubusercontent.com/1105583/63537646-a456f900-c4ec-11e9-859e-7485e338ddbd.png">

EN
<img width="1084" alt="EN" src="https://user-images.githubusercontent.com/1105583/63537653-aa4cda00-c4ec-11e9-80e6-253b470510c4.png">

#### Quais são tickets relevantes?
scieloorg/opac#1391

### Referências
- scieloorg/Web#689
- https://jats.nlm.nih.gov/publishing/tag-library/1.2/element/sub-article.html
