### PR TITLE
Corrige exibição de imagem ampliada de figuras sem ID no XML

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -90,7 +90,7 @@
     
     <xsl:template match="front | body | back | sub-article" mode="fig-individual-modal">
         <!-- cria um modal para cada figura existente no body-->
-        <xsl:apply-templates select=".//fig-group[@id] | .//fig[@id]" mode="modal"></xsl:apply-templates>
+        <xsl:apply-templates select=".//fig-group[@id] | .//fig" mode="modal"></xsl:apply-templates>
     </xsl:template>
     
     <xsl:template match="article" mode="modal-grouped-figs-tables-schemes">


### PR DESCRIPTION
#### O que esse PR faz?
Este PR aplica o modal para figuras, mesmo sem atributo `@id`. Atualmente, caso a tag `fig` não possua o atributo, não é aberto o modal para exibir a versão original da imagem.

#### Onde a revisão poderia começar?
Commit 6289c9f.

#### Como este poderia ser testado manualmente?
1. Obtenha um XML que contenha a tag `fig` sem atributo `id` e ativo digital, como o exemplo abaixo:
<img width="1565" alt="Screen Shot 2020-09-16 at 20 19 21" src="https://user-images.githubusercontent.com/4604104/93402003-ef5f4f00-f859-11ea-9b97-2fc1251c2dd0.png">
2. Execute o comando `htmlgenerator <caminho do XML> --nochecks`
3. Abra o(s) HTML(s) gerados
4. Verifique se a imagem do thumbnail é exibida no modal ao clicar nela.

#### Algum cenário de contexto que queira dar?
Para os casos onde haja mais de uma tag `fig` sem `id`, ainda haverá quebra, sendo necessário corrigir o XML.

### Screenshots
.

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1654

### Referências
.