### PR TITLE
Adiciona novamente as validações de URLs CRediT

### DIFF
--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -1744,20 +1744,20 @@ code for more information.
 
   <pattern id="role_content-type-values">
     <rule context="//contrib-group/contrib/role[@content-type]">
-      <assert test="@content-type = 'https://dictionary.casrai.org/Contributor_Roles/Conceptualization' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Data_curation' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Formal_analysis' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Investigation' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Methodology' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Project_administration' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Resources' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Software' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Supervision' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Validation' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Visualization' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft' or
-                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing'">
+      <assert test="@content-type = 'https://casrai.org/term/contributor-roles-conceptualization' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-data-curation' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-formal-analysis' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-funding-acquisition' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-investigation' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-methodology' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-project-administration' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-resources' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-software' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-supervision' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-validation' or
+                    @content-type = 'https://web.archive.org/web/20180313224017/http://dictionary.casrai.org/Contributor_Roles/Visualization' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-writing-original-draft' or
+                    @content-type = 'https://casrai.org/term/contributor-roles-writing-review-editing'">
         Element 'role', attribute content-type: Invalid value '<value-of select="@content-type"/>'.
       </assert>
     </rule>

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -300,6 +300,10 @@ code for more information.
     <active pattern="chapter-title_cardinality"/>
   </phase>
 
+  <phase id="phase.role">
+    <active pattern="role_content-type-values"/>
+  </phase>
+
   <!--
    Patterns - sets of rules.
   -->
@@ -1738,5 +1742,25 @@ code for more information.
     </rule>
   </pattern>
 
+  <pattern id="role_content-type-values">
+    <rule context="//contrib-group/contrib/role[@content-type]">
+      <assert test="@content-type = 'https://dictionary.casrai.org/Contributor_Roles/Conceptualization' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Data_curation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Formal_analysis' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Investigation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Methodology' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Project_administration' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Resources' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Software' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Supervision' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Validation' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Visualization' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft' or
+                    @content-type = 'https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing'">
+        Element 'role', attribute content-type: Invalid value '<value-of select="@content-type"/>'.
+      </assert>
+    </rule>
+  </pattern>
 </schema>
 

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -6225,3 +6225,80 @@ class SourceTests(PhaseBasedTestCase):
 
         self.assertFalse(self._run_validation(sample))
 
+
+class RoleTests(PhaseBasedTestCase):
+    """Tests for //contrib-group/contrib/role elements.
+    """
+    sch_phase = 'phase.role'
+
+    def test_role_with_free_text(self):
+        sample = u"""<article>
+                      <front>
+                        <article-meta>
+                          <contrib-group>
+                            <contrib>
+                              <role>Autor correspondente</role>
+                            </contrib>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_CRediT_taxonomy_urls(self):
+        for value in [
+            "https://dictionary.casrai.org/Contributor_Roles/Conceptualization",
+            "https://dictionary.casrai.org/Contributor_Roles/Data_curation",
+            "https://dictionary.casrai.org/Contributor_Roles/Formal_analysis",
+            "https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition",
+            "https://dictionary.casrai.org/Contributor_Roles/Investigation",
+            "https://dictionary.casrai.org/Contributor_Roles/Methodology",
+            "https://dictionary.casrai.org/Contributor_Roles/Project_administration",
+            "https://dictionary.casrai.org/Contributor_Roles/Resources",
+            "https://dictionary.casrai.org/Contributor_Roles/Software",
+            "https://dictionary.casrai.org/Contributor_Roles/Supervision",
+            "https://dictionary.casrai.org/Contributor_Roles/Validation",
+            "https://dictionary.casrai.org/Contributor_Roles/Visualization",
+            "https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft",
+            "https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing",
+            ]:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <contrib-group>
+                                <contrib>
+                                  <role content-type="{value}">Autor correspondente</role>
+                                </contrib>
+                              </contrib-group>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """.format(value=value)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_role_with_invalid_taxonomy_url(self):
+        for value in [
+            "https://dictionary.casrai.org/Contributor_Roles/INVALID_URL",
+            "invalid_value",
+            ]:
+            sample = u"""<article>
+                          <front>
+                            <article-meta>
+                              <contrib-group>
+                                <contrib>
+                                  <role content-type="{value}">Autor correspondente</role>
+                                </contrib>
+                              </contrib-group>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """.format(value=value)
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertFalse(self._run_validation(sample))
+

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -6250,20 +6250,20 @@ class RoleTests(PhaseBasedTestCase):
 
     def test_CRediT_taxonomy_urls(self):
         for value in [
-            "https://dictionary.casrai.org/Contributor_Roles/Conceptualization",
-            "https://dictionary.casrai.org/Contributor_Roles/Data_curation",
-            "https://dictionary.casrai.org/Contributor_Roles/Formal_analysis",
-            "https://dictionary.casrai.org/Contributor_Roles/Funding_acquisition",
-            "https://dictionary.casrai.org/Contributor_Roles/Investigation",
-            "https://dictionary.casrai.org/Contributor_Roles/Methodology",
-            "https://dictionary.casrai.org/Contributor_Roles/Project_administration",
-            "https://dictionary.casrai.org/Contributor_Roles/Resources",
-            "https://dictionary.casrai.org/Contributor_Roles/Software",
-            "https://dictionary.casrai.org/Contributor_Roles/Supervision",
-            "https://dictionary.casrai.org/Contributor_Roles/Validation",
-            "https://dictionary.casrai.org/Contributor_Roles/Visualization",
-            "https://dictionary.casrai.org/Contributor_Roles/Writing_original_draft",
-            "https://dictionary.casrai.org/Contributor_Roles/Writing_review_editing",
+            "https://casrai.org/term/contributor-roles-conceptualization",
+            "https://casrai.org/term/contributor-roles-data-curation",
+            "https://casrai.org/term/contributor-roles-formal-analysis",
+            "https://casrai.org/term/contributor-roles-funding-acquisition",
+            "https://casrai.org/term/contributor-roles-investigation",
+            "https://casrai.org/term/contributor-roles-methodology",
+            "https://casrai.org/term/contributor-roles-project-administration",
+            "https://casrai.org/term/contributor-roles-resources",
+            "https://casrai.org/term/contributor-roles-software",
+            "https://casrai.org/term/contributor-roles-supervision",
+            "https://casrai.org/term/contributor-roles-validation",
+            "https://web.archive.org/web/20180313224017/http://dictionary.casrai.org/Contributor_Roles/Visualization",
+            "https://casrai.org/term/contributor-roles-writing-original-draft",
+            "https://casrai.org/term/contributor-roles-writing-review-editing",
             ]:
             sample = u"""<article>
                           <front>


### PR DESCRIPTION
#### O que esse PR faz?
Este PR inclui novamente as validações de URLs da taxonimia CRediT de acordo com as definições mais recentes.

#### Onde a revisão poderia começar?
n/a

#### Como este poderia ser testado manualmente?
Você poderá produzir manualmente um XML que contém a estrutura da taxonomia. Alguns exemplos poderão ser encontrados em https://docs.google.com/document/d/1UwHgZc-99cnRlg5lfbLMPAbfWmDLmgMYY1fxgdh9ScI/edit?usp=sharing.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#218 

### Referências
https://docs.google.com/document/d/1UwHgZc-99cnRlg5lfbLMPAbfWmDLmgMYY1fxgdh9ScI/edit?usp=sharing

