### PR TITLE
Modifica conteúdo de comentário para evitar exceção ValueError

### DIFF
--- a/packtools/domain.py
+++ b/packtools/domain.py
@@ -369,7 +369,10 @@ class XMLValidator(object):
         """
         notice_element = etree.Element('SPS-ERROR')
         notice_element.text = error
-        element.addprevious(etree.Comment('SPS-ERROR: %s' % error))
+        element.addprevious(
+            etree.Comment(
+                ' SPS-ERROR: %s ' % error.replace("--", "- -"))
+        )
 
     def annotate_errors(self, fail_fast=False):
         """Add notes on all elements that have errors.


### PR DESCRIPTION

#### O que esse PR faz?
Resolve um problema inerente das linguagens produzidas pelo SGML.

Insere espaços antes e depois do comentário de forma a evitar a mensagem de erro de que existe `-` no final do comentário.
Insere espaço entre `--` (`- -`) para evitar a mensagem de erro de existe `--` dentro do comentário


#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
ver issue #254

#### Algum cenário de contexto que queira dar?
packtools é usado no XC e o erro ocorreu durante o processamento de um documento.

### Screenshots
n/a

#### Quais são tickets relevantes?
#254

### Referências
n/a
