### PR TITLE
Corrige a apresentação de fórmulas na página do artigo

### DIFF
--- a/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css
+++ b/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css
@@ -9,3 +9,4 @@
     min-height: 131px;
     display: block;
 }
+.formula-container .label { color:  black;} 

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-alternatives.xsl
@@ -7,6 +7,40 @@
     version="1.0">
 
     <xsl:template match="alternatives">
+        <!-- primeiro -->
+        <xsl:apply-templates select="*[1]"/>
+    </xsl:template>
+
+    <xsl:template match="disp-formula/alternatives | inline-formula/alternatives">
+        <xsl:choose>
+            <xsl:when test="$MATH_ELEM_PREFERENCE='tex-math' and tex-math">
+                <xsl:apply-templates select="tex-math" />
+            </xsl:when>
+            <xsl:when test="$MATH_ELEM_PREFERENCE='math' and math">
+                <xsl:apply-templates select="math" />
+            </xsl:when>
+            <xsl:when test="$MATH_ELEM_PREFERENCE='mml:math' and mml:math">
+                <xsl:apply-templates select="mml:math" />
+            </xsl:when>
+            <xsl:when test="tex-math">
+                <xsl:apply-templates select="tex-math" />
+            </xsl:when>
+            <xsl:when test="mml:math">
+                <xsl:apply-templates select="mml:math" />
+            </xsl:when>
+            <xsl:when test="math">
+                <xsl:apply-templates select="math" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="*[1]"></xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>    
+    </xsl:template>
+
+    <xsl:template match="fig/alternatives">
+        <!-- 
+            Apresentar a imagem padrão 
+        -->
         <xsl:choose>
             <xsl:when test="inline-graphic[@specific-use='scielo-web']">
                 <xsl:apply-templates select="inline-graphic[@specific-use='scielo-web']" />

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
@@ -25,15 +25,34 @@
         <xsl:apply-templates select="alternatives" />
     </xsl:template>
 
-    <xsl:template match="tex-math">
+    <xsl:template match="inline-formula/tex-math | inline-formula/alternatives/tex-math">
+        <xsl:choose>
+            <xsl:when test="starts-with(.,'\begin') and contains(.,'\end')">
+                <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:when test="starts-with(.,'\(') and ends-with(.,'\)')">
+                <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:when test="starts-with(.,'$') and ends-with(.,'$')">
+                <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:otherwise>\(<xsl:value-of select="."/>\)</xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="disp-formula/tex-math | disp-formula/alternatives/tex-math">
         <span class="formula-body">
             <xsl:choose>
-                <xsl:when test="contains(.,'\begin{document}') and contains(.,'\end{document}')">
-                    <xsl:value-of select="substring-after(substring-before(.,'\end{document}'),'\begin{document}')"/>
-                </xsl:when>
-                <xsl:otherwise>
+                <xsl:when test="starts-with(.,'\begin') and contains(.,'\end')">
                     <xsl:value-of select="."/>
-                </xsl:otherwise>
+                </xsl:when>
+                <xsl:when test="starts-with(.,'\[') and ends-with(.,'\]')">
+                    <xsl:value-of select="."/>
+                </xsl:when>
+                <xsl:when test="starts-with(.,'$$') and ends-with(.,'$$')">
+                    <xsl:value-of select="."/>
+                </xsl:when>
+                <xsl:otherwise>\[<xsl:value-of select="."/>\]</xsl:otherwise>
             </xsl:choose>
         </span>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-mathml.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-mathml.xsl
@@ -5,7 +5,7 @@
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     exclude-result-prefixes="xlink mml"
     version="1.0">
-    <xsl:template match="mml:math">
+    <xsl:template match="mml:math | math">
         <xsl:copy-of select="."/>
     </xsl:template>
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -187,9 +187,19 @@
                 <script src="{$JS_PATH}/js/min/main-min.js"/>
             </xsl:otherwise>
         </xsl:choose>
-        <xsl:if test=".//math or .//mml:math">
-            <script type="text/javascript"
-                    src="{$MATHJAX}">
+        <xsl:if test=".//tex-math or .//math or .//mml:math">
+            <script>
+            MathJax = {
+              tex: {
+                inlineMath: [['$', '$'], ['\\(', '\\)']]
+              },
+              svg: {
+                fontCache: 'global'
+              }
+            };
+            </script>
+            <script type="text/javascript" id="MathJax-script" async="true"
+              src="{$MATHJAX}">
             </script>
         </xsl:if>
     </xsl:template>

--- a/packtools/catalogs/htmlgenerator/v2.0/config-vars.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-vars.xsl
@@ -16,9 +16,24 @@
     <xsl:param name="legendary"></xsl:param>
     <xsl:param name="abbr_contrib"></xsl:param>
 
+    <xsl:param name="math_elem_preference" select="''"/>
+    <xsl:param name="math_js" select="''"/>
+
     <xsl:param name="output_style"/>
     
-    <xsl:variable name="MATHJAX">https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML</xsl:variable>
+    <xsl:variable name="MATH_ELEM_PREFERENCE">
+        <xsl:choose>
+            <xsl:when test="$math_elem_preference='mml:math'">mml:math</xsl:when>
+            <xsl:otherwise>tex-math</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    <xsl:variable name="MATHJAX">
+        <xsl:choose>
+            <xsl:when test="$math_js!=''"><xsl:value-of select="$math_js"/></xsl:when>
+            <xsl:otherwise>https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-chtml.js</xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
     <xsl:variable name="ABBR_CONTRIB"><xsl:choose>
         <xsl:when test="$abbr_contrib!=''"><xsl:value-of select="$abbr_contrib"/></xsl:when>
         <xsl:otherwise>false</xsl:otherwise>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.8.2'
+__version__ = '2.8.3'
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a apresentação de fórmulas na página do artigo

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python packtools/htmlgenerator.py --nochecks --nonetwork --loglevel DEBUG /Users/roberta.takenaka/xml_packages/com-equcoes.xml
```
[com-equcoes.xml.zip](https://github.com/scieloorg/packtools/files/8174954/com-equcoes.xml.zip)


#### Algum cenário de contexto que queira dar?
TODO: 
- fazer o htmlgenerator receber parâmetros e passar para a XSL
- Atualmente só funciona com `tex-math`. Não está surtindo efeito para `mml:math`
- Será necessário atualizar no opac o endereço do javascript que renderiza as fórmulas 

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2063

### Referências
https://docs.mathjax.org/en/latest/web/start.html
https://docs.mathjax.org/en/latest/input/tex/index.html
https://docs.mathjax.org/en/latest/input/mathml.html