### PR TITLE
Corrige verificação para colocar título em seção de resumo

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
     <xsl:template match="article" mode="article-meta-abstract">
-        <xsl:if test="$q_abstract_title=0">
+        <xsl:if test="$q_abstract &gt; 0 and $q_abstract_title &lt; $q_abstract">
             <xsl:apply-templates select="." mode="abstract-anchor"></xsl:apply-templates>
         </xsl:if>
         <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"></xsl:apply-templates>

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -136,6 +136,125 @@ class HTMLGeneratorTests(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: gen.generate('ru'))
 
+    def test_no_abstract_title_if_there_is_a_title_for_abstract(self):
+        sample = u"""<article
+                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <title>Abstract</title>
+                            <p>Abstract Content</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        title_tags = html.findall('//h1[@class="articleSectionTitle"]')
+        self.assertEqual(len(title_tags), 1)
+        self.assertEqual(title_tags[0].text, "Abstract")
+
+    def test_abstract_title_if_no_title_for_abstract(self):
+        sample = u"""<article
+                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <p>Abstract Content</p>
+                          </abstract>
+                        </article-meta>
+                      </front>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        title_tags = html.findall('//h1[@class="articleSectionTitle"]')
+        self.assertEqual(len(title_tags), 1)
+        self.assertEqual(title_tags[0].text, "Abstract")
+
+    def test_no_abstract_title_if_there_are_titles_for_abstracts(self):
+        sample = u"""<article
+                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <title>Abstract</title>
+                            <p>Abstract Content</p>
+                          </abstract>
+                          <trans-abstract xml:lang="es">
+                            <title>Resumen</title>
+                            <p>Contenido del Resumen</p>
+                          </trans-abstract>
+                        </article-meta>
+                      </front>
+                      <sub-article article-type="translation" xml:lang="pt">
+                        <front-stub>
+                          <abstract>
+                            <title>Resumo</title>
+                            <p>Conteúdo do Resumo</p>
+                          </abstract>
+                        </front-stub>
+                      </sub-article>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        title_tags = html.findall('//h1[@class="articleSectionTitle"]')
+        self.assertEqual(len(title_tags), 3)
+        self.assertEqual(
+            {title_tag.text for title_tag in title_tags},
+            set(["Abstract", "Resumen", "Resumo"])
+        )
+
+    def test_abstract_title_if_no_titles_for_abstracts(self):
+        sample = u"""<article
+                      xmlns:mml="http://www.w3.org/1998/Math/MathML"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      xml:lang="en">
+                      <front>
+                        <article-meta>
+                          <abstract>
+                            <p>Abstract Content</p>
+                          </abstract>
+                          <trans-abstract xml:lang="es">
+                            <p>Contenido del Resumen</p>
+                          </trans-abstract>
+                        </article-meta>
+                      </front>
+                      <sub-article article-type="translation" xml:lang="pt">
+                        <front-stub>
+                          <abstract>
+                            <p>Conteúdo do Resumo</p>
+                          </abstract>
+                        </front-stub>
+                      </sub-article>
+                    </article>"""
+
+        fp = io.BytesIO(sample.encode('utf-8'))
+        et = etree.parse(fp)
+
+        html = domain.HTMLGenerator.parse(et, valid_only=False).generate('en')
+
+        title_tags = html.findall('//h1[@class="articleSectionTitle"]')
+        self.assertEqual(len(title_tags), 1)
+        self.assertEqual(title_tags[0].text, "Abstracts")
+
     def test_if_visual_abstract_image_present_in_html(self):
         sample = u"""<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                       <front>


### PR DESCRIPTION
#### O que esse PR faz?
Faz a verificação da quantidade de resumos e de títulos de resumos para colocar âncora e título para resumos. Também inclui testes unitários.

#### Onde a revisão poderia começar?
Commit 730d8e1.

#### Como este poderia ser testado manualmente?
1. Obtenha um XML sem resumos
2. Gere HTML usando o comando `htmlgenerator <caminho para o XML> --nochecks`
3. Verifique se o HTML não possui título de resumos
4. Obtenha XMLs com um ou mais resumos e sem títulos
5. Execute o passo 2 para cada XML
6. Verifique a presença de título
7. Obtenha XMLs com um ou mais resumos e respectivos títulos
5. Execute o passo 2 para cada XML
6. Verifique se o HTML não possui título de resumos

#### Algum cenário de contexto que queira dar?
Este problema foi identificado após a inclusão de todos os resumos na página do artigo.

### Screenshots
.

#### Quais são tickets relevantes?
#215 

### Referências
.
