### PR TITLE
Remove dependência da lib python-slugify

### DIFF
--- a/packtools/webapp/custom_filters.py
+++ b/packtools/webapp/custom_filters.py
@@ -4,7 +4,6 @@ import re
 from distutils import util
 
 from flask import Markup
-from slugify import slugify
 
 
 dict_status = {"ok": "success"}
@@ -36,7 +35,7 @@ def utility_processor():
         return value or default
 
     def trans_status(status, to_label=False):
-        status = slugify(status.lower())
+        status = status.lower().replace(" ", "-")
         if asbool(to_label):
             return label_status_translation.get(status, status)
         return dict_status.get(status, status)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Jinja2==2.10.1
 lxml==4.3.3
 MarkupSafe==1.1.1
 picles.plumber==0.11
-python-slugify==3.0.2
 pytz==2019.1
 speaklater==1.3
 text-unidecode==1.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ EXTRAS_REQUIRE = {
         'Flask',
         'Flask-BabelEx',
         'Flask-WTF',
-        'python-slugify',
     ]
 }
 
@@ -36,7 +35,6 @@ EXTRAS_REQUIRE = {
 TESTS_REQUIRE = [
     'Flask-Testing>=0.6.2',
     'Flask-BabelEx',
-    'python-slugify',
     'Flask-WTF',
 ]
 


### PR DESCRIPTION
#### O que esse PR faz?

Remove dependência da lib _python-slugify_, que deixou de suportar a versão 3.4 do Python e resulta em erros no CI. 

#### Onde a revisão poderia começar?

Verificando que a lib não é utilizada em mais nenhum lugar além de ` packtools/webapp/custom_filters.py`.

#### Como este poderia ser testado manualmente?

1. Inicialize a aplicação web, com os comandos:

```bash
$ export APP_SETTINGS=packtools.webapp.config.default.ProductionConfig
$ export FLASK_APP=packtools.webapp.app.py
$ flask run
```

2. Acesse http://127.0.0.1:5000 -> Stylechecker, e valide um XML SciELO PS
3. Verifique com o inspetor de códigos que o atributo _class_ do elemento `<label>` possui o valor `label label-style-error`. A função `slugify` era utilizada para produzir `label-style-error`.

#### Algum cenário de contexto que queira dar?

Esta modificação faz com que o packtools volte a funcionar no Python 3.4.

### Screenshots

<img width="715" alt="Screen Shot 2019-10-24 at 10 32 21" src="https://user-images.githubusercontent.com/161335/67490713-0ac1da00-f64a-11e9-8637-d12bfb32aec7.png">


#### Quais são tickets relevantes?
#211 

Faz com que o PR #209 passe no Travis-CI, com a correção do erro reportado em https://travis-ci.org/scieloorg/packtools/jobs/601423287
