### PR TITLE
Apresenta o autor collab antes de et al

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-how2cite.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-how2cite.xsl
@@ -113,10 +113,10 @@
             <xsl:otherwise>
                 <xsl:apply-templates select="contrib[1]" mode="how2cite-contrib">
 
-                </xsl:apply-templates>
+                </xsl:apply-templates> et al.
             </xsl:otherwise>
         </xsl:choose>
-        <xsl:if test="count(contrib)&gt;3">et al</xsl:if>.
+        
     </xsl:template>
 
     <xsl:template match="contrib" mode="how2cite-contrib">
@@ -132,6 +132,10 @@
 
     <xsl:template match="name" mode="how2cite-contrib">
         <xsl:apply-templates select="surname"/>, <xsl:apply-templates select="given-names"/>
+    </xsl:template>
+
+    <xsl:template match="collab" mode="how2cite-contrib">
+        <xsl:apply-templates select="."/>
     </xsl:template>
 
     <xsl:template match="*" mode="how2cite-article-title">

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -391,3 +391,82 @@ class HTMLGeneratorTests(unittest.TestCase):
         u'<ul><li><a href="https://doi.org/10.1590/2236-8906-34/2018" target="_blank">10.1590/2236-8906-34/2018</a></li>',
         html_string
       )
+
+    def test_presents_in_how_to_cite_collab_and_et_al_if_contrib_quantity_is_greater_than_3(self):
+      sample = u"""<article article-type="partial-retraction" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2175-7860201869402</article-id>
+            <article-categories>
+                    <subj-group subj-group-type="heading">
+                            <subject>GSPC - Global Strategy for Plant Conservation</subject>
+                    </subj-group>
+            </article-categories>
+            <title-group>
+                    <article-title>Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC)</article-title>
+            </title-group>
+            <contrib-group>
+                    <contrib contrib-type="author">
+                            <collab>The Brazil Flora Group</collab>
+                            <xref ref-type="aff" rid="aff1"/>
+                    </contrib>
+                    <contrib contrib-type="author">
+                            <name>
+                                    <surname>Filardi</surname>
+                                    <given-names>Fabiana L. Ranzato</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                            <xref ref-type="corresp" rid="c1">1</xref>
+                    </contrib>
+                    <contrib contrib-type="author">
+                            <name>
+                                    <surname>Barros</surname>
+                                    <given-names>Fábio de</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                    </contrib>
+                    <contrib contrib-type="author">
+                            <name>
+                                    <surname>Bicudo</surname>
+                                    <given-names>Carlos E.M.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                    </contrib>
+                    <contrib contrib-type="author">
+                            <name>
+                                    <surname>Cavalcanti</surname>
+                                    <given-names>Taciana B.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                    </contrib>
+            </contrib-group>
+            <author-notes>
+                    <corresp id="c1">
+                            <label>1</label>Author for correspondence: <email>rafaela@jbrj.gov.br</email>, <email>floradobrasil2020@jbrj.gov.br</email>
+                    </corresp>
+                    <fn fn-type="edited-by">
+                            <p>Editor de área: Dr. Renato Pereira</p>
+                    </fn>
+            </author-notes>
+            <pub-date pub-type="epub-ppub">
+                    <season>Oct-Dec</season>
+                    <year>2018</year>
+            </pub-date>
+            <volume>69</volume>
+            <issue>04</issue>
+            <fpage>1513</fpage>
+            <lpage>1527</lpage>
+          </article-meta>
+        </front>
+      </article>"""
+      fp = io.BytesIO(sample.encode('utf-8'))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+      html_string = etree.tostring(html, encoding='unicode', method='html')
+      self.assertIn(
+        u'The Brazil Flora Group et al',
+        html_string
+      )


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta autores identificados com o elemento `contrib/collab`

#### Onde a revisão poderia começar?
`packtools/catalogs/htmlgenerator/v2.0/html-modals-how2cite.xsl: L: 137`

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_htmlgenerator.HTMLGeneratorTests`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1278

### Referências
n/a
