### PR TITLE
Adiciona validação das URLs do CRediT na versão 1.10 do SciELO PS

### DIFF
--- a/packtools/catalogs/__init__.py
+++ b/packtools/catalogs/__init__.py
@@ -23,6 +23,7 @@ default_catalog = {
             'sps-1.7': os.path.join(_CWD, 'scielo-style-1.7.sch'),
             'sps-1.8': os.path.join(_CWD, 'scielo-style-1.8.sch'),
             'sps-1.9': os.path.join(_CWD, 'scielo-style-1.9.sch'),
+            'sps-1.10': os.path.join(_CWD, 'scielo-style-1.10.sch'),
 
             # Collection-specific schema
             'scielo-br': os.path.join(_CWD, 'scielo-br.sch'),

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -1,0 +1,1742 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2019 SciELO <scielo-dev@googlegroups.com>.
+Licensed under the terms of the BSD license. Please see LICENSE in the source
+code for more information.
+-->
+<schema xmlns="http://purl.oclc.org/dsdl/schematron"
+        queryBinding="exslt"
+        xml:lang="en">
+  <ns uri="http://www.w3.org/1999/xlink" prefix="xlink"/>
+  <ns uri="http://exslt.org/regular-expressions" prefix="regexp"/>
+
+  <include href="common.sch"/>
+  <p>
+  *******************************************************************************
+   THINGS TO BE SURE BEFORE EDITING THIS FILE!
+
+   The spec used is ISO-Schematron. 
+   
+   Some useful info:
+     - The query language used is the extended version of XPath specified in XSLT.
+     - The rule context is interpreted according to the Production 1 of XSLT. 
+       The rule context may be the root node, elements, attributes, comments and 
+       processing instructions. 
+     - The assertion test is interpreted according to Production 14 of XPath, as 
+       returning a Boolean value.
+
+   For more info, refer to the official ISO/IEC 19757-3:2006(E) standard.
+  
+   The implementation of the schematron patterns comes with the idea of SPS as a
+   set of constraints on top of JATS' Publishing Tag Set v1.0 (JPTS)[1]. To keep
+   consistency, please make sure:
+  
+     - DTD/XSD constraints are not duplicated here
+     - There is an issue at http://git.io/5EcR4Q with status `Aprovada`
+     - PMC-Style compatibility is desired[2]
+  
+   Always double-check the JPTS and PMC-Style before editing.
+   [1] http://jats.nlm.nih.gov/publishing/tag-library/1.0/
+   [2] https://www.ncbi.nlm.nih.gov/pmc/pmcdoc/tagging-guidelines/article/tags.html
+  *******************************************************************************
+  </p>
+
+  <!--
+   Phases - sets of patterns.
+   These are being used to help on tests isolation.
+  -->
+  <phase id="phase.journal-id">
+    <active pattern="journal-id_notempty"/>
+    <active pattern="journal-id_has_publisher-id"/>
+    <active pattern="journal-id_values"/>
+  </phase>
+
+  <phase id="phase.journal-title-group">
+    <active pattern="has_journal-title_and_abbrev-journal-title"/>
+    <active pattern="journal-title_notempty"/>
+    <active pattern="abbrev-journal-title_notempty"/>
+  </phase>
+
+  <phase id="phase.publisher">
+    <active pattern="publisher"/>
+    <active pattern="publisher_notempty"/>
+  </phase>
+
+  <phase id="phase.article-categories">
+    <active pattern="article_categories"/>
+  </phase>
+
+  <phase id="phase.fpage_or_elocation-id">
+    <active pattern="fpage_or_elocation-id"/>
+    <active pattern="fpage_notempty"/>
+    <active pattern="elocation-id_notempty"/>
+  </phase>
+
+  <phase id="phase.issn">
+    <active pattern="issn_pub_type_epub_or_ppub"/>
+    <active pattern="issn_notempty"/>
+  </phase>
+
+  <phase id="phase.article-id">
+    <active pattern="article-id_notempty"/>
+    <active pattern="article-id_attributes"/>
+    <active pattern="article-id_values"/>
+  </phase>
+
+  <phase id="phase.subj-group">
+    <active pattern="subj_group"/>
+    <active pattern="subj_group_subarticle_pt"/>
+    <active pattern="subj_group_subarticle_es"/>
+    <active pattern="subj_group_subarticle_en"/>
+  </phase>
+
+  <phase id="phase.abstract_lang">
+    <active pattern="abstract"/>
+    <active pattern="abstract_abstract-type_values"/>
+  </phase>
+
+  <phase id="phase.article-title_lang">
+    <active pattern="article-title"/>
+  </phase>
+
+  <phase id="phase.aff_contenttypes">
+    <active pattern="aff_contenttypes"/>
+    <active pattern="aff_contenttypes_contribgroup"/>
+  </phase>
+
+  <phase id="phase.kwd-group_lang">
+    <active pattern="kwdgroup_lang"/>
+  </phase>
+
+  <phase id="phase.counts">
+      <active pattern="counts_tables"/>
+      <active pattern="counts_refs"/>
+      <active pattern="counts_figs"/>
+      <active pattern="counts_equations"/>
+      <active pattern="counts_pages"/>
+  </phase>
+
+  <phase id="phase.pub-date">
+    <active pattern="pub-date_date_type"/>
+    <active pattern="pub-date_publication_format"/>
+    <active pattern="pub-date_type_pub"/>
+    <active pattern="pub-date_type_collection"/>
+    <active pattern="pub-date_type_not_collection"/>
+  </phase>
+
+  <phase id="phase.volume">
+    <active pattern="volume_notempty"/>
+  </phase>
+  
+  <phase id="phase.issue">
+    <active pattern="issue_notempty"/>
+    <active pattern="issue_cardinality"/>
+  </phase>
+
+  <phase id="phase.supplement">
+    <active pattern="supplement"/>
+  </phase>
+
+  <phase id="phase.elocation-id">
+    <active pattern="elocation-id"/>
+  </phase>
+
+  <phase id="phase.history">
+    <active pattern="history"/>
+  </phase>
+
+  <phase id="phase.product">
+    <active pattern="product"/>
+    <active pattern="product_product-type_values"/>
+  </phase>
+
+  <phase id="phase.sectitle">
+    <active pattern="sectitle"/>
+  </phase>
+
+  <phase id="phase.paragraph">
+    <active pattern="paragraph"/>
+  </phase>
+
+  <phase id="phase.rid_integrity">
+    <active pattern="xref-reftype-integrity-aff"/>
+  </phase>
+
+  <phase id="phase.caption">
+    <active pattern="caption_title"/>
+  </phase>
+
+  <phase id="phase.license">
+    <active pattern="license_attributes"/>
+    <active pattern="license"/>
+  </phase>
+
+  <phase id="phase.ack">
+    <active pattern="ack"/>
+  </phase>
+
+  <phase id="phase.element-citation">
+    <active pattern="element-citation"/>
+    <active pattern="element-citation_attributes"/>
+    <active pattern="element-citation_publication-type-values"/>
+  </phase>
+
+  <phase id="phase.person-group">
+    <active pattern="person-group"/>
+    <active pattern="person-group-type_values"/>
+  </phase>
+
+  <phase id="phase.fn-group">
+    <active pattern="fn"/>
+    <active pattern="fn-group"/>
+    <active pattern="fn_attributes"/>
+  </phase>
+
+  <phase id="phase.xhtml-table">
+    <active pattern="xhtml-table"/>
+  </phase>
+
+  <phase id="phase.supplementary-material">
+    <active pattern="supplementary-material_mimetype"/>
+  </phase>
+
+  <phase id="phase.xref_reftype_integrity">
+    <active pattern="xref-reftype-values"/>
+  </phase>
+
+  <phase id="phase.article-attrs">
+    <active pattern="article_attributes"/>
+    <active pattern="article_article-type-values"/>
+    <active pattern="article_specific-use-values"/>
+  </phase>
+
+  <phase id="phase.named-content_attrs">
+    <active pattern="named-content_attributes"/>
+    <active pattern="named-content_content-type-values"/>
+  </phase>
+
+  <phase id="phase.month">
+    <active pattern="month"/>
+    <active pattern="month_cardinality"/>
+  </phase>
+
+  <phase id="phase.size">
+    <active pattern="size_attributes"/>
+    <active pattern="size_units-values"/>
+    <active pattern="size_cardinality"/>
+  </phase>
+
+  <phase id="phase.list">
+    <active pattern="list_attributes"/>
+    <active pattern="list_list-type-values"/>
+  </phase>
+
+  <phase id="phase.media_attributes">
+    <active pattern="media_attributes"/>
+  </phase>
+
+  <phase id="phase.ext-link">
+    <active pattern="ext-link_href_values"/>
+    <active pattern="ext-link_attributes"/>
+  </phase>
+
+  <phase id="phase.sub-article-attrs">
+    <active pattern="sub-article_attributes"/>
+    <active pattern="sub-article_article-type-values"/>
+  </phase>
+
+  <phase id="phase.response-attrs">
+    <active pattern="response_attributes"/>
+    <active pattern="response_response-type-values"/>
+  </phase>
+
+  <phase id="phase.response-reply-type">
+    <active pattern="response_related-article_attributes"/>
+  </phase>
+
+  <phase id="phase.related-article-attrs">
+    <active pattern="related-article_attributes"/>
+    <active pattern="related-article-type-values"/>
+    <active pattern="related-article_ext-link-type-values"/>
+    <active pattern="related-article_correction_attributes"/>
+  </phase>
+
+  <phase id="phase.correction">
+    <active pattern="correction_related-article"/>
+    <active pattern="correction_article-type"/>
+  </phase>
+
+  <phase id="phase.in-brief">
+    <active pattern="inbrief_related-article"/>
+    <active pattern="inbrief_article-type"/>
+  </phase>
+
+  <phase id="phase.funding-group">
+    <active pattern="funding-group"/>
+    <active pattern="funding-group_elements"/>
+  </phase>
+
+  <phase id="phase.aff_country">
+    <active pattern="aff_country-attrs"/>
+    <active pattern="aff_country"/>
+  </phase>
+
+  <phase id="phase.ref">
+    <active pattern="ref"/>
+    <active pattern="ref_notempty"/>
+    <active pattern="element-citation_cardinality"/>
+  </phase>
+
+  <phase id="phase.contrib-id">
+    <active pattern="contrib-id_attributes"/>
+    <active pattern="contrib-id-type-values"/>
+  </phase>
+
+  <phase id="phase.source">
+    <active pattern="source_cardinality"/>
+  </phase>
+
+  <phase id="phase.chapter-title">
+    <active pattern="chapter-title_cardinality"/>
+  </phase>
+
+  <!--
+   Patterns - sets of rules.
+  -->
+  <pattern id="journal-id_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/journal-meta/journal-id"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="journal-id_has_publisher-id">
+    <title>
+      There exists one journal-id[@journal-id-type='publisher-id'].
+    </title>
+
+    <rule context="article/front/journal-meta">
+      <assert test="journal-id[@journal-id-type='publisher-id']">
+        Element 'journal-meta': Missing element journal-id with journal-id-type="publisher-id".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="journal-id_values">
+    <rule context="article/front/journal-meta/journal-id[@journal-id-type]">
+      <assert test="@journal-id-type = 'nlm-ta' or
+                    @journal-id-type = 'publisher-id'">
+        Element 'journal-id', attribute journal-id-type: Invalid value "<value-of select="@journal-id-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="has_journal-title_and_abbrev-journal-title">
+    <rule context="article/front/journal-meta">
+      <assert test="journal-title-group">
+        Element 'journal-meta': Missing element journal-title-group.
+      </assert>
+    </rule>
+
+    <rule context="article/front/journal-meta/journal-title-group">
+      <assert test="journal-title">
+        Element 'journal-title-group': Missing element journal-title.
+      </assert>
+      <assert test="abbrev-journal-title[@abbrev-type='publisher']">
+        Element 'journal-title-group': Missing element abbrev-journal-title with abbrev-type="publisher".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="journal-title_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/journal-meta/journal-title-group/journal-title"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="abbrev-journal-title_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/journal-meta/journal-title-group/abbrev-journal-title"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="publisher">
+    <rule context="article/front/journal-meta">
+      <assert test="publisher">
+        Element 'journal-meta': Missing element publisher.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="publisher_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/journal-meta/publisher/publisher-name"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="article_categories">
+    <rule context="article/front/article-meta">
+      <assert test="article-categories">
+        Element 'article-meta': Missing element article-categories.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="fpage_or_elocation-id">
+    <rule context="article/front/article-meta">
+      <assert test="fpage or elocation-id">
+        Element 'article-meta': Missing elements fpage or elocation-id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="fpage_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/article-meta/fpage"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="elocation-id_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/article-meta/elocation-id"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="issn_pub_type_epub_or_ppub">
+    <rule context="article/front/journal-meta">
+      <assert test="issn[@pub-type='epub'] or issn[@pub-type='ppub']">
+        Element 'journal-meta': Missing element issn with pub-type=("epub" or "ppub").
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="issn_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/journal-meta/issn"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="article-id_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/article-meta/article-id"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="article-id_attributes">
+    <title>
+      Mandatory attributes are present.
+    </title>
+    <rule context="article/front/article-meta">
+      <assert test="article-id[@pub-id-type]">
+        Element 'article-meta': Missing element article-id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article-id_values">
+    <title>
+      Values are known.
+    </title>
+    <rule context="article/front/article-meta/article-id[@pub-id-type] | article/sub-article[@article-type='translation']/front-stub/article-id[@pub-id-type]">
+      <assert test="@pub-id-type = 'doi' or 
+                    @pub-id-type = 'other' or 
+                    @pub-id-type = 'publisher-id'">
+        Element 'article-id', attribute pub-id-type: Invalid value "<value-of select="@pub-id-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern abstract="true" id="subj_group_base">
+    <title>
+      Make sure only one heading is provided per language, in subj-group.
+    </title>
+
+    <rule context="$base_context">
+      <assert test="count(subj-group[@subj-group-type='heading'] | subj-group//subj-group[@subj-group-type='heading']) = 1">
+        Element '<name/>': There must be only one element subj-group with subj-group-type="heading".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern is-a="subj_group_base" id="subj_group">
+    <param name="base_context" value="article/front/article-meta/article-categories"/>
+  </pattern>
+
+  <pattern is-a="subj_group_base" id="subj_group_subarticle_pt">
+    <param name="base_context" value="article/sub-article[@xml:lang='pt']/front-stub/article-categories"/>
+  </pattern>
+  <pattern is-a="subj_group_base" id="subj_group_subarticle_es">
+    <param name="base_context" value="article/sub-article[@xml:lang='es']/front-stub/article-categories"/>
+  </pattern>
+  <pattern is-a="subj_group_base" id="subj_group_subarticle_en">
+    <param name="base_context" value="article/sub-article[@xml:lang='en']/front-stub/article-categories"/>
+  </pattern>
+  <pattern is-a="subj_group_base" id="subj_group_subarticle_fr">
+    <param name="base_context" value="article/sub-article[@xml:lang='fr']/front-stub/article-categories"/>
+  </pattern>
+
+  <pattern id="abstract">
+    <rule context="article[@article-type='research-article'] | article[@article-type='review-article']">
+      <assert test="count(front/article-meta/abstract | front/article-meta/trans-abstract) > 0">
+        Element 'article-meta': Missing element abstract.
+      </assert>
+    </rule>
+    <rule context="article/front/article-meta/abstract">
+      <assert test="not(@xml:lang)">
+        Element 'abstract': Unexpected attribute xml:lang.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="abstract_abstract-type_values">
+    <rule context="//trans-abstract[@abstract-type]">
+      <assert test="@abstract-type = 'graphical'">
+        Element 'trans-abstract', attribute abstract-type: Invalid value "<value-of select="@abstract-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article-title">
+    <rule context="article/front/article-meta/title-group/article-title | 
+                   article/back/ref-list/ref/element-citation/article-title">
+      <assert test="not(@xml:lang)">
+        Element 'article-title': Unexpected attribute xml:lang.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern abstract="true" id="aff_contenttypes_base">
+    <rule context="$base_context/aff/institution">
+      <assert test="@content-type='original' or 
+                    @content-type='orgname' or
+                    @content-type='orgdiv1' or
+                    @content-type='orgdiv2' or
+                    @content-type='normalized'">
+        Element '<name/>', attribute content-type: Invalid value "<value-of select="@content-type"/>". 
+      </assert>
+    </rule>
+    <rule context="$base_context/aff">
+      <assert test="count(institution[@content-type='original']) = 1">
+        Element '<name/>': Must have exactly one element institution with content-type="original".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern is-a="aff_contenttypes_base" id="aff_contenttypes">
+    <param name="base_context" value="article/front/article-meta"/>
+  </pattern>
+
+  <pattern is-a="aff_contenttypes_base" id="aff_contenttypes_contribgroup">
+    <param name="base_context" value="article/front/article-meta/contrib-group"/>
+  </pattern>
+
+  <pattern id="kwdgroup_lang">
+    <title>
+      Make sure all kwd-group elements have xml:lang attribute.
+    </title>
+
+    <rule context="article/front/article-meta/kwd-group">
+      <assert test="@xml:lang">
+        Element 'kwd-group': Missing attribute xml:lang.
+      </assert>  
+    </rule>
+  </pattern>
+
+  <pattern id="counts_tables">
+    <title>
+      Make sure the total number of tables are correct.
+    </title>
+
+    <rule context="article/front/article-meta/counts/table-count">
+      <assert test="@count = count(//table-wrap)">
+        Element 'table-count': Wrong value in table-count.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="counts_refs">
+    <title>
+      Make sure the total number of refs are correct.
+    </title>
+
+    <rule context="article/front/article-meta/counts/ref-count">
+      <assert test="@count = count(//ref)">
+        Element 'ref-count': Wrong value in ref-count.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="counts_figs">
+    <title>
+      Make sure the total number of figures are correct.
+    </title>
+
+    <rule context="article/front/article-meta/counts/fig-count">
+      <assert test="@count = count(//fig)">
+        Element 'fig-count': Wrong value in fig-count.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="counts_equations">
+    <title>
+      Make sure the total number of equations are correct.
+    </title>
+
+    <rule context="article/front/article-meta/counts/equation-count">
+      <assert test="@count = count(//disp-formula)">
+        Element 'equation-count': Wrong value in equation-count.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="counts_pages">
+    <title>
+      Make sure the total number of pages are correct.
+    </title>
+
+    <rule context="article/front/article-meta/counts/page-count">
+      <assert test="(/article/front/article-meta/lpage = 0 and
+                     /article/front/article-meta/fpage = 0 and
+                     @count = 0) or 
+                     (regexp:test(/article/front/article-meta/fpage, '\D', 'i') or
+                      regexp:test(/article/front/article-meta/lpage, '\D', 'i')) or
+                     string-length(/article/front/article-meta/elocation-id) > 0 or
+                     (@count = ((/article/front/article-meta/lpage - /article/front/article-meta/fpage) + 1))">
+        Element 'page-count': Wrong value in page-count.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="pub-date_date_type">
+    <title>
+      Restrict the valid values of @date-type.
+    </title>
+
+    <rule context="article/front/article-meta/pub-date[@date-type]">
+      <assert test="@date-type = 'pub' or
+                    @date-type = 'collection'">
+        Element 'pub-date', attribute date-type: Invalid value "<value-of select="@date-type"/>".
+      </assert>
+    </rule>
+    <rule context="article/front/article-meta/pub-date">
+      <assert test="@date-type">
+        Element 'pub-date': Missing attribute date-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="pub-date_type_pub">
+    <title>
+      Make sure there exists at least one pub-date of type pub.
+    </title>
+
+    <rule context="article/front/article-meta">
+      <assert test="count(pub-date[@date-type = 'pub']) > 0">
+        Element 'article-meta': Missing element pub-date with date-type="pub".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="pub-date_publication_format">
+    <title>
+      Restrict the valid values of @publication-format.
+    </title>
+
+    <rule context="article/front/article-meta/pub-date[@publication-format]">
+      <assert test="@publication-format = 'electronic'">
+        Element 'pub-date', attribute publication-format: Invalid value "<value-of select="@publication-format"/>".
+      </assert>
+    </rule>
+    <rule context="article/front/article-meta/pub-date">
+      <assert test="@publication-format">
+        Element 'pub-date': Missing attribute publication-format.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="pub-date_type_collection">
+    <title>
+      Assert rules on pub-date[@date-type="collection"] child elements.
+    </title>
+
+    <rule context="article/front/article-meta/pub-date[@date-type = 'collection']">
+      <assert test="not(day)">
+        Element 'pub-date': Unexpected element day.
+      </assert>
+      <assert test="year">
+        Element 'pub-date': Missing element year.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="pub-date_type_not_collection">
+    <title>
+      Assert rules on pub-date[@date-type != "pub"] child elements.
+    </title>
+
+    <rule context="article/front/article-meta/pub-date[@date-type != 'collection']">
+      <assert test="day">
+        Element 'pub-date': Missing element day.
+      </assert>
+      <assert test="month">
+        Element 'pub-date': Missing element month.
+      </assert>
+      <assert test="year">
+        Element 'pub-date': Missing element year.
+      </assert>
+      <assert test="not(season)">
+        Element 'pub-date': Unexpected element season.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="volume_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/article-meta/volume"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="issue_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/front/article-meta/issue"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="supplement">
+    <title>
+      Make sure the supplement is not present.
+    </title>
+
+    <rule context="article/front/article-meta">
+      <assert test="not(supplement)">
+        Element 'article-meta': Unexpected element supplement.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="elocation-id">
+    <title>
+      Allow elocation-id to be present only when fpage is absent.
+    </title>
+
+    <rule context="article/front/article-meta/elocation-id | article/back/ref-list/ref/element-citation/elocation-id">
+      <assert test="not(following-sibling::fpage)">
+        Element 'article-meta': Unexpected element elocation-id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="history">
+    <title>
+      Restrict the valid values of history/date/[@date-type].
+    </title>
+
+    <rule context="article/front/article-meta/history/date">
+      <assert test="@date-type = 'received' or 
+                    @date-type = 'accepted' or
+                    @date-type = 'corrected' or
+                    @date-type = 'pub' or
+                    @date-type = 'preprint' or
+                    @date-type = 'retracted' or
+                    @date-type = 'rev-request' or
+                    @date-type = 'rev-recd'">
+        Element 'date', attribute date-type: Invalid value "<value-of select="@date-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="product">
+    <title>
+      Allow product to be present only when article-type is book-review or product-review.
+      Also, make sure product[@product-type='book'].
+    </title>
+
+    <rule context="article/front/article-meta/product">
+      <assert test="/article[@article-type='book-review']">
+        Element 'article-meta': Unexpected element product.
+      </assert>
+      <assert test="@product-type">
+        Element 'product': Missing attribute product-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="product_product-type_values">
+    <title>
+      Make sure the supplied values are valid.
+    </title>
+
+    <rule context="article/front/article-meta/product[@product-type]">
+      <assert test="@product-type = 'book' or
+                    @product-type = 'article' or
+                    @product-type = 'issue' or
+                    @product-type = 'website' or
+                    @product-type = 'film' or
+                    @product-type = 'software' or
+                    @product-type = 'hardware' or
+                    @product-type = 'other'">
+        Element 'product', attribute product-type: Invalid value "<value-of select="@product-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="sectitle">
+    <title>
+      Make sure all sections have a title element.
+    </title>
+
+    <rule context="article/body/sec">
+      <assert test="string-length(title) > 0">
+        Element 'sec': Missing element title.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="paragraph">
+    <title>
+      Make sure paragraphs have no id attr.
+    </title>
+
+    <rule context="//p">
+      <assert test="not(@id)">
+        Element 'p': Unexpected attribute id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <!-- start-block: xref @ref-type integrity -->
+  <pattern abstract="true" id="xref-reftype-integrity-base">
+    <title>
+      Make sure all references to are reachable.
+    </title>
+
+    <rule context="//xref[@ref-type='$ref_type']">
+      <assert test="@rid = $ref_elements">
+        Element '<name/>', attribute rid: Mismatching id value '<value-of select="@rid"/>' of type '<value-of select="@ref-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-aff">
+    <param name="ref_type" value="aff"/>
+    <param name="ref_elements" value="//aff/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-app">
+    <param name="ref_type" value="app"/>
+    <param name="ref_elements" value="//app/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-author-notes">
+    <param name="ref_type" value="author-notes"/>
+    <param name="ref_elements" value="//author-notes/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-bibr">
+    <param name="ref_type" value="bibr"/>
+    <param name="ref_elements" value="//ref/@id | //element-citation/@id | //mixed-citation/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-contrib">
+    <param name="ref_type" value="contrib"/>
+    <param name="ref_elements" value="//contrib/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-corresp">
+    <param name="ref_type" value="corresp"/>
+    <param name="ref_elements" value="//corresp/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-disp-formula">
+    <param name="ref_type" value="disp-formula"/>
+    <param name="ref_elements" value="//disp-formula/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-fig">
+    <param name="ref_type" value="fig"/>
+    <param name="ref_elements" value="//fig/@id | //fig-group/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-fn">
+    <param name="ref_type" value="fn"/>
+    <param name="ref_elements" value="//fn/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-sec">
+    <param name="ref_type" value="sec"/>
+    <param name="ref_elements" value="//sec/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-supplementary-material">
+    <param name="ref_type" value="supplementary-material"/>
+    <param name="ref_elements" value="//supplementary-material/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-table">
+    <param name="ref_type" value="table"/>
+    <param name="ref_elements" value="//table-wrap/@id | //table-wrap-group/@id"/>
+  </pattern>
+
+  <pattern is-a="xref-reftype-integrity-base" id="xref-reftype-integrity-table-fn">
+    <param name="ref_type" value="table-fn"/>
+    <param name="ref_elements" value="//table-wrap-foot/fn/@id"/>
+  </pattern>
+  <!-- end-block -->
+
+  <pattern id="xref-reftype-values">
+    <title>
+      Validate the ref-type value against a list.
+    </title>
+
+    <rule context="//xref[@ref-type]">
+      <assert test="@ref-type = 'aff' or
+                    @ref-type = 'app' or
+                    @ref-type = 'author-notes' or
+                    @ref-type = 'bibr' or 
+                    @ref-type = 'contrib' or
+                    @ref-type = 'corresp' or
+                    @ref-type = 'disp-formula' or
+                    @ref-type = 'fig' or 
+                    @ref-type = 'fn' or
+                    @ref-type = 'sec' or
+                    @ref-type = 'supplementary-material' or
+                    @ref-type = 'table' or
+                    @ref-type = 'table-fn' or
+                    @ref-type = 'boxed-text'">
+        Element 'xref', attribute ref-type: Invalid value "<value-of select="@ref-type"/>".
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="caption_title">
+    <title>
+      Make sure all captions have a title element.
+    </title>
+
+    <rule context="//caption">
+      <assert test="title and string-length(title) > 0">
+        Element 'caption': Missing element title.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="license_attributes">
+    <title>
+      Make sure all mandatory attributes are present
+    </title>
+
+    <rule context="article/front/article-meta/permissions/license">
+      <assert test="@license-type">
+        Element 'license': Missing attribute license-type.
+      </assert>
+      <assert test="@xlink:href">
+        Element 'license': Missing attribute xlink:href.
+      </assert>
+      <assert test="@xml:lang">
+        Element 'license': Missing attribute xml:lang.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="license">
+    <title>
+      Make sure the document has a permissions element, and a valid
+      license (represented as a known href).
+
+      Valid licenses are:
+        - http://creativecommons.org/licenses/by-nc/4.0/
+        - http://creativecommons.org/licenses/by-nc/3.0/
+        - http://creativecommons.org/licenses/by/4.0/
+        - http://creativecommons.org/licenses/by/3.0/
+        - http://creativecommons.org/licenses/by-nc-nd/4.0/
+        - http://creativecommons.org/licenses/by-nc-nd/3.0/
+    </title>
+
+    <rule context="article/front/article-meta">
+      <assert test="permissions">
+        Element 'article-meta': Missing element permissions.
+      </assert>
+    </rule>
+
+    <rule context="article/front/article-meta/permissions">
+      <assert test="license">
+        Element 'permissions': Missing element license.
+      </assert>
+    </rule>
+
+    <rule context="article/front/article-meta/permissions/license[@license-type and @xlink:href]">
+      <assert test="@license-type = 'open-access'">
+        Element 'license', attribute license-type: Invalid value '<value-of select="@license-type"/>'.
+      </assert>
+      <assert test="regexp:test(@xlink:href, '^https?://creativecommons\.org/licenses/')">
+        Element 'license', attribute xlink:href: Invalid value '<value-of select="@xlink:href"/>'.
+      </assert>
+      <assert test="@xml:lang = 'en' or @xml:lang = /article/@xml:lang">
+        Element 'license', attribute xml:lang: Must be 'en' or match with article/@xml:lang.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ack">
+    <title>
+      Ack elements cannot be organized as sections (sec).
+    </title>
+
+    <rule context="article/back/ack">
+      <assert test="not(sec)">
+          Element 'ack': Unexpected element sec.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="element-citation">
+    <title>
+      - Make sure name, etal and collab are not child of element-citation.
+      - element-citation can be only child of ref elements.
+    </title>
+
+    <rule context="article/back/ref-list/ref/element-citation">
+      <assert test="not(name)">
+        Element 'element-citation': Unexpected element name.
+      </assert>
+      <assert test="not(etal)">
+        Element 'element-citation': Unexpected element etal.
+      </assert>
+      <assert test="not(collab)">
+        Element 'element-citation': Unexpected element collab.
+      </assert>
+    </rule>
+
+    <rule context="//element-citation">
+      <assert test="parent::ref">
+        Unexpected element 'element-citation': Allowed only as child of ref elements.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="person-group">
+    <title>
+      Make sure person-group-type is present.
+    </title>
+
+    <rule context="article/back/ref-list/ref/element-citation/person-group | 
+                   article/front/article-meta/product/person-group">
+      <assert test="@person-group-type">
+        Element 'person-group': Missing attribute person-group-type.
+      </assert>
+      <assert test="string-length(normalize-space(text())) = 0">
+        Element 'person-group': Unexpected text content. 
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="person-group-type_values">
+    <title>
+      person-group/@person-group-type value constraints.
+    </title>
+
+    <rule context="article/back/ref-list/ref/element-citation/person-group[@person-group-type] | 
+                   article/front/article-meta/product/person-group[@person-group-type]">
+      <assert test="@person-group-type = 'author' or
+                    @person-group-type = 'compiler' or 
+                    @person-group-type = 'editor' or
+                    @person-group-type = 'translator'">
+        Element 'person-group', attribute person-group-type: Invalid value '<value-of select="@person-group-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="fn_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article/front/article-meta/author-notes/fn | 
+                   article/back/fn-group/fn">
+      <assert test="@fn-type">
+        Element 'fn': Missing attribute fn-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="fn">
+    <title>
+      Make sure fn-type is valid against a white list.
+    </title>
+
+    <rule context="article/back/fn-group/fn[@fn-type]">
+      <assert test="@fn-type = 'abbr' or
+                    @fn-type = 'com' or 
+                    @fn-type = 'financial-disclosure' or
+                    @fn-type = 'supported-by' or
+                    @fn-type = 'presented-at' or
+                    @fn-type = 'supplementary-material' or
+                    @fn-type = 'other'">
+        Element 'fn', attribute fn-type: Invalid value '<value-of select="@fn-type"/>'.
+      </assert>
+    </rule>
+    <rule context="article/front/article-meta/author-notes/fn[@fn-type]">
+      <assert test="@fn-type = 'author' or
+                    @fn-type = 'con' or
+                    @fn-type = 'conflict' or
+                    @fn-type = 'corresp' or
+                    @fn-type = 'current-aff' or
+                    @fn-type = 'deceased' or
+                    @fn-type = 'edited-by' or 
+                    @fn-type = 'equal' or
+                    @fn-type = 'on-leave' or
+                    @fn-type = 'participating-researchers' or
+                    @fn-type = 'present-address' or
+                    @fn-type = 'previously-at' or
+                    @fn-type = 'study-group-members' or
+                    @fn-type = 'other' or
+                    @fn-type = 'presented-at' or 
+                    @fn-type = 'presented-by'">
+        Element 'fn', attribute fn-type: Invalid value '<value-of select="@fn-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="fn-group">
+    <rule context="article/back/fn-group">
+      <assert test="count(title) &lt; 2">
+        Element 'fn-group': There must be zero or one element title.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="xhtml-table">
+    <title>
+      Tables should be fully tagged. tr elements are not supposed to be declared
+      at toplevel.
+    </title>
+
+    <rule context="//table">
+      <assert test="not(tr)">
+        Element 'table': Unexpected element tr.
+      </assert>
+      <assert test="not(tbody//th)">
+        Element 'table': Unexpected element th inside tbody.
+      </assert>
+      <assert test="not(thead//td)">
+        Element 'table': Unexpected element td inside thead.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="supplementary-material_mimetype">
+    <title>
+      The attributes mimetype and mime-subtype are required.
+    </title>
+
+    <rule context="article//supplementary-material">
+      <assert test="@mimetype">
+        Element 'supplementary-material': Missing attribute mimetype.
+      </assert>
+      <assert test="@mime-subtype">
+        Element 'supplementary-material': Missing attribute mime-subtype.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article">
+      <assert test="@article-type">
+        Element 'article': Missing attribute article-type.
+      </assert>
+      <assert test="@xml:lang">
+        Element 'article': Missing attribute xml:lang.
+      </assert>
+      <assert test="@dtd-version">
+        Element 'article': Missing attribute dtd-version.
+      </assert>
+      <assert test="@specific-use">
+        Element 'article': Missing SPS version at the attribute specific-use.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article_article-type-values">
+    <title>
+      Allowed values for article/@article-type
+    </title>
+
+    <rule context="article[@article-type]">
+        <assert test="@article-type = 'addendum' or
+            @article-type = 'research-article' or
+            @article-type = 'review-article' or
+            @article-type = 'letter' or
+            @article-type = 'article-commentary' or
+            @article-type = 'brief-report' or
+            @article-type = 'rapid-communication' or
+            @article-type = 'oration' or
+            @article-type = 'discussion' or
+            @article-type = 'editorial' or
+            @article-type = 'interview' or
+            @article-type = 'correction' or
+            @article-type = 'guidelines' or
+            @article-type = 'other' or
+            @article-type = 'obituary' or
+            @article-type = 'case-report' or
+            @article-type = 'book-review' or
+            @article-type = 'reply' or
+            @article-type = 'retraction' or
+            @article-type = 'partial-retraction' or
+            @article-type = 'clinical-trial' or
+            @article-type = 'announcement' or
+            @article-type = 'calendar' or
+            @article-type = 'in-brief' or
+            @article-type = 'book-received' or
+            @article-type = 'news' or
+            @article-type = 'reprint' or
+            @article-type = 'meeting-report' or
+            @article-type = 'abstract' or
+            @article-type = 'product-review' or
+            @article-type = 'dissertation' or
+            @article-type = 'translation' or
+            @article-type = 'data-article'">
+        Element 'article', attribute article-type: Invalid value '<value-of select="@article-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="article_specific-use-values">
+    <title>
+      The SPS version must be declared in article/@specific-use 
+    </title>
+
+    <rule context="article[@specific-use]">
+      <assert test="@specific-use = 'sps-1.10'">
+        Element 'article', attribute specific-use: Invalid value '<value-of select="@specific-use"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="named-content_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article/front/article-meta/aff/addr-line/named-content">
+      <assert test="@content-type">
+        Element 'named-content': Missing attribute content-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="named-content_content-type-values">
+    <title>
+      Allowed values for named-content/@content-type
+    </title>
+
+    <rule context="article/front/article-meta/aff/addr-line/named-content[@content-type]">
+      <assert test="@content-type = 'city' or
+                    @content-type = 'state'">
+        Element 'named-content', attribute content-type: Invalid value '<value-of select="@content-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="month">
+    <title>
+      Only integers between 1 and 12.
+    </title>
+
+    <rule context="//month">
+      <assert test="regexp:test(current(), '^(0?[1-9]{1}|[10-12]{2})$')">
+        Element 'month': Invalid value '<value-of select="current()"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="size_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article/front/article-meta/product/size | 
+                   article/back/ref-list/ref/element-citation/size">
+      <assert test="@units">
+        Element 'size': Missing attribute units.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="size_units-values">
+    <title>
+      Allowed values for size/@units
+    </title>
+
+    <rule context="article/front/article-meta/product/size[@units] | 
+                   article/back/ref-list/ref/element-citation/size[@units]">
+      <assert test="@units = 'pages'">
+        Element 'size', attribute units: Invalid value '<value-of select="@units"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="list_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="//list">
+      <assert test="@list-type">
+        Element 'list': Missing attribute list-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="list_list-type-values">
+    <title>
+      Allowed values for list/@list-type
+    </title>
+
+    <rule context="//list[@list-type]">
+      <assert test="@list-type = 'order' or
+                    @list-type = 'bullet' or
+                    @list-type = 'alpha-lower' or
+                    @list-type = 'alpha-upper' or
+                    @list-type = 'roman-lower' or
+                    @list-type = 'roman-upper' or
+                    @list-type = 'simple'">
+        Element 'list', attribute list-type: Invalid value '<value-of select="@list-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="media_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="//media">
+      <assert test="@mime-subtype">
+        Element 'media': Missing attribute mime-subtype.
+      </assert>
+      <assert test="@mimetype">
+        Element 'media': Missing attribute mimetype.
+      </assert>
+      <assert test="@xlink:href">
+        Element 'media': Missing attribute xlink:href.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ext-link_attributes">
+    <title>
+      Make sure some attributes are present. Also, the value of 
+      ext-link-type is validated against a white-list.
+    </title>
+
+    <rule context="//ext-link">
+      <assert test="@ext-link-type">
+        Element 'ext-link': Missing attribute ext-link-type.
+      </assert>
+      <assert test="@ext-link-type = 'uri' or
+                    @ext-link-type = 'clinical-trial'">
+        Element 'ext-link', attribute ext-link-type: Invalid value '<value-of select="@ext-link-type"/>'.
+      </assert>
+      <assert test="@xlink:href">
+        Element 'ext-link': Missing attribute xlink:href.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ext-link_href_values">
+    <title>
+        All URIs are supported, except "file", because we dont want references 
+        to local files.
+    </title>
+
+    <rule context="//ext-link[@ext-link-type='uri']">
+      <assert test="regexp:test(@xlink:href, '^[a-zA-Z][a-zA-Z0-9+\.-]+:', 'i')">
+        Element 'ext-link', attribute xlink:href: Missing URI scheme in '<value-of select="@xlink:href"/>'.
+      </assert>
+
+      <assert test="not(starts-with(@xlink:href, 'file:'))">
+        Element 'ext-link', attribute xlink:href: Invalid URI scheme 'file'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="element-citation_attributes">
+    <title>
+      Make sure some attributes are present. 
+    </title>
+
+    <rule context="article/back/ref-list/ref/element-citation">
+      <assert test="@publication-type">
+        Element 'element-citation': Missing attribute publication-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="element-citation_publication-type-values">
+    <title>
+      Allowed values for element-citation/@publication-type
+    </title>
+
+    <rule context="article/back/ref-list/ref/element-citation[@publication-type]">
+      <assert test="@publication-type = 'journal' or
+                    @publication-type = 'book' or
+                    @publication-type = 'webpage' or
+                    @publication-type = 'thesis' or
+                    @publication-type = 'confproc' or
+                    @publication-type = 'patent' or
+                    @publication-type = 'report' or
+                    @publication-type = 'software' or
+                    @publication-type = 'legal-doc' or
+                    @publication-type = 'newspaper' or
+                    @publication-type = 'other' or
+                    @publication-type = 'database' or
+                    @publication-type = 'data'">
+        Element 'element-citation', attribute publication-type: Invalid value '<value-of select="@publication-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="sub-article_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article//sub-article">
+      <assert test="@article-type">
+        Element 'sub-article': Missing attribute article-type.
+      </assert>
+      <assert test="@xml:lang">
+        Element 'sub-article': Missing attribute xml:lang.
+      </assert>
+      <assert test="@id">
+        Element 'sub-article': Missing attribute id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="sub-article_article-type-values">
+    <title>
+      Allowed values for //sub-article/@article-type
+    </title>
+
+    <rule context="//sub-article[@article-type]">
+      <assert test="@article-type = 'abstract' or 
+                    @article-type = 'letter' or 
+                    @article-type = 'reply' or 
+                    @article-type = 'translation'">
+        Element 'sub-article', attribute article-type: Invalid value '<value-of select="@article-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="response_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article//response">
+      <assert test="@response-type">
+        Element 'response': Missing attribute response-type.
+      </assert>
+      <assert test="@xml:lang">
+        Element 'response': Missing attribute xml:lang.
+      </assert>
+      <assert test="@id">
+        Element 'response': Missing attribute id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="response_response-type-values">
+    <title>
+      Allowed values for //response/@response-type
+    </title>
+
+    <rule context="//response[@response-type]">
+      <assert test="@response-type = 'addendum' or 
+                    @response-type = 'discussion' or 
+                    @response-type = 'reply'">
+        Element 'response', attribute response-type: Invalid value '<value-of select="@response-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="response_related-article_attributes">
+    <title>
+      Make sure some attributes are present
+
+      @id is mandatory for all use cases, so it is not implemented in this 
+      pattern.
+    </title>
+
+    <rule context="article//response[@response-type='reply']//related-article">
+      <assert test="@related-article-type = 'commentary-article'">
+        Element 'related-article': Missing attribute related-article-type of type 'commentary-article'.
+      </assert>
+      <assert test="@vol">
+        Element 'related-article': Missing attribute vol.
+      </assert>
+      <assert test="@page or @elocation-id">
+        Element 'related-article': Missing attribute page or elocation-id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="related-article_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article//related-article">
+      <assert test="@related-article-type">
+        Element 'related-article': Missing attribute related-article-type.
+      </assert>
+      <assert test="@id">
+        Element 'related-article': Missing attribute id.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="related-article_correction_attributes">
+    <title>
+      Make sure some attributes are present for corrections.
+      http://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.5-branch/narr/errata.html#errata
+    </title>
+
+    <rule context="article//related-article[@related-article-type = 'corrected-article']">
+      <assert test="@ext-link-type">
+        Element 'related-article': Missing attribute ext-link-type.
+      </assert>
+      <assert test="@xlink:href">
+        Element 'related-article': Missing attribute xlink:href.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="related-article-type-values">
+    <title>
+      Allowed values for //related-article/@related-article-type
+    </title>
+
+    <rule context="//related-article[@related-article-type]">
+      <assert test="@related-article-type = 'corrected-article' or 
+                    @related-article-type = 'commentary-article' or
+                    @related-article-type = 'letter' or
+                    @related-article-type = 'partial-retraction' or
+                    @related-article-type = 'retracted-article'">
+        Element 'related-article', attribute related-article-type: Invalid value '<value-of select="@related-article-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="correction_related-article">
+    <title>
+      Articles of type correction must specify the article it relates to.
+    </title>
+
+    <rule context="article[@article-type='correction']/front/article-meta">
+      <assert test="related-article/@related-article-type = 'corrected-article'">
+        Element 'article-meta': Missing element related-article with related-article-type='corrected-article'.
+      </assert>
+    </rule>
+  </pattern>  
+
+  <pattern id="correction_article-type">
+    <title>
+      Ensure related-article[@related-article-type='corrected-article' is 
+      defined only for correction article types.
+    </title>
+
+    <rule context="article[@article-type != 'correction']/front/article-meta/related-article">
+      <assert test="not(@related-article-type = 'corrected-article')">
+        Element 'related-article', attribute related-article-type: Invalid value 'corrected-article' for article-type '<value-of select="/article/@article-type"/>'. 
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="inbrief_related-article">
+    <title>
+      Articles of type in-brief must specify the article it relates to.
+    </title>
+
+    <rule context="article[@article-type='in-brief']/front/article-meta">
+      <assert test="related-article/@related-article-type = 'article-reference'">
+        Element 'article-meta': Missing element related-article with related-article-type='article-reference'.
+      </assert>
+    </rule>
+  </pattern>  
+
+  <pattern id="inbrief_article-type">
+    <title>
+      Ensure related-article[@related-article-type='article-reference' is 
+      defined only for in-brief article types.
+    </title>
+
+    <rule context="article[@article-type != 'in-brief']/front/article-meta/related-article">
+      <assert test="not(@related-article-type = 'article-reference')">
+        Element 'related-article', attribute related-article-type: Invalid value 'article-reference' for article-type '<value-of select="/article/@article-type"/>'. 
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="funding-group">
+    <title></title>
+
+    <rule context="article/back//fn[@fn-type='financial-disclosure']">
+      <assert test="/article/front/article-meta/funding-group/funding-statement">
+        Element 'fn': Missing element funding-statement.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="funding-group_elements">
+    <title>
+      Make sure mandatory child elements are present.  
+    </title>
+
+    <rule context="article/front/article-meta/funding-group">
+      <assert test="award-group">
+        Element 'funding-group': Missing element award-group.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="aff_country-attrs">
+    <title>
+      Ensure the attribute 'country' is present for all //aff/country elements.
+    </title>
+
+    <rule context="article/front/article-meta/aff/country">
+      <assert test="@country">
+        Element 'country': Missing attribute country.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="aff_country">
+    <title>
+      //aff/country elements cannot be empty.
+    </title>
+
+    <rule context="article/front/article-meta/aff/country">
+      <assert test="string-length(normalize-space(text())) > 0">
+        Element 'country': Missing text content.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ref">
+    <title>
+      element-citation and mixed-citation are mandatory in ref.
+    </title>
+
+    <rule context="article/back/ref-list/ref">
+      <assert test="mixed-citation">
+        Element 'ref': Missing element mixed-citation.
+      </assert>
+      <assert test="element-citation">
+        Element 'ref': Missing element element-citation.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="ref_notempty" is-a="assert-not-empty">
+    <param name="base_context" value="article/back/ref-list/ref/mixed-citation"/>
+    <param name="assert_expr" value="text()"/>
+    <param name="err_message" value="'Element cannot be empty.'"/>
+  </pattern>
+
+  <pattern id="contrib-id_attributes">
+    <title>
+      Make sure some attributes are present
+    </title>
+
+    <rule context="article//contrib-group/contrib-id">
+      <assert test="@contrib-id-type">
+        Element 'contrib-id': Missing attribute contrib-id-type.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="contrib-id-type-values">
+    <title>
+      Allowed values for //contrib/contrib-id/@contrib-id-type
+    </title>
+
+    <rule context="article//contrib-group/contrib-id[@contrib-id-type]">
+      <assert test="@contrib-id-type = 'lattes' or 
+                    @contrib-id-type = 'orcid' or 
+                    @contrib-id-type = 'researchid' or
+                    @contrib-id-type = 'scopus'">
+        Element 'contrib-id', attribute contrib-id-type: Invalid value '<value-of select="@contrib-id-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern abstract="true" id="occurs_zero_or_once">
+    <rule context="$base_context">
+      <assert test="count($element) &lt; 2">
+        Element '<name/>': There must be zero or one element <value-of select="name($element)"/>.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern abstract="true" id="occurs_once">
+    <rule context="$base_context">
+      <assert test="count($element) = 1">
+        Element '<name/>': There must be only one element <value-of select="name($element)"/>.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="source_cardinality" is-a="occurs_zero_or_once">
+    <param name="base_context" value="article/back/ref-list/ref/element-citation | 
+                                      article/front/article-meta/product"/>
+    <param name="element" value="source"/>
+  </pattern>
+
+  <pattern id="size_cardinality" is-a="occurs_zero_or_once">
+    <param name="base_context" value="article/back/ref-list/ref/element-citation | 
+                                      article/front/article-meta/product"/>
+    <param name="element" value="size"/>
+  </pattern>
+
+  <pattern id="month_cardinality" is-a="occurs_zero_or_once">
+    <param name="base_context" value="article/back/ref-list/ref/element-citation"/>
+    <param name="element" value="month"/>
+  </pattern>
+
+  <pattern id="issue_cardinality" is-a="occurs_zero_or_once">
+    <param name="base_context" value="article/back/ref-list/ref/element-citation"/>
+    <param name="element" value="issue"/>
+  </pattern>
+
+  <pattern id="chapter-title_cardinality" is-a="occurs_zero_or_once">
+    <param name="base_context" value="article/back/ref-list/ref/element-citation | 
+                                      article/front/article-meta/product"/>
+    <param name="element" value="chapter-title"/>
+  </pattern>
+
+  <pattern id="element-citation_cardinality" is-a="occurs_once">
+    <param name="base_context" value="article/back/ref-list/ref"/>
+    <param name="element" value="element-citation"/>
+  </pattern>
+
+  <pattern id="related-article_ext-link-type-values">
+    <title>
+      Allowed values for //related-article/@ext-link-type
+    </title>
+
+    <rule context="article/front/article-meta/related-article[@ext-link-type]">
+      <assert test="@ext-link-type = 'doi'">
+        Element 'related-article', attribute ext-link-type: Invalid value '<value-of select="@ext-link-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
+
+</schema>
+

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -300,6 +300,10 @@ code for more information.
     <active pattern="chapter-title_cardinality"/>
   </phase>
 
+  <phase id="phase.role">
+    <active pattern="role_content-type-values"/>
+  </phase>
+
   <!--
    Patterns - sets of rules.
   -->
@@ -1738,5 +1742,25 @@ code for more information.
     </rule>
   </pattern>
 
+  <pattern id="role_content-type-values">
+    <rule context="//contrib-group/contrib/role[@content-type]">
+      <assert test="@content-type = 'https://dictionary.casrai.org/Contributor_Roles/Conceptualization' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Data_curation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Formal_analysis' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Investigation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Methodology' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Project_administration' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Resources' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Software' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Supervision' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Validation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Visualization' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing'">
+        Element 'role', attribute content-type: Invalid value '<value-of select="@content-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
 </schema>
 

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -6225,3 +6225,80 @@ class SourceTests(PhaseBasedTestCase):
 
         self.assertFalse(self._run_validation(sample))
 
+
+class RoleTests(PhaseBasedTestCase):
+    """Tests for //contrib-group/contrib/role elements.
+    """
+    sch_phase = 'phase.role'
+
+    def test_role_with_free_text(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <contrib-group>
+                            <contrib>
+                              <role>Autor correspondente</role>
+                            </contrib>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_CRediT_taxonomy_urls(self):
+        for value in [
+            "https://dictionary.casrai.org/Contributor_Roles/Conceptualization",
+            "https://dictionary.casrai.org/Contributor_Roles/Data_curation",
+            "https://dictionary.casrai.org/Contributor_Roles/Formal_analysis",
+            "https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition",
+            "https://dictionary.casrai.org/Contributor_Roles/Investigation",
+            "https://dictionary.casrai.org/Contributor_Roles/Methodology",
+            "https://dictionary.casrai.org/Contributor_Roles/Project_administration",
+            "https://dictionary.casrai.org/Contributor_Roles/Resources",
+            "https://dictionary.casrai.org/Contributor_Roles/Software",
+            "https://dictionary.casrai.org/Contributor_Roles/Supervision",
+            "https://dictionary.casrai.org/Contributor_Roles/Validation",
+            "https://dictionary.casrai.org/Contributor_Roles/Visualization",
+            "https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft",
+            "https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing",
+            ]:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <contrib-group>
+                                <contrib>
+                                  <role content-type="{value}">Autor correspondente</role>
+                                </contrib>
+                              </contrib-group>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """.format(value=value)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_role_with_invalid_taxonomy_url(self):
+        for value in [
+            "https://dictionary.casrai.org/Contributor_Roles/INVALID_URL",
+            "invalid_value",
+            ]:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <contrib-group>
+                                <contrib>
+                                  <role content-type="{value}">Autor correspondente</role>
+                                </contrib>
+                              </contrib-group>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """.format(value=value)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -1,0 +1,6227 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import unittest
+import io
+
+from lxml import isoschematron, etree
+
+from packtools.catalogs import SCHEMAS
+
+
+SCH = etree.parse(SCHEMAS['sps-1.10'])
+
+
+def TestPhase(phase_name, cache):
+    """Factory of parsed Schematron phases.
+
+    :param phase_name: the phase name
+    :param cache: mapping type
+    """
+    if phase_name not in cache:
+        phase = isoschematron.Schematron(SCH, phase=phase_name)
+        cache[phase_name] = phase
+
+    return cache[phase_name]
+
+
+class PhaseBasedTestCase(unittest.TestCase):
+    cache = {}
+
+    def _run_validation(self, sample):
+        schematron = TestPhase(self.sch_phase, self.cache)
+        return schematron.validate(etree.parse(sample))
+
+
+class JournalIdTests(PhaseBasedTestCase):
+    """Tests for article/front/journal-meta/journal-id elements.
+
+    Ticket #14 makes @journal-id-type="publisher-id" mandatory.
+    Ref: https://github.com/scieloorg/scielo_publishing_schema/issues/14
+    """
+    sch_phase = 'phase.journal-id'
+
+    def test_case1(self):
+        """
+        presence(@nlm-ta) is True
+        presence(@publisher-id) is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-id journal-id-type="nlm-ta">
+                            Rev Saude Publica
+                          </journal-id>
+                          <journal-id journal-id-type="publisher-id">
+                            RSP
+                          </journal-id>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case2(self):
+        """
+        presence(@nlm-ta) is True
+        presence(@publisher-id) is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-id journal-id-type="nlm-ta">
+                            Rev Saude Publica
+                          </journal-id>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_case3(self):
+        """
+        presence(@nlm-ta) is False
+        presence(@publisher-id) is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-id journal-id-type="publisher-id">
+                            RSP
+                          </journal-id>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case4(self):
+        """
+        presence(@nlm-ta) is False
+        presence(@publisher-id) is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-id journal-id-type='doi'>
+                            123.plin
+                          </journal-id>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_publisher_id_cannot_be_empty(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-id journal-id-type="publisher-id"></journal-id>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class JournalTitleGroupTests(PhaseBasedTestCase):
+    """Tests for article/front/journal-meta/journal-title-group elements.
+    """
+    sch_phase = 'phase.journal-title-group'
+
+    def test_journal_title_group_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+    def test_case1(self):
+        """
+        A: presence(journal-title) is True
+        B: presence(abbrev-journal-title[@abbrev-type='publisher']) is True
+        A ^ B is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                            <journal-title>
+                              Revista de Saude Publica
+                            </journal-title>
+                            <abbrev-journal-title abbrev-type='publisher'>
+                              Rev. Saude Publica
+                            </abbrev-journal-title>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case2(self):
+        """
+        A: presence(journal-title) is True
+        B: presence(abbrev-journal-title[@abbrev-type='publisher']) is False
+        A ^ B is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                            <journal-title>
+                              Revista de Saude Publica
+                            </journal-title>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_case3(self):
+        """
+        A: presence(journal-title) is False
+        B: presence(abbrev-journal-title[@abbrev-type='publisher']) is True
+        A ^ B is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                            <abbrev-journal-title abbrev-type='publisher'>
+                              Rev. Saude Publica
+                            </abbrev-journal-title>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_case4(self):
+        """
+        A: presence(journal-title) is False
+        B: presence(abbrev-journal-title[@abbrev-type='publisher']) is False
+        A ^ B is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_empty_journal_title(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                            <journal-title></journal-title>
+                            <abbrev-journal-title abbrev-type='publisher'>Rev. Saude Publica</abbrev-journal-title>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_empty_abbrev_journal_title(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <journal-title-group>
+                            <journal-title>Revista de Saude Publica</journal-title>
+                            <abbrev-journal-title abbrev-type='publisher'></abbrev-journal-title>
+                          </journal-title-group>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class PublisherTests(PhaseBasedTestCase):
+    """Tests for article/front/journal-meta/publisher elements.
+    """
+    sch_phase = 'phase.publisher'
+
+    def test_publisher_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <publisher>
+                            <publisher-name>British Medical Journal</publisher-name>
+                          </publisher>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_publisher_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_publisher_is_empty(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <publisher>
+                            <publisher-name></publisher-name>
+                          </publisher>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ArticleCategoriesTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/article-categories elements.
+    """
+    sch_phase = 'phase.article-categories'
+
+    def test_article_categories_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group>
+                              <subject>ISO/TC 908</subject>
+                              <subject>
+                                SC 2, Measurement and evaluation of...
+                              </subject>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_article_categories_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class fpage_OR_elocationTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/fpage or elocation-id elements.
+    """
+    sch_phase = 'phase.fpage_or_elocation-id'
+
+    def test_case1(self):
+        """
+        fpage is True
+        elocation-id is True
+        fpage v elocation-id is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <fpage>01</fpage>
+                          <elocation-id>E27</elocation-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case2(self):
+        """
+        fpage is True
+        elocation-id is False
+        fpage v elocation-id is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <fpage>01</fpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case3(self):
+        """
+        fpage is False
+        elocation-id is True
+        fpage v elocation-id is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <elocation-id>E27</elocation-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case4(self):
+        """
+        fpage is False
+        elocation-id is False
+        fpage v elocation-id is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_empty_fpage(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <fpage></fpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_empty_elocationid(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <elocation-id></elocation-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ISSNTests(PhaseBasedTestCase):
+    """Tests for article/front/journal-meta/issn elements.
+    """
+    sch_phase = 'phase.issn'
+
+    def test_case1(self):
+        """
+        A: @pub-type='epub' is True
+        B: @pub-type='ppub' is True
+        A v B is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <issn pub-type="epub">
+                            0959-8138
+                          </issn>
+                          <issn pub-type="ppub">
+                            0959-813X
+                          </issn>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case2(self):
+        """
+        A: @pub-type='epub' is True
+        B: @pub-type='ppub' is False
+        A v B is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <issn pub-type="epub">
+                            0959-8138
+                          </issn>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case3(self):
+        """
+        A: @pub-type='epub' is False
+        B: @pub-type='ppub' is True
+        A v B is True
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <issn pub-type="ppub">
+                            0959-813X
+                          </issn>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case4(self):
+        """
+        A: @pub-type='epub' is False
+        B: @pub-type='ppub' is False
+        A v B is False
+        """
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <issn>
+                            0959-813X
+                          </issn>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_empty_issn(self):
+        sample = u"""<article>
+                      <front>
+                        <journal-meta>
+                          <issn pub-type="epub"></issn>
+                        </journal-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ArticleIdTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/article-id elements.
+    """
+    sch_phase = 'phase.article-id'
+
+    def test_article_id_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+    def test_pub_id_type_doi_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-id pub-id-type='other'>
+                            10.1590/1414-431X20143435
+                          </article-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_pub_id_type_doi(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-id pub-id-type='doi'>
+                            10.1590/1414-431X20143434
+                          </article-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_pub_id_type_doi_is_empty(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-id pub-id-type='doi'/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_invalid_pub_id_type(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-id pub-id-type='unknown'>
+                            10.1590/1414-431X20143434
+                          </article-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_invalid_pub_id_type_case2(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-id pub-id-type='unknown'>
+                            10.1590/1414-431X20143434
+                          </article-id>
+                          <article-id pub-id-type='doi'>
+                            10.1590/1414-431X20143434
+                          </article-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_valid_pub_id_type_values(self):
+        for typ in ['doi', 'publisher-id', 'other']:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <article-id pub-id-type='%s'>
+                                10.1590/1414-431X20143433
+                              </article-id>
+                              <article-id pub-id-type='doi'>
+                                10.1590/1414-431X20143434
+                              </article-id>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % typ
+            sample = io.BytesIO(sample.encode('utf-8'))
+            self.assertTrue(self._run_validation(sample))
+
+    def test_valid_pub_id_type_values_on_translations(self):
+        for typ in ['doi', 'publisher-id', 'other']:
+            sample = u"""<article>
+                          <sub-article article-type='translation'>
+                            <front-stub>
+                              <article-id pub-id-type="%s">pLjk3by</article-id>
+                            </front-stub>
+                          </sub-article>
+                        </article>
+                     """ % typ
+            sample = io.BytesIO(sample.encode('utf-8'))
+            self.assertTrue(self._run_validation(sample))
+
+    def test_invalid_pub_id_type_values_on_translations(self):
+        sample = u"""<article>
+                      <sub-article article-type='translation'>
+                        <front-stub>
+                          <article-id pub-id-type="invalid">pLjk3by</article-id>
+                        </front-stub>
+                      </sub-article>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+        self.assertFalse(self._run_validation(sample))
+
+
+class SubjGroupTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/article-categories/subj-group elements.
+    """
+    sch_phase = 'phase.subj-group'
+
+    def test_subj_group_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_without_heading_type(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group subj-group-type="kwd">
+                              <subject content-type="neurosci">
+                                Cellular and Molecular Biology
+                              </subject>
+                              <subj-group>
+                                <subject content-type="neurosci">
+                                  Blood and brain barrier
+                                </subject>
+                              </subj-group>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_heading_type(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>
+                                Cellular and Molecular Biology
+                              </subject>
+                              <subj-group>
+                                <subject content-type="neurosci">
+                                  Blood and brain barrier
+                                </subject>
+                              </subj-group>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_heading_in_subarticle_pt(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>
+                                Original Article
+                              </subject>
+                              <subj-group>
+                                <subject content-type="neurosci">
+                                  Blood and brain barrier
+                                </subject>
+                              </subj-group>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                      <sub-article xml:lang="pt" article-type="translation" id="S01">
+                        <front-stub>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>Artigos Originais</subject>
+                            </subj-group>
+                          </article-categories>
+                        </front-stub>
+                      </sub-article>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_many_heading_in_subarticle_pt(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>
+                                Original Article
+                              </subject>
+                              <subj-group>
+                                <subject content-type="neurosci">
+                                  Blood and brain barrier
+                                </subject>
+                              </subj-group>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                      <sub-article xml:lang="pt" article-type="translation" id="S01">
+                        <front-stub>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>Artigos Originais</subject>
+                            </subj-group>
+                            <subj-group subj-group-type="heading">
+                              <subject>Artigos Piratas</subject>
+                            </subj-group>
+                          </article-categories>
+                        </front-stub>
+                      </sub-article>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_heading_type_in_the_deep(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group>
+                              <subject>
+                                Cellular and Molecular Biology
+                              </subject>
+                              <subj-group subj-group-type="heading">
+                                <subject>
+                                  Blood and brain barrier
+                                </subject>
+                              </subj-group>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_many_heading_type(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>
+                                Cellular and Molecular Biology
+                              </subject>
+                            </subj-group>
+                            <subj-group subj-group-type="heading">
+                              <subject>
+                                Blood and brain barrier
+                              </subject>
+                            </subj-group>
+                          </article-categories>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AbstractLangTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/abstract elements.
+    """
+    sch_phase = 'phase.abstract_lang'
+
+    def test_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <p>Differing socioeconomic positions in...</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_with_lang(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article>
+                      <front>
+                        <article-meta>
+                          <abstract xml:lang="en">
+                            <p>Differing socioeconomic positions in...</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_for_research_article(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="research-article">
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_research_article(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="research-article">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <p>Differing socioeconomic positions in...</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_research_article_only_with_transabstract(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="research-article">
+                      <front>
+                        <article-meta>
+                          <trans-abstract xml:lang="en">
+                            <p>Differing socioeconomic positions in...</p>
+                          </trans-abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_for_review_article(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="review-article">
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_review_article(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="review-article">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <p>Differing socioeconomic positions in...</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_review_article_only_with_transabstract(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="review-article">
+                      <front>
+                        <article-meta>
+                          <trans-abstract xml:lang="en">
+                            <p>Differing socioeconomic positions in...</p>
+                          </trans-abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_transabstract_allowed_types(self):
+        for value in ['graphical',]:
+            sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                        <article article-type="research-article">
+                          <front>
+                            <article-meta>
+                              <trans-abstract abstract-type="%s" xml:lang="en">
+                                <p>Differing socioeconomic positions in...</p>
+                              </trans-abstract>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % value
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_transabstract_disallowed_types(self):
+        sample = u"""<?xml version="1.0" encoding="UTF-8"?>
+                    <article article-type="research-article">
+                      <front>
+                        <article-meta>
+                          <trans-abstract abstract-type="unknown" xml:lang="en">
+                            <p>Differing socioeconomic positions in...</p>
+                          </trans-abstract>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ArticleTitleLangTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/title-group/article-title elements.
+    """
+    sch_phase = 'phase.article-title_lang'
+
+    def test_is_present_in_articlemeta(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <title-group>
+                            <article-title>
+                              Systematic review of day hospital care...
+                            </article-title>
+                          </title-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_in_articlemeta_with_lang(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <title-group>
+                            <article-title xml:lang="en">
+                              Systematic review of day hospital care...
+                            </article-title>
+                          </title-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_is_present_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_in_elementcitation_with_lang(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title xml:lang="pt">Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class KwdGroupLangTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/kwd-group elements.
+    """
+    sch_phase = 'phase.kwd-group_lang'
+
+    def test_single_occurence(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <kwd-group>
+                            <kwd>gene expression</kwd>
+                          </kwd-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_many_occurencies(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <kwd-group xml:lang="en">
+                            <kwd>gene expression</kwd>
+                          </kwd-group>
+                          <kwd-group xml:lang="pt">
+                            <kwd>expressao do gene</kwd>
+                          </kwd-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_many_occurencies_without_lang(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <kwd-group>
+                            <kwd>gene expression</kwd>
+                          </kwd-group>
+                          <kwd-group>
+                            <kwd>expressao do gene</kwd>
+                          </kwd-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AffContentTypeTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/contrib-group
+      - article/front/article-meta
+    """
+    sch_phase = 'phase.aff_contenttypes'
+
+    def test_original_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_original_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution>
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_many_original(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="original">
+                              Galera de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_original_is_present_and_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                          <aff>
+                            <institution>
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_original_is_present_and_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_orgdiv1(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="orgdiv1">
+                              Instituto de Matematica e Estatistica
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_orgdiv2(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="orgdiv2">
+                              Instituto de Matematica e Estatistica
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_orgdiv3_is_not_allowed_anymore(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="orgdiv3">
+                              Instituto de Matematica e Estatistica
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_normalized(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="normalized">
+                              Instituto de Matematica e Estatistica
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_orgdiv4(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <institution content-type="orgdiv4">
+                              Instituto de Matematica e Estatistica
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_orgname_inside_contrib_group(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <contrib-group>
+                            <aff>
+                              <institution content-type="original">
+                                Grupo de ...
+                              </institution>
+                              <institution content-type="orgname">
+                                Instituto de Matematica e Estatistica
+                              </institution>
+                            </aff>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class CountsTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/counts elements.
+    """
+    sch_phase = 'phase.counts'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_table_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_ref_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_fig_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_equation_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_page_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                          </counts>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_tables(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="1"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <table-wrap>
+                              <table frame="hsides" rules="groups">
+                                <colgroup width="25%"><col/><col/><col/><col/></colgroup>
+                                <thead>
+                                  <tr>
+                                    <th style="font-weight:normal" align="left">Modelo</th>
+                                    <th style="font-weight:normal">Estrutura</th>
+                                    <th style="font-weight:normal">Processos</th>
+                                    <th style="font-weight:normal">Resultados</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  <tr>
+                                    <td valign="top">SIPA<sup>1,2</sup></td>
+                                    <td valign="top">Urgência e hospitalar.</td>
+                                    <td valign="top">Realiza triagem para fragilidade.</td>
+                                    <td valign="top">Maior gasto comunitário, menor gasto.</td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                            </table-wrap>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_tables_as_graphic(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="1"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <table-wrap id="t01">
+                              <graphic mimetype="image"
+                                       xlink:href="1414-431X-bjmbr-1414-431X20142875-gt001">
+                              </graphic>
+                            </table-wrap>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_ref(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="1"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                      <back>
+                        <ref-list>
+                          <title>REFERÊNCIAS</title>
+                          <ref id="B1">
+                            <label>1</label>
+                            <mixed-citation>
+                              Béland F, Bergman H, Lebel P, Clarfield AM, Tousignant P, ...
+                            </mixed-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_fig(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="1"/>
+                            <equation-count count="0"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <fig id="f01">
+                              <label>Figura 1</label>
+                              <caption>
+                                <title>Modelo das cinco etapas da pesquisa translacional.</title>
+                              </caption>
+                              <graphic xlink:href="0034-8910-rsp-48-2-0347-gf01"/>
+                            </fig>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_equation(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="1"/>
+                            <page-count count="0"/>
+                          </counts>
+                          <fpage>0</fpage>
+                          <lpage>0</lpage>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <disp-formula>
+                            <tex-math id="M1">
+                            </tex-math>
+                          </disp-formula>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_page(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="11"/>
+                          </counts>
+                          <fpage>140</fpage>
+                          <lpage>150</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_page_wrong_count(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="50"/>
+                          </counts>
+                          <fpage>140</fpage>
+                          <lpage>150</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_non_digit_pages(self):
+        """Non-digit page interval cannot be checked automatically.
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="11"/>
+                          </counts>
+                          <fpage>A140</fpage>
+                          <lpage>A150</lpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_elocationid_pages(self):
+        """Electronic pagination cannot be checked automatically.
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <counts>
+                            <table-count count="0"/>
+                            <ref-count count="0"/>
+                            <fig-count count="0"/>
+                            <equation-count count="0"/>
+                            <page-count count="11"/>
+                          </counts>
+                          <elocation-id>A140</elocation-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class AuthorNotesTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/author-notes elements.
+    """
+    sch_phase = 'phase.fn-group'
+
+    def test_allowed_fn_types(self):
+        for fn_type in ['author', 'con', 'conflict', 'corresp', 'current-aff',
+                'deceased', 'edited-by', 'equal', 'on-leave', 'participating-researchers',
+                'present-address', 'previously-at', 'study-group-members', 'other']:
+
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <author-notes>
+                                <fn fn-type="%s">
+                                  <p>foobar</p>
+                                </fn>
+                              </author-notes>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % fn_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_fn_types(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <author-notes>
+                            <fn fn-type="wtf">
+                              <p>foobar</p>
+                            </fn>
+                          </author-notes>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class PubDateTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/pub-date elements.
+    """
+    sch_phase = 'phase.pub-date'
+
+    def test_date_type_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_publication_format_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_allowed_values_day_month_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_date_type_allowed_values_day_month(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_allowed_values_day_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_allowed_values_month_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_allowed_values_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_pub_type_disallowed_value(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="unknown" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_publication_format_allowed_values(self):
+        for value in ['electronic']:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <pub-date date-type="pub" publication-format="%s">
+                                <day>17</day>
+                                <month>03</month>
+                                <year>2014</year>
+                              </pub-date>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % value
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_publication_format_disallowed_value(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="unknown">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_collection_without_pub_is_not_allowed(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_collection_containing_month_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <month>03</month>
+                            <year>2015</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_date_type_collection_containing_day_month_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <day>12</day>
+                            <month>03</month>
+                            <year>2015</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_collection_containing_day_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <day>12</day>
+                            <year>2015</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_collection_containing_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <year>2015</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_date_type_collection_containing_season(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <season>Jan-Feb</season>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_collection_containing_season_year(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date date-type="pub" publication-format="electronic">
+                            <day>17</day>
+                            <month>03</month>
+                            <year>2014</year>
+                          </pub-date>
+                          <pub-date date-type="collection" publication-format="electronic">
+                            <season>Jan-Feb</season>
+                            <year>2019</year>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class VolumeTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/volume
+      - article/back/ref-list/ref/element-citation/volume
+    """
+    sch_phase = 'phase.volume'
+
+    def test_absent_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_but_empty_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <volume></volume>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_present_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <volume>10</volume>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class IssueTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/issue
+      - article/back/ref-list/ref/element-citation/issue
+    """
+    sch_phase = 'phase.issue'
+
+    def test_absent_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_but_empty_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <issue></issue>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_present_in_front(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <issue>10</issue>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_special_number_support(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <issue>spe</issue>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <issue>10</issue>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_twice_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <issue>02</issue>
+                              <issue>02</issue>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_is_absent_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+class SupplementTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/supplement
+    """
+    sch_phase = 'phase.supplement'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <supplement>Suppl 2</supplement>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ElocationIdTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/elocation-id
+      - article/back/ref-list/ref/element-citation/elocation-id
+    """
+    sch_phase = 'phase.elocation-id'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_fpage(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <elocation-id>E27</elocation-id>
+                          <fpage>12</fpage>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_without_fpage(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <elocation-id>E27</elocation-id>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_absent_back(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_fpage_back(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <elocation-id>E27</elocation-id>
+                              <fpage>12</fpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_without_fpage_back(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <elocation-id>E27</elocation-id>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_and_without_fpage_back(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <elocation-id>E27</elocation-id>
+                              <fpage>12</fpage>
+                            </element-citation>
+                          </ref>
+                          <ref>
+                            <element-citation>
+                              <elocation-id>E27</elocation-id>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class HistoryTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/history
+    """
+    sch_phase = 'phase.history'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_date_type_allowed_values(self):
+        for pub_type in ['accepted', 'corrected', 'pub', 'preprint',
+                'retracted', 'received', 'rev-recd', 'rev-request']:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <history>
+                                <date date-type="%s">
+                                  <day>17</day>
+                                  <month>03</month>
+                                  <year>2014</year>
+                                </date>
+                              </history>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % pub_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_date_type_disallowed_values(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <history>
+                            <date date-type="invalid">
+                              <day>17</day>
+                              <month>03</month>
+                              <year>2014</year>
+                            </date>
+                          </history>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_date_type_allowed_values_multi(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <history>
+                            <date date-type="received">
+                              <day>17</day>
+                              <month>03</month>
+                              <year>2014</year>
+                            </date>
+                            <date date-type="accepted">
+                              <day>17</day>
+                              <month>03</month>
+                              <year>2014</year>
+                            </date>
+                          </history>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class ProductTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/product
+    """
+    sch_phase = 'phase.product'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_absent_allowed_types(self):
+        for art_type in ['book-review', 'product-review']:
+            sample = u"""<article article-type="%s">
+                          <front>
+                            <article-meta>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % art_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_types(self):
+        for art_type in ['book-review']:
+            sample = u"""<article article-type="%s">
+                          <front>
+                            <article-meta>
+                              <product product-type="book">
+                                <person-group person-group-type="author">
+                                  <name>
+                                    <surname>Sobrenome do autor</surname>
+                                    <given-names>Prenomes do autor</given-names>
+                                  </name>
+                                </person-group>
+                                <source>Título do livro</source>
+                                <year>Ano de publicação</year>
+                                <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                                <publisher-loc>Local de publicação</publisher-loc>
+                                <page-count count="total de paginação do livro (opcional)"/>
+                                <isbn>ISBN do livro, se houver</isbn>
+                                <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                              </product>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % art_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_types(self):
+        sample = u"""<article article-type="research-article">
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_no_type(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_product_type(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product>
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_product_types(self):
+        for prod_type in ['book', 'article', 'issue', 'website', 'film',
+                'software', 'hardware', 'other']:
+            sample = u"""<article article-type="book-review">
+                          <front>
+                            <article-meta>
+                              <product product-type="%s">
+                                <person-group person-group-type="author">
+                                  <name>
+                                    <surname>Sobrenome do autor</surname>
+                                    <given-names>Prenomes do autor</given-names>
+                                  </name>
+                                </person-group>
+                                <source>Título do livro</source>
+                                <year>Ano de publicação</year>
+                                <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                                <publisher-loc>Local de publicação</publisher-loc>
+                                <page-count count="total de paginação do livro (opcional)"/>
+                                <isbn>ISBN do livro, se houver</isbn>
+                                <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                              </product>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % prod_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_product_types(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="invalid">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_formatting_and_punctuation(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>,
+                                <given-names>Prenomes do autor</given-names>;
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>,
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class SecTitleTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/body/sec/title
+    """
+    sch_phase = 'phase.sectitle'
+
+    def test_absent(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>Foo bar</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_has_title(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <title>Introduction</title>
+                          <p>Foo bar</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_has_empty_title(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <title></title>
+                          <p>Foo bar</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ParagraphTests(PhaseBasedTestCase):
+    """Tests for //p
+    """
+    sch_phase = 'phase.paragraph'
+
+    def test_sec_without_id(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <title>Intro</title>
+                          <p>Foo bar</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_sec_with_id(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <title>Intro</title>
+                          <p id="p01">Foo bar</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_body_without_id(self):
+        sample = u"""<article>
+                      <body>
+                        <p>Foo bar</p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_body_with_id(self):
+        sample = u"""<article>
+                      <body>
+                        <p id="p01">Foo bar</p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class XrefRidTests(PhaseBasedTestCase):
+    """Tests for //xref[@rid]
+    """
+    sch_phase = 'phase.rid_integrity'
+
+    def test_mismatching_rid(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <contrib-group>
+                            <contrib>
+                              <xref ref-type="aff" rid="aff1">
+                                <sup>I</sup>
+                              </xref>
+                            </contrib>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_matching_rid(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <contrib-group>
+                            <contrib>
+                              <xref ref-type="aff" rid="aff1">
+                                <sup>I</sup>
+                              </xref>
+                            </contrib>
+                          </contrib-group>
+                          <aff id="aff1">
+                            <label>I</label>
+                            <institution content-type="orgname">
+                              Secretaria Municipal de Saude de Belo Horizonte
+                            </institution>
+                            <addr-line>
+                              <named-content content-type="city">Belo Horizonte</named-content>
+                              <named-content content-type="state">MG</named-content>
+                            </addr-line>
+                            <country>Brasil</country>
+                            <institution content-type="original">
+                              Secretaria Municipal de Saude de Belo Horizonte. Belo Horizonte, MG, Brasil
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_mismatching_reftype(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <table-wrap id="t01">
+                          </table-wrap>
+                        </sec>
+                        <sec>
+                          <p>
+                            <xref ref-type="aff" rid="t01">table 1</xref>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class XrefRefTypeTests(PhaseBasedTestCase):
+    """Tests for //xref[@ref-type]
+    """
+    sch_phase = 'phase.xref_reftype_integrity'
+
+    def test_allowed_ref_types(self):
+        for reftype in ['aff', 'app', 'author-notes', 'bibr', 'contrib',
+                        'corresp', 'disp-formula', 'fig', 'fn', 'sec',
+                        'supplementary-material', 'table', 'table-fn',
+                        'boxed-text']:
+            sample = u"""<article>
+                          <body>
+                            <sec>
+                              <p>
+                                <xref ref-type="%s">foo</xref>
+                              </p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % reftype
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_ref_types(self):
+        for reftype in ['chem', 'kwd', 'list', 'other', 'plate'
+                        'scheme', 'statement']:
+            sample = u"""<article>
+                          <body>
+                            <sec>
+                              <p>
+                                <xref ref-type="%s">foo</xref>
+                              </p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % reftype
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+
+
+class CaptionTests(PhaseBasedTestCase):
+    """Tests for //caption
+    """
+    sch_phase = 'phase.caption'
+
+    def test_with_title(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <fig id="f03">
+                          <label>Figura 3</label>
+                          <caption>
+                            <title>
+                              Percentual de atividade mitocondrial.
+                            </title>
+                          </caption>
+                          <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                        </fig>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_without_title(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <fig id="f03">
+                          <label>Figura 3</label>
+                          <caption>
+                            <label>
+                              Percentual de atividade mitocondrial.
+                            </label>
+                          </caption>
+                          <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                        </fig>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_title_and_more(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <fig id="f03">
+                          <label>Figura 3</label>
+                          <caption>
+                            <title>
+                              Percentual de atividade mitocondrial.
+                            </title>
+                            <label>
+                              Percentual de atividade mitocondrial.
+                            </label>
+                          </caption>
+                          <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                        </fig>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class LicenseTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/permissions/license element.
+    """
+    sch_phase = 'phase.license'
+
+    def test_missing_permissions_elem(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_license(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_license_type(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_license_type(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="closed-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_license_href(self):
+        allowed_licenses = [
+            'http://creativecommons.org/licenses/by-nc/4.0/',
+            'http://creativecommons.org/licenses/by-nc/3.0/',
+            'http://creativecommons.org/licenses/by/4.0/',
+            'http://creativecommons.org/licenses/by/3.0/',
+            'http://creativecommons.org/licenses/by-nc-nd/4.0/',
+            'http://creativecommons.org/licenses/by-nc-nd/3.0/',
+            'http://creativecommons.org/licenses/by/3.0/igo/',
+            'http://creativecommons.org/licenses/by-nc/3.0/igo/',
+            'http://creativecommons.org/licenses/by-nc-nd/3.0/igo/',
+        ]
+
+        for license in allowed_licenses:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <front>
+                            <article-meta>
+                              <permissions>
+                                <license license-type="open-access"
+                                         xlink:href="%s"
+                                         xml:lang="en">
+                                  <license-p>
+                                    This is an open-access article distributed under the terms...
+                                  </license-p>
+                                </license>
+                              </permissions>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % license
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_license_href_https_scheme(self):
+        allowed_licenses = [
+            'https://creativecommons.org/licenses/by-nc/4.0/',
+            'https://creativecommons.org/licenses/by-nc/3.0/',
+            'https://creativecommons.org/licenses/by/4.0/',
+            'https://creativecommons.org/licenses/by/3.0/',
+            'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+            'https://creativecommons.org/licenses/by-nc-nd/3.0/',
+            'https://creativecommons.org/licenses/by/3.0/igo/',
+            'https://creativecommons.org/licenses/by-nc/3.0/igo/',
+            'https://creativecommons.org/licenses/by-nc-nd/3.0/igo/',
+        ]
+
+        for license in allowed_licenses:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <front>
+                            <article-meta>
+                              <permissions>
+                                <license license-type="open-access"
+                                         xlink:href="%s"
+                                         xml:lang="en">
+                                  <license-p>
+                                    This is an open-access article distributed under the terms...
+                                  </license-p>
+                                </license>
+                              </permissions>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % license
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_license_href(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://opensource.org/licenses/MIT"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_trailing_slash(self):
+        allowed_licenses = [
+            'https://creativecommons.org/licenses/by-nc/4.0',
+        ]
+
+        for license in allowed_licenses:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <front>
+                            <article-meta>
+                              <permissions>
+                                <license license-type="open-access"
+                                         xlink:href="%s"
+                                         xml:lang="en">
+                                  <license-p>
+                                    This is an open-access article distributed under the terms...
+                                  </license-p>
+                                </license>
+                              </permissions>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % license
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_permissions_within_elements_of_the_body(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <fig id="f01">
+                              <label>Fig. 1</label>
+                              <caption>
+                                <title>título da imagem</title>
+                              </caption>
+                              <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                              <permissions>
+                                <copyright-statement>Copyright © 2014 SciELO</copyright-statement>
+                                <copyright-year>2014</copyright-year>
+                                <copyright-holder>SciELO</copyright-holder>
+                                <license license-type="open-access"
+                                         xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/"
+                                         xml:lang="en">
+                                  <license-p>This work is licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.</license-p>
+                                </license>
+                              </permissions>
+                            </fig>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_copyrighted_elements_within_the_body(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <fig id="f01">
+                              <label>Fig. 1</label>
+                              <caption>
+                                <title>título da imagem</title>
+                              </caption>
+                              <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                              <permissions>
+                                <copyright-statement>Copyright © 2014 SciELO</copyright-statement>
+                                <copyright-year>2014</copyright-year>
+                                <copyright-holder>SciELO</copyright-holder>
+                              </permissions>
+                            </fig>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_irrestrict_use_licenses_within_elements_in_the_body(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                      <body>
+                        <sec>
+                          <p>
+                            <fig id="f01">
+                              <label>Fig. 1</label>
+                              <caption>
+                                <title>título da imagem</title>
+                              </caption>
+                              <graphic xlink:href="1234-5678-rctb-45-05-0110-gf01.tif"/>
+                              <permissions>
+                                <copyright-statement>Copyright © 2014 SciELO</copyright-statement>
+                                <copyright-year>2014</copyright-year>
+                                <copyright-holder>SciELO</copyright-holder>
+                                <license license-type="open-access"
+                                         xlink:href="http://creativecommons.org/licenses/by/2.0/"
+                                         xml:lang="en">
+                                  <license-p>This is an open-access article distributed under the terms of...</license-p>
+                                </license>
+                              </permissions>
+                            </fig>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_main_article_copyright_info(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <copyright-statement>Copyright © 2014 SciELO</copyright-statement>
+                            <copyright-year>2014</copyright-year>
+                            <copyright-holder>SciELO</copyright-holder>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_lang_mismatch(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="pt">
+                              <license-p>
+                                Texto em pt-br...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_lang_mismatch_is_ignored_if_lang_is_en(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                                     xml:lang="en">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_lang_attribute(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+                      <front>
+                        <article-meta>
+                          <permissions>
+                            <license license-type="open-access"
+                                     xlink:href="http://creativecommons.org/licenses/by/4.0/">
+                              <license-p>
+                                This is an open-access article distributed under the terms...
+                              </license-p>
+                            </license>
+                          </permissions>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AckTests(PhaseBasedTestCase):
+    """Tests for article/back/ack element.
+    """
+    sch_phase = 'phase.ack'
+
+    def test_with_sec(self):
+        sample = u"""<article>
+                      <back>
+                        <ack>
+                          <sec>
+                            <p>Some</p>
+                          </sec>
+                        </ack>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_without_sec(self):
+        sample = u"""<article>
+                      <back>
+                        <ack>
+                          <title>Acknowledgment</title>
+                          <p>Some text</p>
+                        </ack>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class ElementCitationTests(PhaseBasedTestCase):
+    """Tests for article/back/ref-list/ref/element-citation element.
+    """
+    sch_phase = 'phase.element-citation'
+
+    def test_with_name_outside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <name>Foo</name>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_name_inside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group>
+                                <name>Foo</name>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_etal_outside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <etal>Foo</etal>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_etal_inside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group>
+                                <etal>Foo</etal>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_with_collab_outside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <collab>Foo</collab>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_collab_inside_persongroup(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group>
+                                <collab>Foo</collab>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_publication_types(self):
+        for pub_type in ['journal', 'book', 'webpage', 'thesis', 'confproc',
+                         'patent', 'software', 'database', 'legal-doc', 'newspaper',
+                         'other', 'report', 'data']:
+            sample = u"""<article>
+                          <back>
+                            <ref-list>
+                              <ref>
+                                <element-citation publication-type="%s">
+                                </element-citation>
+                              </ref>
+                            </ref-list>
+                          </back>
+                        </article>
+                     """ % pub_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_publication_types(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="invalid">
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_outside_ref(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <element-citation publication-type="journal">
+                              <person-group>
+                                <collab>Foo</collab>
+                              </person-group>
+                            </element-citation>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ChapterTitleTests(PhaseBasedTestCase):
+    """Tests for
+      - article/back/ref-list/ref/element-citation/chapter-title
+      - article/front/article-meta/product/chapter-title
+    """
+    sch_phase = 'phase.chapter-title'
+
+    def test_absent_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <chapter-title>Título do capítulo</chapter-title>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_twice_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <chapter-title>Título do capítulo</chapter-title>
+                              <chapter-title> Outro título do capítulo</chapter-title>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_absent_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="chapter">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="chapter">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <chapter-title>Título do capítulo do livro</chapter-title>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_present_twice_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="chapter">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <chapter-title>Título do capítulo do livro</chapter-title>
+                            <chapter-title>Outro título do capítulo do livro</chapter-title>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class PersonGroupTests(PhaseBasedTestCase):
+    """Tests for
+      - article/back/ref-list/ref/element-citation/person-group
+      - article/front/article-meta/product/person-group
+    """
+    sch_phase = 'phase.person-group'
+
+    def test_missing_type(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <person-group>
+                                <name>Foo</name>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_type_at_product(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <person-group>
+                              <name>Foo</name>
+                            </person-group>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_with_type(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <person-group person-group-type="author">
+                                <name>Foo</name>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_types(self):
+        for group_type in ['author', 'compiler', 'editor', 'translator']:
+            sample = u"""<article>
+                          <back>
+                            <ref-list>
+                              <ref>
+                                <element-citation>
+                                  <person-group person-group-type="%s">
+                                    <name>Foo</name>
+                                  </person-group>
+                                </element-citation>
+                              </ref>
+                            </ref-list>
+                          </back>
+                        </article>
+                     """ % group_type
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_type(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <person-group person-group-type="invalid">
+                                <name>Foo</name>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_loose_text_below_element_citation_node(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">HERE
+                                <collab>Foo</collab>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_loose_text_below_product_node(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <person-group person-group-type="author">HERE
+                              <collab>Foo</collab>
+                            </person-group>
+                          </product>
+                        </article-meta>
+                      </front>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <collab>Foo</collab>
+                              </person-group>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class FNGroupTests(PhaseBasedTestCase):
+    """Tests for article/back/fn-group/fn element.
+    """
+    sch_phase = 'phase.fn-group'
+
+    def test_allowed_fn_types(self):
+        for fn_type in ['abbr', 'com', 'financial-disclosure', 'supported-by',
+                'presented-at', 'supplementary-material', 'other']:
+
+            sample = u"""<article>
+                          <back>
+                            <fn-group>
+                              <fn fn-type="%s">
+                                <p>foobar</p>
+                              </fn>
+                            </fn-group>
+                          </back>
+                        </article>
+                     """ % fn_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_fn_types(self):
+        sample = u"""<article>
+                      <back>
+                        <fn-group>
+                          <fn fn-type="invalid">
+                            <p>foobar</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_group_title(self):
+        sample = u"""<article>
+                      <back>
+                        <fn-group>
+                          <title>Notes</title>
+                          <fn fn-type="other">
+                            <p>foobar</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_many_group_titles_are_not_allowed(self):
+        sample = u"""<article>
+                      <back>
+                        <fn-group>
+                          <title>Notes</title>
+                          <title>Notes again</title>
+                          <fn fn-type="other">
+                            <p>foobar</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class XHTMLTableTests(PhaseBasedTestCase):
+    """Tests for //table elements.
+    """
+    sch_phase = 'phase.xhtml-table'
+
+    def test_valid_toplevel(self):
+        for elem in ['caption', 'summary', 'col', 'colgroup', 'thead', 'tfoot', 'tbody']:
+
+            sample = u"""<article>
+                          <body>
+                            <sec>
+                              <p>
+                                <table>
+                                  <%s></%s>
+                                </table>
+                              </p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % (elem, elem)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_invalid_toplevel(self):
+        for elem in ['tr']:
+
+            sample = u"""<article>
+                          <body>
+                            <sec>
+                              <p>
+                                <table>
+                                  <%s></%s>
+                                </table>
+                              </p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % (elem, elem)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+
+    def test_tbody_upon_th(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <table>
+                              <tbody>
+                                <tr>
+                                  <th>Foo</th>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_thead_upon_th(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <table>
+                              <thead>
+                                <tr>
+                                  <th>Foo</th>
+                                </tr>
+                              </thead>
+                            </table>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_thead_upon_td(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <table>
+                              <thead>
+                                <tr>
+                                  <td>Foo</td>
+                                </tr>
+                              </thead>
+                            </table>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class SupplementaryMaterialMimetypeTests(PhaseBasedTestCase):
+    """Tests for article//supplementary-material elements.
+    """
+    sch_phase = 'phase.supplementary-material'
+
+    def test_case1(self):
+        """mimetype is True
+           mime-subtype is True
+           mimetype ^ mime-subtype is True
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <supplementary-material id="S1"
+                                                xlink:title="local_file"
+                                                xlink:href="1471-2105-1-1-s1.pdf"
+                                                mimetype="application"
+                                                mime-subtype="pdf">
+                          <label>Additional material</label>
+                          <caption>
+                            <p>Supplementary PDF file supplied by authors.</p>
+                          </caption>
+                        </supplementary-material>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_case2(self):
+        """mimetype is True
+           mime-subtype is False
+           mimetype ^ mime-subtype is False
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <supplementary-material id="S1"
+                                                xlink:title="local_file"
+                                                xlink:href="1471-2105-1-1-s1.pdf"
+                                                mimetype="application">
+                          <label>Additional material</label>
+                          <caption>
+                            <p>Supplementary PDF file supplied by authors.</p>
+                          </caption>
+                        </supplementary-material>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_case3(self):
+        """mimetype is False
+           mime-subtype is True
+           mimetype ^ mime-subtype is False
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <supplementary-material id="S1"
+                                                xlink:title="local_file"
+                                                xlink:href="1471-2105-1-1-s1.pdf"
+                                                mime-subtype="pdf">
+                          <label>Additional material</label>
+                          <caption>
+                            <p>Supplementary PDF file supplied by authors.</p>
+                          </caption>
+                        </supplementary-material>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_case4(self):
+        """mimetype is False
+           mime-subtype is False
+           mimetype ^ mime-subtype is False
+        """
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <supplementary-material id="S1"
+                                                xlink:title="local_file"
+                                                xlink:href="1471-2105-1-1-s1.pdf">
+                          <label>Additional material</label>
+                          <caption>
+                            <p>Supplementary PDF file supplied by authors.</p>
+                          </caption>
+                        </supplementary-material>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AuthorNotesFNTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/author-notes/fn element.
+    """
+    sch_phase = 'phase.fn-group'
+
+    def test_allowed_fn_types(self):
+        for fn_type in ['author', 'con', 'conflict', 'corresp', 'current-aff',
+                        'deceased', 'edited-by', 'equal', 'on-leave',
+                        'participating-researchers', 'present-address',
+                        'previously-at', 'study-group-members', 'other',
+                        'presented-at', 'presented-by']:
+
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <author-notes>
+                                <fn fn-type="%s">
+                                  <p>foobar</p>
+                                </fn>
+                              </author-notes>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % fn_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_fn_types(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <author-notes>
+                            <fn fn-type="invalid">
+                              <p>foobar</p>
+                            </fn>
+                          </author-notes>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ArticleAttributesTests(PhaseBasedTestCase):
+    """Tests for article element.
+    """
+    sch_phase = 'phase.article-attrs'
+
+    def test_allowed_article_types(self):
+        for art_type in ['addendum', 'research-article', 'review-article',
+                'letter', 'article-commentary', 'brief-report', 'rapid-communication',
+                'oration', 'discussion', 'editorial', 'interview', 'correction',
+                'guidelines', 'other', 'obituary', 'case-report', 'book-review',
+                'reply', 'retraction', 'partial-retraction', 'clinical-trial',
+                'announcement', 'calendar', 'in-brief', 'book-received', 'news',
+                'reprint', 'meeting-report', 'abstract', 'product-review',
+                'dissertation', 'translation', 'data-article']:
+
+            sample = u"""<article article-type="%s" xml:lang="en" dtd-version="1.0" specific-use="sps-1.10">
+                        </article>
+                     """ % art_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_article_type(self):
+        sample = u"""<article article-type="invalid" dtd-version="1.0" specific-use="sps-1.10">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_article_type(self):
+        sample = u"""<article xml:lang="en" dtd-version="1.0" specific-use="sps-1.10">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_xmllang(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.10">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_dtdversion(self):
+        sample = u"""<article article-type="research-article" xml:lang="en" specific-use="sps-1.10">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_sps_version(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" xml:lang="en">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_invalid_sps_version(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" xml:lang="en" specific-use="sps-1.0">
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class NamedContentTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/aff/addr-line/named-content elements.
+    """
+    sch_phase = 'phase.named-content_attrs'
+
+    def test_missing_contenttype(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <addr-line>
+                              <named-content>Foo</named-content>
+                            </addr-line>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_contenttype(self):
+        for ctype in ['city', 'state']:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <aff>
+                                <addr-line>
+                                  <named-content content-type="%s">Foo</named-content>
+                                </addr-line>
+                              </aff>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % ctype
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_contenttype(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <addr-line>
+                              <named-content content-type="invalid">Foo</named-content>
+                            </addr-line>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class MonthTests(PhaseBasedTestCase):
+    """Tests for //month elements.
+    """
+    sch_phase = 'phase.month'
+
+    def test_range_1_12(self):
+        for month in range(1, 13):
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <pub-date>
+                                <month>%s</month>
+                              </pub-date>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % month
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_range_01_12(self):
+        for month in range(1, 13):
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <pub-date>
+                                <month>%02d</month>
+                              </pub-date>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % month
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_out_of_range(self):
+        for month in [0, 13]:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <pub-date>
+                                <month>%s</month>
+                              </pub-date>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % month
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+
+    def test_must_be_integer(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <pub-date>
+                            <month>January</month>
+                          </pub-date>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_is_present_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <month>02</month>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_is_present_twice_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <month>02</month>
+                              <month>02</month>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_is_absent_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class SizeTests(PhaseBasedTestCase):
+    """Tests for:
+      - article/front/article-meta/product/size
+      - article/back/ref-list/ref/element-citation/size
+    """
+    sch_phase = 'phase.size'
+
+    def test_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <size units="pages">2</size>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_in_product(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <size units="pages">2</size>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_in_product(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_twice_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <size units="pages">2</size>
+                              <size units="pages">2</size>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_twice_in_product(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <size units="pages">2</size>
+                            <size units="pages">2</size>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_units_in_product(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <size>2</size>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_units_in_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation>
+                              <size>2</size>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_invalid_units_value(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <product>
+                            <size units="invalid">2</size>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ListTests(PhaseBasedTestCase):
+    """Tests for list elements.
+    """
+    sch_phase = 'phase.list'
+
+    def test_allowed_list_type(self):
+        for list_type in ['order', 'bullet', 'alpha-lower', 'alpha-upper',
+                          'roman-lower', 'roman-upper', 'simple']:
+            sample = u"""<article>
+                          <body>
+                            <sec>
+                              <p>
+                                <list list-type="%s">
+                                  <title>Lista Númerica</title>
+                                  <list-item>
+                                    <p>Nullam gravida tellus eget condimentum egestas.</p>
+                                  </list-item>
+                                  <list-item>
+                                    <list list-type="%s">
+                                      <list-item>
+                                        <p>Curabitur luctus lorem ac feugiat pretium.</p>
+                                      </list-item>
+                                    </list>
+                                  </list-item>
+                                  <list-item>
+                                    <p>Donec pulvinar odio ut enim lobortis, eu dignissim elit accumsan.</p>
+                                  </list-item>
+                                </list>
+                              </p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % (list_type, list_type)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_list_type(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <list list-type="invalid">
+                              <title>Lista Númerica</title>
+                              <list-item>
+                                <p>Nullam gravida tellus eget condimentum egestas.</p>
+                              </list-item>
+                              <list-item>
+                                <list list-type="invalid">
+                                  <list-item>
+                                    <p>Curabitur luctus lorem ac feugiat pretium.</p>
+                                  </list-item>
+                                </list>
+                              </list-item>
+                              <list-item>
+                                <p>Donec pulvinar odio ut enim lobortis, eu dignissim elit accumsan.</p>
+                              </list-item>
+                            </list>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_disallowed_sub_list_type(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <list list-type="order">
+                              <title>Lista Númerica</title>
+                              <list-item>
+                                <p>Nullam gravida tellus eget condimentum egestas.</p>
+                              </list-item>
+                              <list-item>
+                                <list list-type="invalid">
+                                  <list-item>
+                                    <p>Curabitur luctus lorem ac feugiat pretium.</p>
+                                  </list-item>
+                                </list>
+                              </list-item>
+                              <list-item>
+                                <p>Donec pulvinar odio ut enim lobortis, eu dignissim elit accumsan.</p>
+                              </list-item>
+                            </list>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_list_type(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <list>
+                              <title>Lista Númerica</title>
+                              <list-item>
+                                <p>Nullam gravida tellus eget condimentum egestas.</p>
+                              </list-item>
+                              <list-item>
+                                <list>
+                                  <list-item>
+                                    <p>Curabitur luctus lorem ac feugiat pretium.</p>
+                                  </list-item>
+                                </list>
+                              </list-item>
+                              <list-item>
+                                <p>Donec pulvinar odio ut enim lobortis, eu dignissim elit accumsan.</p>
+                              </list-item>
+                            </list>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_sub_list_type(self):
+        sample = u"""<article>
+                      <body>
+                        <sec>
+                          <p>
+                            <list list-type="order">
+                              <title>Lista Númerica</title>
+                              <list-item>
+                                <p>Nullam gravida tellus eget condimentum egestas.</p>
+                              </list-item>
+                              <list-item>
+                                <list>
+                                  <list-item>
+                                    <p>Curabitur luctus lorem ac feugiat pretium.</p>
+                                  </list-item>
+                                </list>
+                              </list-item>
+                              <list-item>
+                                <p>Donec pulvinar odio ut enim lobortis, eu dignissim elit accumsan.</p>
+                              </list-item>
+                            </list>
+                          </p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class MediaTests(PhaseBasedTestCase):
+    """Tests for article/body//p/media elements.
+    """
+    sch_phase = 'phase.media_attributes'
+
+    def test_missing_mimetype(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <p><media mime-subtype="mp4" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_mime_subtype(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <p><media mimetype="video" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_href(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <p><media mimetype="video" mime-subtype="mp4"/></p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_all_present(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <p><media mimetype="video" mime-subtype="mp4" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+
+class ExtLinkTests(PhaseBasedTestCase):
+    """Tests for ext-link elements.
+    """
+    sch_phase = 'phase.ext-link'
+
+    def test_complete(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link ext-link-type="uri" xlink:href="http://www.scielo.org">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_allowed_extlinktype(self):
+        for link_type in ['uri', 'clinical-trial' ]:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <body>
+                            <sec>
+                              <p>Neque porro quisquam est <ext-link ext-link-type="%s" xlink:href="http://www.scielo.org">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                            </sec>
+                          </body>
+                        </article>
+                     """ % link_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_extlinktype(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link ext-link-type="invalid" xlink:href="http://www.scielo.org">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_extlinktype(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link xlink:href="http://www.scielo.org">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_xlinkhref(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link ext-link-type="uri">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_uri_without_scheme(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link ext-link-type="uri" xlink:href="www.scielo.org">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_file_scheme_is_not_allowed(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <body>
+                        <sec>
+                          <p>Neque porro quisquam est <ext-link ext-link-type="uri" xlink:href="file:///etc/passwd">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                        </sec>
+                      </body>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_commonly_used_uri_schemes(self):
+        for uri in ['ftp://ftp.scielo.org', 'http://www.scielo.org', 'urn:foo:bar']:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                          <body>
+                            <sec>
+                              <p>Neque porro quisquam est <ext-link ext-link-type="uri" xlink:href="{uri}">www.scielo.org</ext-link> qui dolorem ipsum quia</p>
+                            </sec>
+                          </body>
+                        </article>
+                     """.format(uri=uri)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+
+class SubArticleAttributesTests(PhaseBasedTestCase):
+    """Tests for sub-article element.
+    """
+    sch_phase = 'phase.sub-article-attrs'
+
+    def test_allowed_article_types(self):
+        for art_type in ['abstract', 'letter', 'reply', 'translation']:
+            sample = u"""<article article-type="research-article" xml:lang="en" dtd-version="1.0" specific-use="sps-1.10">
+                           <sub-article article-type="%s" xml:lang="pt" id="sa1"></sub-article>
+                         </article>
+                     """ % art_type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_article_type(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.10">
+                       <sub-article article-type="invalid" xml:lang="pt" id="trans_pt"></sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_article_type(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.10">
+                       <sub-article xml:lang="pt" id="trans_pt"></sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_xmllang(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.10">
+                       <sub-article article-type="translation" id="trans_pt"></sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_id(self):
+        sample = u"""<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.10">
+                       <sub-article article-type="translation" xml:lang="pt"></sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ResponseAttributesTests(PhaseBasedTestCase):
+    """Tests for response element.
+    """
+    sch_phase = 'phase.response-attrs'
+
+    def test_allowed_response_types(self):
+        for type in ['addendum', 'discussion', 'reply']:
+            sample = u"""<article>
+                           <response response-type="%s" xml:lang="pt" id="r1"></response>
+                         </article>
+                     """ % type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_response_type(self):
+        sample = u"""<article>
+                       <response response-type="invalid" xml:lang="pt" id="r1"></response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_response_type(self):
+        sample = u"""<article>
+                       <response xml:lang="pt" id="r1"></response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_xmllang(self):
+        sample = u"""<article>
+                       <response response-type="invalid" id="r1"></response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_id(self):
+        sample = u"""<article>
+                       <response response-type="invalid" xml:lang="pt"></response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ResponseReplyAttributeTests(PhaseBasedTestCase):
+    """Tests for response[@response-type='reply'] elements.
+    """
+    sch_phase = 'phase.response-reply-type'
+
+    def test_reply_type_demands_an_article_type(self):
+        """ the article-type of value `article-commentary` is required
+        """
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" vol="109" page="87-92"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_reply_with_article_types_different_than_article_commentary(self):
+        """ anything different from `article-commentary` is now valid (03/2018)
+        """
+        sample = u"""<article article-type="research-article">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" vol="109" page="87-92"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_reply_type_missing_related_article(self):
+        """ the article-type of value `article-commentary` is not required anymore
+        """
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_related_article_missing_vol(self):
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" page="87-92"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_article_missing_page(self):
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" vol="109" elocation-id="1q2w"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_related_article_missing_elocationid(self):
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" vol="109" page="87-92"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_related_article_missing_page_and_elocationid(self):
+        sample = u"""<article article-type="article-commentary">
+                       <response response-type="reply" xml:lang="pt" id="r1">
+                         <front-stub>
+                           <related-article related-article-type="commentary-article" id="ra1" vol="109"/>
+                         </front-stub>
+                       </response>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class RelatedArticleTypesTests(PhaseBasedTestCase):
+    """Tests for related-article element.
+    """
+    sch_phase = 'phase.related-article-attrs'
+
+    def test_allowed_related_article_types(self):
+        for type in ['corrected-article', 'commentary-article',
+                     'letter', 'partial-retraction', 'retracted-article']:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                           <front>
+                             <article-meta>
+                               <related-article related-article-type="%s" id="01" ext-link-type="doi" xlink:href="foo"/>
+                             </article-meta>
+                           </front>
+                         </article>
+                     """ % type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_related_article_type(self):
+        sample = u"""<article>
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="invalid" id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_id(self):
+        sample = u"""<article>
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_related_article_type(self):
+        sample = u"""<article>
+                       <front>
+                         <article-meta>
+                           <related-article id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_allowed_ext_link_types(self):
+        for type in ['doi']:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                           <front>
+                             <article-meta>
+                               <related-article related-article-type="corrected-article" id="01" ext-link-type="%s" xlink:href="foo"/>
+                             </article-meta>
+                           </front>
+                         </article>
+                     """ % type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_invalid_ext_link_types(self):
+        for type in ['invalid',]:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                           <front>
+                             <article-meta>
+                               <related-article related-article-type="corrected-article" id="01" ext-link-type="%s" xlink:href="foo"/>
+                             </article-meta>
+                           </front>
+                         </article>
+                     """ % type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+
+    def test_missing_ext_link_type_on_corrected_articles(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article" id="01" xlink:href="foo"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_xlinkhref_on_corrected_articles(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article" id="01" ext-link-type="corrected-article"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class CorrectionTests(PhaseBasedTestCase):
+    """Tests for article[@article-type="correction"] element.
+    """
+    sch_phase = 'phase.correction'
+
+    def test_expected_elements(self):
+        sample = u"""<article article-type="correction">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article" id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_related_article(self):
+        """ must have a related-article[@related-article-type='corrected-article']
+        element.
+        """
+        sample = u"""<article article-type="correction">
+                       <front>
+                         <article-meta>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_article_type_must_be_correction(self):
+        sample = u"""<article article-type="research-article">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="corrected-article" id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class InBriefTests(PhaseBasedTestCase):
+    """Tests for article[@article-type="in-brief"] element.
+    """
+    sch_phase = 'phase.in-brief'
+
+    def test_expected_elements(self):
+        sample = u"""<article article-type="in-brief">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="article-reference" id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_related_article(self):
+        """ must have a related-article[@related-article-type='in-brief']
+        element.
+        """
+        sample = u"""<article article-type="in-brief">
+                       <front>
+                         <article-meta>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_article_type_must_be_in_brief(self):
+        sample = u"""<article article-type="research-article">
+                       <front>
+                         <article-meta>
+                           <related-article related-article-type="article-reference" id="01"/>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class FundingGroupTests(PhaseBasedTestCase):
+    """Tests for article/front/article-meta/funding-group elements.
+    """
+    sch_phase = 'phase.funding-group'
+
+    def test_funding_statement_when_fn_is_present_missing_award_group(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <funding-group>
+                            <funding-statement>This study was supported by FAPEST #12345</funding-statement>
+                          </funding-group>
+                        </article-meta>
+                      </front>
+                      <back>
+                        <fn-group>
+                          <fn id="fn01" fn-type="financial-disclosure">
+                            <p>This study was supported by FAPEST #12345</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_funding_statement_when_fn_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <funding-group>
+                            <award-group>
+                              <funding-source>FAPEST</funding-source>
+                              <award-id>12345</award-id>
+                            </award-group>
+                            <funding-statement>This study was supported by FAPEST #12345</funding-statement>
+                          </funding-group>
+                        </article-meta>
+                      </front>
+                      <back>
+                        <fn-group>
+                          <fn id="fn01" fn-type="financial-disclosure">
+                            <p>This study was supported by FAPEST #12345</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_funding_statement_when_fn_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <funding-group>
+                            <award-group>
+                              <funding-source>FAPEST</funding-source>
+                              <award-id>12345</award-id>
+                            </award-group>
+                          </funding-group>
+                        </article-meta>
+                      </front>
+                      <back>
+                        <fn-group>
+                          <fn id="fn01" fn-type="financial-disclosure">
+                            <p>This study was supported by FAPEST #12345</p>
+                          </fn>
+                        </fn-group>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AffCountryTests(PhaseBasedTestCase):
+    """ //aff/country/@country is required.
+
+    See: https://github.com/scieloorg/packtools/issues/44
+    """
+    sch_phase = 'phase.aff_country'
+
+    def test_country_attribute_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="BR">Brasil</country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_country_attribute_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country>Brasil</country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_country_attribute_value_is_not_validated(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="XZ">Brasil</country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_country_cannot_be_empty(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="XZ"></country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_country_cannot_be_empty_closed_element(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="XZ"/>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class RefTests(PhaseBasedTestCase):
+    """Tests for article/back/ref-list/ref element.
+    """
+    sch_phase = 'phase.ref'
+
+    def test_element_and_mixed_citation_elements(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_element_citation_cannot_be_present_twice(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_element_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_mixed_citation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_mixed_citation_cannot_be_empty(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation></mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class ContribIdTests(PhaseBasedTestCase):
+    """Tests for contrib-id element.
+    """
+    sch_phase = 'phase.contrib-id'
+
+    def test_allowed_contrib_id_type_attrs(self):
+        for type in ['lattes', 'orcid', 'researchid', 'scopus']:
+            sample = u"""<article>
+                           <front>
+                             <article-meta>
+                               <contrib-group>
+                                 <contrib-id contrib-id-type="%s">some id</contrib-id>
+                                 <aff>
+                                   <institution content-type="original">
+                                     Grupo de ...
+                                   </institution>
+                                   <institution content-type="orgname">
+                                     Instituto de Matematica e Estatistica
+                                   </institution>
+                                 </aff>
+                               </contrib-group>
+                             </article-meta>
+                           </front>
+                         </article>
+                     """ % type
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_disallowed_related_article_type(self):
+        sample = u"""<article>
+                       <front>
+                         <article-meta>
+                           <contrib-group>
+                             <contrib-id contrib-id-type="invalid">some id</contrib-id>
+                             <aff>
+                               <institution content-type="original">
+                                 Grupo de ...
+                               </institution>
+                               <institution content-type="orgname">
+                                 Instituto de Matematica e Estatistica
+                               </institution>
+                             </aff>
+                           </contrib-group>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_missing_contrib_id_type(self):
+        sample = u"""<article>
+                       <front>
+                         <article-meta>
+                           <contrib-group>
+                             <contrib-id>some id</contrib-id>
+                             <aff>
+                               <institution content-type="original">
+                                 Grupo de ...
+                               </institution>
+                               <institution content-type="orgname">
+                                 Instituto de Matematica e Estatistica
+                               </institution>
+                             </aff>
+                           </contrib-group>
+                         </article-meta>
+                       </front>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class AffTests(PhaseBasedTestCase):
+    """ /article//aff is required.
+    """
+    sch_phase = 'phase.aff'
+
+    def test_country_is_present(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="BR">Brasil</country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_country_is_absent(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_country_is_absent_in_subarticle(self):
+        for typ in ['abstract', 'letter', 'reply']:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <aff>
+                                <institution content-type="original">
+                                  Grupo de ...
+                                </institution>
+                                <country country="BR">Brasil</country>
+                              </aff>
+                            </article-meta>
+                          </front>
+                          <sub-article article-type="{type}"
+                                       xml:lang="en"
+                                       id="s1">
+                            <front-stub>
+                              <article-categories>
+                                <subj-group subj-group-type="heading">
+                                  <subject>Artigos Originais</subject>
+                                </subj-group>
+                              </article-categories>
+                              <aff>
+                                <institution content-type="original">
+                                  Grupo de ...
+                                </institution>
+                              </aff>
+                            </front-stub>
+                          </sub-article>
+                        </article>
+                     """.format(type=typ)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_country_is_absent_in_subarticle_type_translation(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                            <country country="BR">Brasil</country>
+                          </aff>
+                        </article-meta>
+                      </front>
+                      <sub-article article-type="translation"
+                                   xml:lang="en"
+                                   id="s1">
+                        <front-stub>
+                          <article-categories>
+                            <subj-group subj-group-type="heading">
+                              <subject>Artigos Originais</subject>
+                            </subj-group>
+                          </article-categories>
+                          <aff>
+                            <institution content-type="original">
+                              Grupo de ...
+                            </institution>
+                          </aff>
+                        </front-stub>
+                      </sub-article>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+class SourceTests(PhaseBasedTestCase):
+    """Tests for article//source element.
+    """
+    sch_phase = 'phase.source'
+
+    def test_source_is_absent_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_source_is_present_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_source_is_present_more_than_once_in_elementcitation(self):
+        sample = u"""<article>
+                      <back>
+                        <ref-list>
+                          <ref>
+                            <mixed-citation>Aires M, Paz AA, Perosa CT. Situação de saúde e grau de dependência de pessoas idosas institucionalizadas. <italic>Rev Gaucha Enferm.</italic> 2009;30(3):192-9.</mixed-citation>
+                            <element-citation publication-type="journal">
+                              <person-group person-group-type="author">
+                                <name>
+                                  <surname>Aires</surname>
+                                  <given-names>M</given-names>
+                                </name>
+                                <name>
+                                  <surname>Paz</surname>
+                                  <given-names>AA</given-names>
+                                </name>
+                                <name>
+                                  <surname>Perosa</surname>
+                                  <given-names>CT</given-names>
+                                </name>
+                              </person-group>
+                              <article-title>Situação de saúde e grau de dependência de pessoas idosas institucionalizadas</article-title>
+                              <source>Rev Gaucha Enferm</source>
+                              <source>Rev Gaucha Foo</source>
+                              <year>2009</year>
+                              <volume>30</volume>
+                              <issue>3</issue>
+                              <fpage>192</fpage>
+                              <lpage>199</lpage>
+                            </element-citation>
+                          </ref>
+                        </ref-list>
+                      </back>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_source_is_absent_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_source_is_present_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_source_is_present_more_than_once_in_product(self):
+        sample = u"""<article article-type="book-review">
+                      <front>
+                        <article-meta>
+                          <product product-type="book">
+                            <person-group person-group-type="author">
+                              <name>
+                                <surname>Sobrenome do autor</surname>
+                                <given-names>Prenomes do autor</given-names>
+                              </name>
+                            </person-group>
+                            <source>Título do livro</source>
+                            <source>Título do livro</source>
+                            <year>Ano de publicação</year>
+                            <publisher-name>Nome da casa publicadora/Editora</publisher-name>
+                            <publisher-loc>Local de publicação</publisher-loc>
+                            <page-count count="total de paginação do livro (opcional)"/>
+                            <isbn>ISBN do livro, se houver</isbn>
+                            <inline-graphic>1234-5678-rctb-45-05-690-gf01.tif</inline-graphic>
+                          </product>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -1180,7 +1180,7 @@ class KwdGroupLangTests(PhaseBasedTestCase):
     """
     sch_phase = 'phase.kwd-group_lang'
 
-    def test_single_occurence(self):
+    def test_single_occurence_without_lang(self):
         sample = u"""<article>
                       <front>
                         <article-meta>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validação do conjunto de URLs parte da taxonomia CRedIT para SciELO PS 1.10.

#### Onde a revisão poderia começar?
Sugiro o módulo de testes.

#### Como este poderia ser testado manualmente?
Será necessário obter um XML SciELO PS, se assegurar que a versão em `article[@specific-use = 'sps-1.10']`, e manipular os valores de `contrib/role/@content-type`.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#218 

### Referências
https://github.com/scieloorg/scielo_publishing_schema/blob/3b9184bf185fe43c0a134e0da618ddfcf46c4f40/docs/source/narr/taxonomia-credit.rst

