### PR TITLE
Aplica diretrizes do Crossref durante a transformação de XML em HTML

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta.xsl
@@ -72,7 +72,7 @@
 
     <xsl:template match="article-id[@pub-id-type='doi']" mode="display">
         <xsl:variable name="link">https://doi.org/<xsl:value-of select="."/></xsl:variable>
-        <span class="_doi"><xsl:value-of select="$link"/></span>
+        <a href="{$link}" class="_doi" target="_blank"><xsl:value-of select="$link"/></a>
         &#160;
         <a class="copyLink" data-clipboard-text="{$link}">
             <span class="sci-ico-link"/>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -521,6 +521,24 @@ class HTMLGeneratorTests(unittest.TestCase):
         html_string
       )
 
+    def test_article_meta_doi_should_be_an_explicit_link(self):
+      sample = u"""<article article-type="research-article" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="en"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/r</article-id>
+          </article-meta>
+        </front>
+      </article>"""
+      fp = io.BytesIO(sample.encode("utf-8"))
+      et = etree.parse(fp)
+      html = domain.HTMLGenerator.parse(et, valid_only=False).generate("en")
+      html_string = etree.tostring(html, encoding="unicode", method="html")
+
+      article_header_dois = html.xpath("//span[contains(@class, 'group-doi')]//a[contains(@class, '_doi')]")
+      self.assertEquals(len(article_header_dois), 1)
+
 
 class HTMLGeneratorDispFormulaTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request faz com que o DOI exibido no topo da página do artigo seja encapsulado em uma tag `a `;

#### Onde a revisão poderia começar?
- `packtools/catalogs/htmlgenerator/v2.0/article-text-ref.xsl`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Transforme o XML em um html utilizando o HTMLgenerator;

#### Algum cenário de contexto que queira dar?
Obrigado @robertatakenaka.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
[Diretrizes do Crossref](https://docs.google.com/document/d/1K3Lj031Q6LqYxo33Byh0EzywskO-ywkKg526ENqYa54/edit#)

