### PR TITLE
Revisa e amplia a apresentação do elemento "fig" em vários contextos (front, body, back, sub-article)

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -30,16 +30,16 @@
                 <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" mode="file-location"/>
             </xsl:when>
 
-            <xsl:when test="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]">
-                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-')]" mode="file-location" />
+            <xsl:when test="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-') and @xlink:href!='']">
+                <xsl:apply-templates select="graphic[@specific-use='scielo-web' and starts-with(@content-type, 'scielo-') and @xlink:href!='']" mode="file-location" />
             </xsl:when>
 
-            <xsl:when test="graphic[not(@specific-use) and not(@content-type)]">
-                <xsl:apply-templates select="graphic[not(@specific-use) and not(@content-type)]" mode="file-location" />
+            <xsl:when test="graphic[not(@specific-use) and not(@content-type) and @xlink:href!='']">
+                <xsl:apply-templates select=".//graphic[not(@specific-use) and not(@content-type) and @xlink:href!=''][1]" mode="file-location" />
             </xsl:when>
 
             <xsl:otherwise>
-                <xsl:apply-templates select="*[name()!='graphic'][1]" mode="file-location"></xsl:apply-templates>
+                <xsl:apply-templates select="*[name()!='graphic' and @xlink:href!=''][1]" mode="file-location"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -6,26 +6,34 @@
     exclude-result-prefixes="xlink mml"
     version="1.0">
 
-    <xsl:template match="fig-group">
-        <xsl:choose>
-            <xsl:when test="fig[@xml:lang=$TEXT_LANG]">
-                <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]"></xsl:apply-templates>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="fig[1]"></xsl:apply-templates>
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-    <xsl:template match="fig[.//graphic]">
+    <xsl:template match="fig | fig-group">
+        <!--
+        Cria a miniatura no texto completo, que ao ser clicada mostra a figura
+        ampliada
+        --> 
         <xsl:variable name="location">
-            <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"></xsl:apply-templates>
+            <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"/>
         </xsl:variable>
-        <div class="row fig" id="{@id}">
-            <a name="{@id}"></a>
+        <xsl:variable name="figid">
+            <xsl:choose>
+                <xsl:when test="@id"><xsl:value-of select="@id"/></xsl:when>
+                <xsl:otherwise>IDMISSING</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <div class="row fig" id="{$figid}">
+            <a name="{$figid}"></a>
             <div class="col-md-4 col-sm-4">
-                <a href="" data-toggle="modal" data-target="#ModalFig{@id}">
-                    <div class="thumb" style="background-image: url({$location});">
+                <a href="" data-toggle="modal" data-target="#ModalFig{$figid}">
+                    <div>
+                        <xsl:choose>
+                            <xsl:when test="$location != ''">
+                                <xsl:attribute name="class">thumb</xsl:attribute>
+                                <xsl:attribute name="style">background-image: url(<xsl:value-of select="$location"/>);</xsl:attribute>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:attribute name="class">thumbOff</xsl:attribute>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         Thumbnail
                         <div class="zoom"><span class="sci-ico-zoom"></span></div>
                     </div>
@@ -39,18 +47,6 @@
 
     <xsl:template match="fig-group" mode="file-location">
         <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
-    </xsl:template>
-
-    <xsl:template match="fig[disp-formula and not(graphic)]">
-        <div class="row fig" id="{@id}">
-            <a name="{@id}"></a>
-            <div class="col-md-4 col-sm-4">
-                <xsl:apply-templates select="disp-formula"></xsl:apply-templates>
-            </div>
-            <div class="col-md-8 col-sm-8">
-                <xsl:apply-templates select="." mode="label-caption-thumb"></xsl:apply-templates>
-            </div>
-        </div>
     </xsl:template>
 
     <xsl:template match="fig[graphic]" mode="file-location"><xsl:apply-templates select="graphic" mode="file-location"/></xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -45,12 +45,6 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="fig-group" mode="file-location">
-        <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
-    </xsl:template>
-
-    <xsl:template match="fig[graphic]" mode="file-location"><xsl:apply-templates select="graphic" mode="file-location"/></xsl:template>
-
     <xsl:template match="fig-group" mode="label-caption">
         <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="label-caption"></xsl:apply-templates>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -16,25 +16,6 @@
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    <xsl:template match="fig[graphic]">
-        <xsl:variable name="location">
-            <xsl:apply-templates select="." mode="file-location-thumb"></xsl:apply-templates>
-        </xsl:variable>
-        <div class="row fig" id="{@id}">
-            <a name="{@id}"></a>
-            <div class="col-md-4 col-sm-4">
-                <a href="" data-toggle="modal" data-target="#ModalFig{@id}">
-                    <div class="thumb" style="background-image: url({$location});">
-                        Thumbnail
-                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
-                    </div>
-                </a>
-            </div>
-            <div class="col-md-8 col-sm-8">
-                <xsl:apply-templates select="." mode="label-caption-thumb"></xsl:apply-templates>
-            </div>
-        </div>
-    </xsl:template>
 
     <xsl:template match="fig[.//graphic]">
         <xsl:variable name="location">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -37,21 +37,6 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="abstract[@abstract-type='graphical']//fig[graphic]">
-        <xsl:variable name="location">
-            <xsl:apply-templates select="." mode="file-location"></xsl:apply-templates>
-        </xsl:variable>
-        <div>
-            <span><xsl:apply-templates select="caption"/></span>
-           <img>
-                <xsl:attribute name="style">max-width:100%</xsl:attribute>
-                <xsl:attribute name="src">
-                    <xsl:value-of select="$location"/>
-                </xsl:attribute>
-            </img>
-        </div>
-    </xsl:template>
-
     <xsl:template match="fig-group" mode="file-location">
         <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
@@ -19,12 +19,13 @@
                             </span>
                         </button>
                         <!-- FIXME -->
-                        <xsl:if test="graphic">
+                        <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
+                        <xsl:if test="$location!=''">
                         <a class="link-newWindow showTooltip" target="_blank" data-placement="left">
                             <xsl:attribute name="title"><xsl:apply-templates select="." mode="interface">
                                 <xsl:with-param name="text">Open new window</xsl:with-param>
                             </xsl:apply-templates></xsl:attribute>
-                            <xsl:attribute name="href"><xsl:apply-templates select="." mode="file-location"/></xsl:attribute>
+                            <xsl:attribute name="href"><xsl:value-of select="$location"/></xsl:attribute>
                             <span class="sci-ico-newWindow"></span>
                         </a>
                         </xsl:if>
@@ -46,9 +47,17 @@
     </xsl:template>
     
     <xsl:template match="fig-group" mode="file-location">
-        <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
+        <!--
+            Localização da imagem ampliada
+        -->
+        <xsl:apply-templates select="fig" mode="file-location"/>
     </xsl:template>
 
-    <xsl:template match="fig[graphic]" mode="file-location"><xsl:apply-templates select="graphic" mode="file-location"/></xsl:template>
+    <xsl:template match="fig" mode="file-location">
+        <!--
+            Localização da imagem ampliada
+        -->
+        <xsl:apply-templates select="graphic | alternatives" mode="file-location"/>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
@@ -45,4 +45,10 @@
         </div>
     </xsl:template>
     
+    <xsl:template match="fig-group" mode="file-location">
+        <xsl:apply-templates select="fig[graphic]" mode="file-location"></xsl:apply-templates>
+    </xsl:template>
+
+    <xsl:template match="fig[graphic]" mode="file-location"><xsl:apply-templates select="graphic" mode="file-location"/></xsl:template>
+
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-figs.xsl
@@ -5,8 +5,14 @@
         <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="label-caption"></xsl:apply-templates>
     </xsl:template>
     
-    <xsl:template match="fig[@id] | fig-group[@id]" mode="modal">
-        <div class="modal fade ModalFigs" id="ModalFig{@id}" tabindex="-1" role="dialog" aria-hidden="true">
+    <xsl:template match="fig | fig-group" mode="modal">
+        <xsl:variable name="figid">
+            <xsl:choose>
+                <xsl:when test="@id"><xsl:value-of select="@id"/></xsl:when>
+                <xsl:otherwise>IDMISSING</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>    
+        <div class="modal fade ModalFigs" id="ModalFig{$figid}" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -321,32 +321,36 @@
         </div>        
     </xsl:template>
     
-    <xsl:template match="fig[@id] | fig-group[@id]" mode="tab-content-thumbnail">
+    <xsl:template match="fig | fig-group" mode="tab-content-thumbnail">
         <!--
             cria a miniatura de uma figura no conteúdo da ABA "Figures" 
-        --> 
-        <xsl:choose>
-            <xsl:when test="graphic">
-                <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
-                <div class="col-md-4">
-                    <a data-toggle="modal" data-target="#ModalFig{@id}">
-                        <div class="thumb" style="background-image: url({$location});">
-                            Thumbnail
-                            <div class="zoom"><span class="sci-ico-zoom"></span></div>
-                        </div>
-                    </a>
-                </div>                
-            </xsl:when>
-            <xsl:otherwise>
-                <div class="col-md-4">
-                    <a data-toggle="modal" data-target="#ModalFig{@id}">
-                        <div>
-                            <xsl:apply-templates select="disp-formula"></xsl:apply-templates>
-                        </div>
-                    </a>
-                </div>   
-            </xsl:otherwise>
-        </xsl:choose>
+        -->
+        <xsl:variable name="figid">
+            <xsl:choose>
+                <xsl:when test="@id"><xsl:value-of select="@id"/></xsl:when>
+                <xsl:otherwise>IDMISSING</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="location">
+            <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"/>
+        </xsl:variable>
+        <div class="col-md-4">
+            <a data-toggle="modal" data-target="#ModalFig{$figid}">
+                <div>
+                    <xsl:choose>
+                        <xsl:when test="$location != ''">
+                            <xsl:attribute name="class">thumb</xsl:attribute>
+                            <xsl:attribute name="style">background-image: url(<xsl:value-of select="$location"/>);</xsl:attribute>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:attribute name="class">thumbOff</xsl:attribute>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    Thumbnail
+                    <div class="zoom"><span class="sci-ico-zoom"></span></div>
+                </div>
+            </a>
+        </div>
     </xsl:template>
     
     <xsl:template match="fig" mode="tab-content-label-and-caption">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -9,22 +9,22 @@
         <xsl:apply-templates select="." mode="modal-contribs"/>
 
         <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
-        <xsl:apply-templates select="." mode="modal-all-items"/>
+        <xsl:apply-templates select="." mode="modal-grouped-figs-tables-schemes"/>
 
         <!-- cria um modal para cada figura -->
-        <xsl:apply-templates select="." mode="modal-figs"/>
+        <xsl:apply-templates select="." mode="fig-individual-modal"/>
         
         <!-- cria um modal para cada tabela -->
-        <xsl:apply-templates select="." mode="modal-tables"/>
+        <xsl:apply-templates select="." mode="table-individual-modal"/>
         
         <!-- cria um modal para cada fórmula -->
-        <xsl:apply-templates select="." mode="modal-disp-formulas"/>
+        <xsl:apply-templates select="." mode="scheme-individual-modal"/>
         
         <!-- cria um modal para como citar -->
         <xsl:apply-templates select="." mode="modal-how2cite"/>
     </xsl:template>
     
-    <xsl:template match="*" mode="modal-tables">
+    <xsl:template match="*" mode="table-individual-modal">
         <!-- cria um modal para cada tabela -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -36,7 +36,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="*" mode="modal-disp-formulas">
+    <xsl:template match="*" mode="scheme-individual-modal">
         <!-- cria um modal para cada fórmula -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -48,36 +48,36 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="*" mode="modal-figs">
+    <xsl:template match="*" mode="fig-individual-modal">
         <!-- cria um modal para cada figura -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-figs"/>
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="fig-individual-modal"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="./body" mode="modal-figs"/>                    
+                <xsl:apply-templates select="./body" mode="fig-individual-modal"/>                    
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="body" mode="modal-figs">
+    <xsl:template match="body" mode="fig-individual-modal">
         <!-- cria um modal para cada figura existente no body-->
         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal"></xsl:apply-templates>
     </xsl:template>
     
-    <xsl:template match="*" mode="modal-all-items">
+    <xsl:template match="*" mode="modal-grouped-figs-tables-schemes">
         <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-all-items"/>
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-grouped-figs-tables-schemes"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="./body" mode="modal-all-items"/>                    
+                <xsl:apply-templates select="./body" mode="modal-grouped-figs-tables-schemes"/>                    
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="body" mode="modal-all-items">
+    <xsl:template match="body" mode="modal-grouped-figs-tables-schemes">
         <!-- modal que apresenta juntos figuras, tabelas e fórmulas presentes dentro de body-->
          <xsl:if test=".//fig or .//table-wrap or .//disp-formula[@id]">
              <div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true">
@@ -146,7 +146,7 @@
                                         cria o conteúdo da aba com rótulo "Figures"
                                     -->
                                      <div role="tabpanel" class="tab-pane active" id="figures">
-                                         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal-all-item"></xsl:apply-templates>
+                                         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="tab-content"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
                                  <xsl:if test=".//table-wrap">
@@ -157,7 +157,7 @@
                                          <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig)"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">tables</xsl:attribute>
                                          
-                                         <xsl:apply-templates select=".//table-wrap-group[table-wrap] | .//*[table-wrap and name()!='table-wrap-group']/table-wrap" mode="modal-all-item"></xsl:apply-templates>
+                                         <xsl:apply-templates select=".//table-wrap-group[table-wrap] | .//*[table-wrap and name()!='table-wrap-group']/table-wrap" mode="tab-content"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
                                  <xsl:if test=".//disp-formula[@id]">
@@ -168,7 +168,7 @@
                                          <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig) and not(.//table-wrap)"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">schemes</xsl:attribute>
                                          
-                                         <xsl:apply-templates select=".//disp-formula[@id]" mode="modal-all-item"></xsl:apply-templates>
+                                         <xsl:apply-templates select=".//disp-formula[@id]" mode="tab-content"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
                              </div>
@@ -179,30 +179,30 @@
          </xsl:if>
     </xsl:template>
     
-    <xsl:template match="fig-group[@id]" mode="modal-all-item">
+    <xsl:template match="fig-group[@id]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Figures" a miniatura e legenda de uma figura
             (cujo label e caption estão em mais de um idioma)
         -->       
         <div class="row fig">
-            <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
-            <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="modal-all-item-info"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-thumbnail"></xsl:apply-templates>
+            <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="tab-content-label-and-caption"></xsl:apply-templates>
         </div>        
     </xsl:template>
-    <xsl:template match="fig[@id]" mode="modal-all-item">
+    <xsl:template match="fig[@id]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Figures" a miniatura e legenda de uma figura
             (cujo label e caption estão em apenas um idioma)
         -->         
         <div class="row fig">
             <!-- miniatura -->
-            <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-thumbnail"></xsl:apply-templates>
             <!-- legenda -->
-            <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-label-and-caption"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
-    <xsl:template match="fig[@id] | fig-group[@id]" mode="modal-all-item-display">
+    <xsl:template match="fig[@id] | fig-group[@id]" mode="tab-content-thumbnail">
         <!--
             cria a miniatura de uma figura no conteúdo da ABA "Figures" 
         --> 
@@ -230,7 +230,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="fig" mode="modal-all-item-info">
+    <xsl:template match="fig" mode="tab-content-label-and-caption">
         <!--
             cria a legenda de uma figura no conteúdo da ABA "Figures" 
         -->
@@ -239,33 +239,33 @@
         </div>
     </xsl:template>
     
-    <xsl:template match="table-wrap-group[table-wrap]" mode="modal-all-item">
+    <xsl:template match="table-wrap-group[table-wrap]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Tables" a miniatura e legenda de uma tabela
             do idioma selecionado
         -->         
         <div class="row table">
             <!-- miniatura -->
-            <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-thumbnail"></xsl:apply-templates>
             <!-- legenda -->
-            <xsl:apply-templates select="table-wrap[@xml:lang=$TEXT_LANG]" mode="modal-all-item-info"></xsl:apply-templates>
+            <xsl:apply-templates select="table-wrap[@xml:lang=$TEXT_LANG]" mode="tab-content-label-and-caption"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
-    <xsl:template match="table-wrap[not(@xml:lang)]" mode="modal-all-item">
+    <xsl:template match="table-wrap[not(@xml:lang)]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Tables" a miniatura e legenda de uma tabela
             que não depende do idioma
         -->       
         <div class="row table">
             <!-- miniatura -->
-            <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-thumbnail"></xsl:apply-templates>
             <!-- legenda -->
-            <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-label-and-caption"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
-    <xsl:template match="table-wrap | table-wrap-group" mode="modal-all-item-display">
+    <xsl:template match="table-wrap | table-wrap-group" mode="tab-content-thumbnail">
         <!--
             cria no conteúdo da ABA "Tables" a miniatura de uma tabela
             que não depende do idioma
@@ -281,7 +281,7 @@
         </div>
     </xsl:template>
     
-    <xsl:template match="table-wrap" mode="modal-all-item-info">
+    <xsl:template match="table-wrap" mode="tab-content-label-and-caption">
         <!--
             cria no conteúdo da ABA "Tables" a legenda de uma tabela
         -->
@@ -290,19 +290,19 @@
         </div>
     </xsl:template>
     
-    <xsl:template match="disp-formula[@id]" mode="modal-all-item">
+    <xsl:template match="disp-formula[@id]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Scheme" a miniatura e legenda de uma fórmula
         -->       
         <div class="row fig">
             <!-- miniatura -->
-            <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-thumbnail"></xsl:apply-templates>
             <!-- legenda -->
-            <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
+            <xsl:apply-templates select="." mode="tab-content-label-and-caption"></xsl:apply-templates>
         </div>        
     </xsl:template>
      
-    <xsl:template match="disp-formula[@id]" mode="modal-all-item-display">
+    <xsl:template match="disp-formula[@id]" mode="tab-content-thumbnail">
         <!--
             cria no conteúdo da ABA "Schemes" a miniatura de uma fórmula
         -->
@@ -326,7 +326,7 @@
         </div>
     </xsl:template>
     
-    <xsl:template match="disp-formula[@id]" mode="modal-all-item-info">
+    <xsl:template match="disp-formula[@id]" mode="tab-content-label-and-caption">
         <!--
             cria no conteúdo da ABA "Schemes" a legenda de uma fórmula
         -->

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -176,7 +176,7 @@
                                         cria o conteúdo da aba com rótulo "Figures"
                                     -->
                                      <div role="tabpanel" class="tab-pane active" id="figures">
-                                         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="tab-content"></xsl:apply-templates>
+                                         <xsl:apply-templates select="." mode="figs-tab-content"/>
                                      </div>
                                  </xsl:if>
                                  <xsl:if test="number($total_tables) &gt; 0">
@@ -187,7 +187,7 @@
                                          <xsl:attribute name="class">tab-pane <xsl:if test="number($total_figs) = 0"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">tables</xsl:attribute>
                                          
-                                         <xsl:apply-templates select=".//table-wrap-group[table-wrap] | .//*[table-wrap and name()!='table-wrap-group']/table-wrap" mode="tab-content"></xsl:apply-templates>
+                                         <xsl:apply-templates select="." mode="tables-tab-content"/>
                                      </div>
                                  </xsl:if>
                                  <xsl:if test="number($total_formulas) &gt; 0">
@@ -198,7 +198,7 @@
                                          <xsl:attribute name="class">tab-pane <xsl:if test="number($total_figs) + number($total_tables) = 0"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">schemes</xsl:attribute>
                                          
-                                         <xsl:apply-templates select=".//disp-formula[@id]" mode="tab-content"></xsl:apply-templates>
+                                         <xsl:apply-templates select="." mode="schemes-tab-content"/>
                                      </div>
                                  </xsl:if>
                              </div>
@@ -209,6 +209,95 @@
          </xsl:if>
     </xsl:template>
     
+    <xsl:template match="article" mode="figs-tab-content">
+        <!-- 
+        Conteúdo da aba "Figures", selecionando todas as figuras relacionadas
+        com o idioma do texto selecionado
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="figs-tab-content"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="front | body | back" mode="figs-tab-content"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+ 
+    <xsl:template match="article" mode="tables-tab-content">
+        <!-- 
+        Conteúdo da aba "Tables", selecionando todas as tabelas relacionadas
+        com o idioma do texto selecionado
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="tables-tab-content"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="front | body | back" mode="tables-tab-content"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+ 
+    <xsl:template match="article" mode="schemes-tab-content">
+        <!-- 
+        Conteúdo da aba "Schemes", selecionando todas as fórmulas relacionadas
+        com o idioma do texto selecionado
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="schemes-tab-content"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="front | body | back" mode="schemes-tab-content"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+ 
+    <xsl:template match="sub-article | front | body | back" mode="figs-tab-content">
+        <!-- 
+        Seleciona os elementos que contém "fig",
+        para criar o conteúdo de cada fig no Modal na aba "Figures"
+        -->
+        <xsl:apply-templates select=".//*[fig]" mode="figs-tab-content"/>
+    </xsl:template>
+    
+    <xsl:template match="*[fig]" mode="figs-tab-content">
+        <!-- 
+        cria o conteúdo de uma figura no Modal na aba "Figures"
+        -->
+        <xsl:choose>
+            <xsl:when test="name()='fig-group'">
+                <xsl:apply-templates select="." mode="tab-content"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select=".//fig" mode="tab-content"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="sub-article | front | body | back" mode="tables-tab-content">
+        <!-- 
+        Seleciona os elementos de tabela para
+        criar o conteúdo de cada tabela no Modal na aba "Tables"
+        -->
+        <xsl:apply-templates select=".//table-wrap-group[table-wrap] | .//*[table-wrap and name()!='table-wrap-group']/table-wrap" mode="tab-content"/>
+    </xsl:template>
+
+    <xsl:template match="sub-article | front | body | back" mode="schemes-tab-content">
+        <!-- 
+        Seleciona os elementos disp-formula para
+        criar o conteúdo de cada fórmula no Modal na aba "Schemes"
+        -->
+        <xsl:apply-templates select=".//disp-formula[@id]" mode="tab-content"/>
+    </xsl:template>
+
     <xsl:template match="fig-group[@id]" mode="tab-content">
         <!--
             cria no conteúdo da ABA "Figures" a miniatura e legenda de uma figura

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -99,7 +99,17 @@
             em um dado idioma do texto do artigo
         -->
         <!-- FIXME -->
-         <xsl:if test=".//fig or .//table-wrap or .//disp-formula[@id]">
+        <xsl:variable name="total_figs">
+            <xsl:apply-templates select="." mode="get-total-figs"/>
+        </xsl:variable>
+        <xsl:variable name="total_tables">
+            <xsl:apply-templates select="." mode="get-total-tables"/>
+        </xsl:variable>
+        <xsl:variable name="total_formulas">
+            <xsl:apply-templates select="." mode="get-total-formulas"/>
+        </xsl:variable>
+
+        <xsl:if test="number($total_figs) + number($total_tables) + number($total_formulas) &gt; 0">
              <div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true">
                  <div class="modal-dialog">
                      <div class="modal-content">
@@ -116,7 +126,7 @@
                          </div>
                          <div class="modal-body">
                              <ul class="nav nav-tabs md-tabs" role="tablist">
-                                <xsl:if test=".//fig">
+                                <xsl:if test="number($total_figs) &gt; 0">
                                     <!--
                                         cria aba com rótulo "Figures" e quantidade de figuras
                                     -->
@@ -125,43 +135,43 @@
                                              <xsl:apply-templates select="." mode="interface">
                                                  <xsl:with-param name="text">Figures</xsl:with-param>
                                              </xsl:apply-templates>
-                                             (<xsl:value-of select="count(.//fig-group[@id])+count(.//fig[@id])"/>)
+                                             (<xsl:value-of select="$total_figs"/>)
                                          </a>
                                      </li>
                                  </xsl:if>
-                                 <xsl:if test=".//table-wrap">
+                                 <xsl:if test="number($total_tables) &gt; 0">
                                      <!--
                                         cria aba com rótulo "Tables" e quantidade de tabelas
                                     -->
                                      <li role="presentation">
-                                         <xsl:attribute name="class">col-md-4 col-sm-4 <xsl:if test="not(.//fig)"> active</xsl:if></xsl:attribute>
+                                         <xsl:attribute name="class">col-md-4 col-sm-4 <xsl:if test="number($total_figs) = 0"> active</xsl:if></xsl:attribute>
                                          <a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">
                                              <xsl:apply-templates select="." mode="interface">
                                                  <xsl:with-param name="text">Tables</xsl:with-param>
                                              </xsl:apply-templates>
-                                             (<xsl:value-of select="count(.//table-wrap-group)+count(.//*[table-wrap and name()!='table-wrap-group']//table-wrap)"/>)
+                                             (<xsl:value-of select="$total_tables"/>)
                                          </a>
                                      </li>
                                  </xsl:if>
-                                 <xsl:if test=".//disp-formula[@id]">
+                                 <xsl:if test="number($total_formulas) &gt; 0">
                                      <!--
                                         cria aba com rótulo "Scheme" e quantidade de fórmulas
                                     -->
                                      <li role="presentation">
-                                         <xsl:attribute name="class">col-md-4 col-sm-4<xsl:if test="not(.//fig) and not(.//table-wrap)"> active</xsl:if></xsl:attribute>
+                                         <xsl:attribute name="class">col-md-4 col-sm-4<xsl:if test="number($total_figs) + number($total_tables) = 0"> active</xsl:if></xsl:attribute>
                                          
                                          <a href="#schemes" aria-controls="schemes" role="tab" data-toggle="tab">
                                              <xsl:apply-templates select="." mode="interface">
                                                  <xsl:with-param name="text">Formulas</xsl:with-param>
                                              </xsl:apply-templates>
-                                             (<xsl:value-of select="count(.//disp-formula[@id])"/>)
+                                             (<xsl:value-of select="$total_formulas"/>)
                                          </a>
                                      </li>
                                  </xsl:if>
                              </ul>
                              <div class="clearfix"></div>
                              <div class="tab-content">
-                                 <xsl:if test=".//fig">
+                                 <xsl:if test="number($total_figs) &gt; 0">
                                     <!--
                                         cria o conteúdo da aba com rótulo "Figures"
                                     -->
@@ -169,23 +179,23 @@
                                          <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="tab-content"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
-                                 <xsl:if test=".//table-wrap">
+                                 <xsl:if test="number($total_tables) &gt; 0">
                                     <!--
                                         cria o conteúdo da aba com rótulo "Tables"
                                     -->
                                      <div role="tabpanel">
-                                         <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig)"> active</xsl:if></xsl:attribute>
+                                         <xsl:attribute name="class">tab-pane <xsl:if test="number($total_figs) = 0"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">tables</xsl:attribute>
                                          
                                          <xsl:apply-templates select=".//table-wrap-group[table-wrap] | .//*[table-wrap and name()!='table-wrap-group']/table-wrap" mode="tab-content"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
-                                 <xsl:if test=".//disp-formula[@id]">
+                                 <xsl:if test="number($total_formulas) &gt; 0">
                                     <!--
                                         cria o conteúdo da aba com rótulo "Formulas"
                                     -->
                                      <div role="tabpanel">
-                                         <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig) and not(.//table-wrap)"> active</xsl:if></xsl:attribute>
+                                         <xsl:attribute name="class">tab-pane <xsl:if test="number($total_figs) + number($total_tables) = 0"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">schemes</xsl:attribute>
                                          
                                          <xsl:apply-templates select=".//disp-formula[@id]" mode="tab-content"></xsl:apply-templates>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -25,60 +25,80 @@
     </xsl:template>
     
     <xsl:template match="article" mode="table-individual-modal">
-        <!-- cria um modal para cada tabela -->
+        <!--
+            Cria um modal para cada tabela
+            encontrada em article,
+            de acordo com o idioma selecionado para o texto
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
         <xsl:choose>
-            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body//table-wrap" mode="modal"/>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="table-individual-modal"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="./body//table-wrap" mode="modal"/>                    
+                <xsl:apply-templates select="front | body | back" mode="table-individual-modal"/>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="front | body | back | sub-article" mode="table-individual-modal">
+        <!-- cria um modal para cada tabela existente no body-->
+        <xsl:apply-templates select=".//table-wrap[@xml:lang=$TEXT_LANG] | .//table-wrap[not(@xml:lang)]" mode="modal"/>
     </xsl:template>
     
     <xsl:template match="article" mode="scheme-individual-modal">
-        <!-- cria um modal para cada fórmula -->
+        <!--
+            Cria um modal para cada fórmula
+            encontrada em article,
+            de acordo com o idioma selecionado para o texto
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
         <xsl:choose>
-            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body//disp-formula" mode="modal"/>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="scheme-individual-modal"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="./body//disp-formula" mode="modal"/>                    
+                <xsl:apply-templates select="front | body | back" mode="scheme-individual-modal"/>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="front | body | back | sub-article" mode="scheme-individual-modal">
+        <!-- cria um modal para cada formula existente no body-->
+        <xsl:apply-templates select=".//disp-formula[@id]" mode="modal"/>
     </xsl:template>
     
     <xsl:template match="article" mode="fig-individual-modal">
-        <!-- cria um modal para cada figura -->
+        <!--
+            Cria um modal para cada figura
+            encontrada em article,
+            de acordo com o idioma selecionado para o texto
+        -->
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
         <xsl:choose>
-            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="fig-individual-modal"/>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="front | $translation | back" mode="fig-individual-modal"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:apply-templates select="./body" mode="fig-individual-modal"/>                    
+                <xsl:apply-templates select="front | body | back" mode="fig-individual-modal"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="body" mode="fig-individual-modal">
+    <xsl:template match="front | body | back | sub-article" mode="fig-individual-modal">
         <!-- cria um modal para cada figura existente no body-->
         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal"></xsl:apply-templates>
     </xsl:template>
     
     <xsl:template match="article" mode="modal-grouped-figs-tables-schemes">
-        <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
-        <xsl:choose>
-            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-grouped-figs-tables-schemes"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="./body" mode="modal-grouped-figs-tables-schemes"/>                    
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-    
-    <xsl:template match="body" mode="modal-grouped-figs-tables-schemes">
-        <!-- modal que apresenta juntos figuras, tabelas e fórmulas presentes dentro de body-->
+        <!-- 
+            Modal que apresenta juntos figuras, tabelas e fórmulas presentes
+            em um dado idioma do texto do artigo
+        -->
+        <!-- FIXME -->
          <xsl:if test=".//fig or .//table-wrap or .//disp-formula[@id]">
              <div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true">
                  <div class="modal-dialog">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -355,5 +355,69 @@
         </div>
     </xsl:template>
     
-    
+    <xsl:template match="article" mode="get-total-figs">
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:variable name="f"><xsl:apply-templates select="front" mode="get-total-figs"/></xsl:variable>
+        <xsl:variable name="bk"><xsl:apply-templates select="back" mode="get-total-figs"/></xsl:variable>
+        <xsl:variable name="b">
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="$translation" mode="get-total-figs"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="body" mode="get-total-figs"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="number($f)+number($b)+number($bk)"/>
+    </xsl:template>
+
+    <xsl:template match="article" mode="get-total-tables">
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:variable name="f"><xsl:apply-templates select="front" mode="get-total-tables"/></xsl:variable>
+        <xsl:variable name="bk"><xsl:apply-templates select="back" mode="get-total-tables"/></xsl:variable>
+        <xsl:variable name="b">
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="$translation" mode="get-total-tables"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="body" mode="get-total-tables"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="number($f)+number($b)+number($bk)"/>
+    </xsl:template>
+
+    <xsl:template match="article" mode="get-total-formulas">
+        <xsl:variable name="translation" select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']"/>
+
+        <xsl:variable name="f"><xsl:apply-templates select="front" mode="get-total-formulas"/></xsl:variable>
+        <xsl:variable name="bk"><xsl:apply-templates select="back" mode="get-total-formulas"/></xsl:variable>
+        <xsl:variable name="b">
+        <xsl:choose>
+            <xsl:when test="$translation">
+                <xsl:apply-templates select="$translation" mode="get-total-formulas"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="body" mode="get-total-formulas"/>
+            </xsl:otherwise>
+        </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="number($f)+number($b)+number($bk)"/>
+    </xsl:template>
+
+    <xsl:template match="sub-article | front | body | back" mode="get-total-figs">
+        <xsl:value-of select="count(.//fig-group[@id]/fig[@xml:lang][1]) + count(.//fig[not(@xml:lang)])"/>
+    </xsl:template>
+
+    <xsl:template match="sub-article | front | body | back" mode="get-total-tables">
+        <xsl:value-of select="count(.//table-wrap-group) + count(.//*[table-wrap and name()!='table-wrap-group']//table-wrap)"/>
+    </xsl:template>
+
+    <xsl:template match="sub-article | front | body | back" mode="get-total-formulas">
+        <xsl:value-of select="count(.//disp-formula[@id])"/>
+    </xsl:template>
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
-    <xsl:template match="*" mode="article-modals">
+    <xsl:template match="article" mode="article-modals">
         <!--
             Cria todos os modals do documento
         -->
@@ -24,7 +24,7 @@
         <xsl:apply-templates select="." mode="modal-how2cite"/>
     </xsl:template>
     
-    <xsl:template match="*" mode="table-individual-modal">
+    <xsl:template match="article" mode="table-individual-modal">
         <!-- cria um modal para cada tabela -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -36,7 +36,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="*" mode="scheme-individual-modal">
+    <xsl:template match="article" mode="scheme-individual-modal">
         <!-- cria um modal para cada fórmula -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -48,7 +48,7 @@
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="*" mode="fig-individual-modal">
+    <xsl:template match="article" mode="fig-individual-modal">
         <!-- cria um modal para cada figura -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
@@ -65,7 +65,7 @@
         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal"></xsl:apply-templates>
     </xsl:template>
     
-    <xsl:template match="*" mode="modal-grouped-figs-tables-schemes">
+    <xsl:template match="article" mode="modal-grouped-figs-tables-schemes">
         <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -2,15 +2,30 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
     <xsl:template match="*" mode="article-modals">
+        <!--
+            Cria todos os modals do documento
+        -->
+        <!-- modal do contribs -->
         <xsl:apply-templates select="." mode="modal-contribs"/>
-        <xsl:apply-templates select="." mode="modal-all-items"></xsl:apply-templates>
+
+        <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
+        <xsl:apply-templates select="." mode="modal-all-items"/>
+
+        <!-- cria um modal para cada figura -->
         <xsl:apply-templates select="." mode="modal-figs"/>
+        
+        <!-- cria um modal para cada tabela -->
         <xsl:apply-templates select="." mode="modal-tables"/>
+        
+        <!-- cria um modal para cada fórmula -->
         <xsl:apply-templates select="." mode="modal-disp-formulas"/>
+        
+        <!-- cria um modal para como citar -->
         <xsl:apply-templates select="." mode="modal-how2cite"/>
     </xsl:template>
     
     <xsl:template match="*" mode="modal-tables">
+        <!-- cria um modal para cada tabela -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
                 <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body//table-wrap" mode="modal"/>
@@ -22,6 +37,7 @@
     </xsl:template>
     
     <xsl:template match="*" mode="modal-disp-formulas">
+        <!-- cria um modal para cada fórmula -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
                 <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body//disp-formula" mode="modal"/>
@@ -33,6 +49,7 @@
     </xsl:template>
     
     <xsl:template match="*" mode="modal-figs">
+        <!-- cria um modal para cada figura -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
                 <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-figs"/>
@@ -44,10 +61,12 @@
     </xsl:template>
     
     <xsl:template match="body" mode="modal-figs">
+        <!-- cria um modal para cada figura existente no body-->
         <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal"></xsl:apply-templates>
     </xsl:template>
     
     <xsl:template match="*" mode="modal-all-items">
+        <!-- modal que apresenta juntos figuras, tabelas e fórmulas -->
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
                 <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//body" mode="modal-all-items"/>
@@ -59,6 +78,7 @@
     </xsl:template>
     
     <xsl:template match="body" mode="modal-all-items">
+        <!-- modal que apresenta juntos figuras, tabelas e fórmulas presentes dentro de body-->
          <xsl:if test=".//fig or .//table-wrap or .//disp-formula[@id]">
              <div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true">
                  <div class="modal-dialog">
@@ -77,6 +97,9 @@
                          <div class="modal-body">
                              <ul class="nav nav-tabs md-tabs" role="tablist">
                                 <xsl:if test=".//fig">
+                                    <!--
+                                        cria aba com rótulo "Figures" e quantidade de figuras
+                                    -->
                                     <li role="presentation" class="col-md-4 col-sm-4 active">
                                          <a href="#figures" aria-controls="figures" role="tab" data-toggle="tab">
                                              <xsl:apply-templates select="." mode="interface">
@@ -87,6 +110,9 @@
                                      </li>
                                  </xsl:if>
                                  <xsl:if test=".//table-wrap">
+                                     <!--
+                                        cria aba com rótulo "Tables" e quantidade de tabelas
+                                    -->
                                      <li role="presentation">
                                          <xsl:attribute name="class">col-md-4 col-sm-4 <xsl:if test="not(.//fig)"> active</xsl:if></xsl:attribute>
                                          <a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">
@@ -98,6 +124,9 @@
                                      </li>
                                  </xsl:if>
                                  <xsl:if test=".//disp-formula[@id]">
+                                     <!--
+                                        cria aba com rótulo "Scheme" e quantidade de fórmulas
+                                    -->
                                      <li role="presentation">
                                          <xsl:attribute name="class">col-md-4 col-sm-4<xsl:if test="not(.//fig) and not(.//table-wrap)"> active</xsl:if></xsl:attribute>
                                          
@@ -113,11 +142,17 @@
                              <div class="clearfix"></div>
                              <div class="tab-content">
                                  <xsl:if test=".//fig">
+                                    <!--
+                                        cria o conteúdo da aba com rótulo "Figures"
+                                    -->
                                      <div role="tabpanel" class="tab-pane active" id="figures">
                                          <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal-all-item"></xsl:apply-templates>
                                      </div>
                                  </xsl:if>
                                  <xsl:if test=".//table-wrap">
+                                    <!--
+                                        cria o conteúdo da aba com rótulo "Tables"
+                                    -->
                                      <div role="tabpanel">
                                          <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig)"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">tables</xsl:attribute>
@@ -126,12 +161,14 @@
                                      </div>
                                  </xsl:if>
                                  <xsl:if test=".//disp-formula[@id]">
+                                    <!--
+                                        cria o conteúdo da aba com rótulo "Formulas"
+                                    -->
                                      <div role="tabpanel">
                                          <xsl:attribute name="class">tab-pane <xsl:if test="not(.//fig) and not(.//table-wrap)"> active</xsl:if></xsl:attribute>
                                          <xsl:attribute name="id">schemes</xsl:attribute>
                                          
                                          <xsl:apply-templates select=".//disp-formula[@id]" mode="modal-all-item"></xsl:apply-templates>
-                                         
                                      </div>
                                  </xsl:if>
                              </div>
@@ -142,20 +179,33 @@
          </xsl:if>
     </xsl:template>
     
-    <xsl:template match="fig-group[@id]" mode="modal-all-item">       
+    <xsl:template match="fig-group[@id]" mode="modal-all-item">
+        <!--
+            cria no conteúdo da ABA "Figures" a miniatura e legenda de uma figura
+            (cujo label e caption estão em mais de um idioma)
+        -->       
         <div class="row fig">
             <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
             <xsl:apply-templates select="fig[@xml:lang=$TEXT_LANG]" mode="modal-all-item-info"></xsl:apply-templates>
         </div>        
     </xsl:template>
-    <xsl:template match="fig[@id]" mode="modal-all-item">       
+    <xsl:template match="fig[@id]" mode="modal-all-item">
+        <!--
+            cria no conteúdo da ABA "Figures" a miniatura e legenda de uma figura
+            (cujo label e caption estão em apenas um idioma)
+        -->         
         <div class="row fig">
+            <!-- miniatura -->
             <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <!-- legenda -->
             <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
     <xsl:template match="fig[@id] | fig-group[@id]" mode="modal-all-item-display">
+        <!--
+            cria a miniatura de uma figura no conteúdo da ABA "Figures" 
+        --> 
         <xsl:choose>
             <xsl:when test="graphic">
                 <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
@@ -181,26 +231,45 @@
     </xsl:template>
     
     <xsl:template match="fig" mode="modal-all-item-info">
+        <!--
+            cria a legenda de uma figura no conteúdo da ABA "Figures" 
+        -->
         <div class="col-md-8">
             <xsl:apply-templates select="." mode="label-caption-thumb"></xsl:apply-templates>
         </div>
     </xsl:template>
     
-    <xsl:template match="table-wrap-group[table-wrap]" mode="modal-all-item">       
+    <xsl:template match="table-wrap-group[table-wrap]" mode="modal-all-item">
+        <!--
+            cria no conteúdo da ABA "Tables" a miniatura e legenda de uma tabela
+            do idioma selecionado
+        -->         
         <div class="row table">
+            <!-- miniatura -->
             <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <!-- legenda -->
             <xsl:apply-templates select="table-wrap[@xml:lang=$TEXT_LANG]" mode="modal-all-item-info"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
-    <xsl:template match="table-wrap[not(@xml:lang)]" mode="modal-all-item">       
+    <xsl:template match="table-wrap[not(@xml:lang)]" mode="modal-all-item">
+        <!--
+            cria no conteúdo da ABA "Tables" a miniatura e legenda de uma tabela
+            que não depende do idioma
+        -->       
         <div class="row table">
+            <!-- miniatura -->
             <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <!-- legenda -->
             <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
         </div>        
     </xsl:template>
     
     <xsl:template match="table-wrap | table-wrap-group" mode="modal-all-item-display">
+        <!--
+            cria no conteúdo da ABA "Tables" a miniatura de uma tabela
+            que não depende do idioma
+        -->
         <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
         <div class="col-md-4">
             <a data-toggle="modal" data-target="#ModalTable{@id}">
@@ -213,19 +282,30 @@
     </xsl:template>
     
     <xsl:template match="table-wrap" mode="modal-all-item-info">
+        <!--
+            cria no conteúdo da ABA "Tables" a legenda de uma tabela
+        -->
         <div class="col-md-8">
             <xsl:apply-templates select="." mode="label-caption-thumb"></xsl:apply-templates>
         </div>
     </xsl:template>
     
-    <xsl:template match="disp-formula[@id]" mode="modal-all-item">       
+    <xsl:template match="disp-formula[@id]" mode="modal-all-item">
+        <!--
+            cria no conteúdo da ABA "Scheme" a miniatura e legenda de uma fórmula
+        -->       
         <div class="row fig">
+            <!-- miniatura -->
             <xsl:apply-templates select="." mode="modal-all-item-display"></xsl:apply-templates>
+            <!-- legenda -->
             <xsl:apply-templates select="." mode="modal-all-item-info"></xsl:apply-templates>
         </div>        
     </xsl:template>
      
     <xsl:template match="disp-formula[@id]" mode="modal-all-item-display">
+        <!--
+            cria no conteúdo da ABA "Schemes" a miniatura de uma fórmula
+        -->
         <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
         <div class="col-md-4">
             <a data-toggle="modal" data-target="#ModalScheme{@id}">
@@ -247,6 +327,9 @@
     </xsl:template>
     
     <xsl:template match="disp-formula[@id]" mode="modal-all-item-info">
+        <!--
+            cria no conteúdo da ABA "Schemes" a legenda de uma fórmula
+        -->
         <div class="col-md-8">
             <xsl:apply-templates select="label"></xsl:apply-templates>
         </div>


### PR DESCRIPTION
#### O que esse PR faz?
Revisa e amplia a apresentação do elemento "fig" em vários contextos (front, body, back, sub-article)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```shell
python packtools/htmlgenerator.py --loglevel DEBUG <path de xml> --nochecks --nonetwork
```
onde `<path de xml>` é o caminho do arquivo xml

Resultado do htmlgenerator do master (atual)
[master_antes_de_tk237 2.zip](https://github.com/scieloorg/packtools/files/5392400/master_antes_de_tk237.2.zip)

Resultado do htmlgenerator tk237_novo
[tk237 2.zip](https://github.com/scieloorg/packtools/files/5392401/tk237.2.zip)


#### Algum cenário de contexto que queira dar?
havia bug também no modal que agrupa figura, tabela e fórmulas

<img width="440" alt="Captura de Tela 2020-10-16 às 11 44 16" src="https://user-images.githubusercontent.com/505143/96272819-01412880-0fa5-11eb-9a04-943f16062149.png">

<img width="599" alt="Captura de Tela 2020-10-16 às 11 14 31" src="https://user-images.githubusercontent.com/505143/96272643-c17a4100-0fa4-11eb-91a7-efd2f5da5476.png">

Não foram revisadas as apresentações de tabelas e equações. No mesmo arquivo tk236b.xml, há amostras de variações da apresentação atual destes elementos. Mas acredito que merecem uma revisão.

### Screenshots
n/a

#### Quais são tickets relevantes?
#237

### Referências
n/a
