### PR TITLE
Adiciona suporte a retratações parciais e atualiza labels de retratação

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -19,17 +19,17 @@
     </xsl:template>
 
     <!-- article retraction -->
-    <xsl:template match="article[@article-type='retraction'] | sub-article[@article-type='retraction']" mode="article-meta-related-article">
+    <xsl:template match="article[@article-type='retraction' or @article-type='partial-retraction'] | sub-article[@article-type='retraction' or @article-type='partial-retraction']" mode="article-meta-related-article">
         <div class="panel article-correction-title">
             <div class="panel-heading">
                 <xsl:apply-templates select="." mode="text-labels">
-                    <xsl:with-param name="text">Retraction of</xsl:with-param>
+                    <xsl:with-param name="text">This retraction retracts the following document</xsl:with-param>
                 </xsl:apply-templates>:
             </div>
 
             <div class="panel-body">
                 <ul>
-                    <xsl:apply-templates select=".//related-article" mode="article-meta-related-article"></xsl:apply-templates>
+                    <xsl:apply-templates select=".//related-article[@related-article-type='retracted-article' or @related-article-type='partial-retraction']" mode="article-meta-related-article"></xsl:apply-templates>
                 </ul>
             </div>
         </div>

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -338,10 +338,10 @@
         <name lang="es">Esta errata corrige</name>
     </term>
     <term>
-        <name>Retraction of</name>
-        <name lang="en">Retraction of</name>
-        <name lang="pt">Retratação de</name>
-        <name lang="es">Retractación de</name>
+        <name>This retraction retracts the following document</name>
+        <name lang="en">This retraction retracts the following document</name>
+        <name lang="pt">Esta retratação retrata o documento</name>
+        <name lang="es">Esta retracción retrata el documento</name>
     </term>
     <term>
         <name>How to cite</name>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -319,7 +319,7 @@ class HTMLGeneratorTests(unittest.TestCase):
       html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
       html_string = etree.tostring(html, encoding='unicode', method='html')
 
-      self.assertIn(u'Retratação de', html_string)
+      self.assertIn(u'Esta retratação retrata o documento', html_string)
       self.assertIn(
         u'<ul><li><a href="https://doi.org/10.1590/2236-8906-34/2018" target="_blank">10.1590/2236-8906-34/2018</a></li>',
         html_string
@@ -344,7 +344,7 @@ class HTMLGeneratorTests(unittest.TestCase):
       html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
       html_string = etree.tostring(html, encoding='unicode', method='html')
 
-      self.assertIn(u'Retraction of', html_string)
+      self.assertIn(u'This retraction retracts the following document', html_string)
 
     def test_do_not_show_retraction_box_if_article_is_not_a_retraction(self):
         sample = u"""<article article-type="research-article" dtd-version="1.1"
@@ -365,4 +365,29 @@ class HTMLGeneratorTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         html_string = etree.tostring(html, encoding='unicode', method='html')
 
-        self.assertNotIn(u'Retraction of', html_string)
+        self.assertNotIn(u'This retraction retracts the following document', html_string)
+
+    def test_show_retraction_box_if_article_is_an_partial_retraction(self):
+      sample = u"""<article article-type="partial-retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+            <related-article ext-link-type="doi" id="r01" related-article-type="partial-retraction"
+              xlink:href="10.1590/2236-8906-34/2018"/>
+          </article-meta>
+        </front>
+      </article>"""
+
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+
+      self.assertIn(u'Esta retratação retrata o documento', html_string)
+      self.assertIn(
+        u'<ul><li><a href="https://doi.org/10.1590/2236-8906-34/2018" target="_blank">10.1590/2236-8906-34/2018</a></li>',
+        html_string
+      )


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera os labels utilizados para a retratação de documentos de acordo com o comentário https://github.com/scieloorg/opac/issues/1406#issuecomment-524839144. Também adiciona suporte para retratações parciais como indicado pela SPS https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/1.9-branch/narr/retratacao.html.

#### Onde a revisão poderia começar?
- `packtools/catalogs/htmlgenerator/v2.0/config-labels.xml` L `340`

#### Como este poderia ser testado manualmente?
Para testar esse PR manualmente deve-se:
- Fazer o download de algum documento XML que é do tipo `retraction` (fixture em anexo);
- Executar o `htmlgenerator`;
- Verificar a caixa amarela no html gerado.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![Screen Shot 2019-09-13 at 15 12 05](https://user-images.githubusercontent.com/4604104/64884776-e0d3cb80-d638-11e9-8334-37e5a3060c8f.png)


#### Quais são tickets relevantes?
scieloorg/opac/issues/1400

### Referências
N/A

### Anexos
[2236-8906-hoehnea-45-03-0540.txt](https://github.com/scieloorg/packtools/files/3579441/2236-8906-hoehnea-45-03-0540.txt)

