### PR TITLE
Corrige testes de sps

### DIFF
--- a/tests/sps/test_sps_maker.py
+++ b/tests/sps/test_sps_maker.py
@@ -172,7 +172,7 @@ class Test_make_package_from_uris(TestCase):
             '1414-431X-bjmbr-54-10-e11439-gf02-scielo-267x140.jpg'
         ])
 
-        with zipfile.ZipFile(package_metadata['temp-zipfile']) as zf:
+        with zipfile.ZipFile(package_metadata['zip']) as zf:
             self.assertSetEqual(
                 expected_files,
                 set(zf.namelist()),
@@ -199,7 +199,7 @@ class Test_make_package_from_uris(TestCase):
             '1414-431X-bjmbr-54-10-e11439-gf02-scielo-267x140.jpg'
         ])
 
-        with zipfile.ZipFile(package_metadata['temp-zipfile']) as zf:
+        with zipfile.ZipFile(package_metadata['zip']) as zf:
             self.assertSetEqual(
                 expected_files,
                 set(zf.namelist()),
@@ -247,7 +247,7 @@ class Test_make_package_from_paths(TestCase):
             '1414-431X-bjmbr-54-10-e11439-gf01.jpg',
         ])
 
-        with zipfile.ZipFile(package_metadata['temp-zipfile']) as zf:
+        with zipfile.ZipFile(package_metadata['zip']) as zf:
             self.assertSetEqual(
                 expected_files,
                 set(zf.namelist()),

--- a/tests/sps/test_sps_maker.py
+++ b/tests/sps/test_sps_maker.py
@@ -111,7 +111,7 @@ class Test_get_xml_sps_from_uri(TestCase):
     def test_get_xml_sps_from_uri_raises_download_xml_error(self):
         xml_uri = 'https://kernel.scielo.br'
 
-        with self.assertRaises(sps_maker.exceptions.SPSDownloadXMLError):
+        with self.assertRaises(sps_maker.exceptions.SPSHTTPResourceNotFoundError):
             sps_maker._get_xml_sps_from_uri(xml_uri)
 
 
@@ -156,7 +156,7 @@ class Test_make_package_from_uris(TestCase):
             "name": "1414-431X-bjmbr-54-10-e11439-gf01.jpg"
         }]
 
-        with self.assertRaises(sps_maker.exceptions.SPSDownloadXMLError):
+        with self.assertRaises(sps_maker.exceptions.SPSHTTPResourceNotFoundError):
             sps_maker.make_package_from_uris(xml_uri, renditions_uris_and_names)
 
     @skip("Exige conexão com VPN SciELO")


### PR DESCRIPTION
#### O que esse PR faz?
Faz uma pequena correção em alguns testes de sps, a saber:
1. Renomeia chave `temp-zip` para `zip` (de modo a repercutir o que foi alterado no módulo sps_maker)
2. Corrige exceção esperada em alguns testes (de `SPSDownloadXMLError` para `SPSHTTPResourceNotFoundError`)

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
Basta executar o teste manualmente, como em: `python setup.py test -s tests.sps`

#### Algum cenário de contexto que queira dar?
Este PR apenas inclui alguns códigos-fonte que deveriam ter sido incluídos no PR anterior (#281). Há alguns testes com falha que estão relacionados com html-generator e que não possuem relação com este PR ou o anterior (vide **Figura 1**).

### Screenshots
**Figura 1**. Testes com falha herdados de outros PRs.
![image](https://user-images.githubusercontent.com/2096125/157256384-0c46685b-024b-4b19-b045-78d1f43198f2.png)

#### Quais são tickets relevantes?
N/A

### Referências
N/A
