### PR TITLE
Alterar o HTML do artigo para conter tags image ao invés de imagens como background. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,27 @@ and an HTML previewer is provided:
 ```bash
 $ pip install packtools[webapp]
 ```
+## Tests
 
+To run tests execute:
+
+```bash
+python setup.py test
+```
+
+To run a specific module of tests, type:
+
+```bash
+python setup.py test -s tests.test_htmlgenerator
+```
+
+## Command line execute
+
+```bash
+htmlgenerator example.xml --loglevel=error --nochecks --nonetwork
+```
+
+It will generate the result in the same path of the .xml file.
 
 ## Running the web application
 

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -10,7 +10,7 @@
         <!--
         Cria a miniatura no texto completo, que ao ser clicada mostra a figura
         ampliada
-        --> 
+        -->
         <xsl:variable name="location">
             <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"/>
         </xsl:variable>
@@ -27,14 +27,15 @@
                     <div>
                         <xsl:choose>
                             <xsl:when test="$location != ''">
-                                <xsl:attribute name="class">thumb</xsl:attribute>
-                                <xsl:attribute name="style">background-image: url(<xsl:value-of select="$location"/>);</xsl:attribute>
+                                <xsl:attribute name="class">thumbImg</xsl:attribute>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:attribute name="class">thumbOff</xsl:attribute>
                             </xsl:otherwise>
                         </xsl:choose>
-                        Thumbnail
+                        <img>
+                            <xsl:attribute name="src"><xsl:value-of select="$location"/></xsl:attribute>
+                        </img>
                         <div class="zoom"><span class="sci-ico-zoom"></span></div>
                     </div>
                 </a>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.7.2'
+__version__ = '2.7.3'
 

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -724,7 +724,7 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
-            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.thumbnail.jpg);"]'
+            'div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -774,7 +774,7 @@ class HTMLGeneratorDispFormulaTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
-            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.jpg);"]'
+            'div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -926,7 +926,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
-            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.thumbnail.jpg);"]'
+            'div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0
           )
@@ -978,7 +978,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="articleSection"]/div[@class="row fig"]//a[@data-toggle="modal"]/'
-            'div[@class="thumb" and @style="background-image: url(1234-5678-rctb-45-05-0110-e01.jpg);"]'
+            'div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -1029,10 +1029,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="row fig"]'
-            '//div[@class="thumb" and @style="background-image: url('
-            'https://minio.scielo.br/documentstore/1678-992X/'
-            'Wfy9dhFgfVFZgBbxg4WGVQM/a.jpg'
-            ');"]'
+            '//div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -1051,9 +1048,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="row fig"]'
-            '//div[@class="thumb" and @style="background-image: url('
-            '1234-5678-rctb-45-05-0110-e01.png'
-            ');"]'
+            '//div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -1072,9 +1067,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="row fig"]'
-            '//div[@class="thumb" and @style="background-image: url('
-            '1234-5678-rctb-45-05-0110-e01.jpg'
-            ');"]'
+            '//div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 
@@ -1093,9 +1086,7 @@ class HTMLGeneratorFigTests(unittest.TestCase):
         html = domain.HTMLGenerator.parse(et, valid_only=False).generate('pt')
         thumb_tag = html.xpath(
             '//div[@class="row fig"]'
-            '//div[@class="thumb" and @style="background-image: url('
-            '1234-5678-rctb-45-05-0110-e01.jpg'
-            ');"]'
+            '//div[@class="thumbImg"]/img'
         )
         self.assertTrue(len(thumb_tag) > 0)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,7 +176,7 @@ class ResolveSchematronFilepathTests(unittest.TestCase):
                 lambda: utils.resolve_schematron_filepath(None))
 
     def test_non_existing_builtin(self):
-        self.assertRaises(ValueError, 
+        self.assertRaises(ValueError,
                 lambda: utils.resolve_schematron_filepath('@notexists'))
 
     def test_existing_filepath(self):
@@ -185,7 +185,7 @@ class ResolveSchematronFilepathTests(unittest.TestCase):
 
     def test_non_existing_filepath(self):
         path = list(self.sch_schemas.values())[0] + '.notexists'
-        self.assertRaises(ValueError, 
+        self.assertRaises(ValueError,
                 lambda: utils.resolve_schematron_filepath(path))
 
 
@@ -503,18 +503,19 @@ class TestXMLWebOptimiser(unittest.TestCase):
             return fp.read()
 
     def test_get_all_graphic_images_from_xml(self):
-        expected = {
+        expected = sorted([
             "1234-5678-rctb-45-05-0110-e01.tif",
             "1234-5678-rctb-45-05-0110-e02.tiff",
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
             "1234-5678-rctb-45-05-0110-e04.tif",
-        }
+        ])
         result = self.xml_web_optimiser._get_all_graphic_images_from_xml(
             self.image_filenames
         )
-        for graphic_filename, expected_filename in zip(result, expected):
+
+        for graphic_filename, expected_filename in zip(sorted(result), expected):
             self.assertEqual(graphic_filename, expected_filename)
 
     def test_create_XMLWebOptimiser(self):
@@ -717,18 +718,18 @@ class TestXMLWebOptimiserGraphicsWithNoFileExtention(unittest.TestCase):
             return fp.read()
 
     def test_get_all_graphic_images_from_xml(self):
-        expected = {
+        expected = sorted([
             "1234-5678-rctb-45-05-0110-e01.tif",
             "1234-5678-rctb-45-05-0110-e02.tiff",
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
             "1234-5678-rctb-45-05-0110-e04.tif",
-        }
+        ])
         result = self.xml_web_optimiser._get_all_graphic_images_from_xml(
             self.image_filenames
         )
-        for graphic_filename, expected_filename in zip(result, expected):
+        for graphic_filename, expected_filename in zip(sorted(result), expected):
             self.assertEqual(graphic_filename, expected_filename)
 
     def test_get_all_images_to_optimise(self):
@@ -826,15 +827,15 @@ class TestXMLWebOptimiserValidations(unittest.TestCase):
         result = xml_web_optimiser._get_all_graphic_images_from_xml(
             self.image_filenames
         )
-        expected = {
+        expected = sorted([
             "1234-5678-rctb-45-05-0110-e01.jpg",
             "1234-5678-rctb-45-05-0110-e02.gif",
             "1234-5678-rctb-45-05-0110-gf03.tiff",
             "1234-5678-rctb-45-05-0110-gf03.png",
             "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
             "1234-5678-rctb-45-05-0110-e04.tif",
-        }
-        for graphic_filename, expected_filename in zip(result, expected):
+        ])
+        for graphic_filename, expected_filename in zip(sorted(result), expected):
             self.assertEqual(graphic_filename, expected_filename)
 
     def test_get_all_images_to_optimise_does_not_return_optimised_images(self):


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR altera a forma de apresentar as imagens na página dos artigo do OPAC.

#### Onde a revisão poderia começar?

Por commit

#### Como este poderia ser testado manualmente?

Rodando os testes: 

```
python setup.py test
```

ou 

```
python setup.py test -s tests.test_htmlgenerator

```
#### Algum cenário de contexto que queira dar?

Também nesse PR adicionei como rodar o comando do **htmlgenerator** e uma documentação dos testes.

A nova forma de apresentar as imagens: 

```html 
<a href="" data-toggle="modal" data-target="#ModalFigf03">
    <div class="thumbImg">
        <img src="0034-8910-rsp-48-2-0206-gf03.jpg">
        <div class="zoom"><span class="sci-ico-zoom"></span></div>
    </div>
</a>
```


### Screenshots
N/A

#### Quais são tickets relevantes?

Esse tíquete está relacionado com a atividade: #270 e com a alteração da interface: https://github.com/scieloorg/opac/pull/2035

### Referências
N/A

