### PR TITLE
Corrige a apresentação de `graphic` que aparecem dentro de `table` e de `inline-graphic` que aparecem dentro de `xref`

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
@@ -28,11 +28,13 @@
             </xsl:element>
         </div>
     </xsl:template>
-    <xsl:template match="table/* | table/*/* | table/*/*/*">
+
+    <xsl:template match="tr | td | th | col | colgroup | thead | tfoot | tbody">
         <xsl:element name="{name()}">
             <xsl:apply-templates select="@*|*|text()"></xsl:apply-templates>
         </xsl:element>
     </xsl:template>
+
     <xsl:template match="table-wrap/caption">
         <xsl:apply-templates select="*|text()"></xsl:apply-templates>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-xref.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-xref.xsl
@@ -123,7 +123,8 @@
     <xsl:template match="xref[@ref-type='fn']">
         <xsl:variable name="id"><xsl:value-of select="@rid"/></xsl:variable>
         <span class="ref footnote">
-            <sup class="xref"><xsl:apply-templates select="sup|text()"></xsl:apply-templates></sup>
+            <!-- asterisco pode ser inclusive inline-graphic -->
+            <sup class="xref"><xsl:apply-templates select="*|text()"/></sup>
             <span class="refCtt closed">
                 <span class="refCttPadding">
                     <xsl:apply-templates select="$article//fn[@id=$id]" mode="xref"></xsl:apply-templates>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a apresentação de `graphic` que aparecem dentro de `table` e de `inline-graphic` que aparecem dentro de `xref`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute 
```
python packtools/htmlgenerator.py --nonetwork --nochecks <arquivo>
```
Sendo `<arquivo>` o caminho do arquivo XML.

Ver sugestões de arquivos nos issues: #248 e #250

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#248, #250

### Referências
n/a
