### PR TITLE
Funding group

### DIFF
--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -1,0 +1,46 @@
+import logging
+
+from packtools.sps.utils import xml_utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class FundingGroup:
+    """
+    Class that performs the extraction of values for funding-source and award-id.
+    To return both attributes, award_groups is used.
+    To return only institutions, use funding_sources.
+
+    Parameters
+    ----------
+    xml
+        XML file that contains the attributes of interest.
+
+    Returns
+    -------
+    list
+        Arrangement containing a dictionary that correlates funding-source and award-id or values of one of the attributes.
+    """
+
+    def __init__(self, xml):
+        self._xmltree = xml_utils.get_xml_tree(xml)
+
+    @property
+    def award_groups(self):
+        items = []
+        for node in self._xmltree.xpath(".//funding-group/award-group"):
+            funding_sources = node.xpath("funding-source")
+            award_ids = node.xpath("award-id")
+            d = {}
+            d["funding-source"] = [item.text for item in funding_sources]
+            d["award-id"] = [item.text for item in award_ids]
+            items.append(d)
+        return items
+
+    @property
+    def funding_sources(self):
+        items = []
+        for node in self._xmltree.xpath(".//funding-group/award-group/funding-source"):
+            items.append(node.text)
+        return items

--- a/tests/test_funding_group.py
+++ b/tests/test_funding_group.py
@@ -73,6 +73,8 @@ class FundingGroupOneFundingSourceOneAwardIdTests(unittest.TestCase):
         ]
         result = self.funding_group.award_groups
         self.assertEqual(expected, result)
+
+
 class FundingGroupNFundingSourceOneAwardIdTests(unittest.TestCase):
     def setUp(self):
         xml = (
@@ -98,6 +100,42 @@ class FundingGroupNFundingSourceOneAwardIdTests(unittest.TestCase):
     def test_award_groups(self):
         expected = [
             {'funding-source': ['CNPq', 'FAPESP'], 'award-id': ['#09/06953-4']}
+        ]
+        result = self.funding_group.award_groups
+        self.assertEqual(expected, result)
+
+
+class FundingGroupNFundingSourceOneAwardIdWithFundingStatementTests(unittest.TestCase):
+    def setUp(self):
+        xml = (
+            """
+            <article> 
+                <funding-group>
+                    <award-group>
+                        <funding-source>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior</funding-source>
+                        <funding-source> Fundação de Amparo à Pesquisa do Estado de São Paulo</funding-source>
+                        <award-id>04/08142-0</award-id>
+                    </award-group>
+                    <funding-statement>This study was supported in part by Coordenação
+                    de Aperfeiçoamento de Pessoal de Nível Superior (Capes — Brasília,
+                    Brazil), Fundação de Amparo à Pesquisa do Estado de São Paulo (FAPESP —
+                    Grant no. 04/08142-0; São Paulo, Brazil)</funding-statement>
+                </funding-group>
+            </article>
+            """
+        )
+        self.funding_group = FundingGroup(xml)
+
+    def test_funding_sources(self):
+        expected = ['Coordenação de Aperfeiçoamento de Pessoal de Nível Superior',
+                    ' Fundação de Amparo à Pesquisa do Estado de São Paulo']
+        result = self.funding_group.funding_sources
+        self.assertEqual(expected, result)
+
+    def test_award_groups(self):
+        expected = [
+            {'funding-source': ['Coordenação de Aperfeiçoamento de Pessoal de Nível Superior',
+                                ' Fundação de Amparo à Pesquisa do Estado de São Paulo'], 'award-id': ['04/08142-0']}
         ]
         result = self.funding_group.award_groups
         self.assertEqual(expected, result)

--- a/tests/test_funding_group.py
+++ b/tests/test_funding_group.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import unittest
+
+try:
+    from unittest import mock
+except:
+    import mock
+
+from packtools.sps.models.funding_group import FundingGroup
+
+
+class FundingGroupOneFundingSourceNAwardIdTests(unittest.TestCase):
+    def setUp(self):
+        xml = (
+            """
+            <article> 
+                <funding-group>
+                      <award-group>
+                          <funding-source>CNPQ</funding-source>
+                          <award-id>12345</award-id>
+                          <award-id>67890</award-id>
+                      </award-group>
+                      <award-group>
+                          <funding-source>FAPESP</funding-source>
+                          <award-id>23456</award-id>
+                          <award-id>56789</award-id>
+                      </award-group>
+                </funding-group>
+            </article>
+            """
+        )
+        self.funding_group = FundingGroup(xml)
+
+    def test_funding_sources(self):
+        expected = ['CNPQ', 'FAPESP']
+        result = self.funding_group.funding_sources
+        self.assertEqual(expected, result)
+
+    def test_award_groups(self):
+        expected = [
+            {'funding-source': ['CNPQ'], 'award-id': ['12345', '67890']},
+            {'funding-source': ['FAPESP'], 'award-id': ['23456', '56789']},
+        ]
+        result = self.funding_group.award_groups
+        self.assertEqual(expected, result)
+
+

--- a/tests/test_funding_group.py
+++ b/tests/test_funding_group.py
@@ -73,3 +73,31 @@ class FundingGroupOneFundingSourceOneAwardIdTests(unittest.TestCase):
         ]
         result = self.funding_group.award_groups
         self.assertEqual(expected, result)
+class FundingGroupNFundingSourceOneAwardIdTests(unittest.TestCase):
+    def setUp(self):
+        xml = (
+            """
+            <article> 
+                <funding-group>
+                    <award-group>
+                        <funding-source>CNPq</funding-source>
+                        <funding-source>FAPESP</funding-source>
+                        <award-id>#09/06953-4</award-id>
+                    </award-group>
+                </funding-group>
+            </article>
+            """
+        )
+        self.funding_group = FundingGroup(xml)
+
+    def test_funding_sources(self):
+        expected = ['CNPq', 'FAPESP']
+        result = self.funding_group.funding_sources
+        self.assertEqual(expected, result)
+
+    def test_award_groups(self):
+        expected = [
+            {'funding-source': ['CNPq', 'FAPESP'], 'award-id': ['#09/06953-4']}
+        ]
+        result = self.funding_group.award_groups
+        self.assertEqual(expected, result)

--- a/tests/test_funding_group.py
+++ b/tests/test_funding_group.py
@@ -46,3 +46,30 @@ class FundingGroupOneFundingSourceNAwardIdTests(unittest.TestCase):
         self.assertEqual(expected, result)
 
 
+class FundingGroupOneFundingSourceOneAwardIdTests(unittest.TestCase):
+    def setUp(self):
+        xml = (
+            """
+            <article> 
+                <funding-group>
+                     <award-group>
+                         <funding-source>CNPq</funding-source>
+                         <award-id>1685X6-7</award-id>
+                     </award-group>
+                </funding-group>
+            </article>
+            """
+        )
+        self.funding_group = FundingGroup(xml)
+
+    def test_funding_sources(self):
+        expected = ['CNPq']
+        result = self.funding_group.funding_sources
+        self.assertEqual(expected, result)
+
+    def test_award_groups(self):
+        expected = [
+            {'funding-source': ['CNPq'], 'award-id': ['1685X6-7']}
+        ]
+        result = self.funding_group.award_groups
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a classe FundingGroup que recebe um arquivo XML e retorna instituições de financiamento (_funding_sources_) e os respectivos números de processo (_award-ids_).

#### Onde a revisão poderia começar?
Os _commit's_ referenciam a classe e os testes, individualmente.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
[https://jats.nlm.nih.gov/publishing/tag-library/1.3/element/funding-group.html](url)
[https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/tagset/elemento-funding-group.html](url)
