### PR TITLE
Trata exceção lançada pelo Pillow para prevenção de ataques DOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+before_install: pip install --upgrade pip
 install: pip install tox-travis
 script: tox
 

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -314,7 +314,7 @@ class WebImageGenerator:
             try:
                 parser.feed(file_bytes)
                 image = parser.close()
-            except IOError as exc:
+            except (Image.DecompressionBombError, IOError) as exc:
                 raise exceptions.WebImageGeneratorError(
                     'Error reading image "%s": %s' % (self.filename, str(exc))
                 )

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -364,7 +364,7 @@ class WebImageGenerator:
         """
         try:
             image_file = Image.open(self.image_file_path)
-        except (OSError, IOError, ValueError) as exc:
+        except (Image.DecompressionBombError, OSError, IOError, ValueError) as exc:
             raise exceptions.WebImageGeneratorError(
                 'Error opening image file "%s": %s' % (self.image_file_path, str(exc))
             )

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -336,7 +336,7 @@ class WebImageGenerator:
         """
         try:
             tiff_file = Image.open(self.image_file_path)
-        except (OSError, IOError, ValueError) as exc:
+        except (Image.DecompressionBombError, OSError, IOError, ValueError) as exc:
             raise exceptions.WebImageGeneratorError(
                 'Error opening image file "%s": %s' % (self.image_file_path, str(exc))
             )

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ else:
     EXTRAS_REQUIRE[':python_version<"3.4"'] = ['pathlib>=1.0.1']
 
 if sys.version_info[0:2] == (2, 7):
-    TESTS_REQUIRE.append('mock')
+    TESTS_REQUIRE.append('mock==3.0.5')
 
 setup(
     name="packtools",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -289,6 +289,18 @@ class TestWebImageGenerator(unittest.TestCase):
             os.path.exists(os.path.join(self.extracted_package, "file.png"))
         )
 
+    @mock.patch.object(Image, "open")
+    def test_convert2png_large_image_file_security_error(self, mk_open):
+        mk_open.side_effect = Image.DecompressionBombError("ERROR!")
+        text_file_path = os.path.join(self.extracted_package, "file.txt")
+        web_image_generator = utils.WebImageGenerator(
+            "file.txt", self.extracted_package
+        )
+        with self.assertRaises(exceptions.WebImageGeneratorError) as exc_info:
+            web_image_generator.convert2png()
+        self.assertIn("Error opening image file ", str(exc_info.exception))
+        self.assertIn("file.txt", str(exc_info.exception))
+
     def test_convert2png_ok(self):
         web_image_generator = utils.WebImageGenerator(
             "image_tiff_2.tif", self.extracted_package


### PR DESCRIPTION
#### O que esse PR faz?
Este PR trata exceção lançada pelo Pillow para imagens que ultrapassem as  dimensões limite definida em `Image.MAX_IMAGE_PIXELS` na classe geradora de imagens renderizáveis em WEB. Este tratamento foi incluído na criação de objeto Image por bytes lidos de arquivo, na conversão para PNG e criação de thumbnail à partir de arquivo lido de _path_ informado.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
- Com um pacote SPS contendo um arquivo de imagem que ultrapasse 178.956.970 pixels de dimensões, execute o comando:
```
package_optimiser <caminho-para-pacote-SPS>
```
- A execução do comando deve ser completada com sucesso e mensagem de erro deve ser exibida
- Rode novamente o comando adicionando o argumento `--stopiferror`
- A exceção `packtools.exceptions.WebImageGeneratorError` deve ser lançada, mostrando mensagem de erro da aplicação

#### Algum cenário de contexto que queira dar?
Este erro foi identificado nas aplicações de migração para o SPF e em PC-Programs

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/document-store-migracao#326

### Referências
Documentação do Pillow que informa sobre o tratamento prevenindo ataques DOS: https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.open
