### PR TITLE
Troca o caracter ponto por `_` se aparece no `@id` de figura, equações e tabelas

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fig.xsl
@@ -51,7 +51,7 @@
     </xsl:template>
 
     <xsl:template match="fig | fig-group[@id]" mode="figure-id">
-        <xsl:value-of select="@id"/>
+        <xsl:value-of select="translate(@id,'.','_')"/>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-formula.xsl
@@ -7,8 +7,9 @@
     version="1.0">
     
     <xsl:template match="disp-formula">
-        <div class="row formula" id="e{@id}">
-            <a name="{@id}"></a>
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="disp-formula-id"/></xsl:variable>
+        <div class="row formula" id="e{$id}">
+            <a name="{$id}"></a>
             <div class="col-md-12">
                 <div class="formula-container">
                     <xsl:apply-templates select="*|text()"></xsl:apply-templates>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-table.xsl
@@ -2,11 +2,12 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
     <xsl:template match="table-wrap[@id] | table-wrap-group[@id]">
-        <div class="row table" id="{@id}">
-        <a name="{@id}"/>
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="table-id"/></xsl:variable>
+        <div class="row table" id="{$id}">
+        <a name="{$id}"/>
             
             <div class="col-md-4 col-sm-4">
-                <a data-toggle="modal" data-target="#ModalTable{@id}">
+                <a data-toggle="modal" data-target="#ModalTable{$id}">
                     <div class="thumbOff">
                         Thumbnail
                         <div class="zoom"><span class="sci-ico-zoom"></span></div>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-xref.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-xref.xsl
@@ -8,21 +8,21 @@
     
     <xsl:template match="xref[@ref-type='equation' or @ref-type='disp-formula']">
         <!-- <a href="#{@rid}" class="goto"><span class="sci-ico-fileFormula"></span> <xsl:apply-templates select="*|text()"></xsl:apply-templates></a> -->
-        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalScheme{@rid}">
+        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalScheme{translate(@rid,'.','_')}">
             <span class="sci-ico-fileFormula"></span> 
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
         </a>
     </xsl:template>
     
     <xsl:template match="xref[@ref-type='fig']">
-        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFig{@rid}">
+        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFig{translate(@rid,'.','_')}">
             <span class="sci-ico-fileFigure"></span> 
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
         </a>        
     </xsl:template>
     
     <xsl:template match="xref[@ref-type='table']">
-        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTable{@rid}">
+        <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTable{translate(@rid,'.','_')}">
             <span class="sci-ico-fileTable"></span> 
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
         </a>        

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-scheme.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-scheme.xsl
@@ -2,9 +2,16 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:mml="http://www.w3.org/1998/Math/MathML"
     version="1.0">
+
+    <xsl:template match="disp-formula" mode="disp-formula-id">
+        <xsl:value-of select="translate(@id,'.','_')"/>
+    </xsl:template>
+
     <xsl:template match="disp-formula" mode="modal">
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="disp-formula-id"/></xsl:variable>
+
         <xsl:if test="@id">
-            <div class="modal fade ModalFigs" id="ModalScheme{@id}" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal fade ModalFigs" id="ModalScheme{$id}" tabindex="-1" role="dialog" aria-hidden="true">
                 <div class="modal-dialog modal-lg">
                     <div class="modal-content">
                         <div class="modal-header">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-tables.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-tables.xsl
@@ -6,8 +6,14 @@
     <xsl:template match="table-wrap" mode="modal-header"/>
     <xsl:template match="table-wrap" mode="modal-body-and-footer"/>
     
+    <xsl:template match="table-wrap[@id] | table-wrap-group[@id]" mode="table-id">
+        <xsl:value-of select="translate(@id,'.','_')"/>
+    </xsl:template>
+
     <xsl:template match="table-wrap[@id] | table-wrap-group[@id]" mode="modal">
-        <div class="modal fade ModalTables" id="ModalTable{@id}" tabindex="-1" role="dialog" aria-hidden="true">
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="table-id"/></xsl:variable>
+
+        <div class="modal fade ModalTables" id="ModalTable{$id}" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
 

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -300,10 +300,11 @@
             Para table-wrap:
             - legenda de uma tabela em 1 idioma
         -->
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="table-id"/></xsl:variable>
         <div class="row table">
             <!-- miniatura -->
             <div class="col-md-4">
-                <a data-toggle="modal" data-target="#ModalTable{@id}">
+                <a data-toggle="modal" data-target="#ModalTable{$id}">
                     <div class="thumbOff">
                         Thumbnail
                         <div class="zoom"><span class="sci-ico-zoom"></span></div>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -323,8 +323,10 @@
         <div class="row fig">
             <!-- miniatura -->
             <xsl:variable name="location"><xsl:apply-templates select="." mode="file-location"/></xsl:variable>
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="disp-formula-id"/></xsl:variable>
+
             <div class="col-md-4">
-                <a data-toggle="modal" data-target="#ModalScheme{@id}">
+                <a data-toggle="modal" data-target="#ModalScheme{$id}">
                     <div>
                         <xsl:choose>
                             <xsl:when test="graphic">

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -402,7 +402,7 @@
 
         <xsl:choose>
             <xsl:when test="$content_type='figures'">
-                <xsl:value-of select="count(fig)"/>
+                <xsl:value-of select="count(./fig) + count(.//fig-group) + count(.//*[fig and name()!='fig-group']//fig)"/>
             </xsl:when>
             <xsl:when test="$content_type='tables'">
                 <xsl:value-of select="count(./table-wrap) + count(.//table-wrap-group) + count(.//*[table-wrap and name()!='table-wrap-group']//table-wrap)"/>

--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals.xsl
@@ -247,8 +247,9 @@
             <xsl:variable name="location">
                 <xsl:apply-templates select="alternatives | graphic" mode="file-location-thumb"/>
             </xsl:variable>
+            <xsl:variable name="figid"><xsl:apply-templates select="." mode="figure-id"/></xsl:variable>
             <div class="col-md-4">
-                <a data-toggle="modal" data-target="#ModalFig{@id}">
+                <a data-toggle="modal" data-target="#ModalFig{$figid}">
                     <div>
                         <xsl:choose>
                             <xsl:when test="$location != ''">

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.9.1'
+__version__ = '2.9.2'

--- a/tests/fixtures/dot_in_id/arquivo.xml
+++ b/tests/fixtures/dot_in_id/arquivo.xml
@@ -1,0 +1,7331 @@
+
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">rbef</journal-id>
+      <journal-title-group>
+        <journal-title>Revista Brasileira de Ensino de Física</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Rev. Bras. Ensino Fís.</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">1806-1117</issn>
+      <issn pub-type="epub">1806-9126</issn>
+      <publisher>
+        <publisher-name>Sociedade Brasileira de Física</publisher-name>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id specific-use="scielo-v3" pub-id-type="publisher-id">Tr6nFmXB9F5zsBkxfsRMpXd</article-id>
+      <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1806-11172022000100410</article-id>
+      <article-id pub-id-type="other">00410</article-id>
+      <article-id pub-id-type="doi">10.1590/1806-9126-RBEF-2021-0341</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>Artigos Gerais</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>Modelos de polímeros utilizando o Hamiltoniano de tight-binding</article-title>
+        <trans-title-group xml:lang="en">
+          <trans-title>Polymer models using the tight-binding Hamiltonian</trans-title>
+        </trans-title-group>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Miyazaki</surname>
+            <given-names>Diogo Rikio</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Menezes</surname>
+            <given-names>Natalia Pereira</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0003-0097-9469</contrib-id>
+          <name>
+            <surname>de Lima</surname>
+            <given-names>Ariane Aparecida</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Heilmann</surname>
+            <given-names>Armando</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Zanella</surname>
+            <given-names>Fernando</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Burkarter</surname>
+            <given-names>E.</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff2">
+            <sup>2</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Mariano</surname>
+            <given-names>A. A.</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <name>
+            <surname>Thomazi</surname>
+            <given-names>Fabiano</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff3">
+            <sup>3</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-5110-5214</contrib-id>
+          <name>
+            <surname>Dartora</surname>
+            <given-names>C. A.</given-names>
+          </name>
+          <xref ref-type="corresp" rid="c001">*</xref>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+      </contrib-group>
+      <aff id="aff1">
+        <label>1</label>
+        <institution content-type="original">Universidade Federal do Paraná, Departamento de Engenharia Elétrica, Curitiba, PR, Brasil.</institution>
+        <institution content-type="orgname">Universidade Federal do Paraná</institution>
+        <institution content-type="orgdiv1">Departamento de Engenharia Elétrica</institution>
+        <addr-line>
+          <named-content content-type="city">Curitiba</named-content>
+          <named-content content-type="state">PR</named-content>
+        </addr-line>
+        <country country="BR">Brasil</country>
+      </aff>
+      <aff id="aff2">
+        <label>2</label>
+        <institution content-type="original">Instituto Federal do Paraná, Curitiba, PR, Brasil.</institution>
+        <institution content-type="orgname">Instituto Federal do Paraná</institution>
+        <addr-line>
+          <named-content content-type="city">Curitiba</named-content>
+          <named-content content-type="state">PR</named-content>
+        </addr-line>
+        <country country="BR">Brasil</country>
+      </aff>
+      <aff id="aff3">
+        <label>3</label>
+        <institution content-type="original">Faculdade Educacional Araucária, Curitiba, PR, Brasil</institution>
+        <institution content-type="orgname">Faculdade Educacional Araucária</institution>
+        <addr-line>
+          <named-content content-type="city">Curitiba</named-content>
+          <named-content content-type="state">PR</named-content>
+        </addr-line>
+        <country country="BR">Brasil</country>
+      </aff>
+      <author-notes>
+        <corresp id="c001"><label>*</label> Endereço de correspondência: <email>cadartora@eletrica.ufpr.br</email> </corresp>
+      </author-notes>
+      <pub-date date-type="pub" publication-format="electronic">
+        <day>05</day>
+        <month>01</month>
+        <year>2022</year>
+      </pub-date>
+      <pub-date date-type="collection" publication-format="electronic">
+        <year>2022</year>
+      </pub-date>
+      <volume>44</volume>
+      <elocation-id>e20210341</elocation-id>
+      <history>
+        <date date-type="received">
+          <day>21</day>
+          <month>09</month>
+          <year>2021</year>
+        </date>
+        <date date-type="rev-recd">
+          <day>05</day>
+          <month>11</month>
+          <year>2021</year>
+        </date>
+        <date date-type="accepted">
+          <day>26</day>
+          <month>11</month>
+          <year>2021</year>
+        </date>
+      </history>
+      <permissions>
+        <copyright-statement>Copyright by Sociedade Brasileira de Física. Printed in Brazil.</copyright-statement>
+        <copyright-year>2021</copyright-year>
+        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/deed.en" xml:lang="en">
+          <license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License (CC BY). The use, distribution or reproduction in other forums is permitted, provided the original author(s) and the copyright owner(s) are credited and that the original publication in this journal is cited, in accordance with accepted academic practice. No use, distribution or reproduction is permitted which does not comply with these terms.</license-p>
+        </license>
+      </permissions>
+      <abstract>
+        <p>O modelo de tight-binding é um dos pilares da Física da Matéria Condensada, permitindo descrever de forma bastante simples uma ampla gama de fenômenos de interesse, como por exemplo a estrutura de bandas dos materiais e o transporte eletrônico. Nesse trabalho, o Hamiltoniano de <italic>tight-binding</italic>, escrito em linguagem de segunda quantização, é utilizado na modelagem das densidades de estados de energia em polímeros orgânicos. O procedimento de segunda quantização permite obter as expressões para a determinação dos parâmetros de hopping de forma natural. No âmbito do modelo de tight-binding são analisadas a cadeia atômica infinita e as moléculas do benzeno, do ciclopentadieno e do tiofeno.</p>
+      </abstract>
+      <trans-abstract xml:lang="en">
+        <p>The tight-binding model is a cornerstone of Condensed Matter Physics, describing in a simple way a wide range of phenomena, such as the band structure of materials and the electronic transport. In this paper, the referred model, written in the language of second quantization, is used to describe the density of states in organic polymers. Using the second quantization method the expressions for the hopping parameters emerge quite naturally. The infinite atomic chain, the benzene, cyclopentadiene and tyophene molecules are analyzed within the tight-binding model.</p>
+      </trans-abstract>
+      <kwd-group xml:lang="pt">
+        <title>Palavras-chave:</title>
+        <kwd>Tight-binding</kwd>
+        <kwd>polímeros</kwd>
+        <kwd>hopping</kwd>
+        <kwd>segunda quantização</kwd>
+      </kwd-group>
+      <kwd-group xml:lang="en">
+        <title>Keywords</title>
+        <kwd>Tight-binding</kwd>
+        <kwd>polymers</kwd>
+        <kwd>hopping</kwd>
+        <kwd>second quantization</kwd>
+      </kwd-group>
+      <counts>
+        <fig-count count="10"/>
+        <table-count count="0"/>
+        <equation-count count="67"/>
+        <ref-count count="24"/>
+      </counts>
+    </article-meta>
+  </front>
+  <body>
+    <sec id="S1">
+      <title>1. Introdução</title>
+      <p>Polímeros são macromoléculas formadas pela repetição de uma unidade básica denominada monômero. Tipicamente, os materiais poliméricos possuem em sua estrutura o carbono ou o silício. Aqueles que são originários da química do carbono são conhecidos como polímeros orgânicos [<xref ref-type="bibr" rid="b1">1</xref>, <xref ref-type="bibr" rid="b2">2</xref>]. Dentre os os polímeros inorgânicos os silicones, cuja unidade de repetição envolve o <inline-formula id="S1.p1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>S</mml:mi><mml:mo>⁢</mml:mo><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi>O</mml:mi></mml:mrow></mml:math></inline-formula>, são os mais comuns. Já como exemplos de polímeros à base do carbono podemos citar o DNA, a polianilina, o politiofeno e o polietileno. Materiais poliméricos orgânicos apresentam amplo espectro de propriedades físico-químicas, o que torna possível um vasto leque de aplicações tecnológicas. Por exemplo, do ponto de vista mecânico existem tanto polímeros rígidos quanto flexíveis e elásticos [<xref ref-type="bibr" rid="b1">1</xref>]. Do ponto de vista de condutividade elétrica, há desde os polímeros isolantes, atualmente empregados como isoladores nos sistemas de transmissão e distribuição de energia elétrica, passando pelos semicondutores e condutores [<xref ref-type="bibr" rid="b3">3</xref>, <xref ref-type="bibr" rid="b4">4</xref>, <xref ref-type="bibr" rid="b5">5</xref>, <xref ref-type="bibr" rid="b6">6</xref>], com aplicações na eletrônica orgânica e na fabricação de dispositivos fotovoltaicos [<xref ref-type="bibr" rid="b7">7</xref>, <xref ref-type="bibr" rid="b8">8</xref>, <xref ref-type="bibr" rid="b9">9</xref>, <xref ref-type="bibr" rid="b10">10</xref>, <xref ref-type="bibr" rid="b11">11</xref>, <xref ref-type="bibr" rid="b12">12</xref>, <xref ref-type="bibr" rid="b13">13</xref>].</p>
+      <p>No presente trabalho será dada maior ênfase aos polímeros conjugados, de maior relevância para a área da eletrônica. Seu estudo rendeu o Prêmio Nobel de Química no ano de 2000 para Alan MacDiarmid, Hideki Shirakawa e Alan J. Heeger [<xref ref-type="bibr" rid="b3">3</xref>]. Os polímeros conjugados são caracterizados pela alternância entre ligações simples e duplas, denominadas de sigma (<inline-formula id="S1.p2.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>) e pi (<inline-formula id="S1.p2.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>), respectivamente. As ligações <inline-formula id="S1.p2.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> favorecem a condução de eletricidade, sendo desejáveis em aplicações como a optoeletrônica e a fotovoltaica [<xref ref-type="bibr" rid="b14">14</xref>].</p>
+      <p>A compreensão mais detalhada do comportamento desses polímeros requer o entendimento mais aprofundado da estrutura eletrônica do carbono e suas hibridizações. Ressalta-se que os elementos sempre presentes nas cadeias conjugadas são o carbono e o hidrogênio. A configuração eletrônica do elemento carbono no seu estado fundamental é <inline-formula id="S1.p3.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>1</mml:mn><mml:mo>⁢</mml:mo><mml:msup><mml:mi>s</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msup><mml:mi>s</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, havendo 4 elétrons na camada de valência, de número atômico principal <inline-formula id="S1.p3.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:math></inline-formula>. O processo de hibridização dos orbitais <inline-formula id="S1.p3.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> e <inline-formula id="S1.p3.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula> do carbono favorece a formação das ligações químicas. No caso do carbono ocorrem três tipos de hibridização dos orbitais atômicos, a saber: i) <inline-formula id="S1.p3.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula>, onde um orbital <inline-formula id="S1.p3.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula> mistura-se ao orbital <inline-formula id="S1.p3.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>; ii) <inline-formula id="S1.p3.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, na qual dois dos orbitais <inline-formula id="S1.p3.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>p</mml:mi></mml:math></inline-formula> misturam-se com o orbital <inline-formula id="S1.p3.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>; e iii) <inline-formula id="S1.p3.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, em que todos os orbitais do tipo <inline-formula id="S1.p3.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula> participam da mistura com o orbital <inline-formula id="S1.p3.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> [<xref ref-type="bibr" rid="b15">15</xref>, <xref ref-type="bibr" rid="b16">16</xref>]. Enquanto na hibridização do <inline-formula id="S1.p3.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> ocorrem as ligações do tipo <inline-formula id="S1.p3.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, bastante localizadas, na hibridização <inline-formula id="S1.p3.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, em que o orbital <inline-formula id="S1.p3.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> não se superpõe ao orbital <inline-formula id="S1.p3.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>, ocorre a formação das ligações duplas ou do tipo <inline-formula id="S1.p3.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>.</p>
+      <p>Considerando-se as formas alotrópicas cristalinas do carbono, o diamante tem comportamento elétrico isolante devido ao fato de ocorrer a hibridização <inline-formula id="S1.p4.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> em sua estrutura, enquanto que o grafite tem comportamento condutor de eletricidade como consequência da hibridização <inline-formula id="S1.p4.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>. Os polímeros conjugados são caracterizados pela ocorrência da hibridização <inline-formula id="S1.p4.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>. Enquanto as ligações <inline-formula id="S1.p4.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> proporcionadas pelos orbitais hibridizados vão moldar a forma da estrutura formada, devido às ligações altamente direcionais, as ligações duplas provenientes dos orbitais <inline-formula id="S1.p4.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> irão concorrer de maneira decisiva para as propriedades de transporte de carga elétrica nesses polímeros [<xref ref-type="bibr" rid="b3">3</xref>, <xref ref-type="bibr" rid="b14">14</xref>].</p>
+      <p>O objetivo principal deste trabalho é apresentar de forma didática os modelos de polímeros conjugados a partir do Hamiltoniano de <italic>tight-binding</italic> . Esse Hamiltoniano é um dos pilares da Física da Matéria Condensada, permitindo descrever de forma simples uma ampla gama de fenômenos de interesse, como por exemplo a estrutura de bandas dos materiais e o transporte eletrônico. Aqui o Hamiltoniano de <italic>tight-binding</italic> será escrito em linguagem de segunda quantização. Com o emprego dos métodos da segunda quantização as expressões matemáticas para a determinação dos parâmetros de hopping do modelo surgem de forma natural.</p>
+      <p>O presente trabalho está estruturado da seguinte maneira: Na próxima Seção será apresentado o Hamiltoniano de <italic>tight-binding</italic> em segunda quantização, para férmions não-relativísticos. Expressões gerais para o cálculo dos parâmetros de hopping no modelo de <italic>tight-binding</italic> serão apresentadas. Na Seção 3 será estudado o caso de interação entre primeiros vizinhos em uma cadeia de átomos infinitamente longa. Na Seção 4 serão abordadas alguns monômeros de interesse na obtenção de polímeros conjugados. O problema de hibridização e formação das ligações <inline-formula id="S1.p6.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e <inline-formula id="S1.p6.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> será discutido em maiores detalhes. Finalmente, na Seção 5 serão apresentadas as considerações finais e conclusões.</p>
+    </sec>
+    <sec id="S2">
+      <title>2. O Modelo de Tight-Binding em Segunda Quantização</title>
+      <p>A literatura acerca da segunda quantização, ou teoria quântica dos campos, é vasta e com abordagens distintas, por isso aqui recomendamos ao leitor os livros-texto de Greiner/Reinhardt [<xref ref-type="bibr" rid="b17">17</xref>] e de Kittel [<xref ref-type="bibr" rid="b18">18</xref>], sendo que este último enfatiza as aplicações em Física do Estado Sólido. Como ponto de partida, considere o caso das partículas não-relativísticas em primeira quantização. Essa situação é de grande utilidade pois na matéria ordinária os elétrons, prótons e nêutrons podem ser tratados em boa aproximação como férmions não-relativísticos. A função de ondas <inline-formula id="S2.p1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> descrevendo a amplitude de probabilidade de encontrar uma partícula em torno da posição <inline-formula id="S2.p1.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">r</mml:mtext></mml:math></inline-formula> no instante de tempo <inline-formula id="S2.p1.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>t</mml:mi></mml:math></inline-formula> deve satisfazer a equação de Schrödinger:</p>
+      <p>
+        <disp-formula id="S2.E1">
+          <label>(1)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>i</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi mathvariant="normal">ℏ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mfrac>
+                    <mml:mrow>
+                      <mml:mo>∂</mml:mo>
+                      <mml:mo>⁡</mml:mo>
+                      <mml:mi>ψ</mml:mi>
+                    </mml:mrow>
+                    <mml:mrow>
+                      <mml:mo>∂</mml:mo>
+                      <mml:mo>⁡</mml:mo>
+                      <mml:mi>t</mml:mi>
+                    </mml:mrow>
+                  </mml:mfrac>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:mrow>
+                      <mml:mfrac>
+                        <mml:msup>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                          <mml:mn>2</mml:mn>
+                        </mml:msup>
+                        <mml:mrow>
+                          <mml:mn>2</mml:mn>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>m</mml:mi>
+                        </mml:mrow>
+                      </mml:mfrac>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:msup>
+                          <mml:mo>∇</mml:mo>
+                          <mml:mn>2</mml:mn>
+                        </mml:msup>
+                        <mml:mo>⁡</mml:mo>
+                        <mml:mi>ψ</mml:mi>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>U</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>ψ</mml:mi>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Nessa situação, o Hamiltoniano de uma partícula é dado por <inline-formula id="S2.p1.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>H</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mrow><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi mathvariant="bold">p</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mo>⁢</mml:mo><mml:mo>∇</mml:mo></mml:mrow></mml:mrow></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:msup><mml:mtext mathvariant="bold">p</mml:mtext><mml:mn>2</mml:mn></mml:msup><mml:mo>/</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>m</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>+</mml:mo><mml:mi>U</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>, sendo <inline-formula id="S2.p1.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>U</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> é um termo de energia potencial independente do tempo.</p>
+      <p>A substituição de uma solução do tipo <inline-formula id="S2.p2.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi>E</mml:mi><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>/</mml:mo><mml:mi mathvariant="normal">ℏ</mml:mi></mml:mrow></mml:mrow></mml:msup></mml:mrow></mml:mrow></mml:math></inline-formula> na equação de movimento (<xref ref-type="disp-formula" rid="S2.E1">1</xref>) leva ao problema de autovalor <inline-formula id="S2.p2.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>H</mml:mi><mml:mo>⁢</mml:mo><mml:mi>ϕ</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mi>E</mml:mi><mml:mo>⁢</mml:mo><mml:mi>ϕ</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>. O conjunto das soluções do problema do autovalor, satisfazendo as condições de contorno impostas pelo Hamiltoniano e pela interpretação probabilística da Mecânica Quantica, formará uma base completa de funções, permitindo expandir o campo <inline-formula id="S2.p2.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>ψ</mml:mi></mml:math></inline-formula> na forma que segue:</p>
+      <p>
+        <disp-formula id="S2.E2">
+          <label>(2)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>ψ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi mathvariant="bold">r</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:munder>
+                    <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>c</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msup>
+                      <mml:mi>e</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mi>i</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:msub>
+                              <mml:mi>E</mml:mi>
+                              <mml:mi>n</mml:mi>
+                            </mml:msub>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi>t</mml:mi>
+                          </mml:mrow>
+                          <mml:mo>/</mml:mo>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:msup>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S2.p2.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>c</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:math></inline-formula> são coeficientes complexos, o índice <inline-formula id="S2.p2.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula> corresponde a um conjunto de números quânticos associados à <inline-formula id="S2.p2.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-ésima função <inline-formula id="S2.p2.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>. A condição de ortonormalidade é escrita da seguinte forma:</p>
+      <p>
+        <disp-formula id="S2.E3">
+          <label>(3)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                  <mml:mrow>
+                    <mml:msup>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>3</mml:mn>
+                    </mml:msup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>m</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>δ</mml:mi>
+                  <mml:mrow>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>{</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>1</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mpadded width="+3.3pt">
+                              <mml:mi>se</mml:mi>
+                            </mml:mpadded>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi>m</mml:mi>
+                          </mml:mrow>
+                          <mml:mo>=</mml:mo>
+                          <mml:mi>n</mml:mi>
+                        </mml:mrow>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mpadded width="+3.3pt">
+                              <mml:mi>se</mml:mi>
+                            </mml:mpadded>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi>m</mml:mi>
+                          </mml:mrow>
+                          <mml:mo>≠</mml:mo>
+                          <mml:mi>n</mml:mi>
+                        </mml:mrow>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mi/>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>De acordo com o procedimento de segunda quantização, deve-se converter a função de ondas <inline-formula id="S2.p3.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> em um operador de campo fermiônico, alterando o status dos coeficientes complexos <inline-formula id="S2.p3.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>c</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:math></inline-formula> da expansão, na forma que segue:</p>
+      <p>
+        <disp-formula id="S2.E4">
+          <label>(4)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mover accent="true">
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi mathvariant="bold">r</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:munder>
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                      <mml:mi>n</mml:mi>
+                    </mml:munder>
+                  </mml:mstyle>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msup>
+                      <mml:mi>e</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mi>i</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:msub>
+                              <mml:mi>E</mml:mi>
+                              <mml:mi>n</mml:mi>
+                            </mml:msub>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi>t</mml:mi>
+                          </mml:mrow>
+                          <mml:mo>/</mml:mo>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:msup>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E5">
+          <label>(5)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msup>
+                    <mml:mover accent="true">
+                      <mml:mi>ψ</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>†</mml:mo>
+                  </mml:msup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi mathvariant="bold">r</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:munder>
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                      <mml:mi>n</mml:mi>
+                    </mml:munder>
+                  </mml:mstyle>
+                  <mml:mrow>
+                    <mml:msubsup>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msup>
+                      <mml:mi>e</mml:mi>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mi>i</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mi>n</mml:mi>
+                          </mml:msub>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>t</mml:mi>
+                        </mml:mrow>
+                        <mml:mo>/</mml:mo>
+                        <mml:mi mathvariant="normal">ℏ</mml:mi>
+                      </mml:mrow>
+                    </mml:msup>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S2.p3.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>n</mml:mi></mml:msub></mml:math></inline-formula> é o operador de aniquilação de um férmion no estado quântico <inline-formula id="S2.p3.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>, e o transposto conjugado <inline-formula id="S2.p3.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>n</mml:mi><mml:mo>†</mml:mo></mml:msubsup></mml:math></inline-formula> é o operador de criação de um férmion nesse mesmo estado. Esses operadores atuam em um espaço conhecido como espaço de Fock, cujos estados quânticos são auto-estados de número de partículas. Essa representação é também conhecida como representação de número. Os operadores de criação e aniquilação de férmions satisfazem uma álgebra anti-comutativa, introduzida originalmente por Pascual Jordan e conhecida como álgebra fermiônica, mostrada a seguir:</p>
+      <p>
+        <disp-formula id="S2.E6">
+          <label>(6)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo>{</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo>,</mml:mo>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>j</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>}</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mi>δ</mml:mi>
+                  <mml:mrow>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>j</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E7">
+          <label>(7)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo>{</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo>,</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>j</mml:mi>
+                  </mml:msub>
+                  <mml:mo>}</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>{</mml:mo>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>,</mml:mo>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>j</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>}</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mn>0</mml:mn>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E8">
+          <label>(8)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>n</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mi>i</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E9">
+          <label>(9)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:mn>0</mml:mn>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mn>1</mml:mn>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E10">
+          <label>(10)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mn>1</mml:mn>
+                      <mml:mi>j</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>δ</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>j</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:mn>0</mml:mn>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S2.E11">
+          <label>(11)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>n</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mi>n</mml:mi>
+                        <mml:mn>1</mml:mn>
+                      </mml:msub>
+                      <mml:mo>,</mml:mo>
+                      <mml:msub>
+                        <mml:mi>n</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                      <mml:mo>,</mml:mo>
+                      <mml:mrow>
+                        <mml:mi mathvariant="normal">…</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msub>
+                          <mml:mi>n</mml:mi>
+                          <mml:mi>i</mml:mi>
+                        </mml:msub>
+                      </mml:mrow>
+                      <mml:mo>,</mml:mo>
+                      <mml:mi mathvariant="normal">…</mml:mi>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>n</mml:mi>
+                    <mml:mi>i</mml:mi>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mi>n</mml:mi>
+                        <mml:mn>1</mml:mn>
+                      </mml:msub>
+                      <mml:mo>,</mml:mo>
+                      <mml:msub>
+                        <mml:mi>n</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msub>
+                      <mml:mo>,</mml:mo>
+                      <mml:mrow>
+                        <mml:mi mathvariant="normal">…</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msub>
+                          <mml:mi>n</mml:mi>
+                          <mml:mi>i</mml:mi>
+                        </mml:msub>
+                      </mml:mrow>
+                      <mml:mo>,</mml:mo>
+                      <mml:mi mathvariant="normal">…</mml:mi>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S2.p3.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mi>i</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula> ou <inline-formula id="S2.p3.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>1</mml:mn></mml:math></inline-formula>, <inline-formula id="S2.p3.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">{</mml:mo><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>,</mml:mo><mml:mover accent="true"><mml:mi>B</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo stretchy="false">}</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>⁢</mml:mo><mml:mover accent="true"><mml:mi>B</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:mrow><mml:mo>+</mml:mo><mml:mrow><mml:mover accent="true"><mml:mi>B</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>⁢</mml:mo><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> é o anti-comutador entre os operadores <inline-formula id="S2.p3.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula> e <inline-formula id="S2.p3.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>B</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula>, <inline-formula id="S2.p3.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>,</mml:mo><mml:mrow><mml:mi mathvariant="normal">…</mml:mi><mml:mo>⁢</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mi>i</mml:mi></mml:msub></mml:mrow><mml:mo>,</mml:mo><mml:mi mathvariant="normal">…</mml:mi></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> é um estado com <inline-formula id="S2.p3.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>n</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:math></inline-formula> partículas no estado <inline-formula id="S2.p3.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>1</mml:mn></mml:math></inline-formula>, <inline-formula id="S2.p3.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>n</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:math></inline-formula> partículas no estado <inline-formula id="S2.p3.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> e assim sucessivamente. O operador <inline-formula id="S2.p3.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>n</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>i</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>i</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>i</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:math></inline-formula> é o operador que conta o número de partículas no <inline-formula id="S2.p3.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>i</mml:mi></mml:math></inline-formula>-ésimo estado quântico disponível, sendo denominado operador de número. Define-se o vácuo dos férmions, <inline-formula id="S2.p3.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula>, como o estado no qual não há partículas, de tal forma que</p>
+      <p>
+        <disp-formula id="S2.E12">
+          <label>(12)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>j</mml:mi>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:mn>0</mml:mn>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mn>0</mml:mn>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>pois não é possível aniquilar uma partícula do estado que já não possui nenhuma. Por outro lado, a equação (<xref ref-type="disp-formula" rid="S2.E7">7</xref>) implica que <inline-formula id="S2.p3.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msup><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:msubsup><mml:mi>c</mml:mi><mml:mi>i</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mn>2</mml:mn></mml:msup><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula>, ou seja, não é possível adicionar mais do que uma partícula em um dado estado físico. Observe que:</p>
+      <p>
+        <disp-formula id="S2.E13">
+          <label>(13)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mn>1</mml:mn>
+                      <mml:mi>i</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>i</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mn>0</mml:mn>
+                      <mml:mi>i</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msup>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:msubsup>
+                        <mml:mover accent="true">
+                          <mml:mi>c</mml:mi>
+                          <mml:mo stretchy="false">^</mml:mo>
+                        </mml:mover>
+                        <mml:mi>i</mml:mi>
+                        <mml:mo>†</mml:mo>
+                      </mml:msubsup>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mn>2</mml:mn>
+                  </mml:msup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo fence="true" stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mn>0</mml:mn>
+                      <mml:mi>i</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">⟩</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mn>0</mml:mn>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S2.p3.m20"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:msub><mml:mn>1</mml:mn><mml:mi>i</mml:mi></mml:msub><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>i</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:msub><mml:mn>0</mml:mn><mml:mi>i</mml:mi></mml:msub><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> corresponde ao estado de número com uma única partícula no estado quântico indexado por <inline-formula id="S2.p3.m21"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>i</mml:mi></mml:math></inline-formula>. Portanto, o princípio de exclusão de Pauli é uma consequência direta da própria álgebra fermiônica.</p>
+      <p>Indo mais adiante, em segunda quantização a média de um operador <inline-formula id="S2.p4.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula>, obtida através da expressão <inline-formula id="S2.p4.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">⟨</mml:mo><mml:mrow><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo largeop="true" symmetric="true">∫</mml:mo><mml:mrow><mml:msup><mml:mi>d</mml:mi><mml:mn>3</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:mtext mathvariant="bold">r</mml:mtext><mml:mo>⁢</mml:mo><mml:msup><mml:mi>ψ</mml:mi><mml:mo>†</mml:mo></mml:msup><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo rspace="5.8pt" stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:mpadded width="+3.3pt"><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:mpadded><mml:mo>⁢</mml:mo><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, é convertida em um operador que age sobre os estados de número (ou superposições destes) no espaço de Fock, uma vez que o próprio campo <inline-formula id="S2.p4.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> é agora um operador.</p>
+      <p>Enquanto na primeira quantização a interpretação probabilística requer que <inline-formula id="S2.p5.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo largeop="true" symmetric="true">∫</mml:mo><mml:mrow><mml:msup><mml:mi>d</mml:mi><mml:mn>3</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:mtext mathvariant="bold">r</mml:mtext><mml:mo>⁢</mml:mo><mml:msup><mml:mi>ψ</mml:mi><mml:mo>†</mml:mo></mml:msup><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo rspace="5.8pt" stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:mi>ψ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula>, em segunda quantização essa integral corresponde ao operador de número total de partículas, <inline-formula id="S2.p5.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>N</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula>, conforme segue:</p>
+      <p>
+        <disp-formula id="S2.E14">
+          <label>(14)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mtable columnalign="left">
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mover accent="true">
+                    <mml:mi>N</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msup>
+                    <mml:mover accent="true">
+                      <mml:mi>ψ</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>†</mml:mo>
+                  </mml:msup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mo>−</mml:mo>
+                      <mml:mi>i</mml:mi>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mo>−</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mo stretchy="false">)</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mo>−</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mo stretchy="false">)</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msub>
+                    <mml:mi>δ</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>m</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msubsup>
+                    <mml:mi>c</mml:mi>
+                    <mml:mi>n</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo>.</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Observe que <inline-formula id="S2.p5.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mover accent="true"><mml:mi>N</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mo largeop="true" symmetric="true">∑</mml:mo><mml:mi>n</mml:mi></mml:msub><mml:mrow><mml:msubsup><mml:mi>c</mml:mi><mml:mi>n</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>n</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> é de fato o operador de número total, pois ao atuar sobre um estado de número produz como autovalor a somatória do número de partículas do sistema.</p>
+      <p>O próximo passo é converter a média do Hamiltoniano de uma partícula,</p>
+      <p>
+        <disp-formula id="S2.E15">
+          <label>(15)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                  <mml:mrow>
+                    <mml:msup>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>3</mml:mn>
+                    </mml:msup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msup>
+                      <mml:mi>ψ</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo>,</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo rspace="5.8pt" stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>H</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo>,</mml:mo>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>i</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mo>∇</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo rspace="5.8pt" stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo>,</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>no operador Hamiltoniano em segunda quantização, que permite descrever o problema de muitas partículas, ao invés de uma única. Considere a expansão dos operadores de campo <inline-formula id="S2.p6.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mover accent="true"><mml:mi>ψ</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> em termos de autofunções de energia, ou seja, <inline-formula id="S2.p6.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>H</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo>,</mml:mo><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mo>⁢</mml:mo><mml:mo>∇</mml:mo></mml:mrow></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. Desse modo:</p>
+      <p>
+        <disp-formula id="S2.E16">
+          <label>(16)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mtable>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msup>
+                    <mml:mover accent="true">
+                      <mml:mi>ψ</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>†</mml:mo>
+                  </mml:msup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mi>i</mml:mi>
+                  <mml:mi>ℏ</mml:mi>
+                  <mml:mo>∇</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mi>i</mml:mi>
+                  <mml:mi>ℏ</mml:mi>
+                  <mml:mo>∇</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mo>×</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mo>−</mml:mo>
+                      <mml:mi>i</mml:mi>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mo>−</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mo stretchy="false">)</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msup>
+                    <mml:mi>e</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>i</mml:mi>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                      <mml:mo>−</mml:mo>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mo stretchy="false">)</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>/</mml:mo>
+                      <mml:mi>ℏ</mml:mi>
+                    </mml:mrow>
+                  </mml:msup>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msub>
+                    <mml:mi>δ</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>m</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:msubsup>
+                    <mml:mi>c</mml:mi>
+                    <mml:mi>n</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo>.</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>O caso das partículas livres, quando a energia potencial é nula, <inline-formula id="S2.p7.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>U</mml:mi><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula>, é de especial interesse, permitindo satisfazer a equação de Schrödinger através de ondas planas uniformes, de forma que, omitindo o spin, tem-se <inline-formula id="S2.p7.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>ϕ</mml:mi><mml:mi mathvariant="bold">k</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msup><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>π</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mn>3</mml:mn><mml:mo>/</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:mrow></mml:msup><mml:mo>⁢</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mrow><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi mathvariant="bold">k</mml:mi></mml:mrow><mml:mo>⋅</mml:mo><mml:mi mathvariant="bold">r</mml:mi></mml:mrow></mml:msup></mml:mrow></mml:mrow></mml:math></inline-formula>. Os autovalores de energia associados são dados por <inline-formula id="S2.p7.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>E</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:msup><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:msup><mml:mtext mathvariant="bold">k</mml:mtext><mml:mn>2</mml:mn></mml:msup></mml:mrow><mml:mo>/</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>m</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, e o Hamiltoniano em segunda quantização toma a forma seguinte:</p>
+      <p>
+        <disp-formula id="S2.E17">
+          <label>(17)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:munder>
+                    <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mi mathvariant="bold">k</mml:mi>
+                          <mml:mo>,</mml:mo>
+                          <mml:mi>σ</mml:mi>
+                        </mml:mrow>
+                        <mml:mo>=</mml:mo>
+                        <mml:mo>↑</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>,</mml:mo>
+                      <mml:mo>↓</mml:mo>
+                    </mml:mrow>
+                  </mml:munder>
+                  <mml:mrow>
+                    <mml:mfrac>
+                      <mml:mrow>
+                        <mml:msup>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                          <mml:mn>2</mml:mn>
+                        </mml:msup>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msup>
+                          <mml:mtext mathvariant="bold">k</mml:mtext>
+                          <mml:mn>2</mml:mn>
+                        </mml:msup>
+                      </mml:mrow>
+                      <mml:mrow>
+                        <mml:mn>2</mml:mn>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>m</mml:mi>
+                      </mml:mrow>
+                    </mml:mfrac>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>c</mml:mi>
+                      <mml:mrow>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                        <mml:mo>,</mml:mo>
+                        <mml:mi>σ</mml:mi>
+                      </mml:mrow>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mrow>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                        <mml:mo>,</mml:mo>
+                        <mml:mi>σ</mml:mi>
+                      </mml:mrow>
+                    </mml:msub>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>A inclusão de interações entre partículas de um mesmo tipo, como por exemplo as interações de repulsão coulombiana entre elétrons, faz-se através do chamado ordenamento normal dos operadores de campo, no qual todos os operadores de criação devem aparecer à esquerda dos operadores de aniquilação associados àquele campo. Por exemplo, em uma interação entre pares de partículas idênticas situadas nas posições <inline-formula id="S2.p8.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>1</mml:mn></mml:msub></mml:math></inline-formula> e <inline-formula id="S2.p8.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>2</mml:mn></mml:msub></mml:math></inline-formula>, cuja energia potencial de interação tem a forma <inline-formula id="S2.p8.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>U</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>1</mml:mn></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>2</mml:mn></mml:msub><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, a versão em segunda quantização será escrita da seguinte maneira:</p>
+      <p>
+        <disp-formula id="S2.E18">
+          <label>(18)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>U</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mn>2</mml:mn>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mpadded width="-1.7pt">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mrow>
+                        <mml:mn>2</mml:mn>
+                        <mml:mo>!</mml:mo>
+                      </mml:mrow>
+                    </mml:mfrac>
+                  </mml:mpadded>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo largeop="true" rspace="0.8pt" symmetric="true">∫</mml:mo>
+                    <mml:mrow>
+                      <mml:msup>
+                        <mml:mi>d</mml:mi>
+                        <mml:mn>3</mml:mn>
+                      </mml:msup>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mpadded width="-1.7pt">
+                        <mml:msub>
+                          <mml:mtext mathvariant="bold">r</mml:mtext>
+                          <mml:mn>1</mml:mn>
+                        </mml:msub>
+                      </mml:mpadded>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:mo largeop="true" rspace="0.8pt" symmetric="true">∫</mml:mo>
+                        <mml:mrow>
+                          <mml:msup>
+                            <mml:mi>d</mml:mi>
+                            <mml:mn>3</mml:mn>
+                          </mml:msup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msub>
+                            <mml:mtext mathvariant="bold">r</mml:mtext>
+                            <mml:mn>2</mml:mn>
+                          </mml:msub>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msup>
+                            <mml:mover accent="true">
+                              <mml:mi>ψ</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                            <mml:mo>†</mml:mo>
+                          </mml:msup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>1</mml:mn>
+                            </mml:msub>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msup>
+                            <mml:mover accent="true">
+                              <mml:mi>ψ</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                            <mml:mo>†</mml:mo>
+                          </mml:msup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>2</mml:mn>
+                            </mml:msub>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msub>
+                            <mml:mi>U</mml:mi>
+                            <mml:mn>2</mml:mn>
+                          </mml:msub>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>1</mml:mn>
+                            </mml:msub>
+                            <mml:mo>,</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>2</mml:mn>
+                            </mml:msub>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mover accent="true">
+                            <mml:mi>ψ</mml:mi>
+                            <mml:mo stretchy="false">^</mml:mo>
+                          </mml:mover>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>2</mml:mn>
+                            </mml:msub>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mover accent="true">
+                            <mml:mi>ψ</mml:mi>
+                            <mml:mo stretchy="false">^</mml:mo>
+                          </mml:mover>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>1</mml:mn>
+                            </mml:msub>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Observe atentamente a ordem em que aparecem as variáveis <inline-formula id="S2.p8.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>1</mml:mn></mml:msub></mml:math></inline-formula> e <inline-formula id="S2.p8.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mn>2</mml:mn></mml:msub></mml:math></inline-formula> nos argumentos dos operadores de campo. De forma geral, para interações entre <inline-formula id="S2.p8.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-tuplas de partículas tem-se:</p>
+      <p>
+        <disp-formula id="S2.E19">
+          <label>(19)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>U</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mi>n</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mrow>
+                        <mml:mi>n</mml:mi>
+                        <mml:mo>!</mml:mo>
+                      </mml:mrow>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mrow>
+                      <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                      <mml:mrow>
+                        <mml:msup>
+                          <mml:mi>d</mml:mi>
+                          <mml:mn>3</mml:mn>
+                        </mml:msup>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msub>
+                          <mml:mtext mathvariant="bold">r</mml:mtext>
+                          <mml:mn>1</mml:mn>
+                        </mml:msub>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                          <mml:mrow>
+                            <mml:msup>
+                              <mml:mi>d</mml:mi>
+                              <mml:mn>3</mml:mn>
+                            </mml:msup>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:msub>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mn>2</mml:mn>
+                            </mml:msub>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi mathvariant="normal">…</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mrow>
+                              <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                              <mml:mrow>
+                                <mml:mrow>
+                                  <mml:mrow>
+                                    <mml:msup>
+                                      <mml:mi>d</mml:mi>
+                                      <mml:mn>3</mml:mn>
+                                    </mml:msup>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:msub>
+                                      <mml:mtext mathvariant="bold">r</mml:mtext>
+                                      <mml:mi>n</mml:mi>
+                                    </mml:msub>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:msup>
+                                      <mml:mover accent="true">
+                                        <mml:mi>ψ</mml:mi>
+                                        <mml:mo stretchy="false">^</mml:mo>
+                                      </mml:mover>
+                                      <mml:mo>†</mml:mo>
+                                    </mml:msup>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:mrow>
+                                      <mml:mo stretchy="false">(</mml:mo>
+                                      <mml:msub>
+                                        <mml:mtext mathvariant="bold">r</mml:mtext>
+                                        <mml:mn>1</mml:mn>
+                                      </mml:msub>
+                                      <mml:mo stretchy="false">)</mml:mo>
+                                    </mml:mrow>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:msup>
+                                      <mml:mover accent="true">
+                                        <mml:mi>ψ</mml:mi>
+                                        <mml:mo stretchy="false">^</mml:mo>
+                                      </mml:mover>
+                                      <mml:mo>†</mml:mo>
+                                    </mml:msup>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:mrow>
+                                      <mml:mo stretchy="false">(</mml:mo>
+                                      <mml:msub>
+                                        <mml:mtext mathvariant="bold">r</mml:mtext>
+                                        <mml:mn>2</mml:mn>
+                                      </mml:msub>
+                                      <mml:mo stretchy="false">)</mml:mo>
+                                    </mml:mrow>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:mi mathvariant="normal">…</mml:mi>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:msup>
+                                      <mml:mover accent="true">
+                                        <mml:mi>ψ</mml:mi>
+                                        <mml:mo stretchy="false">^</mml:mo>
+                                      </mml:mover>
+                                      <mml:mo>†</mml:mo>
+                                    </mml:msup>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:mrow>
+                                      <mml:mo stretchy="false">(</mml:mo>
+                                      <mml:msub>
+                                        <mml:mtext mathvariant="bold">r</mml:mtext>
+                                        <mml:mi>n</mml:mi>
+                                      </mml:msub>
+                                      <mml:mo stretchy="false">)</mml:mo>
+                                    </mml:mrow>
+                                  </mml:mrow>
+                                  <mml:mo rspace="4.2pt">×</mml:mo>
+                                  <mml:msub>
+                                    <mml:mi>U</mml:mi>
+                                    <mml:mi>n</mml:mi>
+                                  </mml:msub>
+                                </mml:mrow>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mrow>
+                                  <mml:mo stretchy="false">(</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mn>1</mml:mn>
+                                  </mml:msub>
+                                  <mml:mo>,</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mn>2</mml:mn>
+                                  </mml:msub>
+                                  <mml:mo>,</mml:mo>
+                                  <mml:mi mathvariant="normal">…</mml:mi>
+                                  <mml:mo>,</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mi>n</mml:mi>
+                                  </mml:msub>
+                                  <mml:mo stretchy="false">)</mml:mo>
+                                </mml:mrow>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mover accent="true">
+                                  <mml:mi>ψ</mml:mi>
+                                  <mml:mo stretchy="false">^</mml:mo>
+                                </mml:mover>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mrow>
+                                  <mml:mo stretchy="false">(</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mi>n</mml:mi>
+                                  </mml:msub>
+                                  <mml:mo stretchy="false">)</mml:mo>
+                                </mml:mrow>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mi mathvariant="normal">…</mml:mi>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mover accent="true">
+                                  <mml:mi>ψ</mml:mi>
+                                  <mml:mo stretchy="false">^</mml:mo>
+                                </mml:mover>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mrow>
+                                  <mml:mo stretchy="false">(</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mn>2</mml:mn>
+                                  </mml:msub>
+                                  <mml:mo stretchy="false">)</mml:mo>
+                                </mml:mrow>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mover accent="true">
+                                  <mml:mi>ψ</mml:mi>
+                                  <mml:mo stretchy="false">^</mml:mo>
+                                </mml:mover>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mrow>
+                                  <mml:mo stretchy="false">(</mml:mo>
+                                  <mml:msub>
+                                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                                    <mml:mn>1</mml:mn>
+                                  </mml:msub>
+                                  <mml:mo stretchy="false">)</mml:mo>
+                                </mml:mrow>
+                              </mml:mrow>
+                            </mml:mrow>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mstyle>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Desse modo, o termo representando a interação de pares de partículas no Hamiltoniano em segunda quantização tem a forma forma geral <inline-formula id="S2.p8.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>U</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mn>2</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mo largeop="true" symmetric="true">∑</mml:mo><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>l</mml:mi></mml:mrow></mml:msub><mml:mrow><mml:msub><mml:mi>U</mml:mi><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>l</mml:mi></mml:mrow></mml:msub><mml:mo>⁢</mml:mo><mml:msubsup><mml:mi>c</mml:mi><mml:mi>i</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msubsup><mml:mi>c</mml:mi><mml:mi>j</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mi>c</mml:mi><mml:mi>k</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>c</mml:mi><mml:mi>l</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. Por uma questão de simplicidade, todavia, no presente trabalho termos envolvendo essas interações serão desconsiderados.</p>
+      <p>É importante mencionar que nem sempre são conhecidos os auto-estados de energia do Hamiltoniano completo. Nesse cenário emprega-se na expansão dos campos uma base completa conhecida, proveniente da solução de um Hamiltoniano mais simples. A dependência temporal é incorporada aos operadores de criação e aniquilação e tem-se:</p>
+      <p>
+        <disp-formula id="S2.E20">
+          <label>(20)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mtable>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msup>
+                    <mml:mover accent="true">
+                      <mml:mi>ψ</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>†</mml:mo>
+                  </mml:msup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mi>i</mml:mi>
+                  <mml:mi>ℏ</mml:mi>
+                  <mml:mo>∇</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mo>^</mml:mo>
+                  </mml:mover>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mi>i</mml:mi>
+                  <mml:mi>ℏ</mml:mi>
+                  <mml:mo>∇</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msup>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∫</mml:mo>
+                    </mml:mstyle>
+                    <mml:mtext>​</mml:mtext>
+                  </mml:msup>
+                  <mml:msup>
+                    <mml:mi>d</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msup>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:msubsup>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo>,</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mi>i</mml:mi>
+                  <mml:mi>ℏ</mml:mi>
+                  <mml:mo>∇</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ϕ</mml:mi>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mstyle mathsize="normal" mathvariant="bold">
+                    <mml:mi>r</mml:mi>
+                  </mml:mstyle>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>=</mml:mo>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>m</mml:mi>
+                  </mml:munder>
+                  <mml:munder>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mo>∑</mml:mo>
+                    </mml:mstyle>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:msub>
+                    <mml:mi>t</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>m</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                  <mml:msubsup>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>†</mml:mo>
+                  </mml:msubsup>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>c</mml:mi>
+                      <mml:mo>^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>n</mml:mi>
+                  </mml:msub>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>t</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mo>,</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde os coeficientes <inline-formula id="S2.p9.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:math></inline-formula> são definidos da seguinte maneira:</p>
+      <p>
+        <disp-formula id="S2.E21">
+          <label>(21)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>t</mml:mi>
+                  <mml:mrow>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                  <mml:mrow>
+                    <mml:msup>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>3</mml:mn>
+                    </mml:msup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>m</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>H</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo>,</mml:mo>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>i</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi mathvariant="normal">ℏ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mo>∇</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Os elementos diagonais <inline-formula id="S2.p9.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>m</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mi>m</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> são conhecidos como auto-energias associadas às funções <inline-formula id="S2.p9.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>m</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>. Já para <inline-formula id="S2.p9.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>m</mml:mi><mml:mo>≠</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:math></inline-formula>, os coeficientes <inline-formula id="S2.p9.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:math></inline-formula> são denominados parâmetros de salto ou de hopping, e representam uma energia de transição entre os estados <inline-formula id="S2.p9.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>m</mml:mi></mml:math></inline-formula> e <inline-formula id="S2.p9.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>.</p>
+      <p>Deixa-se como exercício para o leitor demonstrar, utilizando a equação de movimento de Heisenberg para um operador <inline-formula id="S2.p10.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>A</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula>,</p>
+      <p>
+        <disp-formula id="S2.E22">
+          <label>(22)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>i</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi mathvariant="normal">ℏ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mfrac>
+                    <mml:mrow>
+                      <mml:mi>d</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mover accent="true">
+                        <mml:mi>A</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                    </mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>d</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>t</mml:mi>
+                    </mml:mrow>
+                  </mml:mfrac>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>[</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>A</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>,</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo>]</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mover accent="true">
+                      <mml:mi>A</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                  </mml:mrow>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mover accent="true">
+                      <mml:mi>A</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>que os operadores de aniquilação devem satisfazer a seguinte equação de movimento:</p>
+      <p>
+        <disp-formula id="S2.E23">
+          <label>(23)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>i</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi mathvariant="normal">ℏ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mfrac>
+                    <mml:mrow>
+                      <mml:mi>d</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msub>
+                        <mml:mover accent="true">
+                          <mml:mi>c</mml:mi>
+                          <mml:mo stretchy="false">^</mml:mo>
+                        </mml:mover>
+                        <mml:mi>m</mml:mi>
+                      </mml:msub>
+                    </mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>d</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>t</mml:mi>
+                    </mml:mrow>
+                  </mml:mfrac>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:munder>
+                    <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:munder>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>t</mml:mi>
+                      <mml:mrow>
+                        <mml:mi>m</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>n</mml:mi>
+                      </mml:mrow>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mi>n</mml:mi>
+                    </mml:msub>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>O modelo de <italic>tight-binding</italic> é uma aproximação em que as funções de base utilizadas na expansão dos operadores de campo são funções de onda localizadas em torno de cada sítio da rede atômica, e tipicamente envolvem orbitais atômicos, ou superposições de orbitais atômicos, sendo muito útil no cálculo da estrutura de bandas de energia de um sólido. Nas próximas duas seções o modelo de <italic>tight-binding</italic> será utilizado para descrever cadeias atômicas infinitamente longas e alguns monômeros de interesse para as cadeias poliméricas conjugadas.</p>
+      <p>Para finalizar a presente seção, cabe destacar que os orbitais atômicos provenientes de átomos vizinhos não são necessariamente ortogonais entre si, mas é possível encontrar um conjunto ortonormalizado, utilizando o método de Gram-Schmidt, por exemplo. Considerando um conjunto de orbitais atômicos <inline-formula id="S2.p12.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo stretchy="false">{</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>1</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>2</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">…</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mi>n</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow><mml:mo>,</mml:mo><mml:mi mathvariant="normal">…</mml:mi><mml:mo stretchy="false">}</mml:mo></mml:mrow></mml:math></inline-formula> em que <inline-formula id="S2.p12.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mi>n</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> é proveniente do <inline-formula id="S2.p12.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-ésimo átomo da rede, não ortogonais entre si, é possível obter um novo conjunto:</p>
+      <p>
+        <disp-formula id="S2.E24">
+          <label>(24)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mtable columnalign="left">
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>|</mml:mo>
+                  <mml:msup>
+                    <mml:mn>1</mml:mn>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>=</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>1</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>,</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>|</mml:mo>
+                  <mml:msup>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>=</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>2</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mo>〈</mml:mo>
+                  <mml:mn>1</mml:mn>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>2</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>1</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>,</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>|</mml:mo>
+                  <mml:msup>
+                    <mml:mn>3</mml:mn>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>=</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>3</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mo>〈</mml:mo>
+                  <mml:mn>1</mml:mn>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>3</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>1</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mo>〈</mml:mo>
+                  <mml:msup>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>|</mml:mo>
+                  <mml:mn>3</mml:mn>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo stretchy="false">)</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:msup>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>,</mml:mo>
+                </mml:mtd>
+              </mml:mtr>
+              <mml:mtr>
+                <mml:mtd>
+                  <mml:mo>|</mml:mo>
+                  <mml:msup>
+                    <mml:mi>n</mml:mi>
+                    <mml:mo>′</mml:mo>
+                  </mml:msup>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>=</mml:mo>
+                  <mml:mo>|</mml:mo>
+                  <mml:mi>n</mml:mi>
+                  <mml:mo>〉</mml:mo>
+                  <mml:mo>−</mml:mo>
+                  <mml:mstyle displaystyle="true">
+                    <mml:munder>
+                      <mml:mo>∑</mml:mo>
+                      <mml:mrow>
+                        <mml:msup>
+                          <mml:mi>n</mml:mi>
+                          <mml:mo>′</mml:mo>
+                        </mml:msup>
+                        <mml:mtext> </mml:mtext>
+                        <mml:mo>&lt;</mml:mo>
+                        <mml:mtext> </mml:mtext>
+                        <mml:mi>n</mml:mi>
+                      </mml:mrow>
+                    </mml:munder>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mo>〈</mml:mo>
+                      <mml:msup>
+                        <mml:mi>n</mml:mi>
+                        <mml:mo>′</mml:mo>
+                      </mml:msup>
+                      <mml:mo>|</mml:mo>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>〉</mml:mo>
+                      <mml:mo stretchy="false">)</mml:mo>
+                      <mml:mo>|</mml:mo>
+                      <mml:msup>
+                        <mml:mi>n</mml:mi>
+                        <mml:mo>′</mml:mo>
+                      </mml:msup>
+                      <mml:mo>〉</mml:mo>
+                      <mml:mo>.</mml:mo>
+                    </mml:mrow>
+                  </mml:mstyle>
+                </mml:mtd>
+              </mml:mtr>
+            </mml:mtable>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Estão omitidos nas equações acima os fatores de renormalização dos estados a cada passo. Um método semelhante para obter novas funções ortogonalizadas é denominado de ortogonalização de Löwdin, e os orbitais assim obtidos possuem contribuições de átomos distantes [<xref ref-type="bibr" rid="b19">19</xref>]. De modo análogo, em cristais é possível utilizar um conjunto de funções ortogonais conhecido como funções de Wannier, que são localizadas em torno dos sítios atômicos, para construir o modelo de <italic>tight-binding</italic> .</p>
+      <p>Entretanto, a superposição dos orbitais provenientes de átomos vizinhos na rede é usualmente pequena, ou seja:</p>
+      <p>
+        <disp-formula id="S2.E25">
+          <label>(25)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                  <mml:mrow>
+                    <mml:msup>
+                      <mml:mi>d</mml:mi>
+                      <mml:mn>3</mml:mn>
+                    </mml:msup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mtext mathvariant="bold">r</mml:mtext>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi mathvariant="bold">r</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mi>m</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mrow>
+                        <mml:mtext mathvariant="bold">r</mml:mtext>
+                        <mml:mo>-</mml:mo>
+                        <mml:mtext mathvariant="bold">a</mml:mtext>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>≈</mml:mo>
+                <mml:mn>0</mml:mn>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>sendo <inline-formula id="S2.p13.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">a</mml:mtext></mml:math></inline-formula> da rede um vetor conectando o átomo na posição <inline-formula id="S2.p13.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">r</mml:mtext></mml:math></inline-formula> com um de seus primeiros vizinhos, <inline-formula id="S2.p13.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>m</mml:mi></mml:msub></mml:math></inline-formula> e <inline-formula id="S2.p13.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:math></inline-formula> são orbitais atômicos, com conjuntos de números quânticos <inline-formula id="S2.p13.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>m</mml:mi></mml:math></inline-formula> e <inline-formula id="S2.p13.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>, respectivamente. Nessa situação, a etapa de ortogonalização de Gram-Schmidt não se faz necessária na primeira aproximação, e considera-se que o conjunto de todos os orbitais atômicos localizados em torno de seus respectivos átomos forma uma base completa. Note ainda que orbitais atômicos do tipo hidrogenóide tem uma dependência na forma <inline-formula id="S2.p13.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>f</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mi>α</mml:mi><mml:mo>⁢</mml:mo><mml:mi>r</mml:mi></mml:mrow></mml:mrow></mml:msup></mml:mrow></mml:math></inline-formula> com relação à distância, significando que decaem exponencialmente com o aumento da distância em relação à sua origem.</p>
+    </sec>
+    <sec id="S3">
+      <title>3. A Cadeia Infinitamente Longa e Bandas de Energia</title>
+      <p>Uma cadeia monoatômica em uma dimensão espacial é ilustrada na Figura<xref ref-type="fig" rid="S3.F1">1</xref>, podendo representar uma macromolécula linear, como por exemplo o poliacetileno. O comprimento <inline-formula id="S3.p1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>L</mml:mi></mml:math></inline-formula> de uma macromolécula polimérica linear é dado aproximadamente por <inline-formula id="S3.p1.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>L</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mi>N</mml:mi><mml:mo>-</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>, sendo <inline-formula id="S3.p1.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> o número de átomos de carbono na cadeia e <inline-formula id="S3.p1.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>a</mml:mi></mml:math></inline-formula> a distância entre eles, assumindo que esta seja constante. Nesse caso o valor de <inline-formula id="S3.p1.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>a</mml:mi></mml:math></inline-formula> é conhecido como parâmetro de rede. Um modelo de brinquedo (<italic>toy model</italic> ) para uma macromolécula em que <inline-formula id="S3.p1.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo mathvariant="italic">&gt;&gt;</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula> é obtido fazendo o limite <inline-formula id="S3.p1.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow></mml:math></inline-formula>.</p>
+      <fig id="S3.F1">
+        <label>Figura 1:</label>
+        <caption>
+          <title>Cadeia monoatômica em uma dimensão espacial, podendo representar um polímero linear, como por exemplo o poliacetileno.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/6c8b9962d0fb5b437728411c71a55ed0358bca24.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/bce70c1d1e74026030e453bd140621a4f44951b3.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Por uma questão de simplicidade, assuma uma base ortonormalizada formada considerando um único orbital relevante por átomo da rede unidimensional infinita. Em primeira aproximação, admite-se que os parâmetros <inline-formula id="S3.p2.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:math></inline-formula> são não negligenciáveis apenas entre primeiros vizinhos, ou seja, <inline-formula id="S3.p2.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>δ</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:mrow><mml:mo>+</mml:mo><mml:mrow><mml:mi>t</mml:mi><mml:mo>⁢</mml:mo><mml:msub><mml:mi>δ</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>,</mml:mo><mml:mrow><mml:mi>n</mml:mi><mml:mo>±</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:mrow></mml:msub></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. Tanto a equação (<xref ref-type="disp-formula" rid="S2.E21">21</xref>) quanto o requerimento de hermiticidade do Hamiltoniano implicam que <inline-formula id="S3.p2.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:msubsup><mml:mi>t</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>⁢</mml:mo><mml:mi>m</mml:mi></mml:mrow><mml:mo>*</mml:mo></mml:msubsup></mml:mrow></mml:math></inline-formula>. Sem perda de generalidade no que segue, assuma que <inline-formula id="S3.p2.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>t</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mi>t</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:mrow></mml:math></inline-formula>, ou seja, o parâmetro de hopping é puramente real, dado por:</p>
+      <p>
+        <disp-formula id="S3.E26">
+          <label>(26)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mi>t</mml:mi>
+                <mml:mo>=</mml:mo>
+                <mml:mstyle displaystyle="true">
+                  <mml:mrow>
+                    <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                    <mml:mrow>
+                      <mml:msup>
+                        <mml:mi>d</mml:mi>
+                        <mml:mn>3</mml:mn>
+                      </mml:msup>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mtext mathvariant="bold">r</mml:mtext>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:mo stretchy="false">(</mml:mo>
+                        <mml:mi mathvariant="bold">r</mml:mi>
+                        <mml:mo stretchy="false">)</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>H</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:mo stretchy="false">(</mml:mo>
+                        <mml:mi mathvariant="bold">r</mml:mi>
+                        <mml:mo>,</mml:mo>
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>i</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi mathvariant="normal">ℏ</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mo>∇</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo stretchy="false">)</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>ϕ</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:mo stretchy="false">(</mml:mo>
+                        <mml:mrow>
+                          <mml:mtext mathvariant="bold">r</mml:mtext>
+                          <mml:mo>-</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>a</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mover accent="true">
+                              <mml:mi>x</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo stretchy="false">)</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mstyle>
+                <mml:mo>≈</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mn>0</mml:mn>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mrow>
+                      <mml:mo largeop="true" symmetric="true">∫</mml:mo>
+                      <mml:mrow>
+                        <mml:msup>
+                          <mml:mi>d</mml:mi>
+                          <mml:mn>3</mml:mn>
+                        </mml:msup>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mtext mathvariant="bold">r</mml:mtext>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>ϕ</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mi mathvariant="bold">r</mml:mi>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>ϕ</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mrow>
+                            <mml:mtext mathvariant="bold">r</mml:mtext>
+                            <mml:mo>-</mml:mo>
+                            <mml:mrow>
+                              <mml:mi>a</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mover accent="true">
+                                <mml:mi>x</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mstyle>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Note que a cadeia está orientada ao longo da direção <inline-formula id="S3.p2.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>x</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula> e que os orbitais <inline-formula id="S3.p2.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi mathvariant="bold">r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> são considerados puramente reais. Claramente <inline-formula id="S3.p2.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>t</mml:mi></mml:math></inline-formula> envolve a superposição entre orbitais provenientes de átomos vizinhos na cadeia.</p>
+      <p>Desse modo, o Hamiltoniano (<xref ref-type="disp-formula" rid="S2.E20">20</xref>) pode ser escrito explicitamente da seguinte maneira:</p>
+      <p>
+        <disp-formula id="S3.E27">
+          <label>(27)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:munder>
+                        <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                        <mml:mi>j</mml:mi>
+                      </mml:munder>
+                    </mml:mstyle>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mi>E</mml:mi>
+                        <mml:mn>0</mml:mn>
+                      </mml:msub>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msub>
+                        <mml:mover accent="true">
+                          <mml:mi>n</mml:mi>
+                          <mml:mo stretchy="false">^</mml:mo>
+                        </mml:mover>
+                        <mml:mi>j</mml:mi>
+                      </mml:msub>
+                    </mml:mrow>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mstyle displaystyle="true">
+                        <mml:munder>
+                          <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                          <mml:mi>j</mml:mi>
+                        </mml:munder>
+                      </mml:mstyle>
+                      <mml:mrow>
+                        <mml:mo stretchy="false">(</mml:mo>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:msubsup>
+                              <mml:mover accent="true">
+                                <mml:mi>c</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                              <mml:mrow>
+                                <mml:mi>j</mml:mi>
+                                <mml:mo>+</mml:mo>
+                                <mml:mn>1</mml:mn>
+                              </mml:mrow>
+                              <mml:mo>†</mml:mo>
+                            </mml:msubsup>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:msub>
+                              <mml:mover accent="true">
+                                <mml:mi>c</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                              <mml:mi>j</mml:mi>
+                            </mml:msub>
+                          </mml:mrow>
+                          <mml:mo>+</mml:mo>
+                          <mml:mrow>
+                            <mml:msubsup>
+                              <mml:mover accent="true">
+                                <mml:mi>c</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                              <mml:mi>j</mml:mi>
+                              <mml:mo>†</mml:mo>
+                            </mml:msubsup>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:msub>
+                              <mml:mover accent="true">
+                                <mml:mi>c</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                              <mml:mrow>
+                                <mml:mi>j</mml:mi>
+                                <mml:mo>+</mml:mo>
+                                <mml:mn>1</mml:mn>
+                              </mml:mrow>
+                            </mml:msub>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo stretchy="false">)</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>A interpretação desse Hamiltoniano é bastante simples, sendo que o primeiro termo <inline-formula id="S3.p3.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>n</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>j</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> corresponde à energia <inline-formula id="S3.p3.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:math></inline-formula> de um elétron ocupando o orbital no sítio <inline-formula id="S3.p3.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>-ésimo da rede. Já o termo <inline-formula id="S3.p3.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mpadded width="+3.3pt"><mml:mi>t</mml:mi></mml:mpadded><mml:mo>⁢</mml:mo><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>j</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> representa uma energia cinética proveniente de um elétron saltando do orbital inicialmente ocupado no <inline-formula id="S3.p3.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>-ésimo sítio para o orbital do sítio <inline-formula id="S3.p3.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula>, que deve estar inicialmente desocupado. O termo <inline-formula id="S3.p3.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mpadded width="+3.3pt"><mml:mi>t</mml:mi></mml:mpadded><mml:mo>⁢</mml:mo><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>j</mml:mi><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msub></mml:mrow></mml:math></inline-formula> corresponde ao movimento no sentido contrário ao do caso anterior.</p>
+      <p>Para diagonalizar o Hamiltoniano (<xref ref-type="disp-formula" rid="S3.E27">27</xref>) é conveniente expressar os operadores de criação e aniquilação em termos de uma série de Fourier, na forma que segue:</p>
+      <p>
+        <disp-formula id="S3.E28">
+          <label>(28)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>c</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mi>j</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:msqrt>
+                        <mml:mi>N</mml:mi>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:munder>
+                        <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                      </mml:munder>
+                    </mml:mstyle>
+                    <mml:mrow>
+                      <mml:msub>
+                        <mml:mover accent="true">
+                          <mml:mi>c</mml:mi>
+                          <mml:mo stretchy="false">^</mml:mo>
+                        </mml:mover>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                      </mml:msub>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>e</mml:mi>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mi>i</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi mathvariant="bold">k</mml:mi>
+                          </mml:mrow>
+                          <mml:mo>⋅</mml:mo>
+                          <mml:msub>
+                            <mml:mi mathvariant="bold">r</mml:mi>
+                            <mml:mi>j</mml:mi>
+                          </mml:msub>
+                        </mml:mrow>
+                      </mml:msup>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S3.E29">
+          <label>(29)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msubsup>
+                  <mml:mover accent="true">
+                    <mml:mi>c</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mi>j</mml:mi>
+                  <mml:mo>†</mml:mo>
+                </mml:msubsup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:msqrt>
+                        <mml:mi>N</mml:mi>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:munder>
+                        <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                      </mml:munder>
+                    </mml:mstyle>
+                    <mml:mrow>
+                      <mml:msubsup>
+                        <mml:mover accent="true">
+                          <mml:mi>c</mml:mi>
+                          <mml:mo stretchy="false">^</mml:mo>
+                        </mml:mover>
+                        <mml:mi mathvariant="bold">k</mml:mi>
+                        <mml:mo>†</mml:mo>
+                      </mml:msubsup>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>e</mml:mi>
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mrow>
+                            <mml:mrow>
+                              <mml:mi>i</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi mathvariant="bold">k</mml:mi>
+                            </mml:mrow>
+                            <mml:mo>⋅</mml:mo>
+                            <mml:msub>
+                              <mml:mi mathvariant="bold">r</mml:mi>
+                              <mml:mi>j</mml:mi>
+                            </mml:msub>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:msup>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S3.E30">
+          <label>(30)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>δ</mml:mi>
+                  <mml:mrow>
+                    <mml:mi mathvariant="bold">k</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:msup>
+                      <mml:mi mathvariant="bold">k</mml:mi>
+                      <mml:mo>′</mml:mo>
+                    </mml:msup>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mi>N</mml:mi>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:munder>
+                        <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                        <mml:mi>j</mml:mi>
+                      </mml:munder>
+                    </mml:mstyle>
+                    <mml:msup>
+                      <mml:mi>e</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>±</mml:mo>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mi>i</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mrow>
+                              <mml:mo stretchy="false">(</mml:mo>
+                              <mml:mrow>
+                                <mml:mi mathvariant="bold">k</mml:mi>
+                                <mml:mo>-</mml:mo>
+                                <mml:msup>
+                                  <mml:mi mathvariant="bold">k</mml:mi>
+                                  <mml:mo>′</mml:mo>
+                                </mml:msup>
+                              </mml:mrow>
+                              <mml:mo stretchy="false">)</mml:mo>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo>⋅</mml:mo>
+                          <mml:msub>
+                            <mml:mi mathvariant="bold">r</mml:mi>
+                            <mml:mi>j</mml:mi>
+                          </mml:msub>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:msup>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S3.p4.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> é o número total de sítios na rede (podendo ser levado ao limite <inline-formula id="S3.p4.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow></mml:math></inline-formula>), <inline-formula id="S3.p4.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">k</mml:mtext></mml:math></inline-formula> é um vetor de onda no espaço recíproco a <inline-formula id="S3.p4.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">r</mml:mtext></mml:math></inline-formula>, <inline-formula id="S3.p4.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mi>j</mml:mi></mml:msub></mml:math></inline-formula> é o vetor de posição do <inline-formula id="S3.p4.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>-ésimo átomo na rede. A equação (<xref ref-type="disp-formula" rid="S3.E30">30</xref>) é a representação da função delta de Kronecker. Para obter os resultados de uma rede unidimensional deve-se adotar <inline-formula id="S3.p4.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mtext mathvariant="bold">k</mml:mtext><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo>,</mml:mo><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S3.p4.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mi>j</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:msub><mml:mi>x</mml:mi><mml:mi>j</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, de tal forma que <inline-formula id="S3.p4.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mtext mathvariant="bold">k</mml:mtext><mml:mo>⋅</mml:mo><mml:msub><mml:mtext mathvariant="bold">r</mml:mtext><mml:mi>j</mml:mi></mml:msub></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:msub><mml:mi>x</mml:mi><mml:mi>j</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:math></inline-formula>. O leitor é desafiado a demonstrar que, fazendo as substituições de (<xref ref-type="disp-formula" rid="S3.E28">28</xref>) e (<xref ref-type="disp-formula" rid="S3.E29">29</xref>) em (<xref ref-type="disp-formula" rid="S3.E27">27</xref>) e fazendo uso de (<xref ref-type="disp-formula" rid="S3.E30">30</xref>), obtém-se como resultado:</p>
+      <p>
+        <disp-formula id="S3.E31">
+          <label>(31)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:munder>
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                      <mml:mi>k</mml:mi>
+                    </mml:munder>
+                  </mml:mstyle>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">[</mml:mo>
+                      <mml:mrow>
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mn>2</mml:mn>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>cos</mml:mi>
+                            <mml:mo>⁡</mml:mo>
+                            <mml:mrow>
+                              <mml:mo stretchy="false">(</mml:mo>
+                              <mml:mrow>
+                                <mml:mi>k</mml:mi>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:mi>a</mml:mi>
+                              </mml:mrow>
+                              <mml:mo stretchy="false">)</mml:mo>
+                            </mml:mrow>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">]</mml:mo>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msubsup>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mi>k</mml:mi>
+                      <mml:mo>†</mml:mo>
+                    </mml:msubsup>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mover accent="true">
+                        <mml:mi>c</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                      <mml:mi>k</mml:mi>
+                    </mml:msub>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Observe que na representação de posição o Hamiltoniano não é diagonal, mas fazendo uso da periodicidade da rede, torna-se diagonal no espaço recíproco, produzindo um espectro de energia <inline-formula id="S3.p4.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>E</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mi>cos</mml:mi><mml:mo>⁡</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. No limite em que <inline-formula id="S3.p4.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow></mml:math></inline-formula>, <inline-formula id="S3.p4.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>k</mml:mi></mml:math></inline-formula> assume valores no <italic>continuum</italic>, sendo o intervalo <inline-formula id="S3.p4.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo>-</mml:mo><mml:mi>π</mml:mi></mml:mrow><mml:mo>≤</mml:mo><mml:mrow><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow><mml:mo>≤</mml:mo><mml:mi>π</mml:mi></mml:mrow></mml:math></inline-formula> (para o caso unidimenional) conhecido como primeira zona de Brillouin no espaço <inline-formula id="S3.p4.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>k</mml:mi></mml:math></inline-formula>. Forma-se assim uma banda de energias permitidas, com ponto médio em <inline-formula id="S3.p4.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:math></inline-formula> e largura de banda <inline-formula id="S3.p4.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>4</mml:mn><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>. Portanto, quanto maior o valor do parâmetro de hopping mais larga é a banda de energia.</p>
+      <p>A generalização óbvia para esse modelo simples consiste em considerar mais de um orbital por sítio, dando origem a várias bandas de energia. No caso unidimensional o espectro de energia na <inline-formula id="S3.p5.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-ésima banda, proveniente do <inline-formula id="S3.p5.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-ésimo orbital atômico considerado, terá a forma <inline-formula id="S3.p5.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mi>cos</mml:mi><mml:mo>⁡</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. Quanto maior o valor de <inline-formula id="S3.p5.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:math></inline-formula>, correspondendo a um orbital mais externo, mais estendida é a função de onda no espaço real, ocasionando maior superposição entre os orbitais dos primeiros vizinhos na integral de hopping e consequentemente maior será o valor do parâmetro de hopping <inline-formula id="S3.p5.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:math></inline-formula>. Para o caso de uma cadeia linear, as bandas oriundas dos orbitais de maior energia tem maior largura de banda. Essas últimas afirmações podem ser entendidas adotando-se um cenário simplista, em que um átomo da rede corresponde a um poço de potencial simétrico e finito em uma dimensão espacial. Nesse caso, para obter os orbitais <inline-formula id="S3.p5.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>ϕ</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> deve-se resolver a equação de Schrödinger 1D,</p>
+      <p>
+        <disp-formula id="S3.E32">
+          <label>(32)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mo>(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mfrac>
+                            <mml:msup>
+                              <mml:mi mathvariant="normal">ℏ</mml:mi>
+                              <mml:mn>2</mml:mn>
+                            </mml:msup>
+                            <mml:mrow>
+                              <mml:mn>2</mml:mn>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi>m</mml:mi>
+                            </mml:mrow>
+                          </mml:mfrac>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mfrac>
+                            <mml:msup>
+                              <mml:mi>d</mml:mi>
+                              <mml:mn>2</mml:mn>
+                            </mml:msup>
+                            <mml:mrow>
+                              <mml:mi>d</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:msup>
+                                <mml:mi>x</mml:mi>
+                                <mml:mn>2</mml:mn>
+                              </mml:msup>
+                            </mml:mrow>
+                          </mml:mfrac>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>U</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mi>x</mml:mi>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo>)</mml:mo>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>ϕ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>x</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mi>E</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>ϕ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>x</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde a energia potencial é dada por:</p>
+      <p>
+        <disp-formula id="S3.E33">
+          <label>(33)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mi>U</mml:mi>
+                <mml:mo>⁢</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>x</mml:mi>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>=</mml:mo>
+              <mml:mrow>
+                <mml:mo>{</mml:mo>
+                <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                  <mml:mtr>
+                    <mml:mtd columnalign="center">
+                      <mml:mrow>
+                        <mml:mn>0</mml:mn>
+                        <mml:mo>,</mml:mo>
+                      </mml:mrow>
+                    </mml:mtd>
+                    <mml:mtd columnalign="center">
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mpadded width="+3.3pt">
+                              <mml:mi>se</mml:mi>
+                            </mml:mpadded>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mrow>
+                              <mml:mo stretchy="false">|</mml:mo>
+                              <mml:mi>x</mml:mi>
+                              <mml:mo stretchy="false">|</mml:mo>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo>&lt;</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>d</mml:mi>
+                            <mml:mo>/</mml:mo>
+                            <mml:mn>2</mml:mn>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>,</mml:mo>
+                      </mml:mrow>
+                    </mml:mtd>
+                  </mml:mtr>
+                  <mml:mtr>
+                    <mml:mtd columnalign="center">
+                      <mml:mrow>
+                        <mml:msub>
+                          <mml:mi>U</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                        <mml:mo>,</mml:mo>
+                      </mml:mrow>
+                    </mml:mtd>
+                    <mml:mtd columnalign="center">
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mpadded width="+3.3pt">
+                              <mml:mi>se</mml:mi>
+                            </mml:mpadded>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mrow>
+                              <mml:mo stretchy="false">|</mml:mo>
+                              <mml:mi>x</mml:mi>
+                              <mml:mo stretchy="false">|</mml:mo>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo>&gt;</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>d</mml:mi>
+                            <mml:mo>/</mml:mo>
+                            <mml:mn>2</mml:mn>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>,</mml:mo>
+                      </mml:mrow>
+                    </mml:mtd>
+                  </mml:mtr>
+                </mml:mtable>
+                <mml:mi/>
+              </mml:mrow>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>sendo <inline-formula id="S3.p5.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>U</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>&gt;</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula>. As soluções confinadas (ou ligadas) são aquelas para as quais as autoenergias satisfazem a condição <inline-formula id="S3.p5.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>E</mml:mi><mml:mo>&lt;</mml:mo><mml:msub><mml:mi>U</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:mrow></mml:math></inline-formula>, de tal modo que <inline-formula id="S3.p5.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">|</mml:mo></mml:mrow><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>→</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula>. Isso se deve ao fato de que nas regiões em que <inline-formula id="S3.p5.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">|</mml:mo></mml:mrow><mml:mo>&gt;</mml:mo><mml:mrow><mml:mi>d</mml:mi><mml:mo>/</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> a solução <inline-formula id="S3.p5.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> tem a forma <inline-formula id="S3.p5.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>∼</mml:mo><mml:mrow><mml:mi>exp</mml:mi><mml:mo>⁡</mml:mo><mml:mrow><mml:mo>(</mml:mo><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mi>α</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:mrow><mml:mo>)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, sendo <inline-formula id="S3.p5.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>α</mml:mi><mml:mo>=</mml:mo><mml:msqrt><mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:msub><mml:mi>U</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>-</mml:mo><mml:mi>E</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>/</mml:mo><mml:msup><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:msqrt></mml:mrow></mml:math></inline-formula>. Nesse caso, é fácil ver que quanto maior a energia <inline-formula id="S3.p5.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>E</mml:mi></mml:math></inline-formula> associada à função <inline-formula id="S3.p5.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>ϕ</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>x</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, menor a diferença <inline-formula id="S3.p5.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>U</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>-</mml:mo><mml:mi>E</mml:mi></mml:mrow></mml:math></inline-formula> e menor o valor da constante <inline-formula id="S3.p5.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>α</mml:mi></mml:math></inline-formula>, produzindo um orbital mais estendido no espaço.</p>
+      <p>A expansão de <inline-formula id="S3.p6.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> em séries de Taylor nas vizinhanças do ponto <inline-formula id="S3.p6.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>k</mml:mi><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula> resulta em <inline-formula id="S3.p6.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:mrow></mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:msup><mml:mi>a</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mo>⁢</mml:mo><mml:msup><mml:mi>k</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> e tem-se uma relação de dispersão parabólica em torno de <inline-formula id="S3.p6.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:math></inline-formula>. Sabendo-se que a massa efetiva é calculada como <inline-formula id="S3.p6.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msup><mml:mi>m</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>=</mml:mo><mml:mrow><mml:msup><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mn>2</mml:mn></mml:msup><mml:mo>/</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mrow><mml:mrow><mml:msup><mml:mo>∂</mml:mo><mml:mn>2</mml:mn></mml:msup><mml:mo>⁡</mml:mo><mml:mi>E</mml:mi></mml:mrow><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>k</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow><mml:mo>/</mml:mo><mml:mrow><mml:mo>∂</mml:mo><mml:mo>⁡</mml:mo><mml:msup><mml:mi>k</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, tem-se:</p>
+      <p>
+        <disp-formula id="S3.E34">
+          <label>(34)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msup>
+                  <mml:mi>m</mml:mi>
+                  <mml:mo>*</mml:mo>
+                </mml:msup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>-</mml:mo>
+                  <mml:mfrac>
+                    <mml:msup>
+                      <mml:mi mathvariant="normal">ℏ</mml:mi>
+                      <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mrow>
+                      <mml:mn>2</mml:mn>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msub>
+                        <mml:mi>t</mml:mi>
+                        <mml:mi>n</mml:mi>
+                      </mml:msub>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>a</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                  </mml:mfrac>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Se <inline-formula id="S3.p7.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>&gt;</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula>, a massa efetiva é negativa e o ponto <inline-formula id="S3.p7.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:mrow></mml:mrow></mml:math></inline-formula> corresponde ao máximo daquela banda. Nesse caso, ao invés de considerar um elétron de carga negativa e massa negativa, reinterpreta-se a ausência do elétron de massa efetiva negativa e carga negativa em torno desse ponto como uma partícula de massa positiva e carga elétrica positiva, conhecida como lacuna ou buraco. Por outro lado, para <inline-formula id="S3.p7.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>&lt;</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula> o ponto <inline-formula id="S3.p7.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mrow><mml:mn>0</mml:mn><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>-</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi>t</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> corresponderá ao mínimo da banda e presença de uma partícula de massa positiva e carga negativa é naturalmente interpretada como um elétron. Uma conclusão importante nesse contexto é que quanto maior o valor do módulo do parâmetro de hopping, menor será a massa efetiva da partícula associada, o que afeta a mobilidade eletrônica do portador de carga, dada por</p>
+      <p>
+        <disp-formula id="S3.E35">
+          <label>(35)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>μ</mml:mi>
+                  <mml:mi>e</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mfrac>
+                  <mml:mrow>
+                    <mml:mi>e</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>τ</mml:mi>
+                  </mml:mrow>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">|</mml:mo>
+                    <mml:msup>
+                      <mml:mi>m</mml:mi>
+                      <mml:mo>*</mml:mo>
+                    </mml:msup>
+                    <mml:mo stretchy="false">|</mml:mo>
+                  </mml:mrow>
+                </mml:mfrac>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>sendo <inline-formula id="S3.p7.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>e</mml:mi></mml:math></inline-formula> o módulo da carga eletrônica e <inline-formula id="S3.p7.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>τ</mml:mi></mml:math></inline-formula> o tempo associado ao livre caminho médio. Em semicondutores, tipicamente os elétrons na banda de condução têm maior mobilidade do que as lacunas na banda de valência, o que grosseiramente pode ser entendido considerando-se o fato de que o parâmetro de hopping associado às bandas de maior energia têm maior valor absoluto, levando a uma menor massa efetiva.</p>
+    </sec>
+    <sec id="S4">
+      <title>4. Monômeros de Interesse na Obtenção de Polímeros Conjugados</title>
+      <p>Como mencionado anteriormente, os polímeros conjugados são aqueles em que ocorre a alternância das ligações <inline-formula id="S4.p1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p1.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> entre os átomos de carbono da cadeia polimérica, sendo a ligação do tipo <inline-formula id="S4.p1.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> a principal responsável por conferir propriedades fotofísicas e de condutividade elétrica comparáveis à de semicondutores inorgânicos ou de alguns metais. Uma boa revisão pode ser encontrada nas notas da aula magna do Prêmio Nobel de Química do ano de 2000 [<xref ref-type="bibr" rid="b20">20</xref>, <xref ref-type="bibr" rid="b21">21</xref>, <xref ref-type="bibr" rid="b22">22</xref>].</p>
+      <p>Na obtenção de polímeros conjugados, podem ser citados como monômeros de interesse o acetileno e algumas moléculas cíclicas, como o benzeno, que envolve o ciclo aromático de átomos de carbono apenas, bem como o tiofeno, o furano e o pirrol, em que o heteroátomo na cadeia cíclica é o enxofre, o oxigênio e o nitrogênio, respectivamente. A Figura<xref ref-type="fig" rid="S4.F2">2</xref> ilustra os monômeros cíclicos aqui mencionando enquanto que algumas das cadeias poliméricas conjugadas que podem ser obtidas estão ilustradas na Figura<xref ref-type="fig" rid="S4.F3">3</xref>.</p>
+      <fig id="S4.F2">
+        <label>Figura 2:</label>
+        <caption>
+          <title>Alguns monômeros cíclicos relevantes na obtenção de cadeias poliméricas conjugadas.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/d22f1b826f42b38e49449aa44bc3eec5a871dae0.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/7135ee010c648701a45667b78e36b8a83aad0312.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <fig id="S4.F3">
+        <label>Figura 3:</label>
+        <caption>
+          <title>Algumas cadeias poliméricas conjugadas.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/75bb8c3164188f576106d967ca64af397b48c854.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/953e98ff7a79e50a150ccaff4b93672643ecf0db.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Com o intuito de melhor entender o problema dos polímeros conjugados, considere um orbital atômico, cuja expressão é dada por:</p>
+      <p>
+        <disp-formula id="S4.E36">
+          <label>(36)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>l</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>m</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>s</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>r</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>r</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>n</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>l</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>s</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>R</mml:mi>
+                    <mml:mrow>
+                      <mml:mi>n</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>l</mml:mi>
+                    </mml:mrow>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>r</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:msubsup>
+                    <mml:mi>Y</mml:mi>
+                    <mml:mi>l</mml:mi>
+                    <mml:mi>m</mml:mi>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:msub>
+                    <mml:mi>χ</mml:mi>
+                    <mml:mi>s</mml:mi>
+                  </mml:msub>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>sendo <inline-formula id="S4.p3.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mn>2</mml:mn><mml:mo>,</mml:mo><mml:mrow><mml:mn>3</mml:mn><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">…</mml:mi></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> o número quântico principal, <inline-formula id="S4.p3.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>l</mml:mi><mml:mo>=</mml:mo><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>1</mml:mn><mml:mo>.</mml:mo><mml:mo>.</mml:mo><mml:mi>n</mml:mi><mml:mo>-</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula> o número quântico de momento angular orbital, <inline-formula id="S4.p3.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>m</mml:mi><mml:mo>=</mml:mo><mml:mi>l</mml:mi><mml:mo>,</mml:mo><mml:mo>=</mml:mo><mml:mi>l</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mi mathvariant="normal">…</mml:mi><mml:mo>,</mml:mo><mml:mi>l</mml:mi><mml:mo>-</mml:mo><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mi>l</mml:mi></mml:mrow></mml:math></inline-formula> o número quântico magnético e <inline-formula id="S4.p3.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mo>↑</mml:mo><mml:mo>,</mml:mo><mml:mo>↓</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> o número quântico de spin, <inline-formula id="S4.p3.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>r</mml:mi><mml:mo>,</mml:mo><mml:mi>θ</mml:mi><mml:mo>,</mml:mo><mml:mi>φ</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:math></inline-formula> refere-se às coordenadas espaciais no sistema esférico, <inline-formula id="S4.p3.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>R</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>⁢</mml:mo><mml:mi>l</mml:mi></mml:mrow></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>r</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> é uma função com dependência radial, que controla a probabilidade de encontrar um elétron na distância <inline-formula id="S4.p3.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>r</mml:mi></mml:math></inline-formula> a partir do núcleo atômico, <inline-formula id="S4.p3.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msubsup><mml:mi>Y</mml:mi><mml:mi>l</mml:mi><mml:mi>m</mml:mi></mml:msubsup><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>θ</mml:mi><mml:mo>,</mml:mo><mml:mi>φ</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> são as funções harmônicas esféricas e <inline-formula id="S4.p3.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>χ</mml:mi><mml:mi>s</mml:mi></mml:msub></mml:math></inline-formula> é um espinor de Pauli. É sabido que a média do operador de posição <inline-formula id="S4.p3.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">r</mml:mtext></mml:math></inline-formula> de um elétron será tanto maior quanto maior o valor de <inline-formula id="S4.p3.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>, significando maior afastamento em relação ao núcleo atômico, e portanto menor energia de ligação. Na notação da Química o número quântico <inline-formula id="S4.p3.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>l</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mn>2</mml:mn><mml:mo>,</mml:mo><mml:mn>3</mml:mn></mml:mrow></mml:mrow><mml:mo>.</mml:mo><mml:mo>.</mml:mo></mml:mrow></mml:math></inline-formula> é representado pelas letras <inline-formula id="S4.p3.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>,</mml:mo><mml:mi>p</mml:mi><mml:mo>,</mml:mo><mml:mi>d</mml:mi><mml:mo>,</mml:mo><mml:mrow><mml:mi>f</mml:mi><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">…</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>, respectivamente.</p>
+      <p>Sendo o carbono o principal elemento das cadeias poliméricas conjugadas, e considerando-se que os orbitais <italic>2s</italic> e <italic>2p</italic> desse elemento têm energias semelhantes, para a formação de ligações químicas mais estáveis ocorre a formação de orbitais atômicos híbridos, em que os orbitais <inline-formula id="S4.p4.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.p4.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>x</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.p4.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>y</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p4.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, ilustrados na Figura<xref ref-type="fig" rid="S4.F4">4</xref> se misturam. As expressões matemáticas para a dependência angular dos orbitais <inline-formula id="S4.p4.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p4.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula> do carbono são dadas abaixo<xref ref-type="fn" rid="footnote1"><sup>1</sup></xref>:</p>
+      <fig id="S4.F4">
+        <label>Figura 4:</label>
+        <caption>
+          <title>Dependência angular da densidade de probabilidade associada aos orbitais <inline-formula id="S4.F4.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.F4.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>x</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.F4.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>y</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.F4.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/01e02bdeedd004c1b875a8eda5d083ea313453c6.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/940e6819fe4bc68ba0d8dcfb625be48f2594b049.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>
+        <disp-formula id="S4.E37">
+          <label>(37)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>s</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mi>Y</mml:mi>
+                    <mml:mn>0</mml:mn>
+                    <mml:mn>0</mml:mn>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:msqrt>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mrow>
+                        <mml:mn>4</mml:mn>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>π</mml:mi>
+                      </mml:mrow>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                </mml:msqrt>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E38">
+          <label>(38)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>x</mml:mi>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mfrac>
+                        <mml:mn>1</mml:mn>
+                        <mml:msqrt>
+                          <mml:mn>2</mml:mn>
+                        </mml:msqrt>
+                      </mml:mfrac>
+                    </mml:mstyle>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">[</mml:mo>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:msubsup>
+                            <mml:mi>Y</mml:mi>
+                            <mml:mn>1</mml:mn>
+                            <mml:mrow>
+                              <mml:mo>+</mml:mo>
+                              <mml:mn>1</mml:mn>
+                            </mml:mrow>
+                          </mml:msubsup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:mi>θ</mml:mi>
+                            <mml:mo>,</mml:mo>
+                            <mml:mi>φ</mml:mi>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:msubsup>
+                            <mml:mi>Y</mml:mi>
+                            <mml:mn>1</mml:mn>
+                            <mml:mrow>
+                              <mml:mo>-</mml:mo>
+                              <mml:mn>1</mml:mn>
+                            </mml:mrow>
+                          </mml:msubsup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:mi>θ</mml:mi>
+                            <mml:mo>,</mml:mo>
+                            <mml:mi>φ</mml:mi>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">]</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msqrt>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mfrac>
+                        <mml:mn>3</mml:mn>
+                        <mml:mrow>
+                          <mml:mn>4</mml:mn>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>π</mml:mi>
+                        </mml:mrow>
+                      </mml:mfrac>
+                    </mml:mstyle>
+                  </mml:msqrt>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>sin</mml:mi>
+                    <mml:mo>⁡</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>cos</mml:mi>
+                    <mml:mo>⁡</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E39">
+          <label>(39)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>y</mml:mi>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mi>i</mml:mi>
+                      <mml:msqrt>
+                        <mml:mn>2</mml:mn>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">[</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:msubsup>
+                          <mml:mi>Y</mml:mi>
+                          <mml:mn>1</mml:mn>
+                          <mml:mrow>
+                            <mml:mo>+</mml:mo>
+                            <mml:mn>1</mml:mn>
+                          </mml:mrow>
+                        </mml:msubsup>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mi>θ</mml:mi>
+                          <mml:mo>,</mml:mo>
+                          <mml:mi>φ</mml:mi>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:msubsup>
+                          <mml:mi>Y</mml:mi>
+                          <mml:mn>1</mml:mn>
+                          <mml:mrow>
+                            <mml:mo>-</mml:mo>
+                            <mml:mn>1</mml:mn>
+                          </mml:mrow>
+                        </mml:msubsup>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mi>θ</mml:mi>
+                          <mml:mo>,</mml:mo>
+                          <mml:mi>φ</mml:mi>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">]</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msqrt>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mfrac>
+                        <mml:mn>3</mml:mn>
+                        <mml:mrow>
+                          <mml:mn>4</mml:mn>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>π</mml:mi>
+                        </mml:mrow>
+                      </mml:mfrac>
+                    </mml:mstyle>
+                  </mml:msqrt>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>sin</mml:mi>
+                    <mml:mo>⁡</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>sin</mml:mi>
+                    <mml:mo>⁡</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E40">
+          <label>(40)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mn>2</mml:mn>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mi>Y</mml:mi>
+                    <mml:mn>1</mml:mn>
+                    <mml:mn>0</mml:mn>
+                  </mml:msubsup>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                    <mml:mo>,</mml:mo>
+                    <mml:mi>φ</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msqrt>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mfrac>
+                        <mml:mn>3</mml:mn>
+                        <mml:mrow>
+                          <mml:mn>4</mml:mn>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>π</mml:mi>
+                        </mml:mrow>
+                      </mml:mfrac>
+                    </mml:mstyle>
+                  </mml:msqrt>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>cos</mml:mi>
+                    <mml:mo>⁡</mml:mo>
+                    <mml:mi>θ</mml:mi>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>No processo de hibridização, os novos orbitais atômicos originados da superposição serão necessariamente ortonormais no espaço de Hilbert. Das três possibilidades hibridização para o carbono, denominadas <italic>sp</italic>, <inline-formula id="S4.p5.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p5.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, as mais relevantes são as duas últimas. A hibridização <inline-formula id="S4.p5.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> se dá através da superposição entre o orbital <inline-formula id="S4.p5.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> e os orbitais <inline-formula id="S4.p5.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>x</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.p5.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>y</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, formando assim três novos orbitais:</p>
+      <p>
+        <disp-formula id="S4.E41">
+          <label>(41)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:msqrt>
+                        <mml:mn>3</mml:mn>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:mi>s</mml:mi>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>x</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>y</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E42">
+          <label>(42)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>2</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:msqrt>
+                        <mml:mn>6</mml:mn>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:mi>s</mml:mi>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>x</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:mn>2</mml:mn>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>y</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E43">
+          <label>(43)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:msqrt>
+                        <mml:mn>2</mml:mn>
+                      </mml:msqrt>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:mi>s</mml:mi>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>x</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Estes são ortogonais no espaço de Hilbert, mas as direções de máxima propabilidade formam um ângulo de <inline-formula id="S4.p5.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mn>120</mml:mn><mml:mo>∘</mml:mo></mml:msup></mml:math></inline-formula> entre si para esses orbitais no espaço real, enquanto o orbital <inline-formula id="S4.p5.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> não se mistura aos demais, sendo orientado espacialmente num eixo ortogonal ao plano formado pelos orbitais <inline-formula id="S4.p5.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>. Essa situação é ilustrada na Figura<xref ref-type="fig" rid="S4.F5">5</xref>-A. Já a hibridização <inline-formula id="S4.p5.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> leva a uma superposição entre o orbital <inline-formula id="S4.p5.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> e todos os orbitais do tipo <inline-formula id="S4.p5.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:math></inline-formula>:</p>
+      <fig id="S4.F5">
+        <label>Figura 5:</label>
+        <caption>
+          <title>Dependência angular da densidade de probabilidade associada aos orbitais híbridos do tipo (A) <inline-formula id="S4.F5.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> e (B) <inline-formula id="S4.F5.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/ed0ad6bfb7d5a2c986f220a864acfe2d077330da.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/5e6bc59ab3d0530743f6a4553fde5aa36a0ebf21.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>
+        <disp-formula id="S4.E44">
+          <label>(44)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>1</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:mi>s</mml:mi>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>x</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>y</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>z</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E45">
+          <label>(45)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>2</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:mi>s</mml:mi>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>x</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>y</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>z</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E46">
+          <label>(46)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>3</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:mi>s</mml:mi>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>x</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>y</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>+</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>z</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E47">
+          <label>(47)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mi>ψ</mml:mi>
+                    <mml:mn>4</mml:mn>
+                  </mml:msub>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mstyle displaystyle="true">
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:mstyle>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mrow>
+                            <mml:mo fence="true" stretchy="false">|</mml:mo>
+                            <mml:mi>s</mml:mi>
+                            <mml:mo stretchy="false">⟩</mml:mo>
+                          </mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mrow>
+                            <mml:mo fence="true" stretchy="false">|</mml:mo>
+                            <mml:msub>
+                              <mml:mi>p</mml:mi>
+                              <mml:mi>x</mml:mi>
+                            </mml:msub>
+                            <mml:mo stretchy="false">⟩</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mo fence="true" stretchy="false">|</mml:mo>
+                          <mml:msub>
+                            <mml:mi>p</mml:mi>
+                            <mml:mi>y</mml:mi>
+                          </mml:msub>
+                          <mml:mo stretchy="false">⟩</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mrow>
+                        <mml:mo fence="true" stretchy="false">|</mml:mo>
+                        <mml:msub>
+                          <mml:mi>p</mml:mi>
+                          <mml:mi>z</mml:mi>
+                        </mml:msub>
+                        <mml:mo stretchy="false">⟩</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Esses novos orbitais adquirem simetria tetraédrica, em que o ângulo formado pelas direções de máxima probabilidade desses orbitais é de aproximadamente <inline-formula id="S4.p5.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mn>109</mml:mn><mml:mo>∘</mml:mo></mml:msup></mml:math></inline-formula>, o que é mostrado na Figura<xref ref-type="fig" rid="S4.F5">5</xref>-B.</p>
+      <p>Deve-se à superposição de orbitais hibridizados <inline-formula id="S4.p6.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> de átomos de carbono vizinhos a formação dos orbitais moleculares do tipo <inline-formula id="S4.p6.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, enquanto orbitais moleculares do tipo <inline-formula id="S4.p6.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> somente podem ocorrer pela superposição dos orbitais <inline-formula id="S4.p6.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> em átomos de carbono vizinhos, sendo que ambos devem estar hibridizados na forma <inline-formula id="S4.p6.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>. A hibridização do tipo <inline-formula id="S4.p6.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>3</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> somente permite a formação de ligações do tipo <inline-formula id="S4.p6.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>.</p>
+      <p>Tendo em vista que em polímeros conjugados devem ocorrer ligações do tipo <inline-formula id="S4.p7.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, a hibridização <inline-formula id="S4.p7.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> se faz presente. Considere, por simplicidade, a molécula de etileno <inline-formula id="S4.p7.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>C</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>H</mml:mi><mml:mn>4</mml:mn></mml:msub></mml:mrow></mml:math></inline-formula>, em que a ligação química entre apenas dois átomos de carbono se dá através da hibridização <inline-formula id="S4.p7.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula>, permitindo assim a ocorrência de uma ligação dupla entre os átomos de carbono, sendo uma dessas do tipo <inline-formula id="S4.p7.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e a outra do tipo <inline-formula id="S4.p7.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>. Considerando apenas os efeitos da interação de Coulomb entre um elétron de valência e dois átomos de carbono situados nas posições <inline-formula id="S4.p7.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mn>1</mml:mn></mml:msub></mml:math></inline-formula> e <inline-formula id="S4.p7.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mn>2</mml:mn></mml:msub></mml:math></inline-formula>, o Hamiltoniano de uma partícula pode ser expressado da seguinte maneira:</p>
+      <p>
+        <disp-formula id="S4.E48">
+          <label>(48)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mi>e</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mfrac>
+                    <mml:msup>
+                      <mml:mtext mathvariant="bold">p</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mrow>
+                      <mml:mn>2</mml:mn>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>m</mml:mi>
+                    </mml:mrow>
+                  </mml:mfrac>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mfrac>
+                      <mml:mrow>
+                        <mml:msub>
+                          <mml:mi>Z</mml:mi>
+                          <mml:mrow>
+                            <mml:mi>e</mml:mi>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mi>f</mml:mi>
+                          </mml:mrow>
+                        </mml:msub>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msup>
+                          <mml:mi>e</mml:mi>
+                          <mml:mn>2</mml:mn>
+                        </mml:msup>
+                      </mml:mrow>
+                      <mml:mrow>
+                        <mml:mn>4</mml:mn>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>π</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:msub>
+                          <mml:mi>ε</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mrow>
+                    </mml:mfrac>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo>(</mml:mo>
+                      <mml:mrow>
+                        <mml:mfrac>
+                          <mml:mn>1</mml:mn>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">|</mml:mo>
+                            <mml:mrow>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mo>-</mml:mo>
+                              <mml:msub>
+                                <mml:mtext mathvariant="bold">R</mml:mtext>
+                                <mml:mn>1</mml:mn>
+                              </mml:msub>
+                            </mml:mrow>
+                            <mml:mo stretchy="false">|</mml:mo>
+                          </mml:mrow>
+                        </mml:mfrac>
+                        <mml:mo>+</mml:mo>
+                        <mml:mfrac>
+                          <mml:mn>1</mml:mn>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">|</mml:mo>
+                            <mml:mrow>
+                              <mml:mtext mathvariant="bold">r</mml:mtext>
+                              <mml:mo>-</mml:mo>
+                              <mml:msub>
+                                <mml:mtext mathvariant="bold">R</mml:mtext>
+                                <mml:mn>2</mml:mn>
+                              </mml:msub>
+                            </mml:mrow>
+                            <mml:mo stretchy="false">|</mml:mo>
+                          </mml:mrow>
+                        </mml:mfrac>
+                      </mml:mrow>
+                      <mml:mo>)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S4.p7.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mtext mathvariant="bold">p</mml:mtext><mml:mo>=</mml:mo><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mi>i</mml:mi><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">ℏ</mml:mi><mml:mo>⁢</mml:mo><mml:mo>∇</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p7.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mtext mathvariant="bold">r</mml:mtext></mml:math></inline-formula> são os operadores de momento linear e posição do elétron, respectivamente, <inline-formula id="S4.p7.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>e</mml:mi></mml:math></inline-formula> é o módulo da carga do elétron, <inline-formula id="S4.p7.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>m</mml:mi></mml:math></inline-formula> a sua massa e <inline-formula id="S4.p7.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>ε</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:math></inline-formula> é a permissividade dielétrica do vácuo, <inline-formula id="S4.p7.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>Z</mml:mi><mml:mrow><mml:mi>e</mml:mi><mml:mo>⁢</mml:mo><mml:mi>f</mml:mi></mml:mrow></mml:msub><mml:mo>≈</mml:mo><mml:mn>4</mml:mn></mml:mrow></mml:math></inline-formula> é o número atômico efetivo percebido pelos os elétrons de valência, já que a camada completa <inline-formula id="S4.p7.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>1</mml:mn><mml:mo>⁢</mml:mo><mml:msup><mml:mi>s</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> blinda parcialmente a carga do núcleo. Considerando que os orbitais atômicos hibridizados provenientes de cada átomo formam uma base completa, conforme discutido na Seção anterior, é possível calcular diretamente os elementos de matriz <inline-formula id="S4.p7.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo stretchy="false">⟨</mml:mo><mml:mi>α</mml:mi><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mover accent="true"><mml:mi>H</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mi>β</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> para os orbitais do tipo <inline-formula id="S4.p7.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p7.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula>, de tal modo que, utilizando as definições a seguir:</p>
+      <p>
+        <disp-formula id="S4.E49">
+          <label>(49)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>σ</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>e</mml:mi>
+                  </mml:msub>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo rspace="22.5pt">,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E50">
+          <label>(50)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi mathvariant="normal">Δ</mml:mi>
+                  <mml:mi>σ</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>e</mml:mi>
+                  </mml:msub>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:msup>
+                        <mml:mi>p</mml:mi>
+                        <mml:mn>2</mml:mn>
+                      </mml:msup>
+                    </mml:mrow>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E51">
+          <label>(51)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>π</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>e</mml:mi>
+                  </mml:msub>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E52">
+          <label>(52)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi mathvariant="normal">Δ</mml:mi>
+                  <mml:mi>π</mml:mi>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>1</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>H</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>e</mml:mi>
+                  </mml:msub>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>p</mml:mi>
+                      <mml:mi>z</mml:mi>
+                    </mml:msub>
+                    <mml:mo>,</mml:mo>
+                    <mml:msub>
+                      <mml:mtext mathvariant="bold">R</mml:mtext>
+                      <mml:mn>2</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>pode-se colocar o Hamiltoniano na forma matricial:</p>
+      <p>
+        <disp-formula id="S4.E53">
+          <label>(53)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>(</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mi>σ</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi mathvariant="normal">Δ</mml:mi>
+                          <mml:mi>σ</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:msubsup>
+                          <mml:mi mathvariant="normal">Δ</mml:mi>
+                          <mml:mi>σ</mml:mi>
+                          <mml:mo>*</mml:mo>
+                        </mml:msubsup>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mi>σ</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mi>π</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi mathvariant="normal">Δ</mml:mi>
+                          <mml:mi>π</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msubsup>
+                          <mml:mi mathvariant="normal">Δ</mml:mi>
+                          <mml:mi>π</mml:mi>
+                          <mml:mo>*</mml:mo>
+                        </mml:msubsup>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mi>π</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mo rspace="0.8pt">)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Observe que <inline-formula id="S4.p7.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow><mml:mo>,</mml:mo><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mi>j</mml:mi></mml:msub></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> é um orbital do tipo <inline-formula id="S4.p7.m20"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p7.m21"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mi>j</mml:mi></mml:msub></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> é um orbital do tipo <inline-formula id="S4.p7.m22"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula>, centrados no átomo de carbono <inline-formula id="S4.p7.m23"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>j</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>, e ainda <inline-formula id="S4.p7.m24"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">⟨</mml:mo><mml:mrow><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow><mml:mo>,</mml:mo><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mi>i</mml:mi></mml:msub></mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>H</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>e</mml:mi></mml:msub><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mtext mathvariant="bold">R</mml:mtext><mml:mi>j</mml:mi></mml:msub></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>≈</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:math></inline-formula> para quaisquer escolhas <inline-formula id="S4.p7.m25"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mrow><mml:mi>i</mml:mi><mml:mo>,</mml:mo><mml:mi>j</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo>,</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:math></inline-formula>, tendo em vista que orbitais <inline-formula id="S4.p7.m26"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> são ortogonais a orbitais <inline-formula id="S4.p7.m27"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula>. Um cálculo explícito nos mostra que <inline-formula id="S4.p7.m28"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>σ</mml:mi></mml:msub><mml:mo>≈</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mi>π</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:mrow></mml:math></inline-formula>, correspondendo às energias aproximadas do elétron em um orbital de átomo de carbono isolado, enquanto que as energias de interação satisfazem a condição <inline-formula id="S4.p7.m29"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>σ</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow><mml:mo>&gt;</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>π</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, devido ao fato de que os orbitais <inline-formula id="S4.p7.m30"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> que dão origem à ligação <inline-formula id="S4.p7.m31"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> formarão um orbital molecular muito mais localizado do que o orbital molecular do tipo <inline-formula id="S4.p7.m32"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, originado pela superposição dos orbitais atômicos do tipo <inline-formula id="S4.p7.m33"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula>. É fácil diagonalizar (<xref ref-type="disp-formula" rid="S4.E53">53</xref>), que tem a forma diagonal por blocos. Os autovalores de energia são:</p>
+      <p>
+        <disp-formula id="S4.E54">
+          <label>(54)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msubsup>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>σ</mml:mi>
+                  <mml:mo>+</mml:mo>
+                </mml:msubsup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mn>0</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mi mathvariant="normal">Δ</mml:mi>
+                      <mml:mi>σ</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">|</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E55">
+          <label>(55)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msubsup>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>σ</mml:mi>
+                  <mml:mo>-</mml:mo>
+                </mml:msubsup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mn>0</mml:mn>
+                  </mml:msub>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mi mathvariant="normal">Δ</mml:mi>
+                      <mml:mi>σ</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">|</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E56">
+          <label>(56)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msubsup>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>π</mml:mi>
+                  <mml:mo>+</mml:mo>
+                </mml:msubsup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mn>0</mml:mn>
+                  </mml:msub>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mi mathvariant="normal">Δ</mml:mi>
+                      <mml:mi>π</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">|</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E57">
+          <label>(57)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msubsup>
+                  <mml:mi>E</mml:mi>
+                  <mml:mi>π</mml:mi>
+                  <mml:mo>-</mml:mo>
+                </mml:msubsup>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mi>E</mml:mi>
+                    <mml:mn>0</mml:mn>
+                  </mml:msub>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">|</mml:mo>
+                    <mml:msub>
+                      <mml:mi mathvariant="normal">Δ</mml:mi>
+                      <mml:mi>π</mml:mi>
+                    </mml:msub>
+                    <mml:mo stretchy="false">|</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde o sinal <inline-formula id="S4.p7.m34"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo>-</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mo>+</mml:mo><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula> corresponde a um orbital de menor(maior) energia e denominado de ligante(anti-ligante). Denotam-se convencionalmente os orbitais ligantes por <inline-formula id="S4.p7.m35"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p7.m36"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, com energias <inline-formula id="S4.p7.m37"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>σ</mml:mi><mml:mo>-</mml:mo></mml:msubsup></mml:math></inline-formula> e <inline-formula id="S4.p7.m38"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>π</mml:mi><mml:mo>-</mml:mo></mml:msubsup></mml:math></inline-formula>, respectivamente, enquanto que os antiligantes são simbolizados por <inline-formula id="S4.p7.m39"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> e <inline-formula id="S4.p7.m40"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>, com energias <inline-formula id="S4.p7.m41"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>σ</mml:mi><mml:mo>+</mml:mo></mml:msubsup></mml:math></inline-formula> e <inline-formula id="S4.p7.m42"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>π</mml:mi><mml:mo>+</mml:mo></mml:msubsup></mml:math></inline-formula>, respectivamente. Tendo em vista que <inline-formula id="S4.p7.m43"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>σ</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow><mml:mo>&gt;</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>π</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, pode-se concluir que a separação energética entre os orbitais <inline-formula id="S4.p7.m44"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p7.m45"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> será maior que aquela entre os orbitais <inline-formula id="S4.p7.m46"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p7.m47"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>.</p>
+      <fig id="S4.F6">
+        <label>Figura 6:</label>
+        <caption>
+          <title>Esquema de energias dos orbitais ligantes e antiligantes na molécula de etileno.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/17dbffdc0469256383b3a9e950eccf7cdc52f150.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/fb9b81c85c6f4168ee9741a8bdb8d552e917239f.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Os níveis de energia resultantes dos orbitais ligantes e anti-ligantes na molécula de etileno são ilustrados esquematicamente na Figura<xref ref-type="fig" rid="S4.F6">6</xref>. Observe que originalmente há 8 orbitais por átomo de carbono, sendo <inline-formula id="S4.p8.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>6</mml:mn></mml:math></inline-formula> do tipo <inline-formula id="S4.p8.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p8.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> do tipo <inline-formula id="S4.p8.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula>, já considerada a duplicidade do spin, mas somente a metade desses níveis está ocupada em cada átomo, pelo fato de que o carbono possui apenas 4 elétrons de valência. Na formação da molécula, 4 orbitais do tipo <inline-formula id="S4.p8.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> orientados de modo a formar ângulos de <inline-formula id="S4.p8.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mn>120</mml:mn><mml:mo>∘</mml:mo></mml:msup></mml:math></inline-formula> com a linha que une os dois átomos de carbono estão envolvidos em ligações bastante localizadas com os átomos de hidrogênio da molécula. Sendo assim, do total de 4 elétrons de valência de um átomo de carbono, 2 estão envolvidos em ligações com átomos de hidrogênio, e outros 2 serão compartilhados com o outro átomo de carbono. Por conservação do número de graus de liberdade, ao formar a ligação química, 4 orbitais moleculares serão resultantes da superposição entre 2 orbitais do tipo <inline-formula id="S4.p8.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> de cada átomo, considerando-se a duplicidade do spin, esses sendo orientados ao longo da linha que une os átomos de carbono, e 4 orbitais moleculares resultantes da superposição entre 2 orbitais <inline-formula id="S4.p8.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> proveinentes de cada átomo. Como resultado final, <inline-formula id="S4.p8.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> orbitais moleculares corresponderão aos orbitais ligantes do tipo <inline-formula id="S4.p8.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, <inline-formula id="S4.p8.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> aos orbitais ligantes <inline-formula id="S4.p8.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, <inline-formula id="S4.p8.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> aos orbitais anti-ligantes do tipo <inline-formula id="S4.p8.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> e <inline-formula id="S4.p8.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>2</mml:mn></mml:math></inline-formula> aos orbitais anti-ligantes <inline-formula id="S4.p8.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>, havendo um total de <inline-formula id="S4.p8.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>4</mml:mn></mml:math></inline-formula> elétrons compartilhados entre os dois átomos de carbono. Desse modo, todos os orbitais ligantes <inline-formula id="S4.p8.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p8.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> estarão preenchidos, enquanto que os orbitais anti-ligantes estarão desocupados. Na formação de uma cadeia polimérica de <inline-formula id="S4.p8.m20"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> átomos os níveis discretos correspondentes aos orbitais <inline-formula id="S4.p8.m21"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, <inline-formula id="S4.p8.m22"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>, <inline-formula id="S4.p8.m23"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p8.m24"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> passam a se desdobrar em <inline-formula id="S4.p8.m25"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> novos níveis, formando bandas de energia contínuas no limite de <inline-formula id="S4.p8.m26"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow></mml:math></inline-formula>, denominadas bandas <inline-formula id="S4.p8.m27"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, <inline-formula id="S4.p8.m28"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>, <inline-formula id="S4.p8.m29"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p8.m30"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>. O nível de Fermi para esse sistema ficará localizado no ponto médio entre as energias <inline-formula id="S4.p8.m31"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>π</mml:mi><mml:mo>+</mml:mo></mml:msubsup></mml:math></inline-formula> e <inline-formula id="S4.p8.m32"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msubsup><mml:mi>E</mml:mi><mml:mi>π</mml:mi><mml:mo>-</mml:mo></mml:msubsup></mml:math></inline-formula>. Novamente, por conta da condição <inline-formula id="S4.p8.m33"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>σ</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow><mml:mo>&gt;</mml:mo><mml:mrow><mml:mo stretchy="false">|</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>π</mml:mi></mml:msub><mml:mo stretchy="false">|</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, os níveis de energia da banda <inline-formula id="S4.p8.m34"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> estarão mais abaixo do nível de Fermi do que os níveis de energia da banda <inline-formula id="S4.p8.m35"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, e os níveis de energia da banda <inline-formula id="S4.p8.m36"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>σ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> estarão mais acima do nível de Fermi do que os níveis de energia da banda <inline-formula id="S4.p8.m37"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>. Portanto os processos de transporte e de fotocondutividade em baixas energias serão governados pelas bandas <inline-formula id="S4.p8.m38"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p8.m39"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula>.</p>
+      <p>No estudo de semicondutores orgânicos, denominam-se HOMO<xref ref-type="fn" rid="footnote2"><sup>2</sup></xref> e LUMO<xref ref-type="fn" rid="footnote3"><sup>3</sup></xref> o estado de mais alta energia ocupado por um elétron e o estado de mais baixa energia que não esteja ocupado, respectivamente. De maneira usual, o <italic>bandgap</italic> do material é definido como a diferença de energia entre o LUMO e o HOMO.</p>
+      <p>Agora pretende-se analisar a molécula de benzeno, o ciclo conjugado mais estável, sendo constituído de 6 átomos de carbono e 6 átomos de hidrogênio, conforme ilustrado Figura<xref ref-type="fig" rid="S4.F7">7</xref>.</p>
+      <fig id="S4.F7">
+        <label>Figura 7:</label>
+        <caption>
+          <title>A molécula de benzeno: Note que as ligações <inline-formula id="S4.F7.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula>, que se devem aos orbitais <inline-formula id="S4.F7.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> são direcionais, manténdo os elétrons fortemente localizados entre os átomos que formam a ligação. Já a ligação <inline-formula id="S4.F7.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> deve-se a orbitais <inline-formula id="S4.F7.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> perpendiculares ao plano mostrado. Nesse caso, os elétrons nesses orbitais podem saltar de um átomo para outro, fazendo as ligações duplas se moverem, com energia de transição proporcional ao parâmetro de hopping <inline-formula id="S4.F7.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>t</mml:mi><mml:mo>=</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>π</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/17d692fb73cd727b178e359a0e2b13e0a9d80ce5.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/f4829c514600d446814b672d69f2646df542814c.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>A ligação entre os átomos de carbono que dá a forma a essa molécula ocorre por meio de interações <inline-formula id="S4.p11.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> no plano que contém todos os átomos de carbono e de hidrogênio. Essas ligações devem-se aos orbitais hibridizados <inline-formula id="S4.p11.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> do carbono. Como esses formam um ângulo de <inline-formula id="S4.p11.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mn>120</mml:mn><mml:mo>∘</mml:mo></mml:msup></mml:math></inline-formula> entre si, os átomos serão arranjados na forma de um hexágono. Os orbitais <inline-formula id="S4.p11.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>1</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula> dos átomos de hidrogênio se misturam a orbitais do tipo <inline-formula id="S4.p11.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>s</mml:mi><mml:mo>⁢</mml:mo><mml:msup><mml:mi>p</mml:mi><mml:mn>2</mml:mn></mml:msup></mml:mrow></mml:math></inline-formula> do carbono. Ao todo nas ligações <inline-formula id="S4.p11.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> estarão compartilhados 3 elétrons por átomo de carbono e 1 elétrons por átomo do hidrogênio, totalizando assim <inline-formula id="S4.p11.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>24</mml:mn></mml:math></inline-formula> elétrons. Restam ainda <inline-formula id="S4.p11.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>6</mml:mn></mml:math></inline-formula> elétrons provenientes dos átomos de carbono, que ocupam orbitais do tipo <inline-formula id="S4.p11.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> e que serão misturados para formar ligações <inline-formula id="S4.p11.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>. Uma vez que os orbitais <inline-formula id="S4.p11.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> são perpendiculares ao plano da molécula, é equiprovável, por exemplo, para um elétron do átomo 1 na rede ser compartilhado com o átomo 2 ou com o átomo 6 (vide Figura<xref ref-type="fig" rid="S4.F7">7</xref>), e essa ligação <inline-formula id="S4.p11.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> flutua, originando assim uma nuvem. As propriedades de condutividade elétrica e absorção óptica são fortemente influenciadas por essas ligações. Para fins do cálculo que segue, serão levados em conta somente esses orbitais, e o parâmetro de hopping <inline-formula id="S4.p11.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>t</mml:mi><mml:mo>=</mml:mo><mml:msub><mml:mi mathvariant="normal">Δ</mml:mi><mml:mi>π</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> pode ser calculado a partir da expressão (<xref ref-type="disp-formula" rid="S4.E52">52</xref>). Em segunda quantização, o Hamiltoniano da molécula para os orbitais <inline-formula id="S4.p11.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> tem a seguinte forma:</p>
+      <p>
+        <disp-formula id="S4.E58">
+          <label>(58)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:munder>
+                    <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                    <mml:mrow>
+                      <mml:mi>s</mml:mi>
+                      <mml:mo>=</mml:mo>
+                      <mml:mrow>
+                        <mml:mo>↑</mml:mo>
+                        <mml:mo>,</mml:mo>
+                        <mml:mo>↓</mml:mo>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:munder>
+                  <mml:mrow>
+                    <mml:munderover>
+                      <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>j</mml:mi>
+                        <mml:mo>=</mml:mo>
+                        <mml:mn>1</mml:mn>
+                      </mml:mrow>
+                      <mml:mn>6</mml:mn>
+                    </mml:munderover>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">[</mml:mo>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msubsup>
+                            <mml:mover accent="true">
+                              <mml:mi>c</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                            <mml:mrow>
+                              <mml:mi>j</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi>s</mml:mi>
+                            </mml:mrow>
+                            <mml:mo>†</mml:mo>
+                          </mml:msubsup>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msub>
+                            <mml:mover accent="true">
+                              <mml:mi>c</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                            <mml:mrow>
+                              <mml:mi>j</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi>s</mml:mi>
+                            </mml:mrow>
+                          </mml:msub>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:mrow>
+                              <mml:mrow>
+                                <mml:msubsup>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mrow>
+                                      <mml:mi>j</mml:mi>
+                                      <mml:mo>+</mml:mo>
+                                      <mml:mn>1</mml:mn>
+                                    </mml:mrow>
+                                    <mml:mo>,</mml:mo>
+                                    <mml:mi>s</mml:mi>
+                                  </mml:mrow>
+                                  <mml:mo>†</mml:mo>
+                                </mml:msubsup>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:msub>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mi>j</mml:mi>
+                                    <mml:mo>⁢</mml:mo>
+                                    <mml:mi>s</mml:mi>
+                                  </mml:mrow>
+                                </mml:msub>
+                              </mml:mrow>
+                              <mml:mo>+</mml:mo>
+                              <mml:mrow>
+                                <mml:msubsup>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mi>j</mml:mi>
+                                    <mml:mo>,</mml:mo>
+                                    <mml:mi>s</mml:mi>
+                                  </mml:mrow>
+                                  <mml:mo>†</mml:mo>
+                                </mml:msubsup>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:msub>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mrow>
+                                      <mml:mi>j</mml:mi>
+                                      <mml:mo>+</mml:mo>
+                                      <mml:mn>1</mml:mn>
+                                    </mml:mrow>
+                                    <mml:mo>,</mml:mo>
+                                    <mml:mi>s</mml:mi>
+                                  </mml:mrow>
+                                </mml:msub>
+                              </mml:mrow>
+                            </mml:mrow>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">]</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>com a identificação <inline-formula id="S4.p11.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>c</mml:mi><mml:mrow><mml:mn>7</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>c</mml:mi><mml:mrow><mml:mn>1</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:msub></mml:mrow></mml:math></inline-formula>. Note que nesse modelo simplificado, considera-se nula a possibilidade de mudança do número quântico de spin quando ocorre o salto de um átomo para outro, e também está sendo negligenciada a interação repulsiva de Coulomb, quando dois desses elétrons estão no mesmo átomo. A forma mais simples de incluir um termo repulsivo se dá adicionando ao Hamiltoniano a expressão <inline-formula id="S4.p11.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>U</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:msub><mml:mo largeop="true" symmetric="true">∑</mml:mo><mml:mi>j</mml:mi></mml:msub><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>n</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mrow><mml:mi>j</mml:mi><mml:mo>↑</mml:mo><mml:mi/></mml:mrow></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>n</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mrow><mml:mi>j</mml:mi><mml:mo>↓</mml:mo><mml:mi/></mml:mrow></mml:msub></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, sendo <inline-formula id="S4.p11.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>U</mml:mi></mml:math></inline-formula> a energia de Coulomb associada, levando ao conhecido modelo de Hubbard. Nesse caso, note que há um custo energético <inline-formula id="S4.p11.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>U</mml:mi></mml:math></inline-formula> para manter dois elétrons de spins contrários no mesmo sítio.</p>
+      <p>A solução desse problema levando em conta os 6 elétrons simultaneamente tem como base estados da forma <inline-formula id="S4.p12.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msubsup><mml:mo largeop="true" symmetric="true">∏</mml:mo><mml:mrow><mml:mi>j</mml:mi><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mn>6</mml:mn></mml:msubsup><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>↑</mml:mo><mml:mi/></mml:mrow></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>↓</mml:mo><mml:mi/></mml:mrow></mml:msub></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, com as condições de que <inline-formula id="S4.p12.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> indicando que o estado no <inline-formula id="S4.p12.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>-ésimo átomo com spin <inline-formula id="S4.p12.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>s</mml:mi></mml:math></inline-formula> está vazio ou ocupado, e que o número total de elétrons satisfaz <inline-formula id="S4.p12.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mo largeop="true" symmetric="true">∑</mml:mo><mml:mrow><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:msub><mml:msub><mml:mi>n</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:msub></mml:mrow><mml:mo>=</mml:mo><mml:mn>6</mml:mn></mml:mrow></mml:math></inline-formula>. Esse problema torna-se exponencialmente complexo com o aumento do número de graus de liberdade, por exemplo, número total de elétrons e de orbitais atômicos disponíveis.</p>
+      <p>Para um melhor entendimento da natureza do problema, considere como exemplo apenas 2 elétrons, mas que podem ser colocados em <inline-formula id="S4.p13.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>4</mml:mn></mml:math></inline-formula> orbitais distintos, indexados por <inline-formula id="S4.p13.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>a</mml:mi><mml:mo>,</mml:mo><mml:mi>b</mml:mi><mml:mo>,</mml:mo><mml:mi>c</mml:mi><mml:mo>,</mml:mo><mml:mi>d</mml:mi></mml:mrow></mml:math></inline-formula>, já considerando o spin. Suponha que um estado na base de número seja escrito na forma <inline-formula id="S4.p13.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mi>a</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mi>b</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mi>c</mml:mi></mml:msub><mml:mo>,</mml:mo><mml:msub><mml:mi>n</mml:mi><mml:mi>d</mml:mi></mml:msub></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula>, com <inline-formula id="S4.p13.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>n</mml:mi><mml:mi>j</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p13.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mo largeop="true" symmetric="true">∑</mml:mo><mml:mi>j</mml:mi></mml:msub><mml:msub><mml:mi>n</mml:mi><mml:mi>j</mml:mi></mml:msub></mml:mrow><mml:mo>=</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:math></inline-formula>. Nesse caso, a lista de possibilidades é a seguinte: <inline-formula id="S4.p13.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo stretchy="false">{</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>1100</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>1010</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>1001</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>0110</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>0101</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>0011</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo stretchy="false">}</mml:mo></mml:mrow></mml:math></inline-formula>, totalizando <inline-formula id="S4.p13.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>6</mml:mn></mml:math></inline-formula> estados. Isso significa que a representação matricial do Hamiltoniano a ser diagonalizado terá dimensão <inline-formula id="S4.p13.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>6</mml:mn><mml:mo>×</mml:mo><mml:mn>6</mml:mn></mml:mrow></mml:math></inline-formula>. De forma geral, a dimensão do problema será dada pela combinação <inline-formula id="S4.p13.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>C</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>,</mml:mo><mml:mi>p</mml:mi></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:mi>n</mml:mi><mml:mo>!</mml:mo></mml:mrow><mml:mo>/</mml:mo><mml:mrow><mml:mo stretchy="false">[</mml:mo><mml:mrow><mml:mrow><mml:mi>p</mml:mi><mml:mo>!</mml:mo></mml:mrow><mml:mo>⁢</mml:mo><mml:mrow><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mrow><mml:mi>n</mml:mi><mml:mo>-</mml:mo><mml:mi>p</mml:mi></mml:mrow><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mo>!</mml:mo></mml:mrow></mml:mrow><mml:mo stretchy="false">]</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> de <inline-formula id="S4.p13.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula> estados disponíveis, que podem ser ocupados por <inline-formula id="S4.p13.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>p</mml:mi></mml:math></inline-formula> elétrons. Na molécula de benzeno, para os orbitais <inline-formula id="S4.p13.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> teríamos 12 estados disponíveis, já incluindo o spin, para preencher com <inline-formula id="S4.p13.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>6</mml:mn></mml:math></inline-formula> elétrons, o que resulta em uma dimensão do Hamiltoniano de 924 na base de número.</p>
+      <p>Portanto, uma simplificação se faz necessária na solução desse tipo de problema, consistindo em considerar o cenário com apenas um elétron, que pode ser colocado em qualquer um dos estados disponíveis, e uma vez diagonalizado o Hamiltoniano resultante nessa base de um único elétron, faz-se o preenchimento dos níveis de acordo com o princípio de exclusão de Pauli, sempre indo do menor para o maior nível de energia, até que se esgote o número total de elétrons. No caso da molécula de benzeno esse número é <inline-formula id="S4.p14.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>6</mml:mn></mml:math></inline-formula>.</p>
+      <p>Para colocar o Hamiltoniano de <italic>tight-binding</italic> (<xref ref-type="disp-formula" rid="S4.E58">58</xref>) na forma matricial, tendo em vista que o spin nesse problema representa apenas um fator de multiplicidade, pode-se omitir esse grau de liberdade e então calcular os elementos de matriz de <inline-formula id="S4.p15.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>H</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula> na base <inline-formula id="S4.p15.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo stretchy="false">{</mml:mo><mml:mrow><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>1</mml:mn><mml:mo rspace="5.8pt" stretchy="false">⟩</mml:mo></mml:mrow><mml:mo rspace="5.8pt">=</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>100000</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>2</mml:mn><mml:mo rspace="5.8pt" stretchy="false">⟩</mml:mo></mml:mrow><mml:mo rspace="5.8pt">=</mml:mo><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>010000</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>,</mml:mo><mml:mi mathvariant="normal">…</mml:mi></mml:mrow></mml:mrow><mml:mo>,</mml:mo><mml:mrow><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>6</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mn>000001</mml:mn><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:mrow><mml:mo stretchy="false">}</mml:mo></mml:mrow></mml:math></inline-formula>, onde <inline-formula id="S4.p15.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mi>n</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:math></inline-formula> significa que o elétron está localizado no orbital <inline-formula id="S4.p15.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> do <inline-formula id="S4.p15.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>n</mml:mi></mml:math></inline-formula>-ésimo átomo. Considerando-se que <inline-formula id="S4.p15.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mo stretchy="false">⟨</mml:mo><mml:mi>m</mml:mi><mml:mo stretchy="false">|</mml:mo><mml:mi>n</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:msub><mml:mi>δ</mml:mi><mml:mrow><mml:mi>m</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub></mml:mrow></mml:math></inline-formula> e que <inline-formula id="S4.p15.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msubsup><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo>†</mml:mo></mml:msubsup><mml:mo>⁢</mml:mo><mml:msub><mml:mover accent="true"><mml:mi>c</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>j</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mi>n</mml:mi><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>δ</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>⁢</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo fence="true" stretchy="false">|</mml:mo><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo stretchy="false">⟩</mml:mo></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>, pode-se obter:</p>
+      <p>
+        <disp-formula id="S4.E59">
+          <label>(59)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>H</mml:mi>
+                  <mml:mrow>
+                    <mml:mi>m</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>n</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mi>m</mml:mi>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mi>n</mml:mi>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo stretchy="false">⟨</mml:mo>
+                  <mml:mi>m</mml:mi>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:munderover>
+                        <mml:mo largeop="true" movablelimits="false" symmetric="true">∑</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>j</mml:mi>
+                          <mml:mo>=</mml:mo>
+                          <mml:mn>1</mml:mn>
+                        </mml:mrow>
+                        <mml:mn>6</mml:mn>
+                      </mml:munderover>
+                    </mml:mstyle>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">[</mml:mo>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:msub>
+                            <mml:mover accent="true">
+                              <mml:mi>n</mml:mi>
+                              <mml:mo stretchy="false">^</mml:mo>
+                            </mml:mover>
+                            <mml:mi>j</mml:mi>
+                          </mml:msub>
+                        </mml:mrow>
+                        <mml:mo>+</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mrow>
+                            <mml:mo stretchy="false">(</mml:mo>
+                            <mml:mrow>
+                              <mml:mrow>
+                                <mml:msubsup>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mi>j</mml:mi>
+                                    <mml:mo>+</mml:mo>
+                                    <mml:mn>1</mml:mn>
+                                  </mml:mrow>
+                                  <mml:mo>†</mml:mo>
+                                </mml:msubsup>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:msub>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mi>j</mml:mi>
+                                </mml:msub>
+                              </mml:mrow>
+                              <mml:mo>+</mml:mo>
+                              <mml:mrow>
+                                <mml:msubsup>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mi>j</mml:mi>
+                                  <mml:mo>†</mml:mo>
+                                </mml:msubsup>
+                                <mml:mo>⁢</mml:mo>
+                                <mml:msub>
+                                  <mml:mover accent="true">
+                                    <mml:mi>c</mml:mi>
+                                    <mml:mo stretchy="false">^</mml:mo>
+                                  </mml:mover>
+                                  <mml:mrow>
+                                    <mml:mi>j</mml:mi>
+                                    <mml:mo>+</mml:mo>
+                                    <mml:mn>1</mml:mn>
+                                  </mml:mrow>
+                                </mml:msub>
+                              </mml:mrow>
+                            </mml:mrow>
+                            <mml:mo stretchy="false">)</mml:mo>
+                          </mml:mrow>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo stretchy="false">]</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                  <mml:mo fence="true" stretchy="false">|</mml:mo>
+                  <mml:mi>n</mml:mi>
+                  <mml:mo stretchy="false">⟩</mml:mo>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>E</mml:mi>
+                      <mml:mi>π</mml:mi>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>δ</mml:mi>
+                      <mml:mrow>
+                        <mml:mi>m</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>n</mml:mi>
+                      </mml:mrow>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>δ</mml:mi>
+                      <mml:mrow>
+                        <mml:mi>m</mml:mi>
+                        <mml:mo>,</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>n</mml:mi>
+                          <mml:mo>+</mml:mo>
+                          <mml:mn>1</mml:mn>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:msub>
+                  </mml:mrow>
+                  <mml:mo>+</mml:mo>
+                  <mml:mrow>
+                    <mml:mi>t</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>δ</mml:mi>
+                      <mml:mrow>
+                        <mml:mi>m</mml:mi>
+                        <mml:mo>,</mml:mo>
+                        <mml:mrow>
+                          <mml:mi>n</mml:mi>
+                          <mml:mo>-</mml:mo>
+                          <mml:mn>1</mml:mn>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:msub>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Explicitamente em forma matricial o Hamiltoniano toma a seguinte forma:</p>
+      <p>
+        <disp-formula id="S4.E60">
+          <label>(60)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>(</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mn>0</mml:mn>
+                        </mml:msub>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mo>)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Lembre que <inline-formula id="S4.p15.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>m</mml:mi><mml:mo>,</mml:mo><mml:mi>n</mml:mi></mml:mrow></mml:math></inline-formula> devem ser varridos de 1 a 6, e que 7 deve ser identificado com 1, por conta da ciclicidade da molécula. Os autovalores de (<xref ref-type="disp-formula" rid="S4.E60">60</xref>) correspondendo às energias dos orbitais moleculares <inline-formula id="S4.p15.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, são dados por <inline-formula id="S4.p15.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>-</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p15.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mn>3</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>-</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>, enquanto que para os níveis <inline-formula id="S4.p15.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> têm-se <inline-formula id="S4.p15.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>4</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mn>5</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>+</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p15.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>6</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>+</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. Lembre que todos esses níveis são duplamente degenerados devido ao spin, produzindo <inline-formula id="S4.p15.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>12</mml:mn></mml:math></inline-formula> orbitais moleculares distintos. Os 6 orbitais ligantes <inline-formula id="S4.p15.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> vão contribuir para formação de uma densidade de estados semelhante à banda de valência de um semicondutor, enquanto que os 6 orbitais antiligantes <inline-formula id="S4.p15.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> vão contribuir para a formação de uma densidade de estados similar a uma banda de condução. Uma vez que existem 6 elétrons disponíveis, todos os orbitais <inline-formula id="S4.p15.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula> estarão preenchidos e todos os orbitais <inline-formula id="S4.p15.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>π</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:math></inline-formula> estarão vazios. O <italic>bandgap</italic> no presente caso, correspondendo à distância entre o HOMO e o LUMO tem valor de <inline-formula id="S4.p15.m20"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>g</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mn>4</mml:mn></mml:msub><mml:mo>-</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mn>3</mml:mn></mml:msub></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:mrow></mml:math></inline-formula>.</p>
+      <p>De maneira fenomenológica, é possível montar diretamente a matriz que representa o Hamiltoniano de <italic>tight-binding</italic> para um elétron, supondo conhecidos os vínculos entre os átomos primeiros vizinhos, e se for o caso, também segundos vizinhos. Como exercício, considere uma outra molécula cíclica de fundamental importância para o ramo dos polímeros conjugados, o tiofeno (<inline-formula id="S4.p16.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>C</mml:mi><mml:mn>4</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>H</mml:mi><mml:mn>4</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:mi>S</mml:mi></mml:mrow></mml:math></inline-formula>), ilustrado na Figura<xref ref-type="fig" rid="S4.F8">8</xref>. Este monômero é essencial na síntese do P3HT, que é utilizado em estudos com células solares orgânicas [<xref ref-type="bibr" rid="b11">11</xref>].</p>
+      <fig id="S4.F8">
+        <label>Figura 8:</label>
+        <caption>
+          <title>A molécula de tiofeno: um dos átomos de carbono no ciclo é trocado pelo enxofre, cujo índice de sítio é <inline-formula id="S4.F8.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula>. Esse átomo tem um nível diferente de energia no orbital que participa das ligações com os orbitais <inline-formula id="S4.F8.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> do carbono, bem como o parâmetro de salto para um elétron entre os átomos de enxofre e carbono tem valor <inline-formula id="S4.F8.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup><mml:mo>&lt;</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:math></inline-formula>.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/f87149313eb8066553f651b2937ff674a6e25578.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/2c204bb9a49f123a6bd53faa561719ec770888a5.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Para construir o Hamiltoniano de <italic>tight-binding</italic> dessa molécula, considerando apenas interações com primeiros vizinhos e orbitais do tipo <inline-formula id="S4.p17.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>π</mml:mi></mml:math></inline-formula>, pode-se observar na Figura<xref ref-type="fig" rid="S4.F8">8</xref>, que o heteroátomo na estrutura, aqui o enxofre, está indexado por <inline-formula id="S4.p17.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula>, enquanto o carbono ocupa os sítios <inline-formula id="S4.p17.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>,</mml:mo><mml:mn>3</mml:mn><mml:mo>,</mml:mo><mml:mn>4</mml:mn><mml:mo>,</mml:mo><mml:mn>5</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>. Átomos de hidrogênio presentes, que participam em ligações do tipo <inline-formula id="S4.p17.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>σ</mml:mi></mml:math></inline-formula> e não são relevantes para o que segue e foram omitidos na Figura<xref ref-type="fig" rid="S4.F8">8</xref>. Naturalmente, considerando a energia dos orbitais <inline-formula id="S4.p17.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:math></inline-formula> do carbono como referência, a energia associada a um elétron ocupando o orbital do enxofre tem valor <inline-formula id="S4.p17.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi mathvariant="normal">Δ</mml:mi><mml:mo>⁢</mml:mo><mml:mi>E</mml:mi></mml:mrow></mml:math></inline-formula>. A probabilidade de salto do elétron no enxofre, para um dos carbonos vizinhos, nas posições <inline-formula id="S4.p17.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>1</mml:mn></mml:math></inline-formula> e <inline-formula id="S4.p17.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>5</mml:mn></mml:math></inline-formula> é mensurada pelo parâmetro de hopping <inline-formula id="S4.p17.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup><mml:mo>≠</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:math></inline-formula>. Nesse caso, o elemento de matriz que conecta um elétron no sítio <inline-formula id="S4.p17.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>5</mml:mn></mml:math></inline-formula> ao sítio <inline-formula id="S4.p17.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>1</mml:mn></mml:math></inline-formula>, denotado <inline-formula id="S4.p17.m12"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>H</mml:mi><mml:mn>15</mml:mn></mml:msub></mml:math></inline-formula>, terá valor <inline-formula id="S4.p17.m13"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup></mml:math></inline-formula>. O salto no sentido inverso é dado por <inline-formula id="S4.p17.m14"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>H</mml:mi><mml:mn>51</mml:mn></mml:msub><mml:mo>=</mml:mo><mml:msubsup><mml:mi>H</mml:mi><mml:mn>15</mml:mn><mml:mo>*</mml:mo></mml:msubsup></mml:mrow></mml:math></inline-formula>. Aqui vamos admitir por simplicidade que <inline-formula id="S4.p17.m15"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>t</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p17.m16"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup></mml:math></inline-formula> são reais. Como outro exemplo, os elementos <inline-formula id="S4.p17.m17"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>H</mml:mi><mml:mn>34</mml:mn></mml:msub></mml:math></inline-formula> e <inline-formula id="S4.p17.m18"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>H</mml:mi><mml:mn>43</mml:mn></mml:msub></mml:math></inline-formula> da matriz Hamiltoniana devem representar a energia de salto entre os sítios <inline-formula id="S4.p17.m19"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>3</mml:mn></mml:math></inline-formula> e <inline-formula id="S4.p17.m20"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn>4</mml:mn></mml:math></inline-formula>, ocupados por átomos de carbono no presente caso. Realizando a análise de todos os vínculos, obtém-se o Hamiltoniano do tiofeno para um elétron:</p>
+      <p>
+        <disp-formula id="S4.E61">
+          <label>(61)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>C</mml:mi>
+                      <mml:mn>4</mml:mn>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>H</mml:mi>
+                      <mml:mn>4</mml:mn>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>S</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>(</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mi mathvariant="normal">Δ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>E</mml:mi>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msup>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>′</mml:mo>
+                        </mml:msup>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msup>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>′</mml:mo>
+                        </mml:msup>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:msup>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>′</mml:mo>
+                        </mml:msup>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:msup>
+                          <mml:mi>t</mml:mi>
+                          <mml:mo>′</mml:mo>
+                        </mml:msup>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mo>)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Sabe-se ainda que o parâmetro de hopping da ligação <inline-formula id="S4.p18.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>C</mml:mi><mml:mo>-</mml:mo><mml:mi>S</mml:mi></mml:mrow></mml:math></inline-formula> satisfaz a condição <inline-formula id="S4.p18.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup><mml:mo>&lt;</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:math></inline-formula>, sendo <inline-formula id="S4.p18.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>t</mml:mi></mml:math></inline-formula> o hopping nas ligações <inline-formula id="S4.p18.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>C</mml:mi><mml:mo>-</mml:mo><mml:mi>C</mml:mi></mml:mrow></mml:math></inline-formula>. Para fins de comparação, considere uma molécula cíclica muito similar ao tiofeno, composta apenas de átomos de carbono no ciclo, denominada ciclopentadieno (<inline-formula id="S4.p18.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>C</mml:mi><mml:mn>5</mml:mn></mml:msub><mml:mo>⁢</mml:mo><mml:msub><mml:mi>H</mml:mi><mml:mn>6</mml:mn></mml:msub></mml:mrow></mml:math></inline-formula>), cujo Hamiltoniano é dado abaixo:</p>
+      <p>
+        <disp-formula id="S4.E62">
+          <label>(62)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>C</mml:mi>
+                      <mml:mn>5</mml:mn>
+                    </mml:msub>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msub>
+                      <mml:mi>H</mml:mi>
+                      <mml:mn>6</mml:mn>
+                    </mml:msub>
+                  </mml:mrow>
+                </mml:msub>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>(</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi>t</mml:mi>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mo>)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>A análise desse caso relativamente simples permite compreender, dentre outras coisas, o efeito de uma impureza substitucional, nesse caso o enxofre, que é colocado no lugar de um átomo de carbono. O cálculo da densidade de estados, <inline-formula id="S4.p19.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>D</mml:mi><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>E</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, pode ser feito utilizando-se o método da função de Green retardada <inline-formula id="S4.p19.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mover accent="true"><mml:mi>G</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover><mml:mi>R</mml:mi></mml:msub><mml:mo>⁢</mml:mo><mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>E</mml:mi><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mrow></mml:math></inline-formula>, através das equações abaixo [<xref ref-type="bibr" rid="b18">18</xref>, <xref ref-type="bibr" rid="b23">23</xref>]:</p>
+      <p>
+        <disp-formula id="S4.E63">
+          <label>(63)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:msub>
+                    <mml:mover accent="true">
+                      <mml:mi>G</mml:mi>
+                      <mml:mo stretchy="false">^</mml:mo>
+                    </mml:mover>
+                    <mml:mi>R</mml:mi>
+                  </mml:msub>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>E</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:msup>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">[</mml:mo>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mo stretchy="false">(</mml:mo>
+                          <mml:mrow>
+                            <mml:mi>E</mml:mi>
+                            <mml:mo>+</mml:mo>
+                            <mml:mrow>
+                              <mml:mi>i</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi>η</mml:mi>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo stretchy="false">)</mml:mo>
+                        </mml:mrow>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mn mathvariant="bold">1</mml:mn>
+                      </mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mover accent="true">
+                        <mml:mi>H</mml:mi>
+                        <mml:mo stretchy="false">^</mml:mo>
+                      </mml:mover>
+                    </mml:mrow>
+                    <mml:mo stretchy="false">]</mml:mo>
+                  </mml:mrow>
+                  <mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:mn>1</mml:mn>
+                  </mml:mrow>
+                </mml:msup>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <disp-formula id="S4.E64">
+          <label>(64)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>D</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mrow>
+                    <mml:mo stretchy="false">(</mml:mo>
+                    <mml:mi>E</mml:mi>
+                    <mml:mo stretchy="false">)</mml:mo>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>-</mml:mo>
+                  <mml:mrow>
+                    <mml:mstyle displaystyle="true">
+                      <mml:mfrac>
+                        <mml:mn>1</mml:mn>
+                        <mml:mi>π</mml:mi>
+                      </mml:mfrac>
+                    </mml:mstyle>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mi>Im</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo>[</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>Tr</mml:mi>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mrow>
+                          <mml:mo>(</mml:mo>
+                          <mml:mrow>
+                            <mml:msub>
+                              <mml:mover accent="true">
+                                <mml:mi>G</mml:mi>
+                                <mml:mo stretchy="false">^</mml:mo>
+                              </mml:mover>
+                              <mml:mi>R</mml:mi>
+                            </mml:msub>
+                            <mml:mo>⁢</mml:mo>
+                            <mml:mrow>
+                              <mml:mo stretchy="false">(</mml:mo>
+                              <mml:mi>E</mml:mi>
+                              <mml:mo stretchy="false">)</mml:mo>
+                            </mml:mrow>
+                          </mml:mrow>
+                          <mml:mo>)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                      <mml:mo>]</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S4.p19.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mn mathvariant="bold">1</mml:mn></mml:math></inline-formula> é a matriz identidade com a dimensão de <inline-formula id="S4.p19.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>H</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula>, Im denota a parte imaginária e Tr denota o traço de matriz. Idealmente, deve-se tomar o limite <inline-formula id="S4.p19.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>η</mml:mi><mml:mo>→</mml:mo><mml:msup><mml:mn>0</mml:mn><mml:mo>+</mml:mo></mml:msup></mml:mrow></mml:math></inline-formula>. Todavia, para fins de cálculo numérico é necessário considerar um valor finito para o parâmetro <inline-formula id="S4.p19.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>η</mml:mi></mml:math></inline-formula>. E isso não é necessariamente uma limitação muito importante, já que na prática, esse parâmetro pode ser usado para descrever efeitos de relaxação dos níveis de energia.</p>
+      <p>Para fins de comparação, as densidades de estados das moléculas ciclopentadieno e tiofeno são ilustradas na Figura<xref ref-type="fig" rid="S4.F9">9</xref>. Os valores utilizados, normalizados em relação ao parâmetro de hopping da ligação <inline-formula id="S4.p20.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>C</mml:mi><mml:mo>-</mml:mo><mml:mi>C</mml:mi></mml:mrow></mml:math></inline-formula>, foram os seguintes: <inline-formula id="S4.p20.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msup><mml:mi>t</mml:mi><mml:mo>′</mml:mo></mml:msup><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>9</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.p20.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>η</mml:mi><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>02</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p20.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mrow><mml:mi mathvariant="normal">Δ</mml:mi><mml:mo>⁢</mml:mo><mml:mi>E</mml:mi></mml:mrow><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo>-</mml:mo><mml:mn>0.1</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>. Naturalmente, a molécula de ciclopentadieno tem uma simetria maior do que o tiofeno. A quebra de simetria é realizada pela substituição de um átomo de carbono por um de enxofre. É sabido que situações mais simétricas favorecem a degenerescência dos níveis de energia. Na Figura<xref ref-type="fig" rid="S4.F9">9</xref>-A pode-se perceber que para o ciclopendadieno há dois níveis de energia duplamente degenerados, sem considerar ainda o spin, em <inline-formula id="S4.p20.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>E</mml:mi><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mn>6</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p20.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>E</mml:mi><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mrow><mml:mo>-</mml:mo><mml:mn>1</mml:mn></mml:mrow><mml:mo>,</mml:mo><mml:mn>6</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>, admitidos aqui como os orbitais LUMO e HOMO, respectivamente, produzindo um <italic>bandgap</italic><inline-formula id="S4.p20.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>g</mml:mi></mml:msub><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>,</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>. Há ainda um nível de energia superior localizado em <inline-formula id="S4.p20.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:mi>E</mml:mi><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:math></inline-formula>, não degenerado, a menos daquela devida ao spin. O grau de degenerescência de cada nível pode ser inferido a partir das amplitudes das densidades de estados. Para a molécula de tiofeno a densidade de estados está mostrada na Figura<xref ref-type="fig" rid="S4.F9">9</xref>-B. Note que aqueles níveis de energia degenerados no ciclopentadieno se separam, e além da remoção da degenerescência ocorre uma redução do <italic>bandgap</italic> para <inline-formula id="S4.p20.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>g</mml:mi></mml:msub><mml:mo>/</mml:mo><mml:mi>t</mml:mi></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>,</mml:mo><mml:mn>0</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula>. A lição que se pode tirar desse exemplo é que a introdução de impurezas substitucionais remove pelo menos algumas degenerescências no espectro de <inline-formula id="S4.p20.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mover accent="true"><mml:mi>H</mml:mi><mml:mo stretchy="false">^</mml:mo></mml:mover></mml:math></inline-formula> e ainda altera o <italic>bandgap</italic> de energia.</p>
+      <fig id="S4.F9">
+        <label>Figura 9:</label>
+        <caption>
+          <title>Densidades de estados para as moléculas de (A) ciclopentadieno e (B) tiofeno. Note que, dada a similaridade estrutural das duas moléculas, os níveis de energia estão localizados em valores próximos. No entanto, a substituição de um átomo de carbono pelo enxofre remove degenerescências e reduz o valor do <italic>bandgap</italic> .</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/090d995e7d3fe6a3969e5456982f5c684c9ec6ff.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/accc37cae684ae38b9efbff477b3197329875f95.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Finalizando esta presente Seção, considere cadeias poliméricas lineares, como o poliacetileno, cujo estudo pode ser realizado utilizando um Hamiltoniano de <italic>tight-binding</italic> com possibilidade de salto entre primeiros vizinhos, cuja forma matricial para o problema de um elétron é a seguinte:</p>
+      <p>
+        <disp-formula id="S4.E65">
+          <label>(65)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mpadded width="+1.7pt">
+                  <mml:mover accent="true">
+                    <mml:mi>H</mml:mi>
+                    <mml:mo stretchy="false">^</mml:mo>
+                  </mml:mover>
+                </mml:mpadded>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mo>(</mml:mo>
+                  <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>1</mml:mn>
+                          </mml:msub>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msub>
+                              <mml:mi>t</mml:mi>
+                              <mml:mn>12</mml:mn>
+                            </mml:msub>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mn>0</mml:mn>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msubsup>
+                              <mml:mi>t</mml:mi>
+                              <mml:mn>12</mml:mn>
+                              <mml:mo>*</mml:mo>
+                            </mml:msubsup>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>2</mml:mn>
+                          </mml:msub>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:msub>
+                            <mml:mi>t</mml:mi>
+                            <mml:mn>23</mml:mn>
+                          </mml:msub>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mn>0</mml:mn>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mn>0</mml:mn>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msubsup>
+                              <mml:mi>t</mml:mi>
+                              <mml:mn>23</mml:mn>
+                              <mml:mo>*</mml:mo>
+                            </mml:msubsup>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>3</mml:mn>
+                          </mml:msub>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msub>
+                              <mml:mi>t</mml:mi>
+                              <mml:mn>34</mml:mn>
+                            </mml:msub>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mn>0</mml:mn>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mn>0</mml:mn>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mn>0</mml:mn>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msubsup>
+                              <mml:mi>t</mml:mi>
+                              <mml:mn>34</mml:mn>
+                              <mml:mo>*</mml:mo>
+                            </mml:msubsup>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>4</mml:mn>
+                          </mml:msub>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mi mathvariant="normal">⋮</mml:mi>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:msub>
+                            <mml:mi>t</mml:mi>
+                            <mml:mrow>
+                              <mml:mrow>
+                                <mml:mi>N</mml:mi>
+                                <mml:mo>-</mml:mo>
+                                <mml:mn>1</mml:mn>
+                              </mml:mrow>
+                              <mml:mo>,</mml:mo>
+                              <mml:mi>N</mml:mi>
+                            </mml:mrow>
+                          </mml:msub>
+                        </mml:mrow>
+                      </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mpadded width="+5pt">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mpadded>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:mrow>
+                          <mml:mo>-</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msubsup>
+                              <mml:mi>t</mml:mi>
+                              <mml:mrow>
+                                <mml:mrow>
+                                  <mml:mi>N</mml:mi>
+                                  <mml:mo>-</mml:mo>
+                                  <mml:mn>1</mml:mn>
+                                </mml:mrow>
+                                <mml:mo>,</mml:mo>
+                                <mml:mi>N</mml:mi>
+                              </mml:mrow>
+                              <mml:mo>*</mml:mo>
+                            </mml:msubsup>
+                          </mml:mpadded>
+                        </mml:mrow>
+                      </mml:mtd>
+                      <mml:mtd columnalign="center">
+                        <mml:msub>
+                          <mml:mi>E</mml:mi>
+                          <mml:mi>N</mml:mi>
+                        </mml:msub>
+                      </mml:mtd>
+                    </mml:mtr>
+                  </mml:mtable>
+                  <mml:mo rspace="0.8pt">)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>onde <inline-formula id="S4.p21.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> é o número de átomos da cadeia, <inline-formula id="S4.p21.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>E</mml:mi><mml:mi>j</mml:mi></mml:msub></mml:math></inline-formula> é a energia do orbital atômico relevante no <inline-formula id="S4.p21.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>-ésimo átomo da cadeia e <inline-formula id="S4.p21.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>,</mml:mo><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:mrow></mml:msub></mml:math></inline-formula> é o parâmetro de hopping entre os átomos localizados nos sítios <inline-formula id="S4.p21.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula> e <inline-formula id="S4.p21.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:math></inline-formula>, <inline-formula id="S4.p21.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>j</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>1</mml:mn><mml:mo>,</mml:mo><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi mathvariant="normal">…</mml:mi><mml:mo>⁢</mml:mo><mml:mi>N</mml:mi></mml:mrow></mml:mrow></mml:mrow></mml:math></inline-formula>. No caso em que todos os átomos da cadeia são idênticos e não há defeitos deve-se assumir que <inline-formula id="S4.p21.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>t</mml:mi><mml:mrow><mml:mi>j</mml:mi><mml:mo>,</mml:mo><mml:mrow><mml:mi>j</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:mrow></mml:msub><mml:mo>=</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:math></inline-formula> e <inline-formula id="S4.p21.m9"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:msub><mml:mi>E</mml:mi><mml:mi>j</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:msub><mml:mi>E</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:mrow></mml:math></inline-formula> para qualquer <inline-formula id="S4.p21.m10"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>j</mml:mi></mml:math></inline-formula>. A inclusão de defeitos e impurezas se dá através da modificação de alguns valores de energia e de parâmetro de hopping no Hamiltoniano, correspondentes aos sítios onde ocorrem. No caso mais simples da uma cadeia polimérica linear de <inline-formula id="S4.p21.m11"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> átomos de carbono, o Hamiltoniano (<xref ref-type="disp-formula" rid="S4.E65">65</xref>) pode ser escrito explicitamente:</p>
+      <p>
+        <disp-formula id="S4.E66">
+          <label>(66)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mover accent="true">
+                  <mml:mi>H</mml:mi>
+                  <mml:mo stretchy="false">^</mml:mo>
+                </mml:mover>
+                <mml:mo>=</mml:mo>
+                <mml:msub>
+                  <mml:mrow>
+                    <mml:mo>(</mml:mo>
+                    <mml:mtable columnspacing="5pt" displaystyle="true" rowspacing="0pt">
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                      </mml:mtr>
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                      </mml:mtr>
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                      </mml:mtr>
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mtd>
+                      </mml:mtr>
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋮</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">⋱</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                      </mml:mtr>
+                      <mml:mtr>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi mathvariant="normal">…</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mn>0</mml:mn>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:mi>t</mml:mi>
+                        </mml:mtd>
+                        <mml:mtd columnalign="center">
+                          <mml:msub>
+                            <mml:mi>E</mml:mi>
+                            <mml:mn>0</mml:mn>
+                          </mml:msub>
+                        </mml:mtd>
+                      </mml:mtr>
+                    </mml:mtable>
+                    <mml:mo>)</mml:mo>
+                  </mml:mrow>
+                  <mml:mrow>
+                    <mml:mi>N</mml:mi>
+                    <mml:mo>×</mml:mo>
+                    <mml:mi>N</mml:mi>
+                  </mml:mrow>
+                </mml:msub>
+              </mml:mrow>
+              <mml:mo>,</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>sendo um caso particular de matriz de Toeplitz [<xref ref-type="bibr" rid="b24">24</xref>], cujos autovalores são dados por:</p>
+      <p>
+        <disp-formula id="S4.E67">
+          <label>(67)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mi>E</mml:mi>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:mrow>
+                      <mml:mo stretchy="false">(</mml:mo>
+                      <mml:mi>k</mml:mi>
+                      <mml:mo stretchy="false">)</mml:mo>
+                    </mml:mrow>
+                  </mml:mrow>
+                  <mml:mo>=</mml:mo>
+                  <mml:mrow>
+                    <mml:msub>
+                      <mml:mi>E</mml:mi>
+                      <mml:mn>0</mml:mn>
+                    </mml:msub>
+                    <mml:mo>+</mml:mo>
+                    <mml:mrow>
+                      <mml:mn>2</mml:mn>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>t</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mrow>
+                        <mml:mi>cos</mml:mi>
+                        <mml:mo>⁡</mml:mo>
+                        <mml:mrow>
+                          <mml:mo>(</mml:mo>
+                          <mml:mfrac>
+                            <mml:mrow>
+                              <mml:mi>k</mml:mi>
+                              <mml:mo>⁢</mml:mo>
+                              <mml:mi>π</mml:mi>
+                            </mml:mrow>
+                            <mml:mrow>
+                              <mml:mi>N</mml:mi>
+                              <mml:mo>+</mml:mo>
+                              <mml:mn>1</mml:mn>
+                            </mml:mrow>
+                          </mml:mfrac>
+                          <mml:mo>)</mml:mo>
+                        </mml:mrow>
+                      </mml:mrow>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+                <mml:mo rspace="5.8pt">,</mml:mo>
+                <mml:mrow>
+                  <mml:mi>k</mml:mi>
+                  <mml:mo>=</mml:mo>
+                  <mml:mrow>
+                    <mml:mn>1</mml:mn>
+                    <mml:mo>,</mml:mo>
+                    <mml:mrow>
+                      <mml:mn>2</mml:mn>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi mathvariant="normal">…</mml:mi>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>N</mml:mi>
+                    </mml:mrow>
+                  </mml:mrow>
+                </mml:mrow>
+              </mml:mrow>
+              <mml:mo>.</mml:mo>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+      </p>
+      <p>Tomando-se o limite <inline-formula id="S4.p22.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>→</mml:mo><mml:mi mathvariant="normal">∞</mml:mi></mml:mrow></mml:math></inline-formula> o espectro de energias tende ao <italic>continuum</italic> e a largura total da banda de energia terá valor <inline-formula id="S4.p22.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>4</mml:mn><mml:mo>⁢</mml:mo><mml:mi>t</mml:mi></mml:mrow></mml:math></inline-formula>, inexistindo um gap, reproduzindo o resultado obtido na Seção 3 do presente trabalho. Todavia, para <inline-formula id="S4.p22.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> finito e com o preenchimento de níveis até a metade, haverá uma diferença de energia entre o LUMO e o HOMO que dependerá do comprimento da cadeia, aqui representado pelo número total de átomos.</p>
+      <p>As densidades de estados para cadeias lineares contendo <inline-formula id="S4.p23.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>=</mml:mo><mml:mrow><mml:mn>4</mml:mn><mml:mo>,</mml:mo><mml:mn>8</mml:mn></mml:mrow></mml:mrow></mml:math></inline-formula> e 16 átomos de carbono, calculadas através das equações (<xref ref-type="disp-formula" rid="S4.E63">63</xref>) e (<xref ref-type="disp-formula" rid="S4.E64">64</xref>), são mostradas na Figura<xref ref-type="fig" rid="S4.F10">10</xref>. O que fica evidente é a diminuição do gap entre o LUMO e o HOMO com o aumento de <inline-formula id="S4.p23.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula>. Quando o valor do número de átomos <inline-formula id="S4.p23.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula> na cadeia polimérica conjugada é grande, formam-se estruturas de bandas similares aos dos semicondutores inorgânicos (Si,Ge, etc). Os valores do <italic>bandgap</italic>, medidos pela separação entre o HOMO e o LUMO, assumem valores tipicamente entre 1.5 a 3.5 eV, sendo determinantes nas propriedades eletro-ópticas dessas cadeias.</p>
+      <fig id="S4.F10">
+        <label>Figura 10:</label>
+        <caption>
+          <title>Densidades de estados obtidas através da função de Green retardada para cadeias lineares contendo A) <inline-formula id="S4.F10.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>=</mml:mo><mml:mn>4</mml:mn></mml:mrow></mml:math></inline-formula>, B) <inline-formula id="S4.F10.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>=</mml:mo><mml:mn>8</mml:mn></mml:mrow></mml:math></inline-formula> e C) <inline-formula id="S4.F10.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>N</mml:mi><mml:mo>=</mml:mo><mml:mn>16</mml:mn></mml:mrow></mml:math></inline-formula> átomos de carbono, evidenciando a diminuição do gap com o aumento de <inline-formula id="S4.F10.m8"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mi>N</mml:mi></mml:math></inline-formula>.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/a15677950f19bbdbc6039dce578623f50c1c728d.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/Tr6nFmXB9F5zsBkxfsRMpXd/a605d91ac8e22e1d1cd5ab07d131a82c7de7ec31.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Tendo em vista que um material polimérico orgânico é tipicamente obtido da condensação de um conjunto de cadeias poliméricas lineares cujos comprimentos são variáveis, existirá uma estatística associada ao níveis de energia dos orbitais HOMO e LUMO. Uma boa aproximação é considerar distribuições gaussianas em torno dos níveis médios do HOMO e do LUMO. Além disso, podem ocorrer níveis de energia dentro do gap, que são evidências da presença de defeitos, como quebras, impurezas substitucionais, enovelamentos e isomerizações nas cadeias. A dispersão estatística em relação ao comprimento das cadeias poliméricas afeta propriedades de transporte de carga elétrica,como a mobilidade dos portadores de carga, por exemplo.</p>
+    </sec>
+    <sec id="S5">
+      <title>5. Conclusão</title>
+      <p>No presente trabalho foi apresentado o procedimento geral de segunda quantização, especializado para a obtenção dos modelos de <italic>tight-binding</italic>, que constituem um dos pilares da Física da Matéria Condensada. A conversão das funções de ondas descrevendo a amplitude de probabilidade dos elétrons na primera quantização em operadores de campo é realizada através de uma álgebra fermiônica, que foi discutida brevemente. Primeiramente, o método geral foi empregado no estudo de um modelo de brinquedo para uma macromolécula polimérica linear muito longa, através da aproximação de cadeia atômica unidimensional infinita. A diagonalização do Hamiltoniano de <italic>tight-binding</italic> nesse caso leva à formação de uma banda de energia, cuja largura depende do diretamente do parâmetro de salto. Adicionalmente, foi possível prever, com base no comportamento do parâmetro de hopping, que a mobilidade de elétrons na banda de condução tende a ser maior do que a mobilidade das lacunas na banda de valência. Na sequência, alguns monômeros de relevância na área de polímeros orgânicos conjugados foram analisados, dentre eles o benzeno e o tiofeno. O método de <italic>tight-binding</italic> permitiu determinar os níveis de energia HOMO e LUMO do benzeno e, indo um pouco adiante, as densidades de estados do tiofeno e do ciclopentadieno, bem como discutir aspectos gerais associados à estrutura dos níveis de energia de cadeias poliméricas.</p>
+    </sec>
+  </body>
+  <back>
+    <ack>
+      <title>Agradecimentos</title>
+      <p>O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior – Brasil (CAPES) – Código de Financiamento 001.</p>
+    </ack>
+    <ref-list>
+      <title>Referênces</title>
+      <ref id="b1">
+        <label>[1]</label>
+        <mixed-citation>[1] W. Callister Jr. e D.G. Rethwisch, <italic>Fundamentos da Ciência e Engenharia dos Materiais: Abordagem Integrada</italic> (LTC, Rio de Janeiro, 2014).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Callister</surname>
+              <given-names>W.</given-names>
+              <suffix>Jr.</suffix>
+            </name>
+            <name>
+              <surname>Rethwisch</surname>
+              <given-names>D.G.</given-names>
+            </name>
+          </person-group>
+          <source>Fundamentos da Ciência e Engenharia dos Materiais: Abordagem Integrada</source>
+          <publisher-name>LTC</publisher-name>
+          <publisher-loc>Rio de Janeiro</publisher-loc>
+          <year>2014</year>
+        </element-citation>
+      </ref>
+      <ref id="b2">
+        <label>[2]</label>
+        <mixed-citation>[2] J.D. Shackelford, <italic>Ciência dos Materiais</italic> (Pearson, São Paulo, 2008), 6<sup>a</sup> ed.</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Shackelford</surname>
+              <given-names>J.D.</given-names>
+            </name>
+          </person-group>
+          <source>Ciência dos Materiais</source>
+          <publisher-name>Pearson</publisher-name>
+          <publisher-loc>São Paulo</publisher-loc>
+          <year>2008</year>
+          <edition>6<sup>a</sup> ed.</edition>
+        </element-citation>
+      </ref>
+      <ref id="b3">
+        <label>[3]</label>
+        <mixed-citation>[3] H. Shirakawa, E.J. Louis, A.G. MacDiarmid, C.K. Chiang e A.J. Heeger, Journal of the Chemical Society, Chemical Communications 16 , 578 (1977).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Shirakawa</surname>
+              <given-names>H.</given-names>
+            </name>
+            <name>
+              <surname>Louis</surname>
+              <given-names>E.J.</given-names>
+            </name>
+            <name>
+              <surname>MacDiarmid</surname>
+              <given-names>A.G.</given-names>
+            </name>
+            <name>
+              <surname>Chiang</surname>
+              <given-names>C.K.</given-names>
+            </name>
+            <name>
+              <surname>Heeger</surname>
+              <given-names>A.J.</given-names>
+            </name>
+          </person-group>
+          <source>Journal of the Chemical Society, Chemical Communications</source>
+          <volume>16</volume>
+          <page-range>578</page-range>
+          <year>1977</year>
+        </element-citation>
+      </ref>
+      <ref id="b4">
+        <label>[4]</label>
+        <mixed-citation>[4] C.K. Chiang, C.R. Finche, Y.W. Park, A.J. Heeger, H. Shirakawa, E.J. Lois, S.C. Gau e A.G. MacDiarmid, Phys. Rev. Lett. 39 , 1098 (1977).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Chiang</surname>
+              <given-names>C.K.</given-names>
+            </name>
+            <name>
+              <surname>Finche</surname>
+              <given-names>C.R.</given-names>
+            </name>
+            <name>
+              <surname>Park</surname>
+              <given-names>Y.W.</given-names>
+            </name>
+            <name>
+              <surname>Heeger</surname>
+              <given-names>A.J.</given-names>
+            </name>
+            <name>
+              <surname>Shirakawa</surname>
+              <given-names>H.</given-names>
+            </name>
+            <name>
+              <surname>Lois</surname>
+              <given-names>E.J.</given-names>
+            </name>
+            <name>
+              <surname>Gau</surname>
+              <given-names>S.C.</given-names>
+            </name>
+            <name>
+              <surname>MacDiarmid</surname>
+              <given-names>A.G.</given-names>
+            </name>
+          </person-group>
+          <source>Phys. Rev. Lett.</source>
+          <volume>39</volume>
+          <page-range>1098</page-range>
+          <year>1977</year>
+        </element-citation>
+      </ref>
+      <ref id="b5">
+        <label>[5]</label>
+        <mixed-citation>[5] N.S. Sariciftci, L. Smilowitz, A.J. Heeger e F. Wuld, Science 258 , 1474 (1992).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Sariciftci</surname>
+              <given-names>N.S.</given-names>
+            </name>
+            <name>
+              <surname>Smilowitz</surname>
+              <given-names>L.</given-names>
+            </name>
+            <name>
+              <surname>Heeger</surname>
+              <given-names>A.J.</given-names>
+            </name>
+            <name>
+              <surname>Wuld</surname>
+              <given-names>F.</given-names>
+            </name>
+          </person-group>
+          <source>Science</source>
+          <volume>258</volume>
+          <page-range>1474</page-range>
+          <year>1992</year>
+        </element-citation>
+      </ref>
+      <ref id="b6">
+        <label>[6]</label>
+        <mixed-citation>[6] A.J. Heeger, S. Kivelson, J.R. Schrieffer e W.-P. Su, Rev. Mod. Phys. 60 , 781 (1988).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Heeger</surname>
+              <given-names>A.J.</given-names>
+            </name>
+            <name>
+              <surname>Kivelson</surname>
+              <given-names>S.</given-names>
+            </name>
+            <name>
+              <surname>Schrieffer</surname>
+              <given-names>J.R.</given-names>
+            </name>
+            <name>
+              <surname>Su</surname>
+              <given-names>W.-P.</given-names>
+            </name>
+          </person-group>
+          <source>Rev. Mod. Phys.</source>
+          <volume>60</volume>
+          <page-range>781</page-range>
+          <year>1988</year>
+        </element-citation>
+      </ref>
+      <ref id="b7">
+        <label>[7]</label>
+        <mixed-citation>[7] M. Pope, H.P. Kallmann e P. Magnante, J. Chem. Phys. 38 , 2042 (1963).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Pope</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Kallmann</surname>
+              <given-names>H.P.</given-names>
+            </name>
+            <name>
+              <surname>Magnante</surname>
+              <given-names>P.</given-names>
+            </name>
+          </person-group>
+          <source>J. Chem. Phys.</source>
+          <volume>38</volume>
+          <page-range>2042</page-range>
+          <year>1963</year>
+        </element-citation>
+      </ref>
+      <ref id="b8">
+        <label>[8]</label>
+        <mixed-citation>[8] J.J.M. Halls, <italic>Photoconductive properties of conjugated polymers</italic> . Doctoral Thesis, University of Cambridge, Cambridge (1997).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Halls</surname>
+              <given-names>J.J.M.</given-names>
+            </name>
+          </person-group>
+          <source>Photoconductive properties of conjugated polymers</source>
+          <publisher-name>Doctoral Thesis, University of Cambridge</publisher-name>
+          <publisher-loc>Cambridge</publisher-loc>
+          <year>1997</year>
+        </element-citation>
+      </ref>
+      <ref id="b9">
+        <label>[9]</label>
+        <mixed-citation>[9] B.R. Weinberger, M.Akhtar e S.C. Gau, Synthetic Metals 4 , 187 (1982).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Weinberger</surname>
+              <given-names>B.R.</given-names>
+            </name>
+            <name>
+              <surname>Akhtar</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Gau</surname>
+              <given-names>S.C.</given-names>
+            </name>
+          </person-group>
+          <source>Synthetic Metals</source>
+          <volume>4</volume>
+          <page-range>187</page-range>
+          <year>1982</year>
+        </element-citation>
+      </ref>
+      <ref id="b10">
+        <label>[10]</label>
+        <mixed-citation>[10] A.A. Lima, N.P.Menezes, S. Santos, B. Amorim, F. Thomazi, F. Zanella, A. Heilmann, E. Burkarter e C.A. Dartora, Revista Brasileira de Ensino de Física 42 , e20190191 (2020).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Lima</surname>
+              <given-names>A.A.</given-names>
+            </name>
+            <name>
+              <surname>Menezes</surname>
+              <given-names>N.P.</given-names>
+            </name>
+            <name>
+              <surname>Santos</surname>
+              <given-names>S.</given-names>
+            </name>
+            <name>
+              <surname>Amorim</surname>
+              <given-names>B.</given-names>
+            </name>
+            <name>
+              <surname>Thomazi</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Zanella</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Heilmann</surname>
+              <given-names>A.</given-names>
+            </name>
+            <name>
+              <surname>Burkarter</surname>
+              <given-names>E.</given-names>
+            </name>
+            <name>
+              <surname>Dartora</surname>
+              <given-names>C.A.</given-names>
+            </name>
+          </person-group>
+          <source>Revista Brasileira de Ensino de Física</source>
+          <volume>42</volume>
+          <page-range>e20190191</page-range>
+          <year>2020</year>
+        </element-citation>
+      </ref>
+      <ref id="b11">
+        <label>[11]</label>
+        <mixed-citation>[11] F. Thomazi, M. Souza, C.K. Saul, G.A. Viana, F.C. Marques, R. Silvestre, M. Brehm, C.E.B. Marino, E. Burkarter e C.A. Dartora, Current Nanoscience 10 , 877 (2014).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Thomazi</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Souza</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Saul</surname>
+              <given-names>C.K.</given-names>
+            </name>
+            <name>
+              <surname>Viana</surname>
+              <given-names>G.A.</given-names>
+            </name>
+            <name>
+              <surname>Marques</surname>
+              <given-names>F.C.</given-names>
+            </name>
+            <name>
+              <surname>Silvestre</surname>
+              <given-names>R.</given-names>
+            </name>
+            <name>
+              <surname>Brehm</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Marino</surname>
+              <given-names>C.E.B.</given-names>
+            </name>
+            <name>
+              <surname>Burkarter</surname>
+              <given-names>E.</given-names>
+            </name>
+            <name>
+              <surname>Dartora</surname>
+              <given-names>C.A.</given-names>
+            </name>
+          </person-group>
+          <source>Current Nanoscience</source>
+          <volume>10</volume>
+          <page-range>877</page-range>
+          <year>2014</year>
+        </element-citation>
+      </ref>
+      <ref id="b12">
+        <label>[12]</label>
+        <mixed-citation>[12] F. Thomazi, C.K. Saul, C. Marino, E. Burkarter e C.A. Dartora, Current Nanoscience 12 , 611 (2016).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Thomazi</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Saul</surname>
+              <given-names>C.K.</given-names>
+            </name>
+            <name>
+              <surname>Marino</surname>
+              <given-names>C.</given-names>
+            </name>
+            <name>
+              <surname>Burkarter</surname>
+              <given-names>E.</given-names>
+            </name>
+            <name>
+              <surname>Dartora</surname>
+              <given-names>C.A.</given-names>
+            </name>
+          </person-group>
+          <source>Current Nanoscience</source>
+          <volume>12</volume>
+          <page-range>611</page-range>
+          <year>2016</year>
+        </element-citation>
+      </ref>
+      <ref id="b13">
+        <label>[13]</label>
+        <mixed-citation>[13] L.B. Schneider, F. Thomazi, E. Burkarter, C.E.B. Marino, C.K. Saul, A.S. Ito e C.A. Dartora, Current Nanoscience 14 , 403 (2018).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Schneider</surname>
+              <given-names>L.B.</given-names>
+            </name>
+            <name>
+              <surname>Thomazi</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Burkarter</surname>
+              <given-names>E.</given-names>
+            </name>
+            <name>
+              <surname>Marino</surname>
+              <given-names>C.E.B.</given-names>
+            </name>
+            <name>
+              <surname>Saul</surname>
+              <given-names>C.K.</given-names>
+            </name>
+            <name>
+              <surname>Ito</surname>
+              <given-names>A.S.</given-names>
+            </name>
+            <name>
+              <surname>Dartora</surname>
+              <given-names>C.A.</given-names>
+            </name>
+          </person-group>
+          <source>Current Nanoscience</source>
+          <volume>14</volume>
+          <page-range>403</page-range>
+          <year>2018</year>
+        </element-citation>
+      </ref>
+      <ref id="b14">
+        <label>[14]</label>
+        <mixed-citation>[14] Z. Qiu, B.A.G. Hammer e K. Müllen, Progress in Polymer Science 100 , 101179 (2020).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Qiu</surname>
+              <given-names>Z.</given-names>
+            </name>
+            <name>
+              <surname>Hammer</surname>
+              <given-names>B.A.G.</given-names>
+            </name>
+            <name>
+              <surname>Müllen</surname>
+              <given-names>K.</given-names>
+            </name>
+          </person-group>
+          <source>Progress in Polymer Science</source>
+          <volume>100</volume>
+          <page-range>101179</page-range>
+          <year>2020</year>
+        </element-citation>
+      </ref>
+      <ref id="b15">
+        <label>[15]</label>
+        <mixed-citation>[15] C.A. Dartora, M.J. Saldaña Jimenez e F. Zanella, Revista Brasileira de Ensino de Física 37 , 3301 (2015).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Dartora</surname>
+              <given-names>C.A.</given-names>
+            </name>
+            <name>
+              <surname>Saldaña Jimenez</surname>
+              <given-names>M.J.</given-names>
+            </name>
+            <name>
+              <surname>Zanella</surname>
+              <given-names>F.</given-names>
+            </name>
+          </person-group>
+          <source>Revista Brasileira de Ensino de Física</source>
+          <volume>37</volume>
+          <page-range>3301</page-range>
+          <year>2015</year>
+        </element-citation>
+      </ref>
+      <ref id="b16">
+        <label>[16]</label>
+        <mixed-citation>[16] M. Alonso e E.J. Finn, <italic>Física</italic> (Editora Escolar, São Paulo, 2012).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Alonso</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Finn</surname>
+              <given-names>E.J.</given-names>
+            </name>
+          </person-group>
+          <source>Física</source>
+          <publisher-name>Editora Escolar</publisher-name>
+          <publisher-loc>São Paulo</publisher-loc>
+          <year>2012</year>
+        </element-citation>
+      </ref>
+      <ref id="b17">
+        <label>[17]</label>
+        <mixed-citation>[17] W. Greiner e J. Reinhardt, <italic>Field Quantization</italic> (Springer-Verlag, Berlin, Heidelberg, 1996).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Greiner</surname>
+              <given-names>W.</given-names>
+            </name>
+            <name>
+              <surname>Reinhardt</surname>
+              <given-names>J.</given-names>
+            </name>
+          </person-group>
+          <source>Field Quantization</source>
+          <publisher-name>Springer-Verlag</publisher-name>
+          <publisher-loc>Berlin, Heidelberg</publisher-loc>
+          <year>1996</year>
+        </element-citation>
+      </ref>
+      <ref id="b18">
+        <label>[18]</label>
+        <mixed-citation>[18] C. Kittel, <italic>Quantum Theory of Solids</italic> (John Wiley &amp; Sons, New York, 1987), 2<sup>a</sup> ed.</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Kittel</surname>
+              <given-names>C.</given-names>
+            </name>
+          </person-group>
+          <source>Quantum Theory of Solids</source>
+          <publisher-name>John Wiley &amp; Sons</publisher-name>
+          <publisher-loc>New York</publisher-loc>
+          <year>1987</year>
+          <edition>2<sup>a</sup> ed.</edition>
+        </element-citation>
+      </ref>
+      <ref id="b19">
+        <label>[19]</label>
+        <mixed-citation>[19] J.C. Slater e G.F. Koster, Physical Review 94 , 1498 (1954).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Slater</surname>
+              <given-names>J.C.</given-names>
+            </name>
+            <name>
+              <surname>Koster</surname>
+              <given-names>G.F.</given-names>
+            </name>
+          </person-group>
+          <source>Physical Review</source>
+          <volume>94</volume>
+          <page-range>1498</page-range>
+          <year>1954</year>
+        </element-citation>
+      </ref>
+      <ref id="b20">
+        <label>[20]</label>
+        <mixed-citation>[20] A. Heeger, <italic>Semiconducting and Metallic Polymers: The Fourth Generation of Polymeric Materials</italic>, disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/heeger/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/heeger/lecture/</ext-link>, acessado em 01/07/2021.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Heeger</surname>
+              <given-names>A.</given-names>
+            </name>
+          </person-group>
+          <source>Semiconducting and Metallic Polymers: The Fourth Generation of Polymeric Materials</source>
+          <comment>disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/heeger/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/heeger/lecture/</ext-link>,</comment>
+          <date-in-citation>acessado em 01/07/2021.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="b21">
+        <label>[21]</label>
+        <mixed-citation>[21] A.G. MacDiarmid, <italic>“Synthetic Metals”: A Novel Role for Organic Polymers</italic>, disponível: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/macdiarmid/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/macdiarmid/lecture/</ext-link>, acessado em 02/07/2021.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>MacDiarmid</surname>
+              <given-names>A.G.</given-names>
+            </name>
+          </person-group>
+          <source>“Synthetic Metals”: A Novel Role for Organic Polymers</source>
+          <comment>disponível: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/macdiarmid/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/macdiarmid/lecture/</ext-link>,</comment>
+          <date-in-citation>acessado em 02/07/2021.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="b22">
+        <label>[22]</label>
+        <mixed-citation>[22] H. Shirakawa, <italic>The Discovery of Polyacetylene Film: The Dawning of an Era of Conducting Polymers</italic>, disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/shirakawa/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/shirakawa/lecture/</ext-link>, acessado em 01/07/2021.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Shirakawa</surname>
+              <given-names>H.</given-names>
+            </name>
+          </person-group>
+          <source>The Discovery of Polyacetylene Film: The Dawning of an Era of Conducting Polymers</source>
+          <comment>disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.nobelprize.org/prizes/chemistry/2000/shirakawa/lecture/">https://www.nobelprize.org/prizes/chemistry/2000/shirakawa/lecture/</ext-link>,</comment>
+          <date-in-citation>acessado em 01/07/2021.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="b23">
+        <label>[23]</label>
+        <mixed-citation>[23] H.N. Nazareno, <italic>Mecânica Estatística e Funções de Green</italic> (UnB, Brasília, 2010), 2<sup>a</sup> ed.</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Nazareno</surname>
+              <given-names>H.N.</given-names>
+            </name>
+          </person-group>
+          <source>Mecânica Estatística e Funções de Green</source>
+          <publisher-name>UnB</publisher-name>
+          <publisher-loc>Brasília</publisher-loc>
+          <year>2010</year>
+          <edition>2<sup>a</sup> ed.</edition>
+        </element-citation>
+      </ref>
+      <ref id="b24">
+        <label>[24]</label>
+        <mixed-citation>[24] R.M. Gray, Foundations and Trends in Communications and Information Theory 2 , 155 (2006).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Gray</surname>
+              <given-names>R.M.</given-names>
+            </name>
+          </person-group>
+          <source>Foundations and Trends in Communications and Information Theory</source>
+          <volume>2</volume>
+          <page-range>155</page-range>
+          <year>2006</year>
+        </element-citation>
+      </ref>
+    </ref-list>
+    <fn-group>
+      <fn fn-type="other" id="footnote1">
+        <label>1</label>
+        <p>O número quântico de spin será omitido nas expressões para os orbitais <inline-formula id="footnote1.m1"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:mi>s</mml:mi></mml:mrow></mml:math></inline-formula>, <inline-formula id="footnote1.m2"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>x</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula>, <inline-formula id="footnote1.m3"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>y</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> e <inline-formula id="footnote1.m4"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mn>2</mml:mn><mml:mo>⁢</mml:mo><mml:msub><mml:mi>p</mml:mi><mml:mi>z</mml:mi></mml:msub></mml:mrow></mml:math></inline-formula> e nas que se seguirão. Cada um deles é duplamente degenerado devido ao spin eletrônico, que pode assumir as projeções <inline-formula id="footnote1.m5"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mo>↑</mml:mo></mml:math></inline-formula> ou <inline-formula id="footnote1.m6"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mo>↓</mml:mo></mml:math></inline-formula>, significando que caberia um total de 8 elétrons na camada <inline-formula id="footnote1.m7"><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline"><mml:mrow><mml:mi>n</mml:mi><mml:mo>=</mml:mo><mml:mn>2</mml:mn></mml:mrow></mml:math></inline-formula>.</p>
+      </fn>
+      <fn fn-type="other" id="footnote2">
+        <label>2</label>
+        <p> do inglês <italic>highest occupied molecular orbital</italic></p>
+      </fn>
+      <fn fn-type="other" id="footnote3">
+        <label>3</label>
+        <p>do inglês <italic>lowest unoccupied molecular orbital</italic></p>
+      </fn>
+    </fn-group>
+  </back>
+</article>

--- a/tests/fixtures/dot_in_id/tabelas.xml
+++ b/tests/fixtures/dot_in_id/tabelas.xml
@@ -1,0 +1,1464 @@
+
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "http://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">rbef</journal-id>
+      <journal-title-group>
+        <journal-title>Revista Brasileira de Ensino de Física</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Rev. Bras. Ensino Fís.</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">1806-1117</issn>
+      <issn pub-type="epub">1806-9126</issn>
+      <publisher>
+        <publisher-name>Sociedade Brasileira de Física</publisher-name>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id specific-use="scielo-v3" pub-id-type="publisher-id">cRtRZdqFhRZZ35Hn6WvjzKx</article-id>
+      <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1806-11172021000100739</article-id>
+      <article-id pub-id-type="doi">10.1590/1806-9126-RBEF-2021-0153</article-id>
+      <article-id pub-id-type="other">00739</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>Produtos e Materiais Didáticos</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>Desenvolvimento de uma Microbalança de Cristal de Quartzo – MCQ experimental como ferramenta para o ensino de física moderna</article-title>
+        <trans-title-group xml:lang="en">
+          <trans-title>Development of an Experimental Quartz Crystal Microbalance – MCQ as a tool for teaching modern physics</trans-title>
+        </trans-title-group>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-6516-8072</contrib-id>
+          <name>
+            <surname>Lima</surname>
+            <given-names>Gilson Tavares de</given-names>
+          </name>
+          <xref ref-type="corresp" rid="c001">*</xref>
+          <xref ref-type="aff" rid="aff1">
+            <sup>1</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-3560-0749</contrib-id>
+          <name>
+            <surname>Marson</surname>
+            <given-names>Poliana Guerino</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff2">
+            <sup>2</sup>
+          </xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-7120-951X</contrib-id>
+          <name>
+            <surname>Santos</surname>
+            <given-names>Helcileia Dias</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff3">
+            <sup>3</sup>
+          </xref>
+        </contrib>
+        <aff id="aff1">
+          <label>1</label>
+          <institution content-type="original">Instituto Federal de Educação, Ciência e Tecnologia do Tocantins, Araguaína, TO, Brasil.</institution>
+          <institution content-type="orgname">Instituto Federal de Educação</institution>
+          <institution content-type="orgdiv1">Ciência e Tecnologia do Tocantins</institution>
+          <addr-line>
+            <named-content content-type="city">Araguaína</named-content>
+            <named-content content-type="state">TO</named-content>
+          </addr-line>
+          <country country="BR">Brasil</country>
+        </aff>
+        <aff id="aff2">
+          <label>2</label>
+          <institution content-type="original">Universidade Federal do Tocantins, PPG Ciências da Saúde, Palmas, TO, Brasil.</institution>
+          <institution content-type="orgname">Universidade Federal do Tocantins</institution>
+          <institution content-type="orgdiv1">PPG Ciências da Saúde</institution>
+          <addr-line>
+            <named-content content-type="city">Palmas</named-content>
+            <named-content content-type="state">TO</named-content>
+          </addr-line>
+          <country country="BR">Brasil</country>
+        </aff>
+        <aff id="aff3">
+          <label>3</label>
+          <institution content-type="original">Universidade Federal do Tocantins, Escola de Medicina Veterinária e Zootecnia, Araguaína, TO, Brasil.</institution>
+          <institution content-type="orgname">Universidade Federal do Tocantins</institution>
+          <institution content-type="orgdiv1">Escola de Medicina Veterinária e Zootecnia</institution>
+          <addr-line>
+            <named-content content-type="city">Araguaína</named-content>
+            <named-content content-type="state">TO</named-content>
+          </addr-line>
+          <country country="BR">Brasil</country>
+        </aff>
+      </contrib-group>
+      <author-notes>
+        <corresp id="c001"><label>*</label> Endereço de correspondência: <email>gilsontavares@ifto.edu.br</email> </corresp>
+      </author-notes>
+      <pub-date date-type="pub" publication-format="electronic">
+        <day>27</day>
+        <month>10</month>
+        <year>2021</year>
+      </pub-date>
+      <pub-date date-type="collection" publication-format="electronic">
+        <year>2021</year>
+      </pub-date>
+      <volume>43</volume>
+      <elocation-id>e20210153</elocation-id>
+      <history>
+        <date date-type="received">
+          <day>21</day>
+          <month>04</month>
+          <year>2021</year>
+        </date>
+        <date date-type="rev-recd">
+          <day>15</day>
+          <month>06</month>
+          <year>2021</year>
+        </date>
+        <date date-type="accepted">
+          <day>26</day>
+          <month>07</month>
+          <year>2021</year>
+        </date>
+      </history>
+      <permissions>
+        <copyright-statement>Copyright by Sociedade Brasileira de Física. Printed in Brazil.</copyright-statement>
+        <copyright-year>2021</copyright-year>
+        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/deed.en" xml:lang="en">
+          <license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License (CC BY). The use, distribution or reproduction in other forums is permitted, provided the original author(s) and the copyright owner(s) are credited and that the original publication in this journal is cited, in accordance with accepted academic practice. No use, distribution or reproduction is permitted which does not comply with these terms.</license-p>
+        </license>
+      </permissions>
+      <abstract>
+        <p>Neste artigo descrevemos a construção e funcionamento de um MCQ experimental de baixo custo para demonstrar o uso de sensores quartzo para análises micro gravimétricas em meio líquido. Para isso, foi utilizado a plataforma Arduino micro<sup>®</sup> para controlar o interfaceamento com o computador, bem como um frequencímetro para excitação do sensor. Uma interface gráfica gratuita para computadores foi utilizada a fim de controlar o experimento e exibir os dados obtidos em tempo real. Também foram apresentados aplicações do modelo experimental e análises das capacidades de detecção.</p>
+      </abstract>
+      <trans-abstract xml:lang="en">
+        <p>In this article we describe the construction and operation of a low-cost experimental MCQ to demonstrate the use of quartz sensors for micro gravimetric analysis in liquid medium. For this, the Arduino micro<sup>®</sup> platform was used to control the interface with the computer, as well as a frequency meter for sensor excitation. A free graphic interface for computers was used to control the experiment and display the data obtained in real time. Applications of the experimental model and analysis of detection capabilities were also presented.</p>
+      </trans-abstract>
+      <kwd-group xml:lang="pt">
+        <title>Palavras-chave:</title>
+        <kwd>Microbalança de Cristal de Quartzo</kwd>
+        <kwd>Gravimetria</kwd>
+        <kwd>Ferramentas de Ensino</kwd>
+      </kwd-group>
+      <kwd-group xml:lang="en">
+        <title>Keywords</title>
+        <kwd>Quartz Crystal Microbalance</kwd>
+        <kwd>Gravimetry</kwd>
+        <kwd>Teaching Tools</kwd>
+      </kwd-group>
+      <counts>
+        <fig-count count="12"/>
+        <table-count count="4"/>
+        <equation-count count="2"/>
+        <ref-count count="27"/>
+      </counts>
+    </article-meta>
+  </front>
+  <body>
+    <sec id="S1">
+      <title>1. Introdução</title>
+      <p>As técnicas de ensino têm focado mais seus esforços na prática do uso do conhecimento, com o uso de abordagens direcionadas para a resolução de problemas do que no simples uso da informação. Estas abordagens são definidas como Ensino Baseado na Resolução de Problemas (PBL – <italic>Problem Based Learning</italic>) [<xref ref-type="bibr" rid="B1">1</xref>]. Estas técnicas de ensino são mais adequadas para acompanhar a rapidez do desenvolvimento tecnológico, que exige inclusive uma rápida adaptação do processo de ensino-aprendizagem. A experimentação tem um papel vital para as ensino de ciências aplicadas, quando discutimos ciências como engenharias, química, biotecnologia entre outras não se trata apenas do conhecimento teórico, lógico-matemático, hipóteses e equações, mas também de dados, gráficos, tabelas que descrevem um comportamento natural que devem ser oriundos de um processo de experimentação para então, darmos a oportunidade do aluno estabelecer conexão entre os dados da experimentação e a teoria, formando conhecimento integral e com significado [<xref ref-type="bibr" rid="B2">2</xref>].</p>
+      <p>Um outro ponto a ser considerado é em relação à capacidade e usos didáticos dos instrumentos, é que estes equipamentos não excedam muito o exigido na aplicação a qual estão destinados [<xref ref-type="bibr" rid="B3">3</xref>]. Este conceito é de difícil aplicação no ensino, uma vez que a exigência neste nível é geralmente menor que aquela capaz de ser fornecida pelos equipamentos comerciais. Uma forte tendência nas últimas décadas é a miniaturização de dispositivos analíticos, principalmente nas áreas de Mecatrônica e Engenharia Química.</p>
+      <p>O aperfeiçoamento dessas áreas, fortemente influenciado pelos avanços da área de microeletrônica, permitiu o surgimento dos MEMS (<italic>Micro-electromechanicalSystems – Microssistemas Eletromecânicos</italic>) onde sistemas mecânicos e sistemas eletrônicos foram integrados [<xref ref-type="bibr" rid="B4">4</xref>]. Há uma outra forte tendência mundial para o desenvolvimento de equipamentos analíticos chamados de “equipamentos verdes” [<xref ref-type="bibr" rid="B5">5</xref>], que possuem como características baixo impacto ambiental, tanto no seu processo produtivo quanto no seu uso, eficiência energética e baixa toxicidade de reagentes são características necessárias neste tipo de desenvolvimento. Estas técnicas são conhecidas como tecnologias limpas [<xref ref-type="bibr" rid="B6">6</xref>].</p>
+      <p>A área de química teve uma grande evolução, onde a miniaturização permite a obtenção ou manipulação de amostras em volume muito pequeno, tanto na fase pré quanto na analítica. Nesta última, os Microssistemas de Análise Total (μTAS – <italic>Micro Total Analysis System</italic>) são fortemente aplicados por se tratar de sistemas miniaturizados, permitem análises em tempo curto, utilizando poucos recursos e volumes muito pequenos, da ordem de microlitros [<xref ref-type="bibr" rid="B7">7</xref>].</p>
+      <p>Tanto o MEMS quanto o μTAS estão intimamente ligados ao desenvolvimento de novas tecnologias possíveis para o ensino de ciências, química e engenharia e suas ramificações [<xref ref-type="bibr" rid="B7">7</xref>, <xref ref-type="bibr" rid="B8">8</xref>].</p>
+      <p>Santos e colaboradores propuseram um sistema microeletrônico capaz de realizar análises em vários eletrodos de filmes finos [<xref ref-type="bibr" rid="B9">9</xref>].</p>
+      <p>Microssistemas eletrônicos também foram desenvolvidos para uso no ensino e aplicados no ensino de biociências e engenharia [<xref ref-type="bibr" rid="B7">7</xref>]. Seguindo os conceitos de baixo custo, miniaturização e tecnologia limpa a Microbalança de Cristal de Quartzo (MCQ) se apresenta como uma boa alternativa para o desenvolvimento de material de ensino e com possibilidade de uso também em pesquisa básica. A MCQ é um instrumento de análise gravimétrica extremamente sensível que pode medir as alterações de massa nas escalas de micrograma (μg) e nanograma (ng) por unidade de área, normalmente milímetro quadrado (mm<sup>2</sup>) [<xref ref-type="bibr" rid="B10">10</xref>].</p>
+      <p>O quartzo é um material piezoelétrico – materiais que respondem a deformação física produzindo diferença de potencial elétrico (DDP) ou o contrário - que pode, de acordo com a tecnologia de produção oscilar em uma frequência definida [<xref ref-type="bibr" rid="B11">11</xref>]. A frequência de oscilação definida no processo produtivo pode ser alterada pela adição ou remoção de pequenas quantidades de massa na superfície do eletrodo, geralmente de metal. Essa variação na frequência (Δ<italic>f</italic>) pode ser medida com hardware e software adequados e em tempo real, para obter informações úteis sobre interações ou reações moleculares que ocorrem na superfície do eletrodo ou diretamente do cristal, como crescimento de filme, oxidação, corrosão, interação antígeno anticorpo etc.</p>
+      <p>A estrutura simples dos osciladores MCQ e o desenvolvimento da técnica de sistema micro eletromecânico de quartzo (MEMQ) tornaram possível ao longo do tempo desenvolver arranjos miniaturizados de sensores osciladores com frequências muito estáveis [<xref ref-type="bibr" rid="B12">12</xref>, <xref ref-type="bibr" rid="B13">13</xref>].</p>
+      <p>Recentemente, a construção e análise de um MEMQ genérico e a aplicação de um sistema miniaturizado portátil baseado em injeção em câmara de fluxo foram descritos [<xref ref-type="bibr" rid="B14">14</xref>].</p>
+      <p>A MCQ proposta por Liang foi composta de uma microsseringa injetora de amostras desenhada sob medida e um software de monitoramento de frequência.</p>
+      <p>Ademais, foram relatados progressos na construção de um oscilador de frequência para aplicações reais e uma câmara de reação em fluxo, de simples construção e operação. Com base nas propriedades do quartzo, MEMQ’s e os μTAS, este estudo tem como objetivo o desenvolvimento de um equipamento de análise gravimétrica de baixo custo, para uso no ensino nas áreas de ciências, engenharia, química, bioquímica e biotecnologia ou mesmo como ferramenta para pesquisa básica. Levando-se em conta o alto investimento requerido para implantação deste tipo de equipamento no ensino, qualquer tentativa de redução de investimento é relevante.</p>
+      <p>Com a intenção de construir um modelo prototificado de MCQ de baixo custo que favoreça o desenvolvimento e aplicação de práticas experimentais de ensino voltada para análise gravimétrica, foi aplicado um modelo de pesquisa experimental, com base em prova de fundamentos e conceitos da tecnologia em questão. O <italic>design</italic> e construção do protótipo foi realizado nos laboratórios de física o Instituto Federal de Educação, Ciência e Tecnologia do Tocantins, Campus Araguaína – IFTO. As análises de funcionalidade ocorreram no laboratório de Ciências da Universidade Federal do Tocantins UFT – Escola de Medicina Veterinária e Zootecnia, <italic>Campus</italic> Araguaína.</p>
+    </sec>
+    <sec id="S2">
+      <title>2. Materiais e Métodos</title>
+      <p>O sistema MCQ tem vários modos de operação o mais comum (Figura <xref ref-type="fig" rid="S2.F1">1</xref>) consiste em um cristal de quartzo com eletrodos metálicos montados firmemente ligados nas laterais superior e inferior, um suporte para prender o cristal e possibilitar conexão elétrica, frequencímetro que excita o cristal até sua frequência de ressonância, um controlador eletrônico e computador/monitor que lê a mudança de frequência e armazena os parâmetros do processo.</p>
+      <fig id="S2.F1" position="float">
+        <label>Figura 1:</label>
+        <caption>
+          <title>Configuração operacional típico da MCQ.</title>
+        </caption>
+        <alternatives>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/55d47819959ce7275702d2ebcba2725562cd0208.jpg"/>
+          <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/94aada6bb9e15b11f0aa1424b6ce56dd32844978.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+      </fig>
+      <p>Os eletrodos na parte superior e inferior do cristal geralmente têm a forma de um círculo ligado a uma trilha. Essa forma de eletrodo permite que a MCQ oscile apenas na área onde os eletrodos são aderidos [<xref ref-type="bibr" rid="B15">15</xref>].</p>
+      <sec id="S2.SS1">
+        <title>2.1. Arduíno micro</title>
+        <p>O Arduino Micro (Figura <xref ref-type="fig" rid="S2.F2">2</xref>) é um <italic>hardware</italic> de código aberto [<xref ref-type="bibr" rid="B16">16</xref>] usado para elaboração de protótipos de programação de eletrônicos. A placa de circuito e <italic>software</italic> [<xref ref-type="bibr" rid="B17">17</xref>] usa a linguagem C++ simplificada para programação [<xref ref-type="bibr" rid="B18">18</xref>]. O Arduino Micro é muito usado como plataforma de integração e interfaceamento, entre outras qualidades devido a interface do usuário ter configuração amigável e de fácil utilização.</p>
+        <fig id="S2.F2" position="float">
+          <label>Figura 2:</label>
+          <caption>
+            <title>Arduíno Micro [<xref ref-type="bibr" rid="B21">21</xref>].</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/1366d464231ecee0b029e1807c63cde57ad83f8f.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/1e0b13ea99a53c4adb56390067b377a090982ac7.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>É uma placa de circuito com um processador que pode ser programado para executar uma variedade de tarefas. É possível enviar informações do programa de computador para a plataforma para que este se ligue ao circuito ou máquina específica para executar um comando particular, ou controlar processos eletrônicos bem como leitura de sensores diversos tanto de entrada quanto de saída de dados [<xref ref-type="bibr" rid="B19">19</xref>].</p>
+        <p>Diferente da maioria dos programas e placas de circuito [<xref ref-type="bibr" rid="B20">20</xref>], não possui um <italic>hardware</italic> específico para carregar um novo código ou programa na placa, é necessário usar apenas um cabo USB do inglês (<italic>Universal Serial Bus</italic>) para carregar um novo código. Os códigos de programa são mais fáceis de desenvolver tornando a programação mais simplificada.</p>
+      </sec>
+      <sec id="S2.SS2">
+        <title>2.2. Softwares utilizados</title>
+        <p>Dois softwares são necessários para desenvolvimento e operação da MCQ e ambos são de código aberto, são eles: o Arduíno IDE (<italic>Integrated Development Environment</italic>) e OpenQCM<sup>®</sup>. O IDE é um aplicativo multiplataforma desenvolvido em linguagem de programação Java. É usado para desenvolver e fazer upload de Scripts de programação em placas compatíveis com Arduino.</p>
+        <p>O Arduino IDE suporta as linguagens C e C + ⁣ + , neste caso as regras de estruturação do código são diferentes. O Arduino IDE fornece uma biblioteca de software de projeto, que disponibiliza muitos procedimentos comuns de entrada e saída de dados. O código desenvolvido ou baixado pelo usuário requer apenas duas funções básicas para iniciar, o sketch e o loop principal do programa.</p>
+        <p>A versão do IDE utilizado para upload do <italic>firmwere</italic> da MCQ foi a 1.8.10 de 13 de setembro de 2019, o repositório utilizado é o github.com/Arduino, as licenças de uso são LGPL (<italic>Lesser General Public License</italic>) ou GPL (<italic>General Public License</italic>). O segundo software necessário para desenvolvimento da MCQ foi o OpenQCM<sup>®</sup> o projeto do software aproveita os recursos embarcados do <italic>NetBean</italic> s para criar GUI (<italic>Graphic User interface</italic>) interface gráfica de usuário (Figura <xref ref-type="fig" rid="S2.F3">3</xref>). O aplicativo usa as bibliotecas Java de terceiros como: <italic>Ardulink</italic> [<xref ref-type="bibr" rid="B22">22</xref>], uma biblioteca de código aberto para controle e comunicação com placas Arduino, entre elas o Arduíno Micro utilizada nesse projeto. O <italic>Ardulink</italic> também fornece componentes Java <italic>Swing</italic> [<xref ref-type="bibr" rid="B22">22</xref>] prontos, capazes de se comunicar com a placa para leitura serial dos dados de frequência e temperatura do cristal de quartzo.</p>
+        <fig id="S2.F3" position="float">
+          <label>Figura 3:</label>
+          <caption>
+            <title>GUI (<italic>Graphic User Interface</italic>) interface gráfica do usuário OpenQCM<sup>®</sup>.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/6f9d93fe9b60ec0f7f22be0f37804988e6c70b3d.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/9848bd3cc48d5e70f3203a784fd686c4183fe206.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>Para exibição dos dados foi utilizado a J<italic>FreeChar</italic> t [<xref ref-type="bibr" rid="B22">22</xref>] que é uma biblioteca Java de código aberto para plotagem gráfica de dados, essa biblioteca permite a exibição de gráficos em tempo real com leituras de frequência e temperatura. Para que os dados sejam plotados em tempo real e sejam confiáveis, utiliza-se a <italic>CommonsMath</italic> [<xref ref-type="bibr" rid="B22">22</xref>], uma biblioteca de matemática. Os dados de frequência e temperatura podem ser salvas em um arquivo de texto no formato ASCII (<italic>American Standard Code for Information Interchange</italic>). Depois que o arquivo de dados gerado é selecionado, o software anexa os novos dados ao arquivo. O arquivo de dados é formatado da seguinte forma: data (MM/dd/aa) hora (hh: mm: ss) frequência e temperatura [<xref ref-type="bibr" rid="B23">23</xref>].</p>
+      </sec>
+      <sec id="S2.SS3">
+        <title>2.3. Cristal oscilador de Quartzo</title>
+        <p>Na MCQ proposta utilizou-se cristais de osciladores de quartzo com corte AT esse tipo de cristal é laminado do bloco original com um ângulo de 35° em relação ao eixo Z, são os mais utilizados por terem um baixíssimo coeficiente de dependência da temperatura [<xref ref-type="bibr" rid="B24">24</xref>], com frequência de oscilação em forma de cisalhamento de 10 MHz colocado entre dois eletrodos de ouro para conexão elétrica. A superfície do cristal de quartzo é plana e polida, ainda necessária limpeza prévia para o uso. A adesão do eletrodo de ouro a superfície é aprimorada usando um substrato de Titânio (Ti). A Sensibilidade nominal do sensor é de 4,42×10<sup>−9</sup> g Hz<sup>−1</sup> cm<sup>−2</sup>, a relação entre frequência e estabilidade térmica é de ± 20 kHz a 23°C com densidade de 0,0026497 Kg/m<sup>3</sup> a 25°C [<xref ref-type="bibr" rid="B23">23</xref>].</p>
+        <p>A espessura de quartzo é de ∼160 μm com diâmetro total de 13,9 mm, já o eletrodo tem diâmetro 6 mm revestido com Ouro (Au) a espessura do eletrodo é de ∼200 nm (Figura <xref ref-type="fig" rid="S2.F4">4</xref>) a conexão elétrica se dá pelos eletrodos móveis da câmara de reação da MCQ proposta. O cristal usa conexões tipo HC-48/U. Os dados de área e densidade do eletrodo são úteis para quantificação da massa medida sobre o eletrodo, no entanto esses dados não foram medidos no trabalho.</p>
+        <fig id="S2.F4" position="float">
+          <label>Figura 4:</label>
+          <caption>
+            <title>Cristais osciladores de quartzo.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/1fb178bd4b05defaa072ba2067287679b149042a.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/d7d3d564a46c792963d7cb027934fc83ddb2bd38.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+      </sec>
+      <sec id="S2.SS4">
+        <title>2.4. Estrutura de proteção dos componentes eletrônicos</title>
+        <p>Para a construção da estrutura de proteção da MCQ foi utilizado placas de acrílico de 3, 2, e 1 mm de espessura. As placas que compõem o case foram usinados com serra elétrica, as peças de acrílico que constituem a estrutura permanente foram unidas com adesivo líquido tipo cianoacrilato. A juntas móveis foram possíveis com uso de parafusos de 1,5 mm de espessura e 3 mm de comprimento. A estrutura de proteção foi construída para proteção do frequencímetro e do controlador Arduíno, as medidas do case estão ilustradas na Figura <xref ref-type="fig" rid="S2.F5">5</xref>. Há duas entradas, uma tipo micro USB para alimentação elétrica e saída de dados para o computador e outra tipo RJ-45, esta liga o sensor da câmara de reação diretamente ao frequencímetro.</p>
+        <fig id="S2.F5" position="float">
+          <label>Figura 5:</label>
+          <caption>
+            <title>Estrutura de proteção dos componentes eletrônicos.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/7c13f240b30e1bbe9f581574d4e1a09c527a2ad5.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/ec663aea8328f453c21084370452b844212ce726.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>Na imagem também é possível observar o Arduíno micro conectado ao frequencímetro. Todas as partes do desenho de execução do projeto da MCQ foram modeladas com o software <italic>SketchUp Make</italic> 2017<sup>®</sup>.</p>
+      </sec>
+      <sec id="S2.SS5">
+        <title>2.5. Câmara de reação</title>
+        <p>A câmara de reação (Figura <xref ref-type="fig" rid="S2.F6">6</xref>) foi construída com uma variedade maior de materiais em relação a estrutura de proteção, isso por conta da especificidade de seu uso, além dos materiais comuns ao <italic>case</italic> foram utilizados anéis de silicone (3, 5) para vedação das reações em meio líquido, tubos de 1mm de entrada e saída de reagentes (7, 8), eletrodos de latão de 1 mm × 0,5 mm para contato elétrico com sensor (2), placa de fenolite com camada única de cobre para construção de circuito elétrico, imãs de neodímio de 6 mm de diâmetro por 3 mm de altura (6).</p>
+        <fig id="S2.F6" position="float">
+          <label>Figura 6:</label>
+          <caption>
+            <title>Câmara de reação.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/0ad06fa43eb76cd56f7d790a5122934e7e2ec19c.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/16751940c41ce3999a0600555918a9da2dd37884.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>A Figura <xref ref-type="fig" rid="S2.F7">7</xref> mostra a câmara de reação tipo fechada já montada. Este modelo exige a colocação de tubos conectados em bomba peristáltica ou bomba tipo seringa para sucção dos reagentes. A conexão do topo, seja no modo aberto ou fechado é possível com uso de imãs neodímio que também oferece vedação por compressão.</p>
+        <fig id="S2.F7" position="float">
+          <label>Figura 7:</label>
+          <caption>
+            <title>Câmara de reação tipo fechada parcialmente montada.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/6366ef9ebba5b0fe9e93f12707b42b3fcf8bb60d.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/88a31a645cb0f78630b5f02e618cf956af407e38.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+      </sec>
+      <sec id="S2.SS6">
+        <title>2.6. Operação da MCQ</title>
+        <p>Para operação da Microbalança é necessário garantir boa montagem da câmara de reação, a estanqueidade das substâncias permite confiança nas medições, também é necessário seguir a ordem correta dos componentes a serem montados. A Figura <xref ref-type="fig" rid="S2.F8">8</xref> apresenta uma visão geral da MCQ em perspectiva explodida. A sequência adequada de montagem da câmara de reação é ilustrada nas fotos a seguir. É necessário delicadeza na montagem das partes para não incorrer em quebra do cristal ou contaminação na superfície, após limpeza dos componentes para montagem da câmara de reação.</p>
+        <fig id="S2.F8" position="float">
+          <label>Figura 8:</label>
+          <caption>
+            <title>Visão geral da MCQ, (a) botão de acionamento dos eletrodos móveis, (b) eletrodos móveis, (c) silicone de vedação, (d) cristal MCQ, (e) Anel de vedação, (f) imã de neodímio, (g) saída de reagente, (h) entrada de reagentes, (i) câmara de reação aberta, (j) conector RJ-45.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/4d20ecd9aa0288731a43f70a79e3760cf8abe4e4.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/d13618abda1f2042ffbfc1f967d9dd119e926127.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>Antes da colocação do silicone de vedação os eletrodos móveis (Figura <xref ref-type="fig" rid="S2.F8">8</xref>b) devem ser rebaixados girando o botão de acionamento (Figura <xref ref-type="fig" rid="S2.F8">8</xref>a) no sentido horário. É importante perceber no momento da montagem do cristal, se este está alinhado na câmara de reação conforme Figura <xref ref-type="fig" rid="S2.F8">8</xref>d, esse cuidado previne que os contatos do eletrodo móvel e o eletrodo do cristal seja mal feito, diferente disso as reações no quartzo não serão lidas pelo frequencímetro ou haverá muita instabilidade na leitura.</p>
+        <p>Os tubos de entrada e saída devem ser montados na parte superior da câmara de reação antes da colocação sobre o sensor para evitar danos no mesmo (Figura <xref ref-type="fig" rid="S2.F9">9</xref>e). Outro ponto crítico é a colocação deste último componente (Figura <xref ref-type="fig" rid="S2.F9">9</xref>f) isso porque os imãs de neodímio podem comprimir o sensor de forma abrupta e resultar em danos e mau funcionamento do aparelho. Finalmente conecta-se a seringa para sucção de reagentes (Figura <xref ref-type="fig" rid="S2.F9">9</xref>g). Aqui cabe outra ressalva, como em todos os aparelhos MCQ que operam em fluxo com câmara fechada, é imprescindível que os reagentes nunca sejam injetados sobre o cristal. Isso porque a forte elevação de pressão provoca variação excessiva na leitura das frequências, outro ponto é que a estanqueidade da câmara fica prejudicada, e isso pode resultar em extravasamento de líquidos nos componentes elétricos. Quando os líquidos são sugados cria-se um vácuo no interior que extraem possíveis bolhas formadas entre o cristal e o anel de vedação, esse vácuo também diminui a possibilidade de formação de bolhas sobre o cristal bem como possibilita que as soluções entrem em contato com toda a área do cristal. A formação de bolhas diminui consideravelmente a capacidade analítica.</p>
+        <fig id="S2.F9" position="float">
+          <label>Figura 9:</label>
+          <caption>
+            <title>Fotografia da MCQ – Ordem de montagem da câmara de reação: (a) silicone de vedação, (b) instalação do sensor MCQ, (c) anel de vedação, (d) visão superior – alinhamento do sensor na câmara, (e) Tubos de entrada e saída de reagentes, (f) instalação da parte superior da câmara tipo fechada, (g) instalação de seringa.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/77aa32c64b6211cd7df89027f32038051cbb9318.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/df3e6f8962cf2b568b89a2a074cd7d9c5cf78cc2.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+      </sec>
+    </sec>
+    <sec id="S3">
+      <title>3. Resultados e Discussão</title>
+      <sec id="S3.SS1">
+        <title>3.1. Análise de custo da construção da MCQ</title>
+        <p>A execução do projeto da MCQ apresentou um custo muito inferior comparado com equipamentos de mercado, alcançando assim um dos seus principais objetivos que era o baixo custo de produção. Na Tabela <xref ref-type="table" rid="S3.T1">1</xref> são estratificados os principais custos com componentes para que seja feita uma unidade do equipamento. Não foi possível totalizar os custos indiretos deste projeto como tempo, deslocamento de pessoal para pesquisa e aquisição de materiais, gastos com sistemas de informação, eletricidade internet, telefone etc.</p>
+        <table-wrap id="S3.T1" position="float">
+          <label>Tabela 1:</label>
+          <caption>
+            <title>Estratificação dos custos de montagem de uma unidade da MCQ.</title>
+          </caption>
+          <table cellpadding="5" cellspacing="5" frame="hsides" rules="groups">
+            <thead>
+              <tr>
+                <th align="left" valign="top">Item</th>
+                <th align="center" valign="top">Dimensões</th>
+                <th align="center" valign="top">Unidades</th>
+                <th align="center" valign="top">Custo de mercado (r$)</th>
+                <th align="center" valign="top">Custo de aquisição (RS)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left" valign="top">Placas de acrílico</td>
+                <td align="center" valign="top">3 mm</td>
+                <td align="center" valign="top">6.936 mm<sup>2</sup></td>
+                <td align="center" valign="top">1,60</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Placas de acrílico</td>
+                <td align="center" valign="top">1 mm</td>
+                <td align="center" valign="top">2.464 mm<sup>2</sup></td>
+                <td align="center" valign="top">0,40</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Placas de acrílico</td>
+                <td align="center" valign="top">10 mm</td>
+                <td align="center" valign="top">1.938 mm<sup>2</sup></td>
+                <td align="center" valign="top">4,45</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Frequencimetro</td>
+                <td align="center" valign="top">17,7 × 48,2 mm</td>
+                <td align="center" valign="top">1</td>
+                <td align="center" valign="top">240,00</td>
+                <td align="center" valign="top">240,00</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Placa Arduíno micro</td>
+                <td align="center" valign="top">17,7 × 48,2 mm</td>
+                <td align="center" valign="top">1</td>
+                <td align="center" valign="top">15,00</td>
+                <td align="center" valign="top">15,00</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Parafuso</td>
+                <td align="center" valign="top">M2 2,5 × 6 mm</td>
+                <td align="center" valign="top">10</td>
+                <td align="center" valign="top">0,10</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Manta de silicone</td>
+                <td align="center" valign="top">1 mm</td>
+                <td align="center" valign="top">2.464 mm<sup>2</sup></td>
+                <td align="center" valign="top">0,30</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Disco de quartzo</td>
+                <td align="center" valign="top">10 MHz 13,9 mm</td>
+                <td align="center" valign="top">10</td>
+                <td align="center" valign="top">450,00</td>
+                <td align="center" valign="top">450,00</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Imãs de Neodímio</td>
+                <td align="center" valign="top">3 × 6 mm</td>
+                <td align="center" valign="top">8</td>
+                <td align="center" valign="top">10,00</td>
+                <td align="center" valign="top">10,00</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Placa de circuito cobreada</td>
+                <td align="center" valign="top">1 mm</td>
+                <td align="center" valign="top">1.701 mm<sup>2</sup></td>
+                <td align="center" valign="top">7,65</td>
+                <td align="center" valign="top">7,65</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Cola cianoacrilato</td>
+                <td align="center" valign="top">10</td>
+                <td align="center" valign="top">1</td>
+                <td align="center" valign="top">4,00</td>
+                <td align="center" valign="top">4,00</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Conector RJ-45</td>
+                <td align="center" valign="top">13 × 14 mm</td>
+                <td align="center" valign="top">1</td>
+                <td align="center" valign="top">0,10</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Tubos de silicone</td>
+                <td align="center" valign="top">2 × 154 mm</td>
+                <td align="center" valign="top">2</td>
+                <td align="center" valign="top">2,00</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Barra eletrodo latão</td>
+                <td align="center" valign="top">10 mm</td>
+                <td align="center" valign="top">2</td>
+                <td align="center" valign="top">0,50</td>
+                <td align="center" valign="top">0,0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">TOTAL</td>
+                <td/>
+                <td/>
+                <td align="center" valign="top">736,10</td>
+                <td align="center" valign="top">726,65</td>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>Os custos dos componentes totalizaram, R$ 726,65. Vale destacar que, nesse valor, não estão inclusos custo de alguns materiais e serviços que foram reciclados de componentes eletrônicos ou doados com fornecedores envolvidos com a proposta do projeto.</p>
+        <p>Quando comparado com o modelo de referência mais barato disponível no mercado a QCM 10M <italic>Quartz Crystal Microbalance</italic> do fornecedor Gamry Instruments que custa R$ 20.827,92 em valor atual [<xref ref-type="bibr" rid="B25">25</xref>] observa-se que o valor é aproximadamente 28 vezes menor. Cabe ressaltar também que essa diferença é importante quando se observa o propósito do equipamento proposto, já citado ainda introdução desse estudo.</p>
+      </sec>
+      <sec id="S3.SS2">
+        <title>3.2. Estudo da capacidade de análise em meio líquido</title>
+        <p>Para a verificação da Microbalança de cristal de quartzo utilizou-se água pura, de acordo com a teoria baseada na (Equação (<xref ref-type="disp-formula" rid="S3.E1">1</xref>)) de Kanazawa – Gordon [<xref ref-type="bibr" rid="B26">26</xref>] essa equação expressa a variação de frequência de um cristal de quartzo em contato com um líquido em termos de parâmetros físicos do fluido e do quartzo. A relação é:</p>
+        <p><bold>Equação 1:</bold> Equação de Kanazawa – Gordon.</p>
+        <disp-formula id="S3.E1">
+          <label>(1)</label>
+          <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+            <mml:mrow>
+              <mml:mrow>
+                <mml:mi mathvariant="normal">Δ</mml:mi>
+                <mml:mo>⁢</mml:mo>
+                <mml:mi>f</mml:mi>
+              </mml:mrow>
+              <mml:mo>=</mml:mo>
+              <mml:mrow>
+                <mml:mo>-</mml:mo>
+                <mml:mrow>
+                  <mml:msubsup>
+                    <mml:mi>f</mml:mi>
+                    <mml:mn>0</mml:mn>
+                    <mml:mfrac>
+                      <mml:mn>3</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:msubsup>
+                  <mml:mo>⋅</mml:mo>
+                  <mml:msup>
+                    <mml:mrow>
+                      <mml:mo>(</mml:mo>
+                      <mml:mfrac>
+                        <mml:mrow>
+                          <mml:mi>η</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>L</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>ρ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>L</mml:mi>
+                        </mml:mrow>
+                        <mml:mrow>
+                          <mml:mi>π</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>μ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>Q</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>ρ</mml:mi>
+                          <mml:mo>⁢</mml:mo>
+                          <mml:mi>Q</mml:mi>
+                        </mml:mrow>
+                      </mml:mfrac>
+                      <mml:mo>)</mml:mo>
+                    </mml:mrow>
+                    <mml:mfrac>
+                      <mml:mn>1</mml:mn>
+                      <mml:mn>2</mml:mn>
+                    </mml:mfrac>
+                  </mml:msup>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:mrow>
+          </mml:math>
+        </disp-formula>
+        <p>Onde: </p>
+        <p><italic>f</italic><sub>0</sub> = frequência de vibração nominal do cristal seco</p>
+        <p><italic>ηL</italic> = viscosidade absoluta do cristal de quartzo</p>
+        <p><italic>ρL</italic> = densidade do líquido</p>
+        <p><italic>μQ</italic> = módulo de cisalhamento do cristal de quartzo</p>
+        <p><italic>ρQ</italic> = densidade do cristal de quartzo</p>
+        <p>De modo mais simples, a variação no padrão de ressonância de um cristal de quartzo em meio líquido depende do produto da densidade-viscosidade do líquido estudado. A equação acima é dependente das seguintes características: (i) o cristal de quartzo é um sólido, mas com propriedades elásticas, há dissipação e energia na estrutura do cristal bem como na estrutura da câmara (ii) o líquido é newtoniano, o que significa que é um líquido puramente viscoso; (iii) o líquido – se assemelha a uma camada infinita, assim a penetração da onda de cisalhamento é muitas vezes menor que a espessura do líquido.</p>
+        <p>Água pura foi injetada na câmara de reação da MCQ usando uma bomba de seringa. O volume da câmara de medição é de aproximadamente 28 μL. Os parâmetros físicos do fluido e do quartzo são:</p>
+        <p>
+          <disp-formula id="S3.Ex2">
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+              <mml:mrow>
+                <mml:msub>
+                  <mml:mi>f</mml:mi>
+                  <mml:mn>0</mml:mn>
+                </mml:msub>
+                <mml:mo>≅</mml:mo>
+                <mml:mrow>
+                  <mml:mpadded width="+5pt">
+                    <mml:mn>10</mml:mn>
+                  </mml:mpadded>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>M</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>h</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>z</mml:mi>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+              <mml:mrow>
+                <mml:mi>η</mml:mi>
+                <mml:mi>L</mml:mi>
+                <mml:mo>=</mml:mo>
+                <mml:mn>1.002</mml:mn>
+                <mml:mo>×</mml:mo>
+                <mml:mpadded width="+5pt">
+                  <mml:msup>
+                    <mml:mn>10</mml:mn>
+                    <mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mn>2</mml:mn>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mpadded>
+                <mml:mi>g</mml:mi>
+                <mml:mo>⋅</mml:mo>
+                <mml:mi>c</mml:mi>
+                <mml:msup>
+                  <mml:mi>m</mml:mi>
+                  <mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:mn>1</mml:mn>
+                  </mml:mrow>
+                </mml:msup>
+                <mml:mo>⋅</mml:mo>
+                <mml:mpadded width="+5pt">
+                  <mml:msup>
+                    <mml:mi>s</mml:mi>
+                    <mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mn>1</mml:mn>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mpadded>
+                <mml:mrow>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>T</mml:mi>
+                  <mml:mo>=</mml:mo>
+                  <mml:msup>
+                    <mml:mn>20</mml:mn>
+                    <mml:mo>∘</mml:mo>
+                  </mml:msup>
+                  <mml:mo stretchy="false">)</mml:mo>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+              <mml:mrow>
+                <mml:mi>ρ</mml:mi>
+                <mml:mi>L</mml:mi>
+                <mml:mo>=</mml:mo>
+                <mml:mpadded width="+5pt">
+                  <mml:mn>0.9982</mml:mn>
+                </mml:mpadded>
+                <mml:mi>g</mml:mi>
+                <mml:mo>⋅</mml:mo>
+                <mml:mi>c</mml:mi>
+                <mml:msup>
+                  <mml:mi>m</mml:mi>
+                  <mml:mrow>
+                    <mml:mo>-</mml:mo>
+                    <mml:mn>3</mml:mn>
+                  </mml:mrow>
+                </mml:msup>
+                <mml:mrow>
+                  <mml:mo stretchy="false">(</mml:mo>
+                  <mml:mi>T</mml:mi>
+                  <mml:mo>=</mml:mo>
+                  <mml:mn>2</mml:mn>
+                  <mml:mo>-</mml:mo>
+                  <mml:mn>20</mml:mn>
+                  <mml:mmultiscripts>
+                    <mml:mo stretchy="false">)</mml:mo>
+                    <mml:mprescripts/>
+                    <mml:none/>
+                    <mml:mo>∘</mml:mo>
+                  </mml:mmultiscripts>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>μ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>Q</mml:mi>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mrow>
+                        <mml:mrow>
+                          <mml:mn>2.947</mml:mn>
+                          <mml:mo>×</mml:mo>
+                          <mml:mpadded width="+5pt">
+                            <mml:msup>
+                              <mml:mn>10</mml:mn>
+                              <mml:mn>11</mml:mn>
+                            </mml:msup>
+                          </mml:mpadded>
+                        </mml:mrow>
+                        <mml:mo>⁢</mml:mo>
+                        <mml:mi>g</mml:mi>
+                      </mml:mrow>
+                      <mml:mo>⋅</mml:mo>
+                      <mml:mi>c</mml:mi>
+                    </mml:mrow>
+                    <mml:mo>⁢</mml:mo>
+                    <mml:msup>
+                      <mml:mi>m</mml:mi>
+                      <mml:mrow>
+                        <mml:mo>-</mml:mo>
+                        <mml:mn>1</mml:mn>
+                      </mml:mrow>
+                    </mml:msup>
+                  </mml:mrow>
+                  <mml:mo>⋅</mml:mo>
+                  <mml:msup>
+                    <mml:mi>s</mml:mi>
+                    <mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mn>2</mml:mn>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="block">
+              <mml:mrow>
+                <mml:mrow>
+                  <mml:mi>ρ</mml:mi>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:mi>Q</mml:mi>
+                </mml:mrow>
+                <mml:mo>=</mml:mo>
+                <mml:mrow>
+                  <mml:mrow>
+                    <mml:mrow>
+                      <mml:mpadded width="+5pt">
+                        <mml:mn>2.648</mml:mn>
+                      </mml:mpadded>
+                      <mml:mo>⁢</mml:mo>
+                      <mml:mi>g</mml:mi>
+                    </mml:mrow>
+                    <mml:mo>⋅</mml:mo>
+                    <mml:mi>c</mml:mi>
+                  </mml:mrow>
+                  <mml:mo>⁢</mml:mo>
+                  <mml:msup>
+                    <mml:mi>m</mml:mi>
+                    <mml:mrow>
+                      <mml:mo>-</mml:mo>
+                      <mml:mn>3</mml:mn>
+                    </mml:mrow>
+                  </mml:msup>
+                </mml:mrow>
+              </mml:mrow>
+            </mml:math>
+          </disp-formula>
+        </p>
+        <p>Ainda de acordo com a equação de Kanazawa – Gordon, a variação de frequência do ar para a água destilada é Δ<italic>f</italic> = 2020 Hz [<xref ref-type="bibr" rid="B27">27</xref>].</p>
+        <p>A mudança de frequência causada pela injeção de água pura na câmara de reação foi medida usando o seguinte procedimento: A MCQ foi conectada via porta USB e aguardou-se o tempo de estabilização de temperatura e frequência estacionária. Após 30 minutos a frequência inicial da MCQ foi medida e registrada durante um intervalo de mais 30 minutos.</p>
+        <p>A frequência inicial corresponde ao cristal de quartzo em contato com o ar. Após a medição da frequência de contato com ar, água Mili<italic>Q</italic> foi injetada na câmara usando bomba tipo seringa. Um novo período estacionário de 30 minutos foi aguardado, as leituras da MCQ foram registradas. A frequência final corresponde ao cristal de quartzo em contato com água.</p>
+        <p>O resultado da frequência do cristal na mudança do ar para água é calculado como a diferença da frequência final no ar (Δ<italic>f</italic><sub>0</sub>) menos a frequência final na água (Δ<italic>f</italic><sub>1</sub>), como mostrado na Figura <xref ref-type="fig" rid="S3.F10">10</xref>.</p>
+        <fig id="S3.F10" position="float">
+          <label>Figura 10:</label>
+          <caption>
+            <title>Gráfico da variação de frequência na mudança de interface ar-água para confirmação da equação de Kanazawa – Gordon.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/d013c356d3e9fd34b06593b88baaf07b0658b1fb.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/b284544cc3cce5de25158e01e64ddb92414c7ab6.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>Os resultados dos testes demostram Δ<italic>f</italic><sub>0</sub> = 10015849.4 Hz e Δ<italic>f</italic><sub>1</sub> = 10013830.3 Hz mostraram uma boa concordância entre a mudança de frequência medida pela MCQ na mudança da interface do ar para a água pura, a determinação matemática da equação de Kanazawa Gordon também foi confirmada.</p>
+        <p>A equação prevê uma variação na frequência de ressonância na ordem de 2020 Hz. O resultado calculado no teste é de Δ<italic>f</italic><sub><italic>final</italic></sub> = 2018.9 Hz, a diferença para o valor teórico ideal é de ± 1,1 Hz para um cristal de quartzo de 10 MHz na mudança da interface ar para a água pura à temperatura de 20°C. Cabe ressaltar que os valores de Δ<italic>f</italic><sub>0</sub> e Δ<italic>f</italic><sub>1</sub> são valores médios calculados a partir das frequências estáveis após aproximadamente 30 minutos. A partir das características de sensibilidade sensor utilizado, controle da temperatura, e pureza da água chegou a esse grau de similaridade com o valor teórico.</p>
+        <p>O teste e os resultados aqui relatados mostraram a sensibilidade do equipamento proposto para operação em meio líquido, a diferença encontrada neste teste não é obstáculo suficiente para alcançar um dos objetivos propostos uma vez que se optou por <italic>hardware</italic> e <italic>software</italic> de baixo custo em que se esperava possíveis divergências entre valores teóricos e valores medidos.</p>
+      </sec>
+      <sec id="S3.SS3">
+        <title>3.3. Estudo da capacidade de análise gravimétrica em meio líquido</title>
+        <p>Para este estudo foram preparadas três soluções com diferentes concentrações de sacarose 7,5%, 15% e 30% peso/volume (p/v). Uma bomba tipo seringa foi utilizada para injetar as diferentes concentrações na câmara de reação. As soluções foram bombeadas até observação de que a câmara estava totalmente preenchida com a nova solução. Em seguida, a variação de frequência foi aferida em estado estacionário. A medição de frequência foi realizada sempre no equilíbrio de condições estáticas dos líquidos, a câmara de reação foi lavada com água destilada entre injeções das soluções. De fato, o que foi medido nesse experimento foram as variações de frequência causadas por mudança de massa devido ao processo de alteração de densidade e viscosidade da amostra líquida. Essas duas características não são dissociáveis, por isso é necessário lavar a câmara de reação antes de cada nova injeção. Desta forma, é possível medir e comparar a mudança de frequência causada por soluções com diferentes concentrações de sólidos dissolvidos. A variação de frequência da MCQ durante todo o teste com diferentes concentrações de sacarose é mostrada na Figura <xref ref-type="fig" rid="S3.F11">11</xref>.</p>
+        <fig id="S3.F11" position="float">
+          <label>Figura 11:</label>
+          <caption>
+            <title>Gráfico da variação de frequência da MCQ causado por injeções sucessivas de água e sacarose em diferentes concentrações 7,5, 15 e 30% p/v.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/266c212c3e15c20625e933f096304d7bba16843c.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/eb29c9b6c7d228fdc70c250f67045ae3ca9be9f5.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+        <p>A maior variação no sinal de frequência, indicada pelos picos no gráfico, é causada principalmente pela variação abrupta de pressão na superfície do cristal de quartzo devido a injeção das amostras. Mas, essa variação é transitória e não é considerada. É importante notar que o processo de regeneração do sensor não foi medido após as injeções sucessivas. No entanto, a estabilidade do sinal referente a leitura da água (<inline-formula><mml:math id="INEQ38"><mml:mrow><mml:mi mathvariant="normal">Δ</mml:mi><mml:mo>⁢</mml:mo><mml:msub><mml:mi>f</mml:mi><mml:mrow><mml:mover accent="true"><mml:mi>a</mml:mi><mml:mo>´</mml:mo></mml:mover><mml:mo>⁢</mml:mo><mml:mi>g</mml:mi><mml:mo>⁢</mml:mo><mml:mi>u</mml:mi><mml:mo>⁢</mml:mo><mml:mi>a</mml:mi></mml:mrow></mml:msub></mml:mrow></mml:math></inline-formula>) serve como parâmetro branco ou “0” para cálculo diferencial com as diferentes concentrações. Na Tabela <xref ref-type="table" rid="S3.T2">2</xref> é mostrada a frequência medida na MCQ para as três concentrações, a diminuição de frequência em relação a água pura também foi medida.</p>
+        <table-wrap id="S3.T2" position="float">
+          <label>Tabela 2:</label>
+          <caption>
+            <title>Variação de frequência medida nas diferentes concentrações de sacarose.</title>
+          </caption>
+          <table cellpadding="5" cellspacing="5" frame="hsides" rules="groups">
+            <thead>
+              <tr>
+                <th align="left" valign="top">Soluções</th>
+                <th align="center" valign="top">Frequência (Hz)</th>
+                <th align="center" valign="top">4f (Hz)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left" valign="top">Água</td>
+                <td align="center" valign="top">10014141</td>
+                <td align="center" valign="top">0</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Sacarose</td>
+                <td align="center" valign="top">10013825</td>
+                <td align="center" valign="top">2573</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Sacarose 15%</td>
+                <td align="center" valign="top">10013584</td>
+                <td align="center" valign="top">498.4</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Sacarose 30%</td>
+                <td align="center" valign="top">10013301</td>
+                <td align="center" valign="top">781.5</td>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>Este resultado mostra que equipamento proposto responde a variações de concentração de soluto. No entanto para elaboração do teste de ajuste linear e outras provas estatísticas fez-se necessário aumentar o número de análises. A MCQ foi submetida a solução de glicose em água que variaram de 1,6 a 90 mg/mL. Os valores de frequência estáveis para cada concentração são mostrados na Tabela <xref ref-type="table" rid="S3.T3">3</xref>.</p>
+        <table-wrap id="S3.T3" position="float">
+          <label>Tabela 3:</label>
+          <caption>
+            <title>Frequências estáveis de diferentes concentrações de solução de glicose.</title>
+          </caption>
+          <table cellpadding="5" cellspacing="5" frame="hsides" rules="groups">
+            <thead>
+              <tr>
+                <th align="left" valign="top">Análises</th>
+                <th align="center" valign="top">Concentração de glicose (mg/mL)</th>
+                <th align="center" valign="top">Frequência (Hz)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left" valign="top">1</td>
+                <td align="center" valign="top">1,6</td>
+                <td align="center" valign="top">10006837.3</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">2</td>
+                <td align="center" valign="top">3,1</td>
+                <td align="center" valign="top">10006805.5</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">3</td>
+                <td align="center" valign="top">6,3</td>
+                <td align="center" valign="top">10006778.7</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">4</td>
+                <td align="center" valign="top">12,5</td>
+                <td align="center" valign="top">10006744.5</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">5</td>
+                <td align="center" valign="top">25</td>
+                <td align="center" valign="top">10006656</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">6</td>
+                <td align="center" valign="top">50</td>
+                <td align="center" valign="top">10006495.2</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">7</td>
+                <td align="center" valign="top">2,2</td>
+                <td align="center" valign="top">10006861.4</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">8</td>
+                <td align="center" valign="top">4,4</td>
+                <td align="center" valign="top">10006847.5</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">9</td>
+                <td align="center" valign="top">8,8</td>
+                <td align="center" valign="top">10006825.5</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">10</td>
+                <td align="center" valign="top">17,5</td>
+                <td align="center" valign="top">10006783.9</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">11</td>
+                <td align="center" valign="top">35</td>
+                <td align="center" valign="top">10006684.7</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">12</td>
+                <td align="center" valign="top">70</td>
+                <td align="center" valign="top">10006459.7</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">13</td>
+                <td align="center" valign="top">2,8</td>
+                <td align="center" valign="top">10006870</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">14</td>
+                <td align="center" valign="top">5,6</td>
+                <td align="center" valign="top">10006851.8</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">15</td>
+                <td align="center" valign="top">11,3</td>
+                <td align="center" valign="top">10006817.8</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">16</td>
+                <td align="center" valign="top">22,5</td>
+                <td align="center" valign="top">10006750.4</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">17</td>
+                <td align="center" valign="top">45</td>
+                <td align="center" valign="top">10006594.4</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">18</td>
+                <td align="center" valign="top">90</td>
+                <td align="center" valign="top">10006286.9</td>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>Para a verificação da adequação do modelo, os dados foram submetidos a Análise de Covariância – ANOVA. A Tabela <xref ref-type="table" rid="S3.T4">4</xref> mostra os resultados desse tratamento.</p>
+        <table-wrap id="S3.T4" position="float">
+          <label>Tabela 4:</label>
+          <caption>
+            <title>Análise de Covariância – ANOVA.</title>
+          </caption>
+          <table cellpadding="5" cellspacing="5" frame="hsides" rules="groups">
+            <thead>
+              <tr>
+                <th align="left" valign="top">Fonte da Variação</th>
+                <th align="center" valign="top">Grau de Liberdade</th>
+                <th align="center" valign="top">Soma de quadrados</th>
+                <th align="center" valign="top">Quadrado médio</th>
+                <th align="center" valign="top">F</th>
+                <th align="center" valign="top">P</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left" valign="top">Regressão</td>
+                <td align="center" valign="top">1</td>
+                <td align="center" valign="top">435662.88</td>
+                <td align="center" valign="top">435662.88</td>
+                <td align="center" valign="top">382.488</td>
+                <td align="center" valign="top"> &lt; 0.001</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Resíduo</td>
+                <td align="center" valign="top">16</td>
+                <td align="center" valign="top">18224.402</td>
+                <td align="center" valign="top">1139.025</td>
+                <td/>
+                <td/>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Total</td>
+                <td align="center" valign="top">17</td>
+                <td align="center" valign="top">453887.28</td>
+                <td/>
+                <td/>
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>A regressão linear simples (Figura <xref ref-type="fig" rid="S3.F12">12</xref>) mostra que a variação da concentração de glicose nas soluções prevê a variação da frequência medida na MCQ [F (1, 16) = 382.487, p &lt; 0,001; R<sup>2</sup> = 0,959].</p>
+        <fig id="S3.F12" position="float">
+          <label>Figura 12:</label>
+          <caption>
+            <title>Gráfico do ajuste linear da concentração de glicose e variação da frequência.</title>
+          </caption>
+          <alternatives>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/1a5a5133f44d3e9bddbcd64981dfb929cbc6e200.jpg"/>
+            <graphic xlink:href="https://minio.scielo.br/documentstore/1806-9126/cRtRZdqFhRZZ35Hn6WvjzKx/475e74b5c629f7d5f7e807740abae8efc00661a5.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+          </alternatives>
+        </fig>
+      </sec>
+    </sec>
+    <sec id="S4">
+      <title>4. Considerações finais</title>
+      <p>Este estudo teve como objetivo principal a implementação de um protótipo de Microbalança de Cristal de Quartzo de baixo custo capaz de realizar análises micro gravimétricas. Para tanto, foi desenvolvido um protótipo funcional a partir de materiais de fácil acesso que detecta a variação de massa de solutos dissolvidos em eletrodo/cristal específico, processa e transmite sinais para um software, que mostra essas interações em tempo real e armazena os dados. Esta pesquisa possibilitou a aplicação e o uso de técnicas de projeto e construção de dispositivos micro eletromecânicos destinados a implementação e desenvolvimento de ferramenta de ensino capaz de aproximar do ambiente de ensino técnicas de análises micrométricas. A utilização de solutos diluídos com diversas variações de concentração mostrou-se eficaz como ferramenta de validação dos testes micrométricos de massa. A escolha do Arduíno micro<sup>®</sup> como dispositivo controlador do frequencímetro foi essencial para se chegar à solução final. Com o uso desse controlador, foi possível evitar o investimento de tempo e recursos no desenvolvimento de dispositivo capaz de comunicação de dados rápida e estável com o computador. Outra funcionalidade adquirida pelo uso Arduíno foi a capacidade de ajuste simplificado da comunicação com computador, alimentação de todo o sistema via porta USB, dispensado o desenvolvimento de sistema para esse fim, a disponibilidade de ampla biblioteca de scripts de forma gratuita, linguagem de programação fácil e software intuitivo. Esses foram exemplos práticos de como essa placa de prototipagem contribuiu no desenvolvimento do protótipo. permitindo abordagem corretiva dos mecanismos de ajuste sempre que necessário, melhorando a performance e a qualidade dos resultados. Contudo, a montagem do cristal nos eletrodos da MCQ ainda necessita de uma série de passos e cuidados para um selamento perfeito da câmara de reação. Em um trabalho futuro, poderão ser realizados testes com um sistema de selamento mais ágil e seguro. É necessário aplicação de novos testes com outros equipamentos existentes, a fim de verificar a acurácia com os resultados de outros trabalhos relacionados as proposições deste. Quanto à funcionalidade do sistema proposto, foram detectadas algumas limitações, como por exemplo, alta sensibilidade a variações na rede elétrica, assim a estabilidade ótima do sistema só foi atingida com uso notebooks ou desktops desligados da rede elétrica. A conexão em rede sem uso de algum tipo de estabilizador pode vir a prejudicar desempenho do equipamento. Esta tecnologia muito atrativa e relativamente simples para pesquisa e desenvolvimento de instrumentos didáticos para ensino de física e ciências, pode ser muito útil para aproximar a teoria da análise microgravimétrica com prática dentro do universo acadêmico. As técnicas microanalíticas estão disponíveis a muito tempo e com nível de sofisticação altíssimo assim como o investimento para sua aquisição. No entanto, ainda falta no mercado instrumentos voltados para o ensino que ofereçam a oportunidade de contato com essas tecnologias, para que se possa, ainda nos primeiros anos de uma graduação, ou mesmo no ensino básico ou tecnológico pensar em sua implementação, seja dos protocolos de uso ou da tecnologia em si. A solução proposta, neste estudo, se mostrou bastante viável, considerando a propósito e o acerto das análises durante o desenvolvimento. A maior parte dos testes realizados obtiveram resultados satisfatórios, salvo algumas limitações já discutidas. Espera-se que o conceito da MCQ não mais seja associado a algo intangível. Como proposta de melhorias futuras, destacam-se: sofisticação do <italic>design</italic>, simplificação no processo de montagem do cristal, miniaturização dos sistemas eletrônicos, implementação de um sistema de detecção de energia dissipada que aumentaria significativamente a qualidade da análise.</p>
+    </sec>
+  </body>
+  <back>
+    <ref-list>
+      <title>Referênces</title>
+      <ref id="B1">
+        <mixed-citation>W.R.S. Silva, D.P. Souza e S. Rodrigues-Moura, Rev. Pesqui. Qual. 7, 428 (2019).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Silva</surname>
+              <given-names>W.R.S.</given-names>
+            </name>
+            <name>
+              <surname>Souza</surname>
+              <given-names>D.P.</given-names>
+            </name>
+            <name>
+              <surname>Rodrigues-Moura</surname>
+              <given-names>S.</given-names>
+            </name>
+          </person-group>
+          <source>Rev. Pesqui. Qual.</source>
+          <volume>7</volume>
+          <page-range>428</page-range>
+          <year>2019</year>
+        </element-citation>
+      </ref>
+      <ref id="B2">
+        <mixed-citation>A.M.P. Carvalho e L.H. Sasseron, Ensino em Re-Vista 22, 249 (2015).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Carvalho</surname>
+              <given-names>A.M.P.</given-names>
+            </name>
+            <name>
+              <surname>Sasseron</surname>
+              <given-names>L.H.</given-names>
+            </name>
+          </person-group>
+          <source>Ensino em Re-Vista</source>
+          <volume>22</volume>
+          <page-range>249</page-range>
+          <year>2015</year>
+        </element-citation>
+      </ref>
+      <ref id="B3">
+        <mixed-citation>D.R. Shonnard, D.T. Allen, N. Nguyen, S.W. Austin e R. Hesketh, Environ. Sci. Technol. 37, 5453 (2003).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Shonnard</surname>
+              <given-names>D.R.</given-names>
+            </name>
+            <name>
+              <surname>Allen</surname>
+              <given-names>D.T.</given-names>
+            </name>
+            <name>
+              <surname>Nguyen</surname>
+              <given-names>N.</given-names>
+            </name>
+            <name>
+              <surname>Austin</surname>
+              <given-names>S.W.</given-names>
+            </name>
+            <name>
+              <surname>Hesketh</surname>
+              <given-names>R.</given-names>
+            </name>
+          </person-group>
+          <source>Environ. Sci. Technol.</source>
+          <volume>37</volume>
+          <page-range>5453</page-range>
+          <year>2003</year>
+        </element-citation>
+      </ref>
+      <ref id="B4">
+        <mixed-citation>S.E. Lyshevski, <italic>Mems and Nems. Mems and Nems</italic> (CRC Press, Boca Raton, 2018), p. 61.</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Lyshevski</surname>
+              <given-names>S.E.</given-names>
+            </name>
+          </person-group>
+          <source>Mems and Nems. Mems and Nems</source>
+          <publisher-name>CRC Press</publisher-name>
+          <publisher-loc>Boca Raton</publisher-loc>
+          <year>2018</year>
+          <page-range>p. 61.</page-range>
+        </element-citation>
+      </ref>
+      <ref id="B5">
+        <mixed-citation>K. Qian, F. Zhai e Q. Meng, em: <italic>Proceedings of the 2019 3rd International Conference on Education, Management Science and Economics</italic> (Singapura, 2019).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Qian</surname>
+              <given-names>K.</given-names>
+            </name>
+            <name>
+              <surname>Zhai</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Meng</surname>
+              <given-names>Q.</given-names>
+            </name>
+          </person-group>
+          <source>Proceedings of the 2019 3rd International Conference on Education, Management Science and Economics</source>
+          <publisher-name>Singapura</publisher-name>
+          <year>2019</year>
+        </element-citation>
+      </ref>
+      <ref id="B6">
+        <mixed-citation>T.S. Schmidt e J. Huenteler, Glob. Environ. Chang. 38, 8 (2016).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Schmidt</surname>
+              <given-names>T.S.</given-names>
+            </name>
+            <name>
+              <surname>Huenteler</surname>
+              <given-names>J.</given-names>
+            </name>
+          </person-group>
+          <source>Glob. Environ. Chang.</source>
+          <volume>38</volume>
+          <page-range>8</page-range>
+          <year>2016</year>
+        </element-citation>
+      </ref>
+      <ref id="B7">
+        <mixed-citation>Y.S. Kurniawan, Biomed J Sci &amp; Tech Res 12, 9442 (2019).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Kurniawan</surname>
+              <given-names>Y.S.</given-names>
+            </name>
+          </person-group>
+          <source>Biomed J Sci &amp; Tech Res</source>
+          <volume>12</volume>
+          <page-range>9442</page-range>
+          <year>2019</year>
+        </element-citation>
+      </ref>
+      <ref id="B8">
+        <mixed-citation>D.E.W. Patabadige, S. Jia, J. Sibbitts, J. Sadeghi, K. Sellens e C.T. Culbertson, Anal. Chem. 88, 320 (2015).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Patabadige</surname>
+              <given-names>D.E.W.</given-names>
+            </name>
+            <name>
+              <surname>Jia</surname>
+              <given-names>S.</given-names>
+            </name>
+            <name>
+              <surname>Sibbitts</surname>
+              <given-names>J.</given-names>
+            </name>
+            <name>
+              <surname>Sadeghi</surname>
+              <given-names>J.</given-names>
+            </name>
+            <name>
+              <surname>Sellens</surname>
+              <given-names>K.</given-names>
+            </name>
+            <name>
+              <surname>Culbertson</surname>
+              <given-names>C.T.</given-names>
+            </name>
+          </person-group>
+          <source>Anal. Chem.</source>
+          <volume>88</volume>
+          <page-range>320</page-range>
+          <year>2015</year>
+        </element-citation>
+      </ref>
+      <ref id="B9">
+        <mixed-citation>L.C. Santos, F.P. Beraldo, L.F. Hernandez, R.A.M. Carvalho e M.L.P. Silva, Rev. Bras. Apl. Vácuo 25, 75 (2008).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Santos</surname>
+              <given-names>L.C.</given-names>
+            </name>
+            <name>
+              <surname>Beraldo</surname>
+              <given-names>F.P.</given-names>
+            </name>
+            <name>
+              <surname>Hernandez</surname>
+              <given-names>L.F.</given-names>
+            </name>
+            <name>
+              <surname>Carvalho</surname>
+              <given-names>R.A.M.</given-names>
+            </name>
+            <name>
+              <surname>Silva</surname>
+              <given-names>M.L.P.</given-names>
+            </name>
+          </person-group>
+          <source>Rev. Bras. Apl. Vácuo</source>
+          <volume>25</volume>
+          <page-range>75</page-range>
+          <year>2008</year>
+        </element-citation>
+      </ref>
+      <ref id="B10">
+        <mixed-citation>M. Pohanka, Materials (Basel) 11, 448 (2018).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Pohanka</surname>
+              <given-names>M.</given-names>
+            </name>
+          </person-group>
+          <source>Materials (Basel)</source>
+          <volume>11</volume>
+          <page-range>448</page-range>
+          <year>2018</year>
+        </element-citation>
+      </ref>
+      <ref id="B11">
+        <mixed-citation>M. Hussain, F. Rupp, H.P. Wendel e F.K., TrAC – Trends in Analytical Chemistry 102, 194 (2018).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Hussain</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Rupp</surname>
+              <given-names>F.</given-names>
+            </name>
+            <name>
+              <surname>Wendel</surname>
+              <given-names>H.P.</given-names>
+            </name>
+          </person-group>
+          <source>F.K., TrAC – Trends in Analytical Chemistry</source>
+          <volume>102</volume>
+          <page-range>194</page-range>
+          <year>2018</year>
+        </element-citation>
+      </ref>
+      <ref id="B12">
+        <mixed-citation>M. Michalzik, R. Wilke e S. Büttgenbach, Sensors and Actuators, B: Chemical 111–112, 410 (2005).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Michalzik</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Wilke</surname>
+              <given-names>R.</given-names>
+            </name>
+            <name>
+              <surname>Büttgenbach</surname>
+              <given-names>S.</given-names>
+            </name>
+          </person-group>
+          <source>Sensors and Actuators, B: Chemical</source>
+          <volume>111–112</volume>
+          <page-range>410</page-range>
+          <year>2005</year>
+        </element-citation>
+      </ref>
+      <ref id="B13">
+        <mixed-citation>M. Pohanka, O. Pavliš e P. Skládal, Talanta 71, 981 (2007).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Pohanka</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Pavliš</surname>
+              <given-names>O.</given-names>
+            </name>
+            <name>
+              <surname>Skládal</surname>
+              <given-names>P.</given-names>
+            </name>
+          </person-group>
+          <source>Talanta</source>
+          <volume>71</volume>
+          <page-range>981</page-range>
+          <year>2007</year>
+        </element-citation>
+      </ref>
+      <ref id="B14">
+        <mixed-citation>C.L. Liang, S.W. Lee e K.L. Lin, Thin Solid Films 636, 164 (2017).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Liang</surname>
+              <given-names>C.L.</given-names>
+            </name>
+            <name>
+              <surname>Lee</surname>
+              <given-names>S.W.</given-names>
+            </name>
+            <name>
+              <surname>Lin</surname>
+              <given-names>K.L.</given-names>
+            </name>
+          </person-group>
+          <source>Thin Solid Films</source>
+          <volume>636</volume>
+          <page-range>164</page-range>
+          <year>2017</year>
+        </element-citation>
+      </ref>
+      <ref id="B15">
+        <mixed-citation>V.E. Bottom, em: <italic>Thirty Fifth Annual Frequency Control Symposium</italic> (Philadelphia, 2008).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Bottom</surname>
+              <given-names>V.E.</given-names>
+            </name>
+          </person-group>
+          <source>Thirty Fifth Annual Frequency Control Symposium</source>
+          <publisher-name>Philadelphia</publisher-name>
+          <year>2008</year>
+        </element-citation>
+      </ref>
+      <ref id="B16">
+        <mixed-citation>D.A. Mellis, M. Banzi, D. Cuartielles e T. Igoe, <italic>Arduino: An open electronic prototyping platform</italic>, disponível em: <ext-link ext-link-type="uri" xlink:href="http://web.media.mit.edu/mellis/arduino-chi2007-mellis-banzi-cuartielles-igoe.pdf">http://web.media.mit.edu/mellis/arduino-chi2007-mellis-banzi-cuartielles-igoe.pdf</ext-link>, acessado em 14/11/2019.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Mellis</surname>
+              <given-names>D.A.</given-names>
+            </name>
+            <name>
+              <surname>Banzi</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Cuartielles</surname>
+              <given-names>D.</given-names>
+            </name>
+            <name>
+              <surname>Igoe</surname>
+              <given-names>T.</given-names>
+            </name>
+          </person-group>
+          <source>Arduino: An open electronic prototyping platform</source>
+          <comment>disponível em: <ext-link ext-link-type="uri" xlink:href="http://web.media.mit.edu/mellis/arduino-chi2007-mellis-banzi-cuartielles-igoe.pdf">http://web.media.mit.edu/mellis/arduino-chi2007-mellis-banzi-cuartielles-igoe.pdf</ext-link>,</comment>
+          <date-in-citation>acessado em 14/11/2019.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="B17">
+        <mixed-citation>Y.A. Badamasi, em:<italic>Proceedings of the 11th International Conference on Electronics, Computer and Computation (ICECCO)</italic> (Abuja, 2014).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Badamasi</surname>
+              <given-names>Y.A.</given-names>
+            </name>
+          </person-group>
+          <source>Proceedings of the 11th International Conference on Electronics, Computer and Computation (ICECCO)</source>
+          <publisher-loc>Abuja</publisher-loc>
+          <year>2014</year>
+        </element-citation>
+      </ref>
+      <ref id="B18">
+        <mixed-citation>P.C. Minns, <italic>Programming For the PC the MAC and the Arduino Microcontroller System</italic>, disponível em: <ext-link ext-link-type="uri" xlink:href="http://nrl.northumbria.ac.uk/15136/">http://nrl.northumbria.ac.uk/15136/</ext-link>, acessado em 14/11/2019.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Minns</surname>
+              <given-names>P.C.</given-names>
+            </name>
+          </person-group>
+          <source>Programming For the PC the MAC and the Arduino Microcontroller System</source>
+          <comment>disponível em: <ext-link ext-link-type="uri" xlink:href="http://nrl.northumbria.ac.uk/15136/">http://nrl.northumbria.ac.uk/15136/</ext-link>,</comment>
+          <date-in-citation>acessado em 14/11/2019.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="B19">
+        <mixed-citation>M. Margolis, <italic>Arduino Cookbook</italic> (O’Reilly Media, Massachusetts, 2011).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Margolis</surname>
+              <given-names>M.</given-names>
+            </name>
+          </person-group>
+          <source>Arduino Cookbook</source>
+          <publisher-name>O’Reilly Media</publisher-name>
+          <publisher-loc>Massachusetts</publisher-loc>
+          <year>2011</year>
+        </element-citation>
+      </ref>
+      <ref id="B20">
+        <mixed-citation>J. Boxall, <italic>Arduino Worskhop: A hands-on introduction with 65 Projects</italic> (No Starch Press, California, 2013).</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Boxall</surname>
+              <given-names>J.</given-names>
+            </name>
+          </person-group>
+          <source>Arduino Worskhop: A hands-on introduction with 65 Projects</source>
+          <publisher-name>No Starch Press</publisher-name>
+          <publisher-loc>California</publisher-loc>
+          <year>2013</year>
+        </element-citation>
+      </ref>
+      <ref id="B21">
+        <mixed-citation>N. Robert, <italic>Introduction to Arduino Leonardo – The Engineering Projects. Engineering Project</italic>, disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.theengineeringprojects.com/2018/09/introduction-to-arduino-micro.html">https://www.theengineeringprojects.com/2018/09/introduction-to-arduino-micro.html</ext-link>, acessado em 15/06/2021.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Robert</surname>
+              <given-names>N.</given-names>
+            </name>
+          </person-group>
+          <source>Introduction to Arduino Leonardo – The Engineering Projects. Engineering Project</source>
+          <comment>disponível em: <ext-link ext-link-type="uri" xlink:href="https://www.theengineeringprojects.com/2018/09/introduction-to-arduino-micro.html">https://www.theengineeringprojects.com/2018/09/introduction-to-arduino-micro.html</ext-link>,</comment>
+          <date-in-citation>acessado em 15/06/2021.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="B22">
+        <mixed-citation>GitHub: Where the world builds software (2008), <ext-link ext-link-type="uri" xlink:href="https://github.com/collections">https://github.com/collections</ext-link>, acessado em: 09/08/2019</mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <collab>GitHub: Where the world builds software</collab>
+          </person-group>
+          <year>2008</year>
+          <comment><ext-link ext-link-type="uri" xlink:href="https://github.com/collections">https://github.com/collections</ext-link>,</comment>
+          <date-in-citation>acessado em: 09/08/2019</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="B23">
+        <mixed-citation><ext-link ext-link-type="uri" xlink:href="https://openqcm.com/openqcm">https://openqcm.com/openqcm</ext-link>, acessado em 14/11/ 2019.</mixed-citation>
+        <element-citation publication-type="webpage">
+          <comment><ext-link ext-link-type="uri" xlink:href="https://openqcm.com/openqcm">https://openqcm.com/openqcm</ext-link>,</comment>
+          <date-in-citation>acessado em 14/11/ 2019.</date-in-citation>
+        </element-citation>
+      </ref>
+      <ref id="B24">
+        <mixed-citation>H. Varela, M. Malta e R.M. Torresi, Quim. Nova 23, 664 (2000).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Varela</surname>
+              <given-names>H.</given-names>
+            </name>
+            <name>
+              <surname>Malta</surname>
+              <given-names>M.</given-names>
+            </name>
+            <name>
+              <surname>Torresi</surname>
+              <given-names>R.M.</given-names>
+            </name>
+          </person-group>
+          <source>Quim. Nova</source>
+          <volume>23</volume>
+          <page-range>664</page-range>
+          <year>2000</year>
+        </element-citation>
+      </ref>
+      <ref id="B25">
+        <mixed-citation>M. Coolbaugh, <italic>Final Report: Electrochemical Workstation for Research on Chemical Surface Modifications and Characterization of Novel Conductive Polymers</italic>, Johnson C. Smith University Charlotte United States, Charlotte (2015).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Coolbaugh</surname>
+              <given-names>M.</given-names>
+            </name>
+          </person-group>
+          <source>Final Report: Electrochemical Workstation for Research on Chemical Surface Modifications and Characterization of Novel Conductive Polymers</source>
+          <publisher-name>Johnson C. Smith University Charlotte United States</publisher-name>
+          <publisher-loc>Charlotte</publisher-loc>
+          <year>2015</year>
+        </element-citation>
+      </ref>
+      <ref id="B26">
+        <mixed-citation>K.K. Kanazawa e J.G. Gordon, Acta 175, 99 (1985).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Kanazawa</surname>
+              <given-names>K.K.</given-names>
+            </name>
+            <name>
+              <surname>Gordon</surname>
+              <given-names>J.G.</given-names>
+            </name>
+          </person-group>
+          <source>Acta 175</source>
+          <volume>99</volume>
+          <year>1985</year>
+        </element-citation>
+      </ref>
+      <ref id="B27">
+        <mixed-citation>K.K. Kanazawa e J.G. Gordon, Anal. Chem. 57, 1770 (1985).</mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Kanazawa</surname>
+              <given-names>K.K.</given-names>
+            </name>
+            <name>
+              <surname>Gordon</surname>
+              <given-names>J.G.</given-names>
+            </name>
+          </person-group>
+          <source>Anal. Chem.</source>
+          <volume>57</volume>
+          <page-range>1770</page-range>
+          <year>1985</year>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </back>
+</article>


### PR DESCRIPTION
#### O que esse PR faz?
Troca o caracter ponto por `_` se aparece no `@id` de figura, equações e tabelas para que funcione a apresentação dos "modais". Tendo o caracter ponto, o JavaScript não funciona conforme esperado.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

```console
python packtools/htmlgenerator.py --nochecks --nonetwork --loglevel DEBUG tests/fixtures/dot_in_id/tabelas.xml
```

```console
python packtools/htmlgenerator.py --nochecks --nonetwork --loglevel DEBUG tests/fixtures/dot_in_id/arquivo.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a


#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2233

### Referências
n/a
