### PR TITLE
Corrige apresentação de figuras (bug inserido ao tentar resolver questões de preservação)

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -18,8 +18,8 @@
         <div class="row fig" id="{$figid}">
             <a name="{$figid}"></a>
             <div class="col-md-4 col-sm-4">
+                <!-- manter href="" -->
                 <a href="" data-toggle="modal" data-target="#ModalFig{$figid}">
-                    <xsl:attribute name="href"><xsl:value-of select="$location"/></xsl:attribute>
                     <div>
                         <xsl:choose>
                             <xsl:when test="$location != ''">

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,5 +1,5 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.8.3'
+__version__ = '2.8.4'
 

--- a/tests/test_htmlgenerator.py
+++ b/tests/test_htmlgenerator.py
@@ -1511,7 +1511,7 @@ class HTMLGeneratorFigWithoutIdTests(unittest.TestCase):
 
         # div_row_fig_divs[0] has link to image path
         self.assertEqual(
-            "2236-8906-hoehnea-49-e1112020-gf1.jpg",
+            "",
             div_modal_fig_0_a.get("href")
         )
         # div_row_fig_divs[0] has `@data-target` = #ModalFig
@@ -1694,7 +1694,7 @@ class HTMLGeneratorFigWithIdTests(unittest.TestCase):
         <div class="row fig" id="">
             <a name=""></a>
             <div class="col-md-4 col-sm-4">
-                <a href="2236-8906-hoehnea-49-e1112020-gf1.jpg" data-toggle="modal" data-target="#ModalFig">
+                <a href="" data-toggle="modal" data-target="#ModalFig">
                     <div class="thumbImg">
                         <img src="2236-8906-hoehnea-49-e1112020-gf1.jpg">
                         <div class="zoom"><span class="sci-ico-zoom"></span></div>
@@ -1716,8 +1716,9 @@ class HTMLGeneratorFigWithIdTests(unittest.TestCase):
         div_modal_fig_0_a = div_row_fig_divs[0].find("a")
 
         # div_row_fig_divs[0] has link to image path
+		
         self.assertEqual(
-            "2236-8906-hoehnea-49-e1112020-gf1.jpg",
+            "",
             div_modal_fig_0_a.get("href")
         )
         # div_row_fig_divs[0] has `@data-target` = #ModalFig


### PR DESCRIPTION
#### O que esse PR faz?
Corrige apresentação de figuras (bug inserido ao tentar resolver questões de preservação)

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
```console
python packtools/htmlgenerator.py --nochecks --nonetwork --loglevel DEBUG /Users/roberta.takenaka/xml_packages/com-equcoes.xml
```

*Correto*
```html
<div class="row fig" id="f1">
	<a name="f1"></a>
	<div class="col-md-4 col-sm-4">
		<a href="" data-toggle="modal" data-target="#ModalFigf1">
			<div class="thumbImg">
				<img src="https://minio.scielo.br/documentstore/1678-2690/vR75PXVgmxtML8Fx6q6vTbR/17badab522aec3711d3f48741ced33bd7de24e5b.jpg"/>
				<div class="zoom"><span class="sci-ico-zoom"></span></div>
			</div>
		</a>
	</div>

	<div class="col-md-8 col-sm-8">
	<strong></strong><br>
          Plots of the WBXII density with s = 1.
    </div>
</div>
```
*Incorreto*
```html
<div class="row fig" id="f1">
	<a name="f1"></a>
	<div class="col-md-4 col-sm-4">
		<a href="https://minio.scielo.br/documentstore/1678-2690/vR75PXVgmxtML8Fx6q6vTbR/17badab522aec3711d3f48741ced33bd7de24e5b.jpg" data-toggle="modal" data-target="#ModalFigf1">
			<div class="thumbImg">
				<img src="https://minio.scielo.br/documentstore/1678-2690/vR75PXVgmxtML8Fx6q6vTbR/17badab522aec3711d3f48741ced33bd7de24e5b.jpg"/>
				<div class="zoom"><span class="sci-ico-zoom"></span></div>
			</div>
		</a>
	</div>
	<div class="col-md-8 col-sm-8">
		<strong></strong><br>Plots of the WBXII density with s = 1.<br>
	</div>
</div>
```

*Correto*
```text
<a href="" data-toggle="modal" data-target="#ModalFigf1">
```
*Incorreto*
```text
<a href="https://minio.scielo.br/documentstore/1678-2690/vR75PXVgmxtML8Fx6q6vTbR/17badab522aec3711d3f48741ced33bd7de24e5b.jpg" data-toggle="modal" data-target="#ModalFigf1">
```
		
#### Algum cenário de contexto que queira dar?
Há 3 testes não funcionando, mas é do PR https://github.com/scieloorg/packtools/pull/284 sobre fórmula (TODO)
No commit que foi inserido o erro, também foram inseridos códigos desnecessários, mas que não interferem no bug e pode ser corrigido futuramente.

### Screenshots

#### Quais são tickets relevantes?
#285

### Referências
n/a
