### PR TITLE
Otimizador de pacotes SPS para WEB

### DIFF
--- a/packtools/__init__.py
+++ b/packtools/__init__.py
@@ -9,7 +9,7 @@ import platform
 from lxml import etree
 
 from .domain import XMLValidator, HTMLGenerator
-from .utils import XML
+from .utils import XML, SPPackage
 from .version import __version__
 
 
@@ -19,6 +19,7 @@ __all__ = [
     '__version__',
     'get_debug_info',
     'HTMLGenerator',
+    'SPPackage',
 ]
 
 

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -7,7 +7,31 @@
     version="1.0">
     
     <xsl:template match="alternatives">
-        <xsl:apply-templates select="*[name()!='graphic'][1]"></xsl:apply-templates>
+        <xsl:choose>
+            <xsl:when test="inline-graphic[@specific-use='scielo-web']">
+                <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" />
+            </xsl:when>
+            <xsl:when test="graphic[@specific-use='scielo-web']">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[name()!='graphic'][1]"></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="alternatives" mode="file-location">
+        <xsl:choose>
+            <xsl:when test="inline-graphic[@specific-use='scielo-web']">
+                <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" mode="file-location"/>
+            </xsl:when>
+            <xsl:when test="graphic[@specific-use='scielo-web']">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" mode="file-location" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[name()!='graphic'][1]" mode="file-location"></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
    
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -34,6 +34,26 @@
         </div>
     </xsl:template>
 
+    <xsl:template match="fig[.//graphic]">
+        <xsl:variable name="location">
+            <xsl:apply-templates select="alternatives | graphic" mode="file-location"></xsl:apply-templates>
+        </xsl:variable>
+        <div class="row fig" id="{@id}">
+            <a name="{@id}"></a>
+            <div class="col-md-4 col-sm-4">
+                <a href="" data-toggle="modal" data-target="#ModalFig{@id}">
+                    <div class="thumb" style="background-image: url({$location});">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-8 col-sm-8">
+                <xsl:apply-templates select="." mode="label-caption-thumb"></xsl:apply-templates>
+            </div>
+        </div>
+    </xsl:template>
+
     <xsl:template match="abstract[@abstract-type='graphical']//fig[graphic]">
         <xsl:variable name="location">
             <xsl:apply-templates select="." mode="file-location"></xsl:apply-templates>
@@ -65,7 +85,7 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="*[graphic]" mode="file-location"><xsl:apply-templates select="graphic/@xlink:href"/></xsl:template>
+    <xsl:template match="fig[graphic]" mode="file-location"><xsl:apply-templates select="graphic" mode="file-location"/></xsl:template>
 
     <xsl:template match="fig-group" mode="label-caption">
         <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="label-caption"></xsl:apply-templates>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
@@ -21,6 +21,10 @@
 		<span class="label"><xsl:value-of select="."/></span>
 	</xsl:template>
 
+    <xsl:template match="disp-formula[alternatives]" mode="file-location">
+        <xsl:apply-templates select="alternatives" />
+    </xsl:template>
+
     <xsl:template match="tex-math">
         <span class="formula-body">
             <xsl:choose>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-graphic.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-graphic.xsl
@@ -29,6 +29,8 @@
         -->
     </xsl:template>
 
+    <xsl:template match="graphic | inline-graphic" mode="file-location"><xsl:apply-templates select="@xlink:href"/></xsl:template>
+
     <xsl:template match="graphic/@xlink:href | inline-graphic/@xlink:href">
         <xsl:variable name="s"><xsl:value-of select="substring(.,string-length(.)-4)"/></xsl:variable>
         <xsl:variable name="ext"><xsl:if test="contains($s,'.')">.<xsl:value-of select="substring-after($s,'.')"/></xsl:if></xsl:variable>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
@@ -45,6 +45,9 @@
     <xsl:template match="table-wrap/label">
         <strong><xsl:apply-templates></xsl:apply-templates> </strong>
     </xsl:template>
+    <xsl:template match="table-wrap[alternatives]">
+        <xsl:apply-templates select="alternatives" />
+    </xsl:template>
     <xsl:template match="table-wrap-foot">
         <div class="ref-list">
             <ul class="refList footnote">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
@@ -31,7 +31,7 @@
                         <h4 class="modal-title"><span class="sci-ico-fileFigure"></span> <xsl:apply-templates select="." mode="label-caption"></xsl:apply-templates></h4>                 
                     </div>
                     <div class="modal-body">
-                        <xsl:apply-templates select="graphic"/>
+                        <xsl:apply-templates select="alternatives | graphic"/>
                         <xsl:apply-templates select="disp-formula"></xsl:apply-templates>
                         <xsl:apply-templates select="attrib"></xsl:apply-templates>
                     </div>

--- a/packtools/exceptions.py
+++ b/packtools/exceptions.py
@@ -2,6 +2,7 @@ class PacktoolsError(Exception):
     """ The root of all evil in this lib.
     """
 
+
 class XMLDoctypeError(PacktoolsError, TypeError):
     """ To handle missing or unsupported DOCTYPE definitions.
     """
@@ -19,4 +20,14 @@ class UndefinedDTDError(PacktoolsError, TypeError):
 
 class HTMLGenerationError(PacktoolsError):
     """ Generic errors during HTML generation phase.
+    """
+
+
+class SPPackageError(PacktoolsError):
+    """ Generic errors during SP Package optimisation.
+    """
+
+
+class XMLWebOptimiserError(SPPackageError):
+    """ Generic errors during XML WEB optimisation.
     """

--- a/packtools/package_optimiser.py
+++ b/packtools/package_optimiser.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+import os
+import pkg_resources
+import argparse
+import logging
+import sys
+
+import packtools
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@packtools.utils.config_xml_catalog
+def main():
+
+    packtools_version = pkg_resources.get_distribution("packtools").version
+
+    parser = argparse.ArgumentParser(description="WEB Images generator CLI utility")
+    parser.add_argument("SPPackage", help="SP Package Zip file path.")
+    parser.add_argument(
+        "New_SPPackage", nargs="?", default='', help="Optimised SP Package Zip file path."
+    )
+    parser.add_argument(
+        '--preservefiles',
+        action='store_true',
+        help='preserve extracted and optimised files in aux directory',
+    )
+    parser.add_argument("--version", action="version", version=packtools_version)
+    parser.add_argument("--loglevel", default="WARNING")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.loglevel.upper()))
+
+    print("Please wait, this may take a while...", file=sys.stderr)
+
+    if len(args.New_SPPackage) > 0:
+        new_package_file_path = args.New_SPPackage
+    else:
+        new_package_file_path = os.path.splitext(args.SPPackage)[0] + "_optimised.zip"
+
+    package = packtools.SPPackage.from_file(
+        args.SPPackage, os.path.splitext(args.SPPackage)[0]
+    )
+    package.optimise(
+        new_package_file_path=new_package_file_path, preserve_files=args.preservefiles
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ speaklater==1.3
 text-unidecode==1.2
 Werkzeug==0.15.6
 WTForms==2.2.1
+Pillow==6.2.2

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ if int(setuptools.__version__.split('.', 1)[0]) < 18:
 else:
     EXTRAS_REQUIRE[':python_version<"3.4"'] = ['pathlib>=1.0.1']
 
+if sys.version_info[0:2] == (2, 7):
+    TESTS_REQUIRE.append('mock')
 
 setup(
     name="packtools",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ with open('packtools/version.py') as fp:
 INSTALL_REQUIRES = [
     'lxml>=3.4.0',
     'picles.plumber>=0.11',
+    'Pillow~=6.2',
 ]
 
 
@@ -85,6 +86,7 @@ setup(
         "console_scripts":[
             "stylechecker=packtools.stylechecker:main",
             "htmlgenerator=packtools.htmlgenerator:main",
+            "package_optimiser=packtools.package_optimiser:main",
         ]
     }
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,13 @@ import shutil
 
 from PIL import Image
 
-from packtools import utils
+from packtools import utils, exceptions
+
+
+try:
+    from unittest import mock
+except:
+    import mock
 
 
 BASE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -266,7 +272,51 @@ class TestXMLWebOptimiser(unittest.TestCase):
             image_filename, image_element = image
             self.assertEqual(expected_filename, image_filename)
 
-    def test_get_optimised_xml(self):
+    @mock.patch("packtools.utils.LOGGER")
+    def test_get_optimised_xml_get_image_error(self, MockLogger):
+        def mock_get_optimised_image(filename):
+            if "1234-5678-rctb-45-05-0110-e02.tiff" in filename:
+                raise exceptions.SPPackageError(
+                    "Error reading 1234-5678-rctb-45-05-0110-e02.tiff"
+                )
+            return os.path.splitext(filename)[0] + ".png"
+
+        def mock_get_image_thumbnail(filename):
+            if "1234-5678-rctb-45-05-0110-e01.tif" in filename:
+                raise exceptions.SPPackageError(
+                    "Error reading 1234-5678-rctb-45-05-0110-e01.tif"
+                )
+            return os.path.splitext(filename)[0] + ".thumbnail.jpg"
+
+        expected = [
+            ("1234-5678-rctb-45-05-0110-e01.png",),
+            (
+                "1234-5678-rctb-45-05-0110-gf03.png",
+                "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
+            ),
+            ("1234-5678-rctb-45-05-0110-e04.png",),
+        ]
+        xml_result = self.xml_web_optimiser.get_optimised_xml(
+            mock_get_optimised_image, mock_get_image_thumbnail
+        )
+        MockLogger.error.assert_any_call(
+            "Error optimising image: %s",
+            "Error reading 1234-5678-rctb-45-05-0110-e02.tiff",
+        )
+        MockLogger.error.assert_any_call(
+            "Error creating image thumbnail: %s",
+            "Error reading 1234-5678-rctb-45-05-0110-e01.tif",
+        )
+        for alternatives, expected_files in zip(
+            xml_result.findall("//alternatives"), expected
+        ):
+            path = './graphic[@specific-use="scielo-web"]|./inline-graphic[@specific-use="scielo-web"]'
+            for image, expected_href in zip(alternatives.xpath(path), expected_files):
+                self.assertEqual(
+                    image.attrib["{http://www.w3.org/1999/xlink}href"], expected_href
+                )
+
+    def test_get_optimised_xml_ok(self):
         def mock_get_optimised_image(filename):
             return os.path.splitext(filename)[0] + ".png"
 
@@ -289,12 +339,12 @@ class TestXMLWebOptimiser(unittest.TestCase):
             mock_get_optimised_image, mock_get_image_thumbnail
         )
         for alternatives, expected_files in zip(
-            xml_result.findall('//alternatives'), expected
+            xml_result.findall("//alternatives"), expected
         ):
             path = './graphic[@specific-use="scielo-web"]|./inline-graphic[@specific-use="scielo-web"]'
             for image, expected_href in zip(alternatives.xpath(path), expected_files):
                 self.assertEqual(
-                    image.attrib["{http://www.w3.org/1999/xlink}href"], expected_href,
+                    image.attrib["{http://www.w3.org/1999/xlink}href"], expected_href
                 )
 
 
@@ -386,6 +436,16 @@ class TestSPPackage(unittest.TestCase):
             self.assertEqual(
                 image_element.attrib["{http://www.w3.org/1999/xlink}href"],
                 expected_href,
+            )
+
+    def test_optimise_image_raises_error_if_error_extracting_file(self):
+        inexistent_file = "inexistent_file.tiff"
+        web_image_generator = utils.WebImageGenerator(
+            "inexistent_file.tiff", self.extracted_package
+        )
+        with self.assertRaises(exceptions.SPPackageError) as exc_info:
+            self.sp_package._optimise_image(
+                inexistent_file, web_image_generator.convert2png
             )
 
     def test_optimise_creates_optimised_zip(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,52 @@
 from __future__ import unicode_literals
 import unittest
 import zipfile
-from tempfile import NamedTemporaryFile
+import tempfile
+import os
+import io
+import shutil
+
+from PIL import Image
 
 from packtools import utils
+
+
+BASE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<article xmlns:xlink="http://www.w3.org/1999/xlink"
+     dtd-version="1.0"
+     article-type="research-article"
+     xml:lang="en">
+<front>
+<article-meta>
+</article-meta>
+</front>
+<body>
+<sec>
+  <p>The Eh measurements... <xref ref-type="disp-formula" rid="e01">equation 1</xref>(in mV):</p>
+  <disp-formula id="e01">
+    <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>
+  </disp-formula>
+  <p>We also used an... <inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>.</p>
+</sec>
+<fig id="f03">
+    <label>Fig. 3</label>
+    <caption>
+        <title>titulo da imagem</title>
+    </caption>
+    <alternatives>
+        <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.tiff"/>
+        <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.png" specific-use="scielo-web"/>
+        <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+    </alternatives>
+</fig>
+<p>We also used an ... based on the equation:<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e04.tif"/>.</p>
+</body>
+</article>"""
+
+
+def create_image_file(filename, format):
+    new_image = Image.new("RGB", (50, 50))
+    new_image.save(filename, format)
 
 
 class CachedMethodTests(unittest.TestCase):
@@ -55,7 +98,7 @@ class CachedMethodTests(unittest.TestCase):
 class XrayTests(unittest.TestCase):
 
     def _make_test_archive(self, arch_data):
-        fp = NamedTemporaryFile()
+        fp = tempfile.NamedTemporaryFile()
         with zipfile.ZipFile(fp, 'w') as zipfp:
             for archive, data in arch_data:
                 zipfp.writestr(archive, data)
@@ -139,3 +182,117 @@ class ResolveSchematronFilepathTests(unittest.TestCase):
         self.assertRaises(ValueError, 
                 lambda: utils.resolve_schematron_filepath(path))
 
+
+class TestWebImageGenerator(unittest.TestCase):
+    def setUp(self):
+        self.extracted_package = tempfile.mkdtemp(".")
+        image_files = (
+            ("image_tiff_1.tiff", "TIFF"),
+            ("image_tiff_2.tif", "TIFF"),
+            ("image_jpg_3.jpg", "JPEG"),
+        )
+        for image_filename, format in image_files:
+            image_file_path = os.path.join(self.extracted_package, image_filename)
+            create_image_file(image_file_path, format)
+
+    def tearDown(self):
+        shutil.rmtree(self.extracted_package)
+
+    def test_create_WebImageGenerator(self):
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_1.tiff", self.extracted_package
+        )
+        self.assertEqual(
+            web_image_generator.image_file_path,
+            os.path.join(self.extracted_package, "image_tiff_1.tiff"),
+        )
+
+    def test_convert2png(self):
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_2.tif", self.extracted_package
+        )
+        web_image_generator.convert2png()
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.extracted_package,
+                    os.path.splitext("image_tiff_2.tif")[0] + ".png",
+                )
+            )
+        )
+
+    def test_create_thumbnail(self):
+        filename = os.path.join(self.extracted_package, "image_tiff_1.png")
+        create_image_file(filename, "PNG")
+
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_1.png", self.extracted_package
+        )
+        web_image_generator.create_thumbnail()
+        thumbnail_filename = os.path.splitext(filename)[0] + ".thumbnail.jpg"
+        self.assertTrue(os.path.exists(thumbnail_filename))
+
+
+class TestXMLWebOptimiser(unittest.TestCase):
+    def setUp(self):
+        self.xml_file = utils.XML(io.BytesIO(BASE_XML))
+        self.xml_filename = "1234-5678-rctb-45-05-0110.xml"
+        self.xml_web_optimiser = utils.XMLWebOptimiser(self.xml_file, self.xml_filename)
+
+    def test_create_XMLWebOptimiser(self):
+        self.assertEqual(self.xml_web_optimiser.xml_file, self.xml_file)
+        self.assertEqual(self.xml_web_optimiser.xml_filename, self.xml_filename)
+
+    def test_get_all_images_to_optimise(self):
+        images = self.xml_web_optimiser._get_all_images_to_optimise()
+        expected = [
+            "1234-5678-rctb-45-05-0110-e01.tif",
+            "1234-5678-rctb-45-05-0110-e02.tiff",
+            "1234-5678-rctb-45-05-0110-e04.tif",
+        ]
+        result = [image for image in images]
+        self.assertEqual(len(result), len(expected))
+        for image, expected_filename in zip(result, expected):
+            image_filename, image_element = image
+            self.assertEqual(expected_filename, image_filename)
+
+    def test_get_all_images_to_thumbnail(self):
+        images = self.xml_web_optimiser._get_all_images_to_thumbnail()
+
+        expected = ["1234-5678-rctb-45-05-0110-e01.tif"]
+        result = [image for image in images]
+        self.assertEqual(len(result), len(expected))
+        for image, expected_filename in zip(result, expected):
+            image_filename, image_element = image
+            self.assertEqual(expected_filename, image_filename)
+
+    def test_get_optimised_xml(self):
+        def mock_get_optimised_image(filename):
+            return os.path.splitext(filename)[0] + ".png"
+
+        def mock_get_image_thumbnail(filename):
+            return os.path.splitext(filename)[0] + ".thumbnail.jpg"
+
+        expected = [
+            (
+                "1234-5678-rctb-45-05-0110-e01.png",
+                "1234-5678-rctb-45-05-0110-e01.thumbnail.jpg",
+            ),
+            ("1234-5678-rctb-45-05-0110-e02.png",),
+            (
+                "1234-5678-rctb-45-05-0110-gf03.png",
+                "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
+            ),
+            ("1234-5678-rctb-45-05-0110-e04.png",),
+        ]
+        xml_result = self.xml_web_optimiser.get_optimised_xml(
+            mock_get_optimised_image, mock_get_image_thumbnail
+        )
+        for alternatives, expected_files in zip(
+            xml_result.findall('//alternatives'), expected
+        ):
+            path = './graphic[@specific-use="scielo-web"]|./inline-graphic[@specific-use="scielo-web"]'
+            for image, expected_href in zip(alternatives.xpath(path), expected_files):
+                self.assertEqual(
+                    image.attrib["{http://www.w3.org/1999/xlink}href"], expected_href,
+                )


### PR DESCRIPTION
#### O que esse PR faz?
Cria uma cópia otimizada de pacotes SPS para WEB. Para cada documento em XML do pacote, são criadas imagens alternativas às imagens em formato TIFF e thumbnails para serem exibidos na página de artigos. Essas imagens, junto com a imagem original, são incluídas como alternativas no XML.
Também é possível executar a otimização de pacotes SPS através do comando `package_optimiser`.
Por fim, também implementa as alterações no HTMLGenerator para ler as imagens alternativas, dando prioridade para as otimizadas `scielo-web`.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
- Instale os `requirements.txt` e a nova versão
- Com um pacote SPS em arquivo compactado ZIP, execute o comando:
```bash
package_optimiser --loglevel INFO <caminho para o pacote SPS>
```
- Confira também as opções do comando:
```bash
package_optimiser --help
```
- Um pacote otimizado deve ter sido gerado
- Com os XMLs otimizados, execute o comando `htmlgenerator` com eles.
- Os HTMLs renderizados devem estar com as imagens otimizadas.

#### Algum cenário de contexto que queira dar?
Por enquanto não está sendo renderizado o HTML utilizando os thumbnails das imagens.

### Screenshots
N/A

#### Quais são tickets relevantes?
#216

### Referências
Documentação do Pillow (biblioteca para manipulação de arquivos de imagens): https://pillow.readthedocs.io/
