### PR TITLE
Ajusta leitura de XMLs no otimizador para que seja independente da DTD

### DIFF
--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -459,7 +459,8 @@ class XMLWebOptimiser(object):
                 "Error instantiating XMLWebOptimiser: read_file cannot be None"
             )
         self._read_file = read_file
-        self._xml_file = XML(io.BytesIO(self._read_file(filename)))
+        self._xml_file = XML(io.BytesIO(self._read_file(filename)), load_dtd=False)
+        self._xml_doctype = self._xml_file.docinfo.doctype
         self._image_filenames = self._get_all_graphic_images_from_xml(image_filenames)
 
     def _get_all_graphic_images_from_xml(self, image_filenames):
@@ -646,6 +647,7 @@ class XMLWebOptimiser(object):
 
         return etree.tostring(
             self._xml_file,
+            doctype=self._xml_doctype or None,
             xml_declaration=True,
             method="xml",
             encoding="utf-8",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o otimizador WEB para que ele faça a leitura dos XMLs sem o carregamento da DTD no parser. Também foi feito ajuste em mensagem do comando do otimizador e a inclusão do DOCTYPE no retorno da otimização, quando já existente no documento.

#### Onde a revisão poderia começar?
Em `packtools/utils.py`.

#### Como este poderia ser testado manualmente?
Com um pacote SPS, comprimido em arquivo ZIP, que contenha documentos XML inválidos pela DTD:
1. Execute o comando `package_optimiser <caminho do pacote SPS>`
2. Observe que o documento e seus ativos digitais são otimizados sem erros

#### Algum cenário de contexto que queira dar?
Este problema foi identificado durante o processo de migração da coleção BR.

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store-migracao/issues/317

### Referências
.