### PR TITLE
Corrige várias questões nos resumos

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 2.7.1 (2021-06-14)
+
+* Fix abstracts (#265)
+
 ## 2.7.0 (2021-03-31)
 
 * Generate HTML specially for the website (#258)

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -6,7 +6,7 @@
         <!-- apresenta todos os resumos que existir -->
         <xsl:variable name="q" select="count(.//abstract[.//text()])+count(.//trans-abstract[.//text()])"/>
         <xsl:if test="$q &gt; 0">
-            <xsl:apply-templates select="." mode="abstract-anchor"/>
+            <xsl:apply-templates select="." mode="add-anchor-and-title-for-abstracts-without-title"/>
             <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"/>
         </xsl:if>
     </xsl:template>
@@ -26,21 +26,28 @@
     </xsl:template>
 
 
-    <xsl:template match="*" mode="abstract-anchor">
-        <div class="articleSection">
-            <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="text-labels">
-                <xsl:with-param name="text"><xsl:choose>
-                    <xsl:when test="count(.//abstract)+count(.//trans-abstract) &gt; 1">Abstracts</xsl:when>
-                    <xsl:otherwise>Abstract</xsl:otherwise>
-                </xsl:choose></xsl:with-param>
-            </xsl:apply-templates></xsl:attribute>
-            <h1 class="articleSectionTitle"><xsl:apply-templates select="." mode="text-labels">
-                <xsl:with-param name="text"><xsl:choose>
-                    <xsl:when test="count(.//abstract)+count(.//trans-abstract) &gt; 1">Abstracts</xsl:when>
-                    <xsl:otherwise>Abstract</xsl:otherwise>
-                </xsl:choose></xsl:with-param>
-            </xsl:apply-templates></h1>
-        </div>
+    <xsl:template match="*" mode="create-anchor-and-title-for-abstracts-without-title">
+        <xsl:variable name="q_titles" select="count(.//abstract[title])+count(.//trans-abstract[title])"/>
+        <xsl:if test="$q_titles = 0">
+            <xsl:variable name="q_abstracts" select="count(.//abstract[.//text()])+count(.//trans-abstract[.//text()])"/>
+
+            <!-- obtém o título traduzido para Abstracts ou Abstract -->
+            <xsl:variable name="title">
+                <xsl:apply-templates select="." mode="text-labels">
+                    <xsl:with-param name="text">
+                        <xsl:choose>
+                            <xsl:when test="$q_abstracts=1">Abstract</xsl:when>
+                            <xsl:otherwise>Abstracts</xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:with-param>
+                </xsl:apply-templates>
+            </xsl:variable>
+            
+            <!-- insere a âncora e o título -->
+            <div class="articleSection" data-anchor="{$title}">
+                <h1 class="articleSectionTitle"><xsl:value-of select="$title"/></h1>
+            </div>
+        </xsl:if>
     </xsl:template>
     
     <xsl:template match="*[contains(name(),'abstract')]" mode="index">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -65,16 +65,30 @@
             <xsl:apply-templates select="*[name()!='title']"/>
 
             <!-- Apresenta as palavras-chave no idioma correspondente -->
-            <xsl:apply-templates select="../kwd-group[@xml:lang=$lang]" mode="keywords"></xsl:apply-templates>
-            <xsl:if test="not(../kwd-group[@xml:lang=$lang])">
-                <xsl:apply-templates select="../kwd-group[1]" mode="keywords"/>
-            </xsl:if>
+            <xsl:apply-templates select="." mode="keywords"/>
         </div>
         <xsl:if test="not(title)">
         <hr/>
         </xsl:if>
     </xsl:template>
     
+    <xsl:template match="abstract[not(@xml:lang)] | trans-abstract[not(@xml:lang)]" mode="keywords">
+        <!-- apresenta as palavras-chaves no idioma de article/@xml:lang ou sub-article/@xml:lang -->
+        <xsl:variable name="lang">
+            <xsl:choose>
+                <xsl:when test="../../@xml:lang"><xsl:value-of select="../../@xml:lang"/></xsl:when>
+                <xsl:when test="../../../@xml:lang"><xsl:value-of select="../../../@xml:lang"/></xsl:when>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:apply-templates select="../kwd-group[@xml:lang=$lang]" mode="keywords"/>
+    </xsl:template>
+
+    <xsl:template match="abstract[@xml:lang] | trans-abstract[@xml:lang]" mode="keywords">
+        <!-- apresenta as palavras-chaves no idioma correspondente -->
+        <xsl:variable name="lang" select="@xml:lang"/>
+        <xsl:apply-templates select="../kwd-group[@xml:lang=$lang]" mode="keywords"/>
+    </xsl:template>
+
     <xsl:template match="abstract[not(title)] | trans-abstract[not(title)]" mode="anchor-and-title">
     </xsl:template>
 

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -12,6 +12,7 @@
     </xsl:template>
     
     <xsl:template match="article" mode="article-meta-no-abstract-keywords">
+        <!-- Apresenta keywords para artigos sem resumo -->
         <xsl:if test="not(.//abstract)">
             <xsl:choose>
                 <xsl:when test=".//sub-article[@article-type='translation' and @xml:lang=$TEXT_LANG]//kwd-group">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -6,11 +6,55 @@
         <!-- apresenta todos os resumos que existir -->
         <xsl:variable name="q" select="count(.//abstract[.//text()])+count(.//trans-abstract[.//text()])"/>
         <xsl:if test="$q &gt; 0">
-            <xsl:apply-templates select="." mode="add-anchor-and-title-for-abstracts-without-title"/>
-            <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"/>
+
+            <xsl:choose>
+                <xsl:when test=".//abstract//list">
+                    <!-- é highlights mas não está usando o atributo abstract-type -->
+                    <!-- apresenta os resumos do tipo key-points (highlights) -->
+                    <xsl:apply-templates select="." mode="abstract-highlights"/>
+
+                    <!-- apresenta a âncora e o título, ou seja, Abstract, Resumo, ou Resumen -->
+                    <xsl:apply-templates select="." mode="create-anchor-and-title-for-abstracts-without-title"/>
+
+                    <!-- apresenta os resumos diferentes de key-points -->
+                    <xsl:apply-templates select="." mode="abstract-not-highlights"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <!-- apresenta os resumos do tipo key-points (highlights) -->
+                    <xsl:apply-templates select="." mode="abstract-key-points"/>
+
+                    <!-- apresenta a âncora e o título, ou seja, Abstract, Resumo, ou Resumen -->
+                    <xsl:apply-templates select="." mode="create-anchor-and-title-for-abstracts-without-title"/>
+
+                    <!-- apresenta os resumos diferentes de key-points -->
+                    <xsl:apply-templates select="." mode="abstract-not-key-points"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:if>
     </xsl:template>
+
+    <xsl:template match="article" mode="abstract-key-points">
+        <!-- apresenta os resumos do tipo key-points (highlights) -->
+        <xsl:apply-templates select=".//abstract[@abstract-type='key-points']" mode="layout"/>
+        <xsl:apply-templates select=".//trans-abstract[@abstract-type='key-points']" mode="layout"/>
+    </xsl:template>
     
+    <xsl:template match="article" mode="abstract-not-key-points">
+        <!-- apresenta os resumos diferentes de key-points -->
+        <xsl:apply-templates select=".//abstract[not(@abstract-type) or @abstract-type!='key-points']|.//trans-abstract[not(@abstract-type) or @abstract-type!='key-points']" mode="layout"/>
+    </xsl:template>
+
+    <xsl:template match="article" mode="abstract-highlights">
+        <!-- apresenta os resumos do tipo highlights (highlights) -->
+        <xsl:apply-templates select=".//abstract[.//list]" mode="layout"/>
+        <xsl:apply-templates select=".//trans-abstract[.//list]" mode="layout"/>
+    </xsl:template>
+
+    <xsl:template match="article" mode="abstract-not-highlights">
+        <!-- apresenta os resumos diferentes de highlights -->
+        <xsl:apply-templates select=".//abstract[not(.//list)]|.//trans-abstract[not(.//list)]" mode="layout"/>
+    </xsl:template>
+
     <xsl:template match="article" mode="article-meta-no-abstract-keywords">
         <!-- Apresenta keywords para artigos sem resumo -->
         <xsl:if test="not(.//abstract)">
@@ -25,7 +69,7 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="*" mode="create-anchor-and-title-for-abstracts-without-title">
+    <xsl:template match="article" mode="create-anchor-and-title-for-abstracts-without-title">
         <xsl:variable name="q_titles" select="count(.//abstract[title])+count(.//trans-abstract[title])"/>
         <xsl:if test="$q_titles = 0">
             <xsl:variable name="q_abstracts" select="count(.//abstract[.//text()])+count(.//trans-abstract[.//text()])"/>
@@ -48,7 +92,7 @@
             </div>
         </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="*[contains(name(),'abstract')]" mode="index">
         <xsl:param name="lang"/>
         <xsl:if test="normalize-space(@xml:lang)=normalize-space($lang)"><xsl:value-of select="position()"/></xsl:if>
@@ -64,16 +108,23 @@
             <!-- Apresenta os demais elementos do resumo -->
             <xsl:apply-templates select="*[name()!='title']"/>
 
-            <!-- Apresenta as palavras-chave no idioma correspondente -->
-            <xsl:if test="not(@abstract-type) or @abstract-type!='key-points'">
-                <xsl:apply-templates select="." mode="keywords"/>
-            </xsl:if>
+            <!--
+            Apresenta as palavras-chave no idioma correspondente, se aplicável
+            -->
+            <xsl:choose>
+                <xsl:when test="@abstract-type='key-points' or .//list">
+                    <!-- para HIGHLIGHTS não apresentar keywords -->
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:apply-templates select="." mode="keywords"/>
+                </xsl:otherwise>
+            </xsl:choose>
         </div>
         <xsl:if test="not(title)">
         <hr/>
         </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="abstract[not(@xml:lang)] | trans-abstract[not(@xml:lang)]" mode="keywords">
         <!-- apresenta as palavras-chaves no idioma de article/@xml:lang ou sub-article/@xml:lang -->
         <xsl:variable name="lang">
@@ -132,14 +183,16 @@
     </xsl:template>
     
     <xsl:template match="article" mode="article-meta-abstract-gs">
+        <!-- PÁGINA DO RESUMO -->
+        <!-- APRESENTA O RESUMO NO IDIOMA CORRESPONDENTE -->
         <xsl:choose>
             <xsl:when test="@xml:lang=$gs_abstract_lang">
                 <!-- idioma selecionado é o mesmo que o do texto completo -->
-                <xsl:apply-templates select=".//article-meta/abstract" mode="layout"/>
+                <xsl:apply-templates select=".//article-meta/abstract[(not(@abstract-type) or @abstract-type!='key-points') and not(.//list)]" mode="layout"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select=".//trans-abstract[@xml:lang=$gs_abstract_lang]" mode="layout"/>
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$gs_abstract_lang]//abstract" mode="layout"/>
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$gs_abstract_lang]//abstract[(not(@abstract-type) or @abstract-type!='key-points') and not(.//list)]" mode="layout"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -25,7 +25,6 @@
         </xsl:if>
     </xsl:template>
 
-
     <xsl:template match="*" mode="create-anchor-and-title-for-abstracts-without-title">
         <xsl:variable name="q_titles" select="count(.//abstract[title])+count(.//trans-abstract[title])"/>
         <xsl:if test="$q_titles = 0">
@@ -59,21 +58,13 @@
         <xsl:variable name="lang" select="@xml:lang"/>
         <xsl:variable name="index"><xsl:apply-templates select="..//*[contains(name(),'abstract') and title]" mode="index"><xsl:with-param name="lang" select="$lang"></xsl:with-param></xsl:apply-templates></xsl:variable>
         <div>
-            <xsl:if test="title">
-                <xsl:attribute name="class">articleSection</xsl:attribute>
-                <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="title"/></xsl:attribute>
-            </xsl:if>
-            <xsl:if test="@xml:lang='ar'">
-                <xsl:attribute name="dir">rtl</xsl:attribute>
-            </xsl:if>
-                
-            <xsl:if test="title">
-                <h1>
-                    <xsl:attribute name="class">articleSectionTitle</xsl:attribute>
-                    <xsl:apply-templates select="." mode="title"></xsl:apply-templates>
-                </h1>
-            </xsl:if>
+            <!-- Apresenta a âncora e o título, ou seja, Abstract, Resumo, ou Resumen -->
+            <xsl:apply-templates select="." mode="anchor-and-title"/>
+
+            <!-- Apresenta os demais elementos do resumo -->
             <xsl:apply-templates select="*[name()!='title']"/>
+
+            <!-- Apresenta as palavras-chave no idioma correspondente -->
             <xsl:apply-templates select="../kwd-group[@xml:lang=$lang]" mode="keywords"></xsl:apply-templates>
             <xsl:if test="not(../kwd-group[@xml:lang=$lang])">
                 <xsl:apply-templates select="../kwd-group[1]" mode="keywords"/>
@@ -84,6 +75,26 @@
         </xsl:if>
     </xsl:template>
     
+    <xsl:template match="abstract[not(title)] | trans-abstract[not(title)]" mode="anchor-and-title">
+    </xsl:template>
+
+    <xsl:template match="abstract[title] | trans-abstract[title]" mode="anchor-and-title">
+        <!-- Apresenta a âncora e o título, ou seja, Abstract, Resumo, ou Resumen -->
+
+        <!-- âncora -->
+        <xsl:attribute name="class">articleSection</xsl:attribute>
+        <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="title"/></xsl:attribute>
+        <xsl:if test="@xml:lang='ar'">
+            <xsl:attribute name="dir">rtl</xsl:attribute>
+        </xsl:if>
+
+        <!-- título -->
+        <h1>
+            <xsl:attribute name="class">articleSectionTitle</xsl:attribute>
+            <xsl:apply-templates select="." mode="title"></xsl:apply-templates>
+        </h1>
+    </xsl:template>
+
     <xsl:template match="abstract/title | trans-abstract/title">
         <xsl:apply-templates select="*|text()"/>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -65,7 +65,9 @@
             <xsl:apply-templates select="*[name()!='title']"/>
 
             <!-- Apresenta as palavras-chave no idioma correspondente -->
-            <xsl:apply-templates select="." mode="keywords"/>
+            <xsl:if test="not(@abstract-type) or @abstract-type!='key-points'">
+                <xsl:apply-templates select="." mode="keywords"/>
+            </xsl:if>
         </div>
         <xsl:if test="not(title)">
         <hr/>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -3,10 +3,12 @@
     version="1.0">
 
     <xsl:template match="article" mode="article-meta-abstract">
-        <xsl:if test="$q_abstract &gt; 0 and $q_abstract_title &lt; $q_abstract">
-            <xsl:apply-templates select="." mode="abstract-anchor"></xsl:apply-templates>
+        <!-- apresenta todos os resumos que existir -->
+        <xsl:variable name="q" select="count(.//abstract[.//text()])+count(.//trans-abstract[.//text()])"/>
+        <xsl:if test="$q &gt; 0">
+            <xsl:apply-templates select="." mode="abstract-anchor"/>
+            <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"/>
         </xsl:if>
-        <xsl:apply-templates select=".//abstract|.//trans-abstract" mode="layout"></xsl:apply-templates>
     </xsl:template>
     
     <xsl:template match="article" mode="article-meta-no-abstract-keywords">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-list.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-list.xsl
@@ -18,24 +18,24 @@
     <xsl:template match="list">
         <xsl:param name="position"></xsl:param>
         <xsl:choose>
-            <xsl:when test="@list-type!='bullet'">
-                <ol>
-                    <xsl:apply-templates select="@*|*">
-                        <xsl:with-param name="position" select="position()"></xsl:with-param>
-                    </xsl:apply-templates>
-                </ol>
-            </xsl:when>
-            <xsl:otherwise>
+            <xsl:when test="@list-type='bullet'">
                 <ul>
                     <xsl:apply-templates select="@*|*">
                         <xsl:with-param name="position" select="position()"></xsl:with-param>
                     </xsl:apply-templates>
                 </ul>
+            </xsl:when>
+            <xsl:otherwise>
+                <ol>
+                    <xsl:apply-templates select="@*|*">
+                        <xsl:with-param name="position" select="position()"></xsl:with-param>
+                    </xsl:apply-templates>
+                </ol>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
     
-    <xsl:template match="@list-type">
+    <xsl:template match="@list-type[.!='bullet']">
         <!-- 1|a|A|i|I -->
         <xsl:attribute name="type">
             <xsl:choose>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.7.0'
+__version__ = '2.7.1'
 

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
     long_description_content_type="text/markdown",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",
-    maintainer="Gustavo Fonseca",
-    maintainer_email="gustavo.fonseca@scielo.org",
+    maintainer="SciELO Team",
+    maintainer_email="scielo-dev@googlegroups.com",
     license="BSD License",
     url="http://docs.scielo.org",
     packages=setuptools.find_packages(


### PR DESCRIPTION
#### O que esse PR faz?
Corrige várias questões nos resumos:
- garantir que apresentação de _highlights_ tem que ser antes dos demais resumos
- os _highlights_ não tem palavras-chaves
- o primeiro resumo está com as palavras-chaves em idioma incorreto (isso só ocorre nos XML cujo grupo de palavras chaves está em ordem diferente da dos resumos)
- artigo não tem resumo, mas apresenta o título "Abstract" (isso ocorre porque no XML tem a tag `<abstract/>` vazia)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
executando:

```console
python packtools/htmlgenerator.py --loglevel DEBUG --nonetwork --nochecks arquivo.xml
````


#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
[tk265.zip](https://github.com/scieloorg/packtools/files/6641198/tk265.zip)

#### Quais são tickets relevantes?
#265
closes #217

### Referências
n/a
