### PR TITLE
Adiciona o uso da imagem de thumbnail na página do artigo, ajusta a prioridade para utilizar imagens sem o atributo ``specific-use``.

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet 
+<xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     exclude-result-prefixes="xlink mml"
     version="1.0">
-    
+
     <xsl:template match="alternatives">
         <xsl:choose>
             <xsl:when test="inline-graphic[@specific-use='scielo-web']">
                 <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" />
             </xsl:when>
-            <xsl:when test="graphic[@specific-use='scielo-web']">
+            <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
                 <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" />
+            </xsl:when>
+            <xsl:when test="graphic[not(@specific-use) and not(@content-type)]">
+                <xsl:apply-templates select="graphic[not(@specific-use) and not(@content-type)]" />
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="*[name()!='graphic'][1]"></xsl:apply-templates>
@@ -22,16 +25,46 @@
 
     <xsl:template match="alternatives" mode="file-location">
         <xsl:choose>
+
             <xsl:when test="inline-graphic[@specific-use='scielo-web']">
                 <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" mode="file-location"/>
             </xsl:when>
-            <xsl:when test="graphic[@specific-use='scielo-web']">
-                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" mode="file-location" />
+
+            <xsl:when test="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]" mode="file-location" />
             </xsl:when>
+
+            <xsl:when test="graphic[not(@specific-use) and not(@content-type)]">
+                <xsl:apply-templates select="graphic[not(@specific-use) and not(@content-type)]" mode="file-location" />
+            </xsl:when>
+
             <xsl:otherwise>
                 <xsl:apply-templates select="*[name()!='graphic'][1]" mode="file-location"></xsl:apply-templates>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-   
+
+    <xsl:template match="alternatives" mode="file-location-thumb">
+        <xsl:choose>
+
+            <xsl:when test="inline-graphic[@specific-use='scielo-web']">
+                <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" mode="file-location-thumb"/>
+            </xsl:when>
+            <xsl:when test="inline-graphic[not(@specific-use='scielo-web')]">
+                <xsl:apply-templates select="inline-graphic[not(@specific-use='scielo-web')]" mode="file-location-thumb"/>
+            </xsl:when>
+
+            <xsl:when test="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]" mode="file-location-thumb" />
+            </xsl:when>
+            <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" mode="file-location-thumb" />
+            </xsl:when>
+
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[name()!='graphic'][1]" mode="file-location-thumb"></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -17,7 +17,9 @@
         </xsl:choose>
     </xsl:template>
     <xsl:template match="fig[graphic]">
-        <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"></xsl:apply-templates></xsl:variable>
+        <xsl:variable name="location">
+            <xsl:apply-templates select="." mode="file-location-thumb"></xsl:apply-templates>
+        </xsl:variable>
         <div class="row fig" id="{@id}">
             <a name="{@id}"></a>
             <div class="col-md-4 col-sm-4">
@@ -36,7 +38,7 @@
 
     <xsl:template match="fig[.//graphic]">
         <xsl:variable name="location">
-            <xsl:apply-templates select="alternatives | graphic" mode="file-location"></xsl:apply-templates>
+            <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"></xsl:apply-templates>
         </xsl:variable>
         <div class="row fig" id="{@id}">
             <a name="{@id}"></a>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-graphic.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-graphic.xsl
@@ -9,7 +9,7 @@
         <xsl:variable name="location"><xsl:apply-templates select="@xlink:href"></xsl:apply-templates></xsl:variable>
         <xsl:variable name="s"><xsl:value-of select="substring($location,string-length($location)-3)"/></xsl:variable>
         <xsl:variable name="ext"><xsl:if test="contains($s,'.')">.<xsl:value-of select="substring-after($s,'.')"/></xsl:if></xsl:variable>
-        
+
         <xsl:choose>
             <xsl:when test="$ext='.svg'">
                 <object type="image/svg+xml">
@@ -23,13 +23,15 @@
                     <xsl:attribute name="src"><xsl:value-of select="$location"/></xsl:attribute>
                 </img>
             </xsl:otherwise>
-        </xsl:choose>      
+        </xsl:choose>
         <!--
         <xsl:comment><xsl:value-of select="$s"/> </xsl:comment>
         -->
     </xsl:template>
 
     <xsl:template match="graphic | inline-graphic" mode="file-location"><xsl:apply-templates select="@xlink:href"/></xsl:template>
+
+    <xsl:template match="graphic | inline-graphic" mode="file-location-thumb"><xsl:apply-templates select="@xlink:href"/></xsl:template>
 
     <xsl:template match="graphic/@xlink:href | inline-graphic/@xlink:href">
         <xsl:variable name="s"><xsl:value-of select="substring(.,string-length(.)-4)"/></xsl:variable>
@@ -38,6 +40,6 @@
             <xsl:when test="$ext='.tif' or $ext='.tiff'"><xsl:value-of select="substring-before(.,$ext)"/>.jpg</xsl:when>
             <xsl:when test="$ext=''"><xsl:value-of select="."/>.jpg</xsl:when>
             <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
-        </xsl:choose>      
+        </xsl:choose>
     </xsl:template>
 </xsl:stylesheet>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.6.4'
+__version__ = '2.6.5'
 

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -618,7 +618,7 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
             html.find('//p//img[@src="1234-5678-rctb-45-05-0110-e02.jpg"]')
         )
 
-    def test_graphic_images_alternatives_must_prioritize_scielo_web_in_fig(self):
+    def test_graphic_images_alternatives_must_prioritize_scielo_web_and_content_type_in_fig_when_thumb(self):
         graphic1 = """
         <fig id="e01">
             <alternatives>
@@ -636,7 +636,48 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
-            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.png);"]'
+            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.thumbnail.jpg);"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0
+          )
+
+    def test_graphic_images_alternatives_must_prioritize_scielo_in_modal(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" specific-use="scielo-web" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<alternatives><inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.png" /></alternatives>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e01.png"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+    def test_graphic_images_alternatives_must_get_first_graphic_in_modal_when_not_scielo_web_and_not_content_type_atribute(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png"/>
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<alternatives><inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.png" /></alternatives>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e01.png"]'
         )
         self.assertTrue(len(thumb_tag) > 0)
 

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -641,11 +641,12 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
         self.assertTrue(len(thumb_tag) > 0
           )
 
-    def test_graphic_images_alternatives_must_prioritize_scielo_in_modal(self):
+    def test_graphic_images_alternatives_must_prioritize_scielo_web_attribute_in_modal(self):
         graphic1 = """
         <fig id="e01">
             <alternatives>
-                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" specific-use="scielo-web" />
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e03.png" specific-use="scielo-web" />
                 <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
             </alternatives>
         </fig>
@@ -657,9 +658,10 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
         et = etree.parse(fp)
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
-            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e01.png"]'
+            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e03.png"]'
         )
         self.assertTrue(len(thumb_tag) > 0)
+
 
     def test_graphic_images_alternatives_must_get_first_graphic_in_modal_when_not_scielo_web_and_not_content_type_atribute(self):
         graphic1 = """


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o uso da imagem de thumbnail na página do artigo, ajusta a prioridade para também utilizar imagens sem o atributo ``specific-use``.  

#### Onde a revisão poderia começar?

Olhando os commits. 

Rodando os testes unitários com: 

```shell 
python setup.py test
```

Ou somente o módulo alterado: 

```shell 
python -m unittest discover -s tests -p "test_html*.py"
```


#### Como este poderia ser testado manualmente?

No tíquete referente a esse PR é possível obter dois xmls, onde temos a situação de imagens com e sem o atributo ``specific-use``. 

Utilizando o comando ``htmlgenerator --nochecks {XML}`` é possível verificar o resultado no HTML resultante. 


#### Algum cenário de contexto que queira dar?

Importante ter em mente a priorização acordado entre a equipe no tíquete: https://github.com/scieloorg/opac/issues/1643 (Comentários)

### Screenshots
N/A

#### Quais são tickets relevantes?

Tíquete referente a esse PR: https://github.com/scieloorg/opac/issues/1643 

### Referências

Utilizei como referência nossa amiga de trabalho @robertatakenaka, muito grato pelo apoio para execução dessa atividade.

