### PR TITLE
Corrige o link para o artigo retratado considerando que pode ter outro padrão

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -99,8 +99,18 @@
         </li>
     </xsl:template>
     
-    <xsl:template match="related-article/@xlink:href">
+    <xsl:template match="related-article[@ext-link-type='doi']/@xlink:href">
         <a href="https://doi.org/{.}" target="_blank">
+            <xsl:value-of select="."/>
+        </a>
+    </xsl:template>
+    <xsl:template match="related-article[@ext-link-type='scielo-pid']/@xlink:href">
+        <a href="/article/{.}" target="_blank">
+            <xsl:value-of select="."/>
+        </a>
+    </xsl:template>
+    <xsl:template match="related-article[@ext-link-type='scielo-aid']/@xlink:href">
+        <a href="/article/{.}" target="_blank">
             <xsl:value-of select="."/>
         </a>
     </xsl:template>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -391,3 +391,53 @@ class HTMLGeneratorTests(unittest.TestCase):
         u'<ul><li><a href="https://doi.org/10.1590/2236-8906-34/2018" target="_blank">10.1590/2236-8906-34/2018</a></li>',
         html_string
       )
+
+    def test_presents_link_to_retreted_document_using_pid(self):
+      sample = u"""<article article-type="partial-retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+            <related-article ext-link-type="scielo-pid" id="r01" related-article-type="partial-retraction"
+              xlink:href="S0864-34662016000200003"/>
+          </article-meta>
+        </front>
+      </article>"""
+
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+
+      self.assertIn(u'Esta retratação retrata o documento', html_string)
+      self.assertIn(
+        u'<ul><li><a href="/article/S0864-34662016000200003" target="_blank">S0864-34662016000200003</a></li>',
+        html_string
+      )
+
+    def test_presents_link_to_retreted_document_using_aid(self):
+      sample = u"""<article article-type="partial-retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2236-8906-34/2018-retratacao</article-id>
+            <related-article ext-link-type="scielo-aid" id="r01" related-article-type="partial-retraction"
+              xlink:href="12345567799"/>
+          </article-meta>
+        </front>
+      </article>"""
+
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+
+      self.assertIn(u'Esta retratação retrata o documento', html_string)
+      self.assertIn(
+        u'<ul><li><a href="/article/12345567799" target="_blank">12345567799</a></li>',
+        html_string
+      )


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o link para o artigo retratado considerando que pode ser formado pelo PID e/ou SciELO ID, além do DOI

#### Onde a revisão poderia começar?
packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_htmlgenerator.HTMLGeneratorTests`

#### Algum cenário de contexto que queira dar?
Ao acessar
https://www.scielosp.org/article/rcsp/2016.v42n4/663-663/

O link:
<img width="751" alt="Captura de Tela 2019-10-22 às 15 22 11" src="https://user-images.githubusercontent.com/505143/67316964-c1ee1200-f4df-11e9-9e90-d7c36c704274.png">

Deve ser
https://www.scielosp.org/article/S0864-34662016000200003

no lugar de
https://doi.org/S0864-34662016000200003

### Screenshots
n/a

#### Quais são tickets relevantes?
#207 

### Referências
n/a
