### PR TITLE
Reestruturação do otimizador de pacotes SPS

### DIFF
--- a/packtools/__init__.py
+++ b/packtools/__init__.py
@@ -9,7 +9,7 @@ import platform
 from lxml import etree
 
 from .domain import XMLValidator, HTMLGenerator
-from .utils import XML, SPPackage
+from .utils import XML, SPPackage, XMLWebOptimiser
 from .version import __version__
 
 
@@ -20,6 +20,7 @@ __all__ = [
     'get_debug_info',
     'HTMLGenerator',
     'SPPackage',
+    'XMLWebOptimiser',
 ]
 
 

--- a/packtools/exceptions.py
+++ b/packtools/exceptions.py
@@ -31,3 +31,8 @@ class SPPackageError(PacktoolsError):
 class XMLWebOptimiserError(SPPackageError):
     """ Generic errors during XML WEB optimisation.
     """
+
+
+class WebImageGeneratorError(SPPackageError):
+    """ Generic errors during WEB Image optimisation.
+    """

--- a/packtools/package_optimiser.py
+++ b/packtools/package_optimiser.py
@@ -26,6 +26,11 @@ def main():
         action='store_true',
         help='preserve extracted and optimised files in aux directory',
     )
+    parser.add_argument(
+        '--stopiferror',
+        action='store_true',
+        help='stop execution if an error occurs',
+    )
     parser.add_argument("--version", action="version", version=packtools_version)
     parser.add_argument("--loglevel", default="WARNING")
     args = parser.parse_args()
@@ -40,7 +45,9 @@ def main():
         new_package_file_path = os.path.splitext(args.SPPackage)[0] + "_optimised.zip"
 
     package = packtools.SPPackage.from_file(
-        args.SPPackage, os.path.splitext(args.SPPackage)[0]
+        args.SPPackage,
+        os.path.splitext(args.SPPackage)[0],
+        stop_if_error=args.stopiferror,
     )
     package.optimise(
         new_package_file_path=new_package_file_path, preserve_files=args.preservefiles

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -666,6 +666,32 @@ class SPPackage(object):
             extracted_package = os.path.splitext(package_file_path)[0]
         return cls(package2optimise, extracted_package)
 
+    def _optimise_to_zipfile(self, new_package_file_path, xml_filename, xml_related_files):
+        with zipfile.ZipFile(new_package_file_path, "w") as new_zip_file:
+            xml_web_optimiser = self._get_optimise_web_xml(
+                xml_filename, xml_related_files
+            )
+            # Write optimised XML to new Zipfile
+            optimised_xml = xml_web_optimiser.get_xml_file()
+            xml_zip_info = self._package_file.getinfo(xml_filename)
+            new_zip_file.writestr(
+                xml_filename, optimised_xml, xml_zip_info.compress_type
+            )
+            # Write optimised assets to new Zipfile
+            for asset_filename, asset_bytes in xml_web_optimiser.get_optimised_assets():
+                if asset_bytes is not None:
+                    new_zip_file.writestr(asset_filename, asset_bytes)
+            for asset_filename, asset_bytes in xml_web_optimiser.get_assets_thumbnails():
+                if asset_bytes is not None:
+                    new_zip_file.writestr(asset_filename, asset_bytes)
+            # Write other XML related files to new Zipfile
+            for xml_related_file in xml_related_files:
+                zip_info = self._package_file.getinfo(xml_related_file)
+                new_zip_file.writestr(
+                    xml_related_file,
+                    self._package_file.read(xml_related_file),
+                    zip_info.compress_type,
+                )
 
     def _get_optimise_web_xml(self, xml_filename, xml_related_files):
         image_filenames = [

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -501,7 +501,7 @@ class XMLWebOptimiser(object):
     def _get_all_images_to_thumbnail(self):
         namespaces = {"xlink": "http://www.w3.org/1999/xlink"}
         images = self._xml_file.xpath("//graphic[@xlink:href]", namespaces=namespaces)
-        images_parents = (image.getparent() for image in images)
+        images_parents = {image.getparent() for image in images}
         for images_parent in images_parents:
             alternatives = images_parent.xpath(
                 "./graphic[@xlink:href]", namespaces=namespaces
@@ -738,12 +738,12 @@ class SPPackage(object):
         :param preserve_files (default=True): preserve extracted and optimised files in
             aux directory. If False, it will delete files after written in new Package.
         """
-        zipped_filenames = self._package_file.namelist()
         if new_package_file_path is None:
             new_package_file_path = self._extracted_package + "_optimised.zip"
         LOGGER.info(
             "Generating new SciELO Publishing Package %s", new_package_file_path
         )
+        zipped_filenames = self._package_file.namelist()
         xmls_filenames = [
             xml_filename
             for xml_filename in zipped_filenames

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -336,7 +336,7 @@ class WebImageGenerator:
         """
         try:
             tiff_file = Image.open(self.image_file_path)
-        except (FileNotFoundError, IOError, ValueError) as exc:
+        except (OSError, IOError, ValueError) as exc:
             raise exceptions.WebImageGeneratorError(
                 'Error opening image file "%s": %s' % (self.image_file_path, str(exc))
             )
@@ -364,7 +364,7 @@ class WebImageGenerator:
         """
         try:
             image_file = Image.open(self.image_file_path)
-        except (FileNotFoundError, IOError, ValueError) as exc:
+        except (OSError, IOError, ValueError) as exc:
             raise exceptions.WebImageGeneratorError(
                 'Error opening image file "%s": %s' % (self.image_file_path, str(exc))
             )

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -344,6 +344,8 @@ class WebImageGenerator:
             png_file = tiff_file.copy()
             new_filename = os.path.splitext(self.image_file_path)[0] + ".png"
             if destination_path is not None and len(destination_path) > 0:
+                if not os.path.exists(destination_path):
+                    os.makedirs(destination_path)
                 new_filename = os.path.join(
                     destination_path, os.path.basename(new_filename)
                 )
@@ -372,6 +374,8 @@ class WebImageGenerator:
             thumbnail_file = image_file.copy()
             new_filename = os.path.splitext(self.image_file_path)[0] + ".thumbnail.jpg"
             if destination_path is not None and len(destination_path) > 0:
+                if not os.path.exists(destination_path):
+                    os.makedirs(destination_path)
                 new_filename = os.path.join(
                     destination_path, os.path.basename(new_filename)
                 )
@@ -435,6 +439,8 @@ class XMLWebOptimiser(object):
             filename, image_filenames, read_file, stop_if_error
         )
         bytes = xml_web_optimiser.get_xml_file()
+        optimised_assets = xml_web_optimiser.get_optimised_assets()
+        assets_thumbnails = xml_web_optimiser.get_assets_thumbnails()
 
     :param filename: (str) XML file name
     :param image_filenames: (list) list of image file names 

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -619,9 +619,17 @@ class XMLWebOptimiser(object):
             pretty_print=True,
         )
 
-            try:
-            else:
+    def get_optimised_assets(self):
+        """Generate tuples of PNG file name and bytes of each image produced by TIFF
+        images referenced in XML content."""
+        for optimised_asset in self._optimised_assets:
+            yield optimised_asset
 
+    def get_assets_thumbnails(self):
+        """Generate tuples of thumbnail file name and bytes of each image produced by
+        images referenced in XML content."""
+        for asset_thumbnail in self._assets_thumbnails:
+            yield asset_thumbnail
 
 
 class SPPackage(object):

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -407,8 +407,7 @@ class WebImageGenerator:
         if self._image_object is None:
             raise exceptions.WebImageGeneratorError(
                 'Error optimising image bytes from "%s": '
-                'no original file bytes was given.'
-                % self.filename
+                "no original file bytes was given." % self.filename
             )
 
         return self._get_bytes("PNG")
@@ -451,7 +450,9 @@ class XMLWebOptimiser(object):
         handled exceptions, otherwise it logs error message.
     """
 
-    def __init__(self, filename, image_filenames, read_file, work_dir, stop_if_error=False):
+    def __init__(
+        self, filename, image_filenames, read_file, work_dir, stop_if_error=False
+    ):
         self.filename = filename
         self.work_dir = work_dir
         self.stop_if_error = stop_if_error
@@ -493,7 +494,9 @@ class XMLWebOptimiser(object):
             './/inline-graphic[@xlink:href and not(@specific-use="scielo-web")]',
         ]
         namespaces = {"xlink": "http://www.w3.org/1999/xlink"}
-        iterators = [self._xml_file.xpath(path, namespaces=namespaces) for path in paths]
+        iterators = [
+            self._xml_file.xpath(path, namespaces=namespaces) for path in paths
+        ]
         for image in itertools.chain(*iterators):
             if is_image_to_optimise(image):
                 yield image.attrib["{http://www.w3.org/1999/xlink}href"], image
@@ -573,7 +576,9 @@ class XMLWebOptimiser(object):
         if optimise:
             return add_image(image_filename)
 
-    def _add_alternative_to_alternatives_tag(self, image_element, alternative_attr_values):
+    def _add_alternative_to_alternatives_tag(
+        self, image_element, alternative_attr_values
+    ):
         image_parent = image_element.getparent()
         new_alternative = etree.Element(image_element.tag)
         for attrb, value in alternative_attr_values:
@@ -673,7 +678,9 @@ class SPPackage(object):
             extracted_package = os.path.splitext(package_file_path)[0]
         return cls(package2optimise, extracted_package, stop_if_error)
 
-    def _optimise_to_zipfile(self, new_package_file_path, xml_filename, xml_related_files):
+    def _optimise_to_zipfile(
+        self, new_package_file_path, xml_filename, xml_related_files
+    ):
         with zipfile.ZipFile(new_package_file_path, "a") as new_zip_file:
             xml_web_optimiser = self._get_optimise_web_xml(
                 xml_filename, xml_related_files
@@ -688,7 +695,10 @@ class SPPackage(object):
             for asset_filename, asset_bytes in xml_web_optimiser.get_optimised_assets():
                 if asset_bytes is not None:
                     new_zip_file.writestr(asset_filename, asset_bytes)
-            for asset_filename, asset_bytes in xml_web_optimiser.get_assets_thumbnails():
+            for (
+                asset_filename,
+                asset_bytes,
+            ) in xml_web_optimiser.get_assets_thumbnails():
                 if asset_bytes is not None:
                     new_zip_file.writestr(asset_filename, asset_bytes)
             # Write other XML related files to new Zipfile

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -344,8 +344,6 @@ class WebImageGenerator:
             png_file = tiff_file.copy()
             new_filename = os.path.splitext(self.image_file_path)[0] + ".png"
             if destination_path is not None and len(destination_path) > 0:
-                if not os.path.exists(destination_path):
-                    os.makedirs(destination_path)
                 new_filename = os.path.join(
                     destination_path, os.path.basename(new_filename)
                 )
@@ -374,8 +372,6 @@ class WebImageGenerator:
             thumbnail_file = image_file.copy()
             new_filename = os.path.splitext(self.image_file_path)[0] + ".thumbnail.jpg"
             if destination_path is not None and len(destination_path) > 0:
-                if not os.path.exists(destination_path):
-                    os.makedirs(destination_path)
                 new_filename = os.path.join(
                     destination_path, os.path.basename(new_filename)
                 )
@@ -438,8 +434,6 @@ class XMLWebOptimiser(object):
             filename, image_filenames, read_file, stop_if_error
         )
         bytes = xml_web_optimiser.get_xml_file()
-        optimised_assets = xml_web_optimiser.get_optimised_assets()
-        assets_thumbnails = xml_web_optimiser.get_assets_thumbnails()
 
     :param filename: (str) XML file name
     :param image_filenames: (list) list of image file names 

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -506,6 +506,21 @@ class XMLWebOptimiser(object):
                     alternative_node.append(new_alternative)
                     image_parent.append(alternative_node)
 
+    def _add_alternative_to_anternatives_tag(self, image_element, alternative_attr_values):
+        image_parent = image_element.getparent()
+        new_alternative = etree.Element(image_element.tag)
+        for attrb, value in alternative_attr_values:
+            new_alternative.set(attrb, value)
+        if image_parent.tag == "alternatives":
+            image_parent.append(new_alternative)
+        else:
+            alternative_node = etree.Element("alternatives")
+            alternative_node.tail = image_element.tail
+            image_element.tail = None
+            alternative_node.append(image_element)
+            alternative_node.append(new_alternative)
+            image_parent.append(alternative_node)
+
         for image_filename, image_element in self._get_all_images_to_thumbnail():
             try:
                 new_filename = get_image_thumbnail(image_filename)

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -386,6 +386,42 @@ class WebImageGenerator:
             finally:
                 image_file.close()
 
+    def _get_bytes(self, format):
+        image_file = io.BytesIO()
+        try:
+            self._image_object.convert("RGB").save(image_file, format)
+        except (ValueError, IOError) as exc:
+            raise exceptions.WebImageGeneratorError(
+                'Error optimising image bytes from "%s": %s' % (self.filename, str(exc))
+            )
+        else:
+            return image_file.getvalue()
+
+    def get_png_bytes(self):
+        """Generate a PNG image byte-like object from image file set in
+        ``self._image_object``."""
+        if self._image_object is None:
+            raise exceptions.WebImageGeneratorError(
+                'Error optimising image bytes from "%s": '
+                'no original file bytes was given.'
+                % self.filename
+            )
+
+        return self._get_bytes("PNG")
+
+    def get_thumbnail_bytes(self):
+        """Generate a thumbnail image byte-like object from image file set in
+        ``self._image_object``."""
+        if self._image_object is None:
+            raise exceptions.WebImageGeneratorError(
+                'Error optimising image bytes from "%s": '
+                'no original file bytes was given.'
+                % self.filename
+            )
+
+        self._image_object.thumbnail(self.thumbnail_size)
+        return self._get_bytes("JPEG")
+
 
 class XMLWebOptimiser(object):
     """Optimise XML document to be properly rendered to HTML, with alternatives to

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -434,6 +434,8 @@ class XMLWebOptimiser(object):
             filename, image_filenames, read_file, stop_if_error
         )
         bytes = xml_web_optimiser.get_xml_file()
+        optimised_assets = xml_web_optimiser.get_optimised_assets()
+        assets_thumbnails = xml_web_optimiser.get_assets_thumbnails()
 
     :param filename: (str) XML file name
     :param image_filenames: (list) list of image file names 

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -573,7 +573,7 @@ class XMLWebOptimiser(object):
         if optimise:
             return add_image(image_filename)
 
-    def _add_alternative_to_anternatives_tag(self, image_element, alternative_attr_values):
+    def _add_alternative_to_alternatives_tag(self, image_element, alternative_attr_values):
         image_parent = image_element.getparent()
         new_alternative = etree.Element(image_element.tag)
         for attrb, value in alternative_attr_values:
@@ -599,7 +599,7 @@ class XMLWebOptimiser(object):
                     ("{http://www.w3.org/1999/xlink}href", new_filename),
                     ("specific-use", "scielo-web"),
                 )
-                self._add_alternative_to_anternatives_tag(
+                self._add_alternative_to_alternatives_tag(
                     image_element, alternative_attr_values
                 )
 
@@ -613,7 +613,7 @@ class XMLWebOptimiser(object):
                     ("specific-use", "scielo-web"),
                     ("content-type", "scielo-267x140"),
                 )
-                self._add_alternative_to_anternatives_tag(
+                self._add_alternative_to_alternatives_tag(
                     image_element, alternative_attr_values
                 )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -287,20 +287,26 @@ class TestWebImageGenerator(unittest.TestCase):
         )
 
     def test_convert2png_to_destination_path(self):
-        destination_path = tempfile.mkdtemp(".")
+        destination_path = os.path.join(self.extracted_package, "destination_path")
+        os.makedirs(destination_path)
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_2.tif", self.extracted_package
         )
         web_image_generator.convert2png(destination_path)
 
-        is_conversion_ok = os.path.exists(
-            os.path.join(
-                destination_path,
-                os.path.splitext("image_tiff_2.tif")[0] + ".png",
-            )
+        self.assertTrue(
+            os.path.exists(os.path.join(destination_path, "image_tiff_2.png"))
         )
-        shutil.rmtree(destination_path)
-        self.assertTrue(is_conversion_ok)
+
+    def test_convert2png_create_destination_path_if_it_does_not_exist(self):
+        destination_path = os.path.join(self.extracted_package, "destination_path")
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_2.tif", self.extracted_package
+        )
+        web_image_generator.convert2png(destination_path)
+        self.assertTrue(
+            os.path.exists(os.path.join(destination_path, "image_tiff_2.png"))
+        )
 
     def test_create_thumbnail_file_does_not_exist(self):
         web_image_generator = utils.WebImageGenerator(
@@ -346,18 +352,31 @@ class TestWebImageGenerator(unittest.TestCase):
         self.assertTrue(os.path.exists(thumbnail_filename))
 
     def test_create_thumbnail_to_destination_path(self):
-        destination_path = tempfile.mkdtemp(".")
+        destination_path = os.path.join(self.extracted_package, "destination_path")
+        os.makedirs(destination_path)
         filename = os.path.join(self.extracted_package, "image_tiff_1.png")
         create_image_file(filename, "PNG")
 
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_1.png", self.extracted_package
         )
-        web_image_generator.create_thumbnail()
-        thumbnail_filename = os.path.splitext(filename)[0] + ".thumbnail.jpg"
-        is_thumbnail_ok = os.path.exists(thumbnail_filename)
-        shutil.rmtree(destination_path)
-        self.assertTrue(is_thumbnail_ok)
+        web_image_generator.create_thumbnail(destination_path)
+        self.assertTrue(
+            os.path.exists(os.path.join(destination_path, "image_tiff_1.thumbnail.jpg"))
+        )
+
+    def test_create_thumbnail_create_destination_path_if_it_does_not_exist(self):
+        destination_path = os.path.join(self.extracted_package, "destination_path")
+        filename = os.path.join(self.extracted_package, "image_tiff_1.png")
+        create_image_file(filename, "PNG")
+
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_1.png", self.extracted_package
+        )
+        web_image_generator.create_thumbnail(destination_path)
+        self.assertTrue(
+            os.path.exists(os.path.join(destination_path, "image_tiff_1.thumbnail.jpg"))
+        )
 
     def test_get_png_bytes_no_image_object(self):
         web_image_generator = utils.WebImageGenerator(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -831,60 +831,6 @@ class TestSPPackage(unittest.TestCase):
         package = utils.SPPackage.from_file(self.tmp_package, "/tmp/test")
         self.assertEqual(package._extracted_package, "/tmp/test")
 
-    def test_optimise_xml_to_web_optimised_images(self):
-        self.sp_package._optimise_xml_to_web(
-            utils.XML(io.BytesIO(BASE_XML)), "somedocument.xml"
-        )
-
-        expected = [
-            "1234-5678-rctb-45-05-0110-e01.png",
-            "1234-5678-rctb-45-05-0110-e02.png",
-            "1234-5678-rctb-45-05-0110-e04.png",
-        ]
-        for file in expected:
-            self.assertTrue(os.path.exists(os.path.join(self.extracted_package, file)))
-        self.assertFalse(
-            os.path.exists(
-                os.path.join(
-                    self.extracted_package, "1234-5678-rctb-45-05-0110-gf03.png"
-                )
-            )
-        )
-
-    def test_optimise_xml_to_web_optimises_xmls(self):
-        self.sp_package._optimise_xml_to_web(
-            utils.XML(io.BytesIO(BASE_XML)), "somedocument.xml"
-        )
-        self.assertTrue(
-            os.path.exists(os.path.join(self.extracted_package, "somedocument.xml"))
-        )
-        expected = [
-            "1234-5678-rctb-45-05-0110-e01.png",
-            "1234-5678-rctb-45-05-0110-e01.thumbnail.jpg",
-            "1234-5678-rctb-45-05-0110-e02.png",
-            "1234-5678-rctb-45-05-0110-gf03.png",
-            "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
-            "1234-5678-rctb-45-05-0110-e04.png",
-        ]
-        path = '//graphic[@specific-use="scielo-web"]|//inline-graphic[@specific-use="scielo-web"]'
-        xml_file_path = os.path.join(self.extracted_package, "somedocument.xml")
-        xml_file = utils.XML(xml_file_path)
-        for image_element, expected_href in zip(xml_file.xpath(path), expected):
-            self.assertEqual(
-                image_element.attrib["{http://www.w3.org/1999/xlink}href"],
-                expected_href,
-            )
-
-    def test_optimise_image_raises_error_if_error_extracting_file(self):
-        inexistent_file = "inexistent_file.tiff"
-        web_image_generator = utils.WebImageGenerator(
-            "inexistent_file.tiff", self.extracted_package
-        )
-        with self.assertRaises(exceptions.SPPackageError) as exc_info:
-            self.sp_package._optimise_image(
-                inexistent_file, web_image_generator.convert2png
-            )
-
     def test_optimise_creates_optimised_zip(self):
         self.sp_package.optimise()
         self.assertTrue(os.path.exists(self.optimised_package))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,7 +207,39 @@ class TestWebImageGenerator(unittest.TestCase):
             os.path.join(self.extracted_package, "image_tiff_1.tiff"),
         )
 
-    def test_convert2png(self):
+    def test_convert2png_file_does_not_exist(self):
+        web_image_generator = utils.WebImageGenerator(
+            "no_file.tif", self.extracted_package
+        )
+        with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
+            web_image_generator.convert2png()
+        self.assertIn(
+            "Error opening image file ", str(exc_info.exception)
+        )
+        self.assertIn("no_file.tif", str(exc_info.exception))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.extracted_package, "no_file.png"))
+        )
+
+    def test_convert2png_no_image_file(self):
+        text_file_path = os.path.join(self.extracted_package, "file.txt")
+        with open(text_file_path, "w") as fp:
+            fp.write("Text file content.")
+
+        web_image_generator = utils.WebImageGenerator(
+            "file.txt", self.extracted_package
+        )
+        with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
+            web_image_generator.convert2png()
+        self.assertIn(
+            "Error opening image file ", str(exc_info.exception)
+        )
+        self.assertIn("file.txt", str(exc_info.exception))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.extracted_package, "file.png"))
+        )
+
+    def test_convert2png_ok(self):
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_2.tif", self.extracted_package
         )
@@ -221,7 +253,55 @@ class TestWebImageGenerator(unittest.TestCase):
             )
         )
 
-    def test_create_thumbnail(self):
+    def test_convert2png_to_destination_path(self):
+        destination_path = tempfile.mkdtemp(".")
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_2.tif", self.extracted_package
+        )
+        web_image_generator.convert2png(destination_path)
+
+        is_conversion_ok = os.path.exists(
+            os.path.join(
+                destination_path,
+                os.path.splitext("image_tiff_2.tif")[0] + ".png",
+            )
+        )
+        shutil.rmtree(destination_path)
+        self.assertTrue(is_conversion_ok)
+
+    def test_create_thumbnail_file_does_not_exist(self):
+        web_image_generator = utils.WebImageGenerator(
+            "no_file.tif", self.extracted_package
+        )
+        with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
+            web_image_generator.create_thumbnail()
+        self.assertIn(
+            "Error opening image file ", str(exc_info.exception)
+        )
+        self.assertIn("no_file.tif", str(exc_info.exception))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.extracted_package, "no_file.png"))
+        )
+
+    def test_create_thumbnail_no_image_file(self):
+        text_file_path = os.path.join(self.extracted_package, "file.txt")
+        with open(text_file_path, "w") as fp:
+            fp.write("Text file content.")
+
+        web_image_generator = utils.WebImageGenerator(
+            "file.txt", self.extracted_package
+        )
+        with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
+            web_image_generator.create_thumbnail()
+        self.assertIn(
+            "Error opening image file ", str(exc_info.exception)
+        )
+        self.assertIn("file.txt", str(exc_info.exception))
+        self.assertFalse(
+            os.path.exists(os.path.join(self.extracted_package, "file.png"))
+        )
+
+    def test_create_thumbnail_ok(self):
         filename = os.path.join(self.extracted_package, "image_tiff_1.png")
         create_image_file(filename, "PNG")
 
@@ -231,6 +311,20 @@ class TestWebImageGenerator(unittest.TestCase):
         web_image_generator.create_thumbnail()
         thumbnail_filename = os.path.splitext(filename)[0] + ".thumbnail.jpg"
         self.assertTrue(os.path.exists(thumbnail_filename))
+
+    def test_create_thumbnail_to_destination_path(self):
+        destination_path = tempfile.mkdtemp(".")
+        filename = os.path.join(self.extracted_package, "image_tiff_1.png")
+        create_image_file(filename, "PNG")
+
+        web_image_generator = utils.WebImageGenerator(
+            "image_tiff_1.png", self.extracted_package
+        )
+        web_image_generator.create_thumbnail()
+        thumbnail_filename = os.path.splitext(filename)[0] + ".thumbnail.jpg"
+        is_thumbnail_ok = os.path.exists(thumbnail_filename)
+        shutil.rmtree(destination_path)
+        self.assertTrue(is_thumbnail_ok)
 
 
 class TestXMLWebOptimiser(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -792,12 +792,17 @@ class TestSPPackage(unittest.TestCase):
         self.tmp_package = os.path.join(self.temp_package_dir, "sps_package.zip")
         self.extracted_package = os.path.splitext(self.tmp_package)[0]
         self.optimised_package = self.extracted_package + "_optimised.zip"
+        self.xml_filename = "1234-5678-rctb-45-05-0110.xml"
 
-        with zipfile.ZipFile(self.tmp_package, "a") as self.archive:
-            xml_file_path = os.path.join(self.temp_img_dir, "somedocument.xml")
+        with zipfile.ZipFile(self.tmp_package, "w") as self.archive:
+            xml_file_path = os.path.join(self.temp_img_dir, self.xml_filename)
             with open(xml_file_path, "wb") as xml_file:
-                xml_file.write(BASE_XML)
-            self.archive.write(xml_file_path, "somedocument.xml")
+                graphic_01 = '<graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>'
+                graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+                xml_content = BASE_XML.format(graphic_01, graphic_02)
+                xml_file.write(xml_content.encode("utf-8"))
+            self.archive.write(xml_file_path, self.xml_filename)
+            self.archive.write(xml_file_path, "1234-5678-rctb-45-05-0110.pdf")
             image_files = (
                 ("1234-5678-rctb-45-05-0110-e01.tif", "TIFF"),
                 ("1234-5678-rctb-45-05-0110-e02.tiff", "TIFF"),
@@ -873,7 +878,7 @@ class TestSPPackage(unittest.TestCase):
             "1234-5678-rctb-45-05-0110-e04.png",
         ]
         with zipfile.ZipFile(self.optimised_package) as zf:
-            xml_file = utils.XML(io.BytesIO(zf.read("somedocument.xml")))
+            xml_file = utils.XML(io.BytesIO(zf.read(self.xml_filename)))
             path = '//graphic[@specific-use="scielo-web"]|//inline-graphic[@specific-use="scielo-web"]'
             for image_element, expected_href in zip(xml_file.xpath(path), expected):
                 self.assertEqual(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,9 +246,7 @@ class TestWebImageGenerator(unittest.TestCase):
         )
         with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
             web_image_generator.convert2png()
-        self.assertIn(
-            "Error opening image file ", str(exc_info.exception)
-        )
+        self.assertIn("Error opening image file ", str(exc_info.exception))
         self.assertIn("no_file.tif", str(exc_info.exception))
         self.assertFalse(
             os.path.exists(os.path.join(self.extracted_package, "no_file.png"))
@@ -264,9 +262,7 @@ class TestWebImageGenerator(unittest.TestCase):
         )
         with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
             web_image_generator.convert2png()
-        self.assertIn(
-            "Error opening image file ", str(exc_info.exception)
-        )
+        self.assertIn("Error opening image file ", str(exc_info.exception))
         self.assertIn("file.txt", str(exc_info.exception))
         self.assertFalse(
             os.path.exists(os.path.join(self.extracted_package, "file.png"))
@@ -314,9 +310,7 @@ class TestWebImageGenerator(unittest.TestCase):
         )
         with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
             web_image_generator.create_thumbnail()
-        self.assertIn(
-            "Error opening image file ", str(exc_info.exception)
-        )
+        self.assertIn("Error opening image file ", str(exc_info.exception))
         self.assertIn("no_file.tif", str(exc_info.exception))
         self.assertFalse(
             os.path.exists(os.path.join(self.extracted_package, "no_file.png"))
@@ -332,9 +326,7 @@ class TestWebImageGenerator(unittest.TestCase):
         )
         with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
             web_image_generator.create_thumbnail()
-        self.assertIn(
-            "Error opening image file ", str(exc_info.exception)
-        )
+        self.assertIn("Error opening image file ", str(exc_info.exception))
         self.assertIn("file.txt", str(exc_info.exception))
         self.assertFalse(
             os.path.exists(os.path.join(self.extracted_package, "file.png"))
@@ -387,7 +379,7 @@ class TestWebImageGenerator(unittest.TestCase):
         self.assertEqual(
             str(exc_info.exception),
             'Error optimising image bytes from "image_tiff_1.tiff": '
-            'no original file bytes was given.'
+            "no original file bytes was given.",
         )
 
     def test_get_png_bytes_ok(self):
@@ -417,7 +409,7 @@ class TestWebImageGenerator(unittest.TestCase):
         self.assertEqual(
             str(exc_info.exception),
             'Error optimising image bytes from "image_tiff_1.tiff": '
-            'no original file bytes was given.'
+            "no original file bytes was given.",
         )
 
     def test_get_thumbnail_bytes_ok(self):
@@ -453,7 +445,7 @@ class TestXMLWebOptimiser(unittest.TestCase):
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
-            "1234-5678-rctb-45-05-0110-e04.tif"
+            "1234-5678-rctb-45-05-0110-e04.tif",
         ]
         image_format_seq = ["TIFF", "TIFF", "TIFF", "PNG", "JPEG", "TIFF"]
         for filename, format in zip(self.image_filenames, image_format_seq):
@@ -514,7 +506,9 @@ class TestXMLWebOptimiser(unittest.TestCase):
             image_filename, image_element = image
             self.assertEqual(image_filename, expected_filename)
 
-    def test_get_optimised_image_with_filename_no_existing_file_in_image_filenames(self):
+    def test_get_optimised_image_with_filename_no_existing_file_in_image_filenames(
+        self,
+    ):
         def dummy_optimise(filename):
             return None
 
@@ -527,6 +521,7 @@ class TestXMLWebOptimiser(unittest.TestCase):
     def test_add_optimised_image_no_existing_file_in_source(self):
         def mocked_read_file_exception(filename):
             raise exceptions.SPPackageError("File not found")
+
         self.xml_web_optimiser._read_file = mocked_read_file_exception
         new_filename = self.xml_web_optimiser._add_optimised_image(
             "1234-5678-rctb-45-05-0110-e01.tif"
@@ -546,6 +541,7 @@ class TestXMLWebOptimiser(unittest.TestCase):
     def test_add_assets_thumbnails_no_existing_file_in_source(self):
         def mocked_read_file_exception(filename):
             raise exceptions.SPPackageError("File not found")
+
         self.xml_web_optimiser._read_file = mocked_read_file_exception
         new_filename = self.xml_web_optimiser._add_assets_thumbnails(
             "1234-5678-rctb-45-05-0110-e01.tif"
@@ -603,7 +599,9 @@ class TestXMLWebOptimiser(unittest.TestCase):
             "1234-5678-rctb-45-05-0110-e02.png",
             "1234-5678-rctb-45-05-0110-e04.png",
         ]
-        for optimised_asset, expected_filename in zip(optimised_assets, expected_filenames):
+        for optimised_asset, expected_filename in zip(
+            optimised_assets, expected_filenames
+        ):
             image_filename, image_bytes = optimised_asset
             self.assertEqual(image_filename, expected_filename)
             self.assertIsNotNone(image_bytes)
@@ -646,7 +644,7 @@ class TestXMLWebOptimiserGraphicsWithNoFileExtention(unittest.TestCase):
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
-            "1234-5678-rctb-45-05-0110-e04.tif"
+            "1234-5678-rctb-45-05-0110-e04.tif",
         ]
         image_format_seq = ["TIFF", "TIFF", "TIFF", "PNG", "JPEG", "TIFF"]
         for filename, format in zip(self.image_filenames, image_format_seq):
@@ -729,7 +727,7 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
-            "1234-5678-rctb-45-05-0110-e04.tif"
+            "1234-5678-rctb-45-05-0110-e04.tif",
         ]
         image_format_seq = ["JPEG", "GIF", "TIFF", "PNG", "JPEG", "TIFF"]
         for filename, format in zip(self.image_filenames, image_format_seq):
@@ -766,7 +764,7 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         self.assertEqual(expected[0], image_filename)
 
     def test_get_all_images_to_thumbnail_does_not_return_images_with_thumbnail(self):
-        graphic_01 = ''
+        graphic_01 = ""
         graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.gif"/>'
         xml_file = BASE_XML.format(graphic_01, graphic_02).encode("utf-8")
         xml_file_path = os.path.join(self.work_dir, self.xml_filename)
@@ -784,7 +782,7 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_add_alternative_to_alternatives_tag_add_image_tags_to_new_alternatives(
-        self
+        self,
     ):
         xml_file = BASE_XML.format("", "").encode("utf-8")
         xml_file_path = os.path.join(self.work_dir, self.xml_filename)
@@ -811,7 +809,10 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         xml_web_optimiser._xml_file = xml_tag
         image_element = xml_tag.find(".//graphic")
         alternative_attr_values = (
-            ("{http://www.w3.org/1999/xlink}href", "1234-5678-rctb-45-05-0110-gf03.png"),
+            (
+                "{http://www.w3.org/1999/xlink}href",
+                "1234-5678-rctb-45-05-0110-gf03.png",
+            ),
             ("specific-use", "scielo-web"),
         )
         xml_web_optimiser._add_alternative_to_alternatives_tag(
@@ -821,13 +822,14 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         alternatives_tags = xml_tag.findall("fig/alternatives")
         self.assertIsNotNone(alternatives_tags)
         expected_hrefs = [
-            "1234-5678-rctb-45-05-0110-gf03.tiff", "1234-5678-rctb-45-05-0110-gf03.png"
+            "1234-5678-rctb-45-05-0110-gf03.tiff",
+            "1234-5678-rctb-45-05-0110-gf03.png",
         ]
         for image_element in alternatives_tags[0].getchildren():
             self.assertEqual(image_element.tag, "graphic")
 
     def test_add_alternative_to_alternatives_tag_add_image_tags_to_existing_alternatives(
-        self
+        self,
     ):
         xml_file = BASE_XML.format("", "").encode("utf-8")
         xml_file_path = os.path.join(self.work_dir, self.xml_filename)
@@ -853,7 +855,10 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         xml_web_optimiser._xml_file = xml_tag
         image_element = xml_tag.find(".//inline-graphic")
         alternative_attr_values = (
-            ("{http://www.w3.org/1999/xlink}href", "1234-5678-rctb-45-05-0110-gf03.gif"),
+            (
+                "{http://www.w3.org/1999/xlink}href",
+                "1234-5678-rctb-45-05-0110-gf03.gif",
+            ),
             ("specific-use", "scielo-web"),
         )
         xml_web_optimiser._add_alternative_to_alternatives_tag(
@@ -881,14 +886,11 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
 
         with self.assertRaises(exceptions.XMLWebOptimiserError) as exc_info:
             xml_web_optimiser = utils.XMLWebOptimiser(
-                self.xml_filename,
-                self.image_filenames,
-                None,
-                self.work_dir,
+                self.xml_filename, self.image_filenames, None, self.work_dir,
             )
         self.assertEqual(
             str(exc_info.exception),
-            "Error instantiating XMLWebOptimiser: read_file cannot be None"
+            "Error instantiating XMLWebOptimiser: read_file cannot be None",
         )
 
 
@@ -905,7 +907,9 @@ class TestSPPackage(unittest.TestCase):
             xml_file_path = os.path.join(self.temp_img_dir, self.xml_filename)
             with open(xml_file_path, "wb") as xml_file:
                 graphic_01 = '<graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>'
-                graphic_02 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+                graphic_02 = (
+                    '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+                )
                 xml_content = BASE_XML.format(graphic_01, graphic_02)
                 xml_file.write(xml_content.encode("utf-8"))
             self.archive.write(xml_file_path, self.xml_filename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -945,7 +945,7 @@ class TestSPPackage(unittest.TestCase):
         self.tmp_package = os.path.join(self.temp_package_dir, "sps_package.zip")
         self.extracted_package = os.path.splitext(self.tmp_package)[0]
         self.optimised_package = self.extracted_package + "_optimised.zip"
-        self.xml_filename = "1234-5678-rctb-45-05-0110.xml"
+        self.xml_filename = "somedocument.xml"
 
         with zipfile.ZipFile(self.tmp_package, "w") as self.archive:
             xml_file_path = os.path.join(self.temp_img_dir, self.xml_filename)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -283,26 +283,20 @@ class TestWebImageGenerator(unittest.TestCase):
         )
 
     def test_convert2png_to_destination_path(self):
-        destination_path = os.path.join(self.extracted_package, "destination_path")
-        os.makedirs(destination_path)
+        destination_path = tempfile.mkdtemp(".")
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_2.tif", self.extracted_package
         )
         web_image_generator.convert2png(destination_path)
 
-        self.assertTrue(
-            os.path.exists(os.path.join(destination_path, "image_tiff_2.png"))
+        is_conversion_ok = os.path.exists(
+            os.path.join(
+                destination_path,
+                os.path.splitext("image_tiff_2.tif")[0] + ".png",
+            )
         )
-
-    def test_convert2png_create_destination_path_if_it_does_not_exist(self):
-        destination_path = os.path.join(self.extracted_package, "destination_path")
-        web_image_generator = utils.WebImageGenerator(
-            "image_tiff_2.tif", self.extracted_package
-        )
-        web_image_generator.convert2png(destination_path)
-        self.assertTrue(
-            os.path.exists(os.path.join(destination_path, "image_tiff_2.png"))
-        )
+        shutil.rmtree(destination_path)
+        self.assertTrue(is_conversion_ok)
 
     def test_create_thumbnail_file_does_not_exist(self):
         web_image_generator = utils.WebImageGenerator(
@@ -344,31 +338,18 @@ class TestWebImageGenerator(unittest.TestCase):
         self.assertTrue(os.path.exists(thumbnail_filename))
 
     def test_create_thumbnail_to_destination_path(self):
-        destination_path = os.path.join(self.extracted_package, "destination_path")
-        os.makedirs(destination_path)
+        destination_path = tempfile.mkdtemp(".")
         filename = os.path.join(self.extracted_package, "image_tiff_1.png")
         create_image_file(filename, "PNG")
 
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_1.png", self.extracted_package
         )
-        web_image_generator.create_thumbnail(destination_path)
-        self.assertTrue(
-            os.path.exists(os.path.join(destination_path, "image_tiff_1.thumbnail.jpg"))
-        )
-
-    def test_create_thumbnail_create_destination_path_if_it_does_not_exist(self):
-        destination_path = os.path.join(self.extracted_package, "destination_path")
-        filename = os.path.join(self.extracted_package, "image_tiff_1.png")
-        create_image_file(filename, "PNG")
-
-        web_image_generator = utils.WebImageGenerator(
-            "image_tiff_1.png", self.extracted_package
-        )
-        web_image_generator.create_thumbnail(destination_path)
-        self.assertTrue(
-            os.path.exists(os.path.join(destination_path, "image_tiff_1.thumbnail.jpg"))
-        )
+        web_image_generator.create_thumbnail()
+        thumbnail_filename = os.path.splitext(filename)[0] + ".thumbnail.jpg"
+        is_thumbnail_ok = os.path.exists(thumbnail_filename)
+        shutil.rmtree(destination_path)
+        self.assertTrue(is_thumbnail_ok)
 
     def test_get_png_bytes_no_image_object(self):
         web_image_generator = utils.WebImageGenerator(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR reestrutura o otimizador de pacotes SPS e deixa pública a otimização de XMLs. Com isso, é possível:

* Fazer a otimização de um arquivo XML com seus ativos digitais através do uso da interface pública da biblioteca, sem a necessidade de estar em um pacote SPS em arquivo compactado
* Parar o processo de otimização caso algum erro ocorra: arquivo não encontrado, erro no arquivo de imagem original
* Facilitar a manutenção

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
- Instale os `requirements.txt` e a nova versão
- Com um pacote SPS em arquivo compactado ZIP, execute o comando:
```bash
package_optimiser --loglevel INFO <caminho para o pacote SPS>
```
- Confira também as opções do comando:
```bash
package_optimiser --help
```
- Um pacote otimizado deve ter sido gerado
- Com os XMLs otimizados, execute o comando `htmlgenerator` com eles.
- Os HTMLs renderizados devem estar com as imagens otimizadas.

#### Algum cenário de contexto que queira dar?
Tentei ao máximo organizar os commits para que eles fossem independentes, não interferindo nos outros, nos dando mais flexibilidade para revertê-los individualmente caso necessário mas não foi possível. Foi priorizado a divisão em commits para facilitar a revisão.

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store-migracao/issues/283

### Referências
.

