### PR TITLE
Altera XSL do artigo para apresentar todos os resumos no texto completo

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -2,17 +2,10 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
     <xsl:template match="article" mode="article-meta-abstract">
-        <xsl:choose>
-            <xsl:when test=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//abstract">
-                <xsl:apply-templates select=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]" mode="article-meta-abstract"></xsl:apply-templates>
-            </xsl:when>
-            <xsl:when test="front/article-meta//abstract">
-                <xsl:if test="$q_abstract_title=0">
-                    <xsl:apply-templates select="." mode="abstract-anchor"></xsl:apply-templates>
-                </xsl:if>
-                <xsl:apply-templates select="front/article-meta//abstract|front/article-meta//trans-abstract" mode="layout"></xsl:apply-templates>
-            </xsl:when>
-        </xsl:choose>
+        <xsl:if test="$q_abstract_title=0">
+            <xsl:apply-templates select="." mode="abstract-anchor"></xsl:apply-templates>
+        </xsl:if>
+        <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"></xsl:apply-templates>
     </xsl:template>
     
     <xsl:template match="article" mode="article-meta-no-abstract-keywords">
@@ -27,13 +20,7 @@
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
-    <xsl:template match="sub-article[@article-type='translation']" mode="article-meta-abstract">
-        <xsl:if test="$q_abstract_title=0">
-            <xsl:apply-templates select="." mode="abstract-anchor"></xsl:apply-templates>
-        </xsl:if>
-        <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"></xsl:apply-templates>
-    </xsl:template>
+
     <xsl:template match="*" mode="abstract-anchor">
         <div class="articleSection">
             <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="text-labels">


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera aplicação de template XSL para os resumos, que separava o que era `abstracts` e `trans-abstracts` de `article` e `sub-article`. Agora, aplica o template para todos os abstracts e trans-abstracts de forma que todos sempre serão apresentados na página do texto completo, independente do idioma.

#### Onde a revisão poderia começar?
Commit 2085d82.

#### Como este poderia ser testado manualmente?
1. Obtenha um artigo em XML com texto completo em 2 idiomas e com resumos em diferentes idiomas, inclusive dos textos completos. Exemplo no anexo [1]
2. Execute o comando `htmlgenerator <caminho para o XML> --nochecks`
3. Abra os HTMLs gerados
4. Verifique a apresentação de todos os resumos nos 2 HTMLs

#### Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
o revisor a fim de facilitar o entendimento da funcionalidade.

### Screenshots

#### Texto completo em Inglês

<img width="970" alt="Screen Shot 2020-12-01 at 17 39 33" src="https://user-images.githubusercontent.com/18053487/100794531-76a17500-33fc-11eb-84a9-a64548dda001.png">

#### Texto completo em Português

<img width="949" alt="Screen Shot 2020-12-01 at 17 39 56" src="https://user-images.githubusercontent.com/18053487/100794487-66899580-33fc-11eb-98a7-ce51b8659c9b.png">

### Anexos
[1] - [1809-4422-asoc-20-01-00065.xml.zip](https://github.com/scieloorg/packtools/files/5625329/1809-4422-asoc-20-01-00065.xml.zip)


#### Quais são tickets relevantes?
#215

### Referências
.
