### PR TITLE
Corrige a apresentação de fórmulas representadas por `mml:math`

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-mathml.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-mathml.xsl
@@ -5,7 +5,30 @@
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     exclude-result-prefixes="xlink mml"
     version="1.0">
-    <xsl:template match="mml:math | math">
+
+    <xsl:template match="math">
         <xsl:copy-of select="."/>
+    </xsl:template>
+
+    
+    <xsl:template match="mml:math">
+        <!-- Remove o namespace mml para que os browser possam renderizar as fórmulas -->
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*|*|text()" mode="no-namespace"/>
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="@*" mode="no-namespace">
+        <xsl:attribute name="{name()}">
+            <xsl:apply-templates select="text()"/>
+        </xsl:attribute>
+    </xsl:template>
+    <xsl:template match="*" mode="no-namespace">
+        <!-- Remove o namespace mml para que os browser possam renderizar as fórmulas -->
+        <xsl:element name="{local-name()}">
+            <xsl:apply-templates select="@*|*|text()" mode="no-namespace"/>
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="text()" mode="no-namespace">
+        <xsl:value-of select="."/>
     </xsl:template>
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/config-vars.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-vars.xsl
@@ -30,7 +30,7 @@
     <xsl:variable name="MATHJAX">
         <xsl:choose>
             <xsl:when test="$math_js!=''"><xsl:value-of select="$math_js"/></xsl:when>
-            <xsl:otherwise>https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-chtml.js</xsl:otherwise>
+            <xsl:otherwise>https://cdn.jsdelivr.net/npm/mathjax@3.0.0/es5/tex-mmlmath-chtml.js</xsl:otherwise>
         </xsl:choose>
     </xsl:variable>
 

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.9.0'
+__version__ = '2.9.1'

--- a/tests/fixtures/mmlmath/f.xml
+++ b/tests/fixtures/mmlmath/f.xml
@@ -1,0 +1,219 @@
+
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">mr</journal-id>
+      <journal-title-group>
+        <journal-title>Materials Research</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Mat. Res.</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">1516-1439</issn>
+      <issn pub-type="epub">1980-5373</issn>
+      <publisher>
+        <publisher-name>ABM, ABC, ABPol</publisher-name>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id specific-use="scielo-v3" pub-id-type="publisher-id">nnBRGz6Rc3nYKcyrLsDCLRt</article-id>
+      <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1516-14392022000100285</article-id>
+      <article-id pub-id-type="other">00285</article-id>
+      <article-id pub-id-type="doi">10.1590/1980-5373-MR-2021-0526</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>Articles</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>Structure, Characteristics and Corrosion Behaviour of Gold Nanocoating Thin Film for Biomedical Applications</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-8406-0566</contrib-id>
+          <name>
+            <surname>Wadullah</surname>
+            <given-names>Haitham M.</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff01">
+            <sup>a</sup>
+          </xref>
+          <xref ref-type="corresp" rid="c01">*</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Ali</surname>
+            <given-names>Mohammed Hadi</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff02">
+            <sup>b</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Abdulrazzaq</surname>
+            <given-names>Tariq Khalid</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff01">
+            <sup>a</sup>
+          </xref>
+        </contrib>
+        <aff id="aff01">
+          <label>a</label>
+          <institution content-type="orgname">Northern Technical University</institution>
+          <institution content-type="orgdiv1">Engineering Technical College</institution>
+          <addr-line>
+            <named-content content-type="city">Mosul</named-content>
+          </addr-line>
+          <country country="IQ">Iraq</country>
+          <institution content-type="original">Northern Technical University, Engineering Technical College, Mosul, Iraq.</institution>
+        </aff>
+        <aff id="aff02">
+          <label>b</label>
+          <institution content-type="orgname">Middle Technical University</institution>
+          <institution content-type="orgdiv1">AL-Suwaira Technical Institute</institution>
+          <addr-line>
+            <named-content content-type="city">Baghdad</named-content>
+          </addr-line>
+          <country country="IQ">Iraq</country>
+          <institution content-type="original">Middle Technical University, AL-Suwaira Technical Institute, Baghdad, Iraq.</institution>
+        </aff>
+      </contrib-group>
+      <author-notes>
+        <corresp id="c01"><label>*</label>e-mail: <email>haitham@ntu.edu.iq</email></corresp>
+      </author-notes>
+      <pub-date date-type="pub" publication-format="electronic">
+        <day>07</day>
+        <month>03</month>
+        <year>2022</year>
+      </pub-date>
+      <pub-date date-type="collection" publication-format="electronic">
+        <year>2022</year>
+      </pub-date>
+      <volume>25</volume>
+      <elocation-id>e20210526</elocation-id>
+      <history>
+        <date date-type="received">
+          <day>10</day>
+          <month>10</month>
+          <year>2021</year>
+        </date>
+        <date date-type="rev-recd">
+          <day>11</day>
+          <month>02</month>
+          <year>2022</year>
+        </date>
+        <date date-type="accepted">
+          <day>13</day>
+          <month>02</month>
+          <year>2022</year>
+        </date>
+      </history>
+      <permissions>
+        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/" xml:lang="en">
+          <license-p>This is an Open Access article distributed under the terms of the <underline>Creative Commons Attribution License</underline>, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
+        </license>
+      </permissions>
+      <abstract>
+        <p>Nanocoatings thin films are layers deposited to improve required properties and corrosion resistance as a major objective for materials that are used for various biomedical applications such as biosensors. In this study, Gold (Au) thin films with 50 nm and 100 nm have been synthesized on Ni-Cr-Mo alloys by magnetron sputtering deposition technique. X-Ray diffraction (XRD), Atomic Force Microscopy (AFM), and Energy-dispersive X-Ray spectroscopy /Scanning Electron Microscopy (EDS/SEM ) have been used to distinguish the surfaces morphology. The results showed that there is no defects or micro-cracks with a uniform and homogenous film. It has spherical nanoparticles diameter morphology with 200-400 nm shaped to fine aggregation. The roughness average (Ra) decreased from 3.91 nm for 50 nm films to 3.70 nm for 100nm films with FCC crystal structure (111) for gold thin films. In vivo, after 50 nm and 100 nm nanocoated thin film by gold, a significant improvement in the localized corrosion resistance has been obtained in artificial saliva corrosive media at 37 °C compared with the uncoated surface.</p>
+      </abstract>
+      <kwd-group xml:lang="en">
+        <title>Keywords:</title>
+        <kwd>Corrosion resistance</kwd>
+        <kwd>sputtering deposition process</kwd>
+        <kwd>gold thin films</kwd>
+        <kwd>Ni-Cr-Mo biomaterial alloy</kwd>
+      </kwd-group>
+      <counts>
+        <fig-count count="6"/>
+        <table-count count="4"/>
+        <equation-count count="2"/>
+        <ref-count count="21"/>
+      </counts>
+    </article-meta>
+  </front>
+  <body>
+
+    <p><disp-formula id="e03"><math id="m3"><msqrt>
+  <mo> - </mo>
+  <mn> 1 </mn>
+</msqrt></math>
+</disp-formula></p>
+<p>
+
+      <disp-formula id="e01">
+        <mml:math id="m1">
+          <mml:mrow>
+            <mml:mi>D</mml:mi>
+            <mml:mo>=</mml:mo>
+            <mml:mfrac>
+              <mml:mi>γ</mml:mi>
+              <mml:mrow>
+                <mml:msqrt>
+                  <mml:mrow>
+                    <mml:msup>
+                      <mml:mi>β</mml:mi>
+                      <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mo>+</mml:mo>
+                    <mml:mo> </mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>β</mml:mi>
+                      <mml:mrow>
+                        <mml:mi>s</mml:mi>
+                        <mml:mi>t</mml:mi>
+                        <mml:mi>d</mml:mi>
+                      </mml:mrow>
+                      <mml:mn>2</mml:mn>
+                    </mml:msubsup>
+                    <mml:mo> </mml:mo>
+                    <mml:mo> </mml:mo>
+                    <mml:mi>c</mml:mi>
+                    <mml:mi>o</mml:mi>
+                    <mml:mi>s</mml:mi>
+                    <mml:mi>θ</mml:mi>
+                  </mml:mrow>
+                </mml:msqrt>
+              </mml:mrow>
+            </mml:mfrac>
+          </mml:mrow>
+        </mml:math>
+        <label>(1)</label>
+      </disp-formula></p>
+<p>
+<disp-formula id="e02"><mml:math id="m2">
+<mml:mrow>
+  <mml:mi>x</mml:mi>
+  <mml:mo>=</mml:mo>
+  <mml:mfrac>
+    <mml:mrow>
+      <mml:mrow>
+        <mml:mo>-</mml:mo>
+        <mml:mi>b</mml:mi>
+      </mml:mrow>
+      <mml:mo>&#xB1;<!--PLUS-MINUS SIGN--></mml:mo>
+      <mml:msqrt>
+        <mml:mrow>
+          <mml:msup>
+            <mml:mi>b</mml:mi>
+            <mml:mn>2</mml:mn>
+          </mml:msup>
+          <mml:mo>-</mml:mo>
+          <mml:mrow>
+            <mml:mn>4</mml:mn>
+            <mml:mo>&#x2062;<!--INVISIBLE TIMES--></mml:mo>
+            <mml:mi>a</mml:mi>
+            <mml:mo>&#x2062;<!--INVISIBLE TIMES--></mml:mo>
+            <mml:mi>c</mml:mi>
+          </mml:mrow>
+        </mml:mrow>
+      </mml:msqrt>
+    </mml:mrow>
+    <mml:mrow>
+      <mml:mn>2</mml:mn>
+      <mml:mo>&#x2062;<!--INVISIBLE TIMES--></mml:mo>
+      <mml:mi>a</mml:mi>
+    </mml:mrow>
+  </mml:mfrac>
+</mml:mrow></mml:math>
+</disp-formula></p>
+</body></article>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a apresentação de fórmulas representadas por `mml:math`, removendo o namespace das tags, desta forma os navegadores conseguem renderizá-las. No entanto, nem todos os navegadores conseguem.

<img width="784" alt="Captura de Tela 2022-03-09 às 11 50 40" src="https://user-images.githubusercontent.com/505143/157466013-8184645f-cb05-4fdc-8b61-cf72d59d4313.png">

https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math acessado nesta data

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

```console
python packtools/htmlgenerator.py --nochecks --nonetwork --loglevel DEBUG tests/fixtures/mmlmath/f.xml
```

#### Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
o revisor a fim de facilitar o entendimento da funcionalidade.

### Screenshots
n/a

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/2231

Exemplos: 
https://www.scielo.br/j/mr/a/nnBRGz6Rc3nYKcyrLsDCLRt/?lang=en#
https://www.scielo.br/j/rbef/a/Tr6nFmXB9F5zsBkxfsRMpXd

### Referências
https://developer.mozilla.org/en-US/docs/Web/MathML/Element/math

