### PR TITLE
Seleciona o elemento `graphic` também considerando o valor do atributo `@xlink:href`, que não pode ser "vazio"

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -47,18 +47,21 @@
     <xsl:template match="alternatives" mode="file-location-thumb">
         <xsl:choose>
 
-            <xsl:when test="inline-graphic[@specific-use='scielo-web']">
-                <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" mode="file-location-thumb"/>
+            <xsl:when test="inline-graphic[@xlink:href!='' and @specific-use='scielo-web']">
+                <xsl:apply-templates select="inline-graphic[@xlink:href!='' and @specific-use='scielo-web']" mode="file-location-thumb"/>
             </xsl:when>
-            <xsl:when test="inline-graphic[not(@specific-use='scielo-web')]">
-                <xsl:apply-templates select="inline-graphic[not(@specific-use='scielo-web')]" mode="file-location-thumb"/>
+            <xsl:when test="inline-graphic[@xlink:href!='' and not(@specific-use='scielo-web')]">
+                <xsl:apply-templates select="inline-graphic[@xlink:href!='' and not(@specific-use='scielo-web')]" mode="file-location-thumb"/>
             </xsl:when>
 
-            <xsl:when test="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]">
-                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]" mode="file-location-thumb" />
+            <xsl:when test="graphic[@xlink:href!='' and @specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]">
+                <xsl:apply-templates select="graphic[@xlink:href!='' and @specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]" mode="file-location-thumb" />
             </xsl:when>
-            <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
-                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" mode="file-location-thumb" />
+            <xsl:when test="graphic[@xlink:href!='' and @specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
+                <xsl:apply-templates select="graphic[@xlink:href!='' and @specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" mode="file-location-thumb" />
+            </xsl:when>
+            <xsl:when test=".//graphic[@xlink:href!='']">
+                <xsl:apply-templates select=".//graphic[@xlink:href!=''][1]" mode="file-location-thumb" />
             </xsl:when>
 
             <xsl:otherwise>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -11,8 +11,8 @@
             <xsl:when test="inline-graphic[@specific-use='scielo-web']">
                 <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" />
             </xsl:when>
-            <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
-                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" />
+            <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-')) and @xlink:href!='']">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-')) and @xlink:href!='']" />
             </xsl:when>
             <xsl:when test=".//graphic[not(@specific-use) and not(@content-type) and @xlink:href!='']">
                 <xsl:apply-templates select=".//graphic[not(@specific-use) and not(@content-type) and @xlink:href!=''][1]" />

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -14,8 +14,8 @@
             <xsl:when test="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]">
                 <xsl:apply-templates select="graphic[@specific-use='scielo-web' and not(starts-with(@content-type, 'scielo-'))]" />
             </xsl:when>
-            <xsl:when test="graphic[not(@specific-use) and not(@content-type)]">
-                <xsl:apply-templates select="graphic[not(@specific-use) and not(@content-type)]" />
+            <xsl:when test=".//graphic[not(@specific-use) and not(@content-type) and @xlink:href!='']">
+                <xsl:apply-templates select=".//graphic[not(@specific-use) and not(@content-type) and @xlink:href!=''][1]" />
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="*[name()!='graphic'][1]"></xsl:apply-templates>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -994,6 +994,78 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         )
         self.assertTrue(len(thumb_tag) > 0)
 
+    def test_article_text_alternatives_mode_file_location_thumb_must_choose_graphic_with_scielo_web_and_no_content_type_because_xlink_href_is_empty(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif" />
+                <graphic specific-use="scielo-web" xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="" />
+            </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="row fig"]'
+            '//div[@class="thumb" and @style="background-image: url('
+            '1234-5678-rctb-45-05-0110-e01.png'
+            ');"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+    def test_article_text_alternatives_mode_file_location_thumb_must_choose_graphic_with_no_scielo_web_and_no_content_type_because_xlink_href_is_empty(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.jpg" />
+                <graphic specific-use="scielo-web" xlink:href="" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="" />
+            </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="row fig"]'
+            '//div[@class="thumb" and @style="background-image: url('
+            '1234-5678-rctb-45-05-0110-e01.jpg'
+            ');"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+    def test_article_text_alternatives_mode_file_location_thumb_must_choose_graphic_with_no_scielo_web_and_no_content_type_because_xlink_href_is_absent(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.jpg" />
+                <graphic specific-use="scielo-web" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" />
+            </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="row fig"]'
+            '//div[@class="thumb" and @style="background-image: url('
+            '1234-5678-rctb-45-05-0110-e01.jpg'
+            ');"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
     def test_article_text_alternatives_mode_file_location_must_choose_graphic_with_xlink_href_not_empty(self):
         graphic1 = """
           <fig id="f01">
@@ -1022,3 +1094,5 @@ class HTMLGeneratorFigTests(unittest.TestCase):
             '"]'
         )
         self.assertTrue(len(img) == 0)
+
+

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -994,4 +994,31 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         )
         self.assertTrue(len(thumb_tag) > 0)
 
-
+    def test_article_text_alternatives_mode_file_location_must_choose_graphic_with_xlink_href_not_empty(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+              <graphic xlink:href="" />
+              <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+              <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.jpg" />
+          </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        img = html.xpath(
+            '//div[@class="modal-body"]/img[@src="'
+            '1234-5678-rctb-45-05-0110-e01.png'
+            '"]'
+        )
+        self.assertTrue(len(img) > 0)
+        img = html.xpath(
+            '//div[@class="modal-body"]/img[@src="'
+            '1234-5678-rctb-45-05-0110-e01.jpg'
+            '"]'
+        )
+        self.assertTrue(len(img) == 0)

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -814,3 +814,157 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
             '//div[@class="modal-body"]/img[@src="1234-5678-rctb-45-05-0110-e01.jpg"]'
         )
         self.assertIsNotNone(modal_body)
+
+
+class HTMLGeneratorFigTests(unittest.TestCase):
+    def setUp(self):
+        self.sample = u"""<article article-type="research-article" dtd-version="1.1"
+        specific-use="sps-1.8" xml:lang="pt"
+        xmlns:mml="http://www.w3.org/1998/Math/MathML"
+        xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+          <article-meta>
+            <article-id pub-id-type="doi">10.1590/2175-7860201869402</article-id>
+            <title-group>
+                <article-title>
+                    Article Title
+                </article-title>
+            </title-group>
+            <pub-date pub-type="epub-ppub">
+                <season>Oct-Dec</season>
+                <year>2018</year>
+            </pub-date>
+            <supplementary-material mimetype="application"
+                                    mime-subtype="tiff"
+                                    xlink:href="1234-5678-rctb-45-05-0110-suppl02.tif"/>
+          </article-meta>
+        </front>
+          <body>
+            <sec>
+              <p>The Eh measurements... <xref ref-type="disp-formula" rid="e01">equation 1</xref>(in mV):</p>
+              {graphic1}
+              <p>We also used an... {graphic2}.</p>
+            </sec>
+          </body>
+      </article>"""
+
+    def test_graphic_images_alternatives_must_prioritize_scielo_web_and_content_type_in_fig_when_thumb(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif" />
+                <graphic specific-use="scielo-web" xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<alternatives><inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff" /><inline-graphic specific-use="scielo-web" xlink:href="1234-5678-rctb-45-05-0110-e02.png" /></alternatives>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
+            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.thumbnail.jpg);"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0
+          )
+
+    def test_graphic_images_alternatives_must_prioritize_scielo_web_attribute_in_modal(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e03.png" specific-use="scielo-web" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<alternatives><inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.png" /></alternatives>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e03.png"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+
+    def test_graphic_images_alternatives_must_get_first_graphic_in_modal_when_not_scielo_web_and_not_content_type_atribute(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png"/>
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<alternatives><inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.png" /></alternatives>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@id="ModalFige01"]//img[@src="1234-5678-rctb-45-05-0110-e01.png"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+    def test_graphic_tiff_image_href_must_be_replaces_by_jpeg_file_extension_in_fig(self):
+        graphic1 = """
+        <fig id="e01">
+            <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif" />
+        </fig>
+        """
+        graphic2 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
+            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.jpg);"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+    def test_graphic_images_alternatives_must_prioritize_scielo_web_in_modal_fig(self):
+        graphic1 = """
+        <fig id="e01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif" />
+                <graphic specific-use="scielo-web" xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.thumbnail.jpg" />
+            </alternatives>
+        </fig>
+        """
+        graphic2 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        modal_body = html.find(
+            '//div[@class="modal-body"]/img[@src="1234-5678-rctb-45-05-0110-e01.png"]'
+        )
+        self.assertIsNotNone(modal_body)
+
+    def test_graphic_tiff_image_href_must_be_replaces_by_jpeg_file_extension_in_modal_fig(self):
+        graphic1 = """
+        <fig id="e01">
+            <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif" />
+        </fig>
+        """
+        graphic2 = '<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e02.tiff"/>'
+        fp = io.BytesIO(
+            self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+        )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        modal_body = html.find(
+            '//div[@class="modal-body"]/img[@src="1234-5678-rctb-45-05-0110-e01.jpg"]'
+        )
+        self.assertIsNotNone(modal_body)

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -1095,4 +1095,47 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         )
         self.assertTrue(len(img) == 0)
 
+    def test_article_text_alternatives_chooses_graphic_with_no_scielo_web_and_no_content_type_because_xlink_href_is_empty(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.png" />
+                <graphic specific-use="scielo-web" xlink:href="" />
+                <graphic specific-use="scielo-web" content-type="scielo-20x20" xlink:href="1234-5678-rctb-45-05-0110-e01.jpg" />
+            </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        img_tag = html.xpath(
+            '//div[@class="modal-body"]/img[@src="'
+            '1234-5678-rctb-45-05-0110-e01.png'
+            '"]'
+        )
+        self.assertTrue(len(img_tag) > 0)
 
+    def test_article_text_alternatives_chooses_graphic_with_no_scielo_web_and_no_content_type_because_xlink_href_is_absent(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.jpg" />
+                <graphic specific-use="scielo-web" />
+            </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        img_tag = html.xpath(
+            '//div[@class="modal-body"]/img[@src="'
+            '1234-5678-rctb-45-05-0110-e01.jpg'
+            '"]'
+        )
+        self.assertTrue(len(img_tag) > 0)

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -968,3 +968,30 @@ class HTMLGeneratorFigTests(unittest.TestCase):
             '//div[@class="modal-body"]/img[@src="1234-5678-rctb-45-05-0110-e01.jpg"]'
         )
         self.assertIsNotNone(modal_body)
+
+    def test_article_text_alternatives_mode_file_location_thumb_must_choose_graphic_with_xlink_href_not_empty(self):
+        graphic1 = """
+          <fig id="f01">
+            <alternatives>
+              <graphic xlink:href=""/>
+              <graphic xlink:href="https://minio.scielo.br/documentstore/1678-992X/Wfy9dhFgfVFZgBbxg4WGVQM/a.jpg"/>
+              <graphic xlink:href="https://minio.scielo.br/documentstore/1678-992X/Wfy9dhFgfVFZgBbxg4WGVQM/b.jpg"/>
+          </alternatives>
+          </fig>
+          """
+        graphic2 = ""
+        fp = io.BytesIO(
+              self.sample.format(graphic1=graphic1, graphic2=graphic2).encode('utf-8')
+          )
+        et = etree.parse(fp)
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
+        thumb_tag = html.xpath(
+            '//div[@class="row fig"]'
+            '//div[@class="thumb" and @style="background-image: url('
+            'https://minio.scielo.br/documentstore/1678-992X/'
+            'Wfy9dhFgfVFZgBbxg4WGVQM/a.jpg'
+            ');"]'
+        )
+        self.assertTrue(len(thumb_tag) > 0)
+
+


### PR DESCRIPTION
#### O que esse PR faz?
Dentre as alternativas, seleciona o elemento `graphic` também considerando o valor do atributo `@xlink:href`, que não pode ser "vazio"

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Use o pacote em anexo, ou crie um pacote XML de acordo com a descrição mencionada no issue #236
Execute:
```bash
python htmlgenerator.py --loglevel DEBUG <arquivo xml> 
```
[tk236 2.zip](https://github.com/scieloorg/packtools/files/5257496/tk236.2.zip)

#### Algum cenário de contexto que queira dar?
No zip, coloquei duas situações:
- `<graphic xlink:href="fig.png"/><graphic xlink:href="fig.jpg"/>` (apresentação fica melhor)
- `<graphic xlink:href="fig.jpg"/><graphic xlink:href="fig.png"/>` 

A lógica é pegar o primeiro `<graphic/>` que satisfaça a condição de ter `@xlink:href` diferente de `''`.

### Screenshots
n/a

#### Quais são tickets relevantes?
#236

### Referências
n/a
