### PR TITLE
Adiciona destaque para a retratação de documentos

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -17,7 +17,25 @@
             </xsl:when>
         </xsl:choose>
     </xsl:template>
-    
+
+    <!-- article retraction -->
+    <xsl:template match="article[@article-type='retraction'] | sub-article[@article-type='retraction']" mode="article-meta-related-article">
+        <div class="panel article-correction-title">
+            <div class="panel-heading">
+                <xsl:apply-templates select="." mode="text-labels">
+                    <xsl:with-param name="text">Retraction of</xsl:with-param>
+                </xsl:apply-templates>:
+            </div>
+
+            <div class="panel-body">
+                <ul>
+                    <xsl:apply-templates select=".//related-article" mode="article-meta-related-article"></xsl:apply-templates>
+                </ul>
+            </div>
+        </div>
+    </xsl:template>
+    <!-- /article retraction -->
+
     <xsl:template match="*" mode="article-meta-related-articles">
         <!-- 
         <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/0102-311X00064615"></related-article>

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -338,6 +338,12 @@
         <name lang="es">Esta errata corrige</name>
     </term>
     <term>
+        <name>Retraction of</name>
+        <name lang="en">Retraction of</name>
+        <name lang="pt">Retratação de</name>
+        <name lang="es">Retractación de</name>
+    </term>
+    <term>
         <name>How to cite</name>
         <name lang="en">How to cite</name>
         <name lang="pt">Como citar</name>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -299,3 +299,70 @@ class HTMLGeneratorTests(unittest.TestCase):
       self.assertIn('<strong>Recebido</strong><br>9 Jul 2018</li>', html_string)
       self.assertIn('<strong>Aceito</strong><br>14 Jan 2019</li>', html_string)
       self.assertIn('<strong>Publicado</strong><br>31 Maio 2019</li>', html_string)
+
+    def test_show_retraction_box_if_article_is_an_retraction(self):
+      sample = u"""<article article-type="retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+            <related-article ext-link-type="doi" id="r01" related-article-type="retracted-article"
+              xlink:href="10.1590/2236-8906-34/2018"/>
+          </article-meta>
+        </front>
+      </article>"""
+
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+
+      self.assertIn(u'Retratação de', html_string)
+      self.assertIn(
+        u'<ul><li><a href="https://doi.org/10.1590/2236-8906-34/2018" target="_blank">10.1590/2236-8906-34/2018</a></li>',
+        html_string
+      )
+
+    def test_should_translate_retraction_to_english(self):
+      sample = u"""<article article-type="retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="en"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+            <related-article ext-link-type="doi" id="r01" related-article-type="retracted-article"
+              xlink:href="10.1590/2236-8906-34/2018"/>
+          </article-meta>
+        </front>
+      </article>"""
+
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+
+      self.assertIn(u'Retraction of', html_string)
+
+    def test_do_not_show_retraction_box_if_article_is_not_a_retraction(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.1"
+          specific-use="sps-1.8" xml:lang="pt"
+          xmlns:mml="http://www.w3.org/1998/Math/MathML"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+          <front>
+            <article-meta>
+              <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+              <related-article ext-link-type="doi" id="r01" related-article-type="retracted-article"
+                xlink:href="10.1590/2236-8906-34/2018"/>
+            </article-meta>
+          </front>
+        </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        html_string = etree.tostring(html, encoding='unicode', method='html')
+
+        self.assertNotIn(u'Retraction of', html_string)


### PR DESCRIPTION
#### O que esse PR faz?
Este Pull Request implementa o quadro de destaque para documentos que retratam outros documentos assim como já acontecia com documentos que são erratas.

#### Onde a revisão poderia começar?
- `packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl` L `20`

#### Como este poderia ser testado manualmente?
Para testar esse PR manualmente deve-se:
- Fazer o download de algum documento XML que é do tipo `retraction` (fixture em anexo);
- Executar o `htmlgenerator`;
- Verificar a caixa amarela no html gerado.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
<img width="1013" alt="Screen Shot 2019-09-09 at 09 57 43" src="https://user-images.githubusercontent.com/4604104/64532669-544ba500-d2e8-11e9-9b9d-b080f2bbfbd4.png">



#### Quais são tickets relevantes?
scieloorg/opac/issues/1400

### Referências
N/A

### Anexos
[2236-8906-hoehnea-45-03-0540.txt](https://github.com/scieloorg/packtools/files/3579441/2236-8906-hoehnea-45-03-0540.txt)

