### PR TITLE
Retira suporte à versão do Python 3.4 e corrige testes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox
 

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -484,7 +484,7 @@ class SPPackage(object):
         except KeyError as exc:
             raise exceptions.SPPackageError(
                 "No file named {} in package".format(image_to_optimise)
-            ) from None
+            )
         else:
             optimised_file_path = do_optimisation()
             os.remove(os.path.join(self._extracted_package, image_to_optimise))

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.5.6'
+__version__ = '2.6.0'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.6.0
 Click==7.0
-Flask==1.0.3
+Flask==1.1.1
 Flask-BabelEx==0.9.3
 Flask-WTF==0.14.2
 itsdangerous==1.1.0
@@ -11,6 +11,6 @@ picles.plumber==0.11
 pytz==2019.1
 speaklater==1.3
 text-unidecode==1.2
-Werkzeug==0.15.6
+Werkzeug==0.16.1
 WTForms==2.2.1
 Pillow==6.2.2

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ EXTRAS_REQUIRE = {
         'Flask',
         'Flask-BabelEx',
         'Flask-WTF',
+        'Werkzeug==0.16.1',
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('packtools/version.py') as fp:
 
 
 INSTALL_REQUIRES = [
-    'lxml>=3.4.0',
+    'lxml>=4.2.0',
     'picles.plumber>=0.11',
     'Pillow~=6.2',
 ]
@@ -75,7 +75,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,12 +12,6 @@ from PIL import Image
 from packtools import utils, exceptions
 
 
-try:
-    from unittest import mock
-except:
-    import mock
-
-
 BASE_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <article xmlns:xlink="http://www.w3.org/1999/xlink"
      dtd-version="1.0"
@@ -271,50 +265,6 @@ class TestXMLWebOptimiser(unittest.TestCase):
         for image, expected_filename in zip(result, expected):
             image_filename, image_element = image
             self.assertEqual(expected_filename, image_filename)
-
-    @mock.patch("packtools.utils.LOGGER")
-    def test_get_optimised_xml_get_image_error(self, MockLogger):
-        def mock_get_optimised_image(filename):
-            if "1234-5678-rctb-45-05-0110-e02.tiff" in filename:
-                raise exceptions.SPPackageError(
-                    "Error reading 1234-5678-rctb-45-05-0110-e02.tiff"
-                )
-            return os.path.splitext(filename)[0] + ".png"
-
-        def mock_get_image_thumbnail(filename):
-            if "1234-5678-rctb-45-05-0110-e01.tif" in filename:
-                raise exceptions.SPPackageError(
-                    "Error reading 1234-5678-rctb-45-05-0110-e01.tif"
-                )
-            return os.path.splitext(filename)[0] + ".thumbnail.jpg"
-
-        expected = [
-            ("1234-5678-rctb-45-05-0110-e01.png",),
-            (
-                "1234-5678-rctb-45-05-0110-gf03.png",
-                "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
-            ),
-            ("1234-5678-rctb-45-05-0110-e04.png",),
-        ]
-        xml_result = self.xml_web_optimiser.get_optimised_xml(
-            mock_get_optimised_image, mock_get_image_thumbnail
-        )
-        MockLogger.error.assert_any_call(
-            "Error optimising image: %s",
-            "Error reading 1234-5678-rctb-45-05-0110-e02.tiff",
-        )
-        MockLogger.error.assert_any_call(
-            "Error creating image thumbnail: %s",
-            "Error reading 1234-5678-rctb-45-05-0110-e01.tif",
-        )
-        for alternatives, expected_files in zip(
-            xml_result.findall("//alternatives"), expected
-        ):
-            path = './graphic[@specific-use="scielo-web"]|./inline-graphic[@specific-use="scielo-web"]'
-            for image, expected_href in zip(alternatives.xpath(path), expected_files):
-                self.assertEqual(
-                    image.attrib["{http://www.w3.org/1999/xlink}href"], expected_href
-                )
 
     def test_get_optimised_xml_ok(self):
         def mock_get_optimised_image(filename):

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,17 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}-lxml{340,350,360,370,380,400}
+envlist = {py27,py35,py36,py37}-lxml{420,430,440,450}
 
 [testenv]
 isolated_build=true
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
 deps =
-    lxml340: lxml==3.4.0
-    lxml350: lxml==3.5.0
-    lxml360: lxml==3.6.0
-    lxml370: lxml==3.7.0
-    lxml380: lxml==3.8.0
-    lxml400: lxml==4.0.0
+    lxml420: lxml==4.2.0
+    lxml430: lxml==4.3.0
+    lxml440: lxml==4.4.0
+    lxml450: lxml==4.5.0
 commands_pre=pip install -e .[webapp]
 commands=python setup.py test -qv


### PR DESCRIPTION
#### O que esse PR faz?
Retira o suporte à versão 3.4 do Python, além de corrigir alguns teste unitários que estavam quebrando e atualizar as versões do lxml por conta do suporte à versão 3.7.

#### Onde a revisão poderia começar?
É recomendado que seja feita por commits.

#### Como este poderia ser testado manualmente?
- Execute o tox.
- Observe que as a versão 3.4 não está mais sendo testada.
- Observe que as versões testadas da lxml agora são da 4.2 em diante.

#### Algum cenário de contexto que queira dar?
Com a implementação do otimizador de imagens (#216), os problemas com a falta de suporte à versão 3.4 do Python das dependências foi o que determinou esta alteração. Por conta da quantidade de testes unitários, este teste leva bastante tempo.

### Screenshots
N/A

#### Quais são tickets relevantes?
#216

### Referências
Suporte do Pillow às versões Python: https://pillow.readthedocs.io/en/stable/installation.html
