### PR TITLE
Trata erros na criação de instância de conversor de imagens na otimização de XMLs

### DIFF
--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -540,10 +540,14 @@ class XMLWebOptimiser(object):
         except exceptions.SPPackageError as exc:
             self._handle_image_exception(exc)
         else:
-            web_image_generator = WebImageGenerator(
-                image_filename, self.work_dir, image_file_bytes
-            )
-            return web_image_generator
+            try:
+                web_image_generator = WebImageGenerator(
+                    image_filename, self.work_dir, image_file_bytes
+                )
+            except exceptions.WebImageGeneratorError as exc:
+                self._handle_image_exception(exc)
+            else:
+                return web_image_generator
 
     def _add_optimised_image(self, image_filename):
         web_image_generator = self._get_web_image_generator(image_filename)


### PR DESCRIPTION
#### O que esse PR faz?
Quando formatos de arquivos não são suportados pelo Pillow, uma exceção será lançada e, por isso, este tratamento se faz necessário no otimizador de XMLs para que, de acordo com o atributo `stop_if_error`, a execução seja ou não interrompida. Também foram adicionados logs de debug.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
1. Com um pacote SPS contendo arquivos SVG e documento referenciando-os, utilize o comando `package_optimiser` com a opção `--stopiferror`
2. A execução da otimização deve ser interrompida
3. Repita o comando acima sem a opção `--stopiferror`
4. A execução não deve ser interrompida, somente deve haver o log do problema.

#### Algum cenário de contexto que queira dar?
Erro detectado durante a execução do DS Migração de XMLs nativos.

### Screenshots
n/a

#### Quais são tickets relevantes?
#227 

### Referências
.