### PR TITLE
Adiciona regras de pareceres e CRediT para SciELO PS 1.10

### DIFF
--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -1432,7 +1432,8 @@ code for more information.
       <assert test="@article-type = 'abstract' or 
                     @article-type = 'letter' or 
                     @article-type = 'reply' or 
-                    @article-type = 'translation'">
+                    @article-type = 'translation' or
+                    @article-type = 'referee-report'">
         Element 'sub-article', attribute article-type: Invalid value '<value-of select="@article-type"/>'.
       </assert>
     </rule>

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -748,7 +748,8 @@ code for more information.
                     @date-type = 'preprint' or
                     @date-type = 'retracted' or
                     @date-type = 'rev-request' or
-                    @date-type = 'rev-recd'">
+                    @date-type = 'rev-recd' or
+                    @date-type = 'referee-report-received'">
         Element 'date', attribute date-type: Invalid value "<value-of select="@date-type"/>".
       </assert>
     </rule>

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -307,6 +307,11 @@ code for more information.
   <phase id="phase.referee-report">
     <active pattern="referee-report_mandatory_elements"/>
     <active pattern="referee-report_related-object_href_notempty"/>
+    <active pattern="referee-report_role_specific-use_values"/>
+  </phase>
+
+  <phase id="phase.referee-report_sub-article">
+    <active pattern="referee-report_role_specific-use_values"/>
   </phase>
 
   <!--
@@ -1786,6 +1791,15 @@ code for more information.
       </assert>
       <assert test="@ext-link-type = 'doi'">
         Element 'related-object': Missing attribute ext-link-type='doi'. 
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="referee-report_role_specific-use_values">
+    <rule context="article[@article-type = 'referee-report']/front/article-meta/contrib-group/contrib | article/sub-article[@article-type = 'referee-report']/front-stub/contrib-group/contrib">
+      <assert test="role/@specific-use = 'reviewer' or
+                    role/@specific-use = 'editor'">
+        Element 'contrib': missing element role with specific-use='reviewer' or specific-use='editor'.
       </assert>
     </rule>
   </pattern>

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -1202,7 +1202,8 @@ code for more information.
             @article-type = 'product-review' or
             @article-type = 'dissertation' or
             @article-type = 'translation' or
-            @article-type = 'data-article'">
+            @article-type = 'data-article' or
+            @article-type = 'referee-report'">
         Element 'article', attribute article-type: Invalid value '<value-of select="@article-type"/>'.
       </assert>
     </rule>

--- a/packtools/catalogs/scielo-style-1.10.sch
+++ b/packtools/catalogs/scielo-style-1.10.sch
@@ -304,6 +304,11 @@ code for more information.
     <active pattern="role_content-type-values"/>
   </phase>
 
+  <phase id="phase.referee-report">
+    <active pattern="referee-report_mandatory_elements"/>
+    <active pattern="referee-report_related-object_href_notempty"/>
+  </phase>
+
   <!--
    Patterns - sets of rules.
   -->
@@ -1764,5 +1769,25 @@ code for more information.
       </assert>
     </rule>
   </pattern>
+
+  <pattern id="referee-report_mandatory_elements">
+    <rule context="article[@article-type = 'referee-report']/front/article-meta">
+      <assert test="related-object/@object-type = 'peer-reviewed-material'">
+        Element 'article-meta': missing element related-object with object-type='peer-reviewed-material'.
+      </assert>
+    </rule>
+  </pattern>
+
+  <pattern id="referee-report_related-object_href_notempty">
+    <rule context="article[@article-type = 'referee-report']/front/article-meta/related-object[@object-type='peer-reviewed-material']">
+      <assert test="string-length(normalize-space(@xlink:href)) > 0">
+        Element 'related-object', attribute xlink:href: Missing value.
+      </assert>
+      <assert test="@ext-link-type = 'doi'">
+        Element 'related-object': Missing attribute ext-link-type='doi'. 
+      </assert>
+    </rule>
+  </pattern>
+
 </schema>
 

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -6302,3 +6302,124 @@ class RoleTests(PhaseBasedTestCase):
 
             self.assertFalse(self._run_validation(sample))
 
+
+class RefereeReportTests(PhaseBasedTestCase):
+    """
+    Validations related to open peer-review.
+
+    Tests for article[@article-type = "referee-report"] elements.
+    """
+    sch_phase = 'phase.referee-report'
+
+    def test_related_object_is_mandatory(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998" 
+                            ext-link-type="doi"/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertTrue(self._run_validation(sample))
+
+    def test_missing_related_object(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_object_with_missing_xlinkhref(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            ext-link-type="doi"/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_object_with_empty_xlinkhref(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="" 
+                            ext-link-type="doi"/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_object_with_empty_ext_link_type(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998" 
+                            ext-link-type=""/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_object_with_missing_ext_link_type(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998"/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_object_with_invalid_ext_link_type(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998" 
+                            ext-link-type="unknown"/>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -5059,7 +5059,7 @@ class SubArticleAttributesTests(PhaseBasedTestCase):
     sch_phase = 'phase.sub-article-attrs'
 
     def test_allowed_article_types(self):
-        for art_type in ['abstract', 'letter', 'reply', 'translation']:
+        for art_type in ['abstract', 'letter', 'reply', 'translation', 'referee-report']:
             sample = u"""<article article-type="research-article" xml:lang="en" dtd-version="1.0" specific-use="sps-1.10">
                            <sub-article article-type="%s" xml:lang="pt" id="sa1"></sub-article>
                          </article>

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -2523,18 +2523,6 @@ class HistoryTests(PhaseBasedTestCase):
 
         self.assertTrue(self._run_validation(sample))
 
-    def test_(self):
-        sample = u"""<article>
-                      <front>
-                        <article-meta>
-                        </article-meta>
-                      </front>
-                    </article>
-                 """
-        sample = io.BytesIO(sample.encode('utf-8'))
-
-        self.assertTrue(self._run_validation(sample))
-
     def test_date_type_allowed_values(self):
         for pub_type in ['accepted', 'corrected', 'pub', 'preprint',
                 'retracted', 'received', 'rev-recd', 'rev-request']:

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -6412,3 +6412,131 @@ class RefereeReportTests(PhaseBasedTestCase):
 
         self.assertFalse(self._run_validation(sample))
 
+    def test_role_is_mandatory(self):
+        for role in ["reviewer", "editor"]:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                          <front>
+                            <article-meta>
+                              <related-object 
+                                object-type="peer-reviewed-material" 
+                                id="r01" 
+                                xlink:href="10.1590/abd1806-4841.20142998" 
+                                ext-link-type="doi"/>
+                              <contrib-group>
+                                <contrib>
+                                  <role specific-use="%s">%s</role>
+                                </contrib>
+                              </contrib-group>
+                            </article-meta>
+                          </front>
+                        </article>
+                     """ % (role, role.title())
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_role_with_missing_specific_use(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998" 
+                            ext-link-type="doi"/>
+                          <contrib-group>
+                            <contrib>
+                              <role>Reviewer</role>
+                            </contrib>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_role_with_unknown_specific_use(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="referee-report">
+                      <front>
+                        <article-meta>
+                          <related-object 
+                            object-type="peer-reviewed-material" 
+                            id="r01" 
+                            xlink:href="10.1590/abd1806-4841.20142998" 
+                            ext-link-type="doi"/>
+                          <contrib-group>
+                            <contrib>
+                              <role specific-use="unknown">Unknown</role>
+                            </contrib>
+                          </contrib-group>
+                        </article-meta>
+                      </front>
+                    </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+
+class RefereeReportSubArticleTests(PhaseBasedTestCase):
+    """
+    Validations related to open peer-review.
+
+    Tests for article/sub-article[@article-type = "referee-report"] elements.
+    """
+    sch_phase = 'phase.referee-report_sub-article'
+
+    def test_related_object_is_mandatory(self):
+        for role in ["reviewer", "editor"]:
+            sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                           <sub-article article-type="referee-report">
+                             <front-stub>
+                               <contrib-group>
+                                 <contrib>
+                                   <role specific-use="%s">%s</role>
+                                 </contrib>
+                               </contrib-group>
+                             </front-stub>
+                           </sub-article>
+                         </article>
+                     """ % (role, role.title())
+            sample = io.BytesIO(sample.encode('utf-8'))
+
+            self.assertTrue(self._run_validation(sample))
+
+    def test_related_with_missing_specific_use(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                       <sub-article article-type="referee-report">
+                         <front-stub>
+                           <contrib-group>
+                             <contrib>
+                               <role>Unknown</role>
+                             </contrib>
+                           </contrib-group>
+                         </front-stub>
+                       </sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+
+    def test_related_with_unknown_specific_use(self):
+        sample = u"""<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                       <sub-article article-type="referee-report">
+                         <front-stub>
+                           <contrib-group>
+                             <contrib>
+                               <role specific-use="unknown">Unknown</role>
+                             </contrib>
+                           </contrib-group>
+                         </front-stub>
+                       </sub-article>
+                     </article>
+                 """
+        sample = io.BytesIO(sample.encode('utf-8'))
+
+        self.assertFalse(self._run_validation(sample))
+

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -4346,7 +4346,7 @@ class ArticleAttributesTests(PhaseBasedTestCase):
                 'reply', 'retraction', 'partial-retraction', 'clinical-trial',
                 'announcement', 'calendar', 'in-brief', 'book-received', 'news',
                 'reprint', 'meeting-report', 'abstract', 'product-review',
-                'dissertation', 'translation', 'data-article']:
+                'dissertation', 'translation', 'data-article', 'referee-report']:
 
             sample = u"""<article article-type="%s" xml:lang="en" dtd-version="1.0" specific-use="sps-1.10">
                         </article>

--- a/tests/test_schematron_1_10.py
+++ b/tests/test_schematron_1_10.py
@@ -2525,7 +2525,8 @@ class HistoryTests(PhaseBasedTestCase):
 
     def test_date_type_allowed_values(self):
         for pub_type in ['accepted', 'corrected', 'pub', 'preprint',
-                'retracted', 'received', 'rev-recd', 'rev-request']:
+                'retracted', 'received', 'rev-recd', 'rev-request',
+                'referee-report-received']:
             sample = u"""<article>
                           <front>
                             <article-meta>


### PR DESCRIPTION
Adiciona regras de validação definidas na versão 1.0 da SciELO PS para pareceres abertos e taxonimia CRediT.

#### Onde a revisão poderia começar?
Penso que pelos códigos de testes.

#### Como este poderia ser testado manualmente?
Não será fácil, mas caso queira muito terá que preparar arquivos XML (que podem ser encontrados no diretório _tests/samples_) com as estruturas documentadas em https://docs.google.com/document/d/18ZiEUSqbxGlh0IprIUJF-N54m6ni7NXzVfjH9xc6DFw/edit?usp=sharing e https://docs.google.com/document/d/1UwHgZc-99cnRlg5lfbLMPAbfWmDLmgMYY1fxgdh9ScI/edit?usp=sharing.

#### Algum cenário de contexto que queira dar?
A integração destes códigos é pré-requisito para o lançamento da SciELO PS 1.10.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
* https://docs.google.com/document/d/18ZiEUSqbxGlh0IprIUJF-N54m6ni7NXzVfjH9xc6DFw/edit?usp=sharing
* https://docs.google.com/document/d/1UwHgZc-99cnRlg5lfbLMPAbfWmDLmgMYY1fxgdh9ScI/edit?usp=sharing.

