### PR TITLE
Adiciona classe ArticleRenditions

### DIFF
--- a/packtools/sps/models/article_renditions.py
+++ b/packtools/sps/models/article_renditions.py
@@ -1,3 +1,19 @@
 class ArticleRenditions:
     def __init__(self, xmltree):
         self.xmltree = xmltree
+
+    @property
+    def article_renditions(self):
+        _renditions = []
+
+        main_rendition = Rendition(
+            self.xmltree.find("."),
+            True,
+        )
+        _renditions.append(main_rendition)
+
+        for sub_article in self.xmltree.xpath(".//sub-article[@article-type='translation']"):
+            _renditions.append(Rendition(sub_article))
+
+        return _renditions
+

--- a/packtools/sps/models/article_renditions.py
+++ b/packtools/sps/models/article_renditions.py
@@ -17,3 +17,12 @@ class ArticleRenditions:
 
         return _renditions
 
+
+class Rendition:
+    def __init__(self, node, is_main_language=False):
+        self.node = node
+        self.is_main_language=is_main_language
+
+    @property
+    def language(self):
+        return self.node.get("{http://www.w3.org/XML/1998/namespace}lang")

--- a/packtools/sps/models/article_renditions.py
+++ b/packtools/sps/models/article_renditions.py
@@ -1,0 +1,3 @@
+class ArticleRenditions:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.11.1'
+__version__ = '2.11.2'

--- a/tests/sps/test_article_renditions.py
+++ b/tests/sps/test_article_renditions.py
@@ -22,3 +22,13 @@ def generate_xmltree(extralang1, extralang2=None, extralang3=None):
     """
     return xml_utils.get_xml_tree(xml.format(extralang1, extralang2, extralang3))
 
+
+class ArticleRenditionsTest(TestCase):
+    def test_article_assets_with_one_language(self):
+      data = """<article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang='es'></article>"""
+      xmltree = xml_utils.get_xml_tree(data)
+
+      expected = ['es']
+      obtained = [r.language for r in ArticleRenditions(xmltree).article_renditions]
+
+      self.assertListEqual(expected, obtained)

--- a/tests/sps/test_article_renditions.py
+++ b/tests/sps/test_article_renditions.py
@@ -32,3 +32,13 @@ class ArticleRenditionsTest(TestCase):
       obtained = [r.language for r in ArticleRenditions(xmltree).article_renditions]
 
       self.assertListEqual(expected, obtained)
+
+
+    def test_article_assets_with_two_languages(self):
+      snippet = """<sub-article xml:lang='es' article-type='translation'><front-stub></front-stub></sub-article>"""
+      xmltree = generate_xmltree(snippet)
+
+      expected = ['pt', 'es']
+      obtained = [r.language for r in ArticleRenditions(xmltree).article_renditions]
+
+      self.assertListEqual(expected, obtained)

--- a/tests/sps/test_article_renditions.py
+++ b/tests/sps/test_article_renditions.py
@@ -42,3 +42,16 @@ class ArticleRenditionsTest(TestCase):
       obtained = [r.language for r in ArticleRenditions(xmltree).article_renditions]
 
       self.assertListEqual(expected, obtained)
+
+
+    def test_article_assets_with_three_languages(self):
+      snippet = """
+      <sub-article xml:lang='es' article-type='translation'><front-stub></front-stub></sub-article>
+      <sub-article xml:lang='it' article-type='translation'><front-stub></front-stub></sub-article>
+      """
+      xmltree = generate_xmltree(snippet)
+
+      expected = ['pt', 'es', 'it']
+      obtained = [r.language for r in ArticleRenditions(xmltree).article_renditions]
+
+      self.assertListEqual(expected, obtained)

--- a/tests/sps/test_article_renditions.py
+++ b/tests/sps/test_article_renditions.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from packtools.sps.utils import xml_utils
+
+from packtools.sps.models.article_renditions import ArticleRenditions
+
+
+def generate_xmltree(extralang1, extralang2=None, extralang3=None):
+    xml = """
+    <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+        <front>
+            <article-meta>
+                {0}
+            </article-meta>
+        </front>
+        {1}
+        {2}
+        <body>
+            <sec><p>The Eh measurements... <xref ref-type="fig" rid="f01">Figura 1</xref>:</p></sec>
+        </body>
+    </article>
+    """
+    return xml_utils.get_xml_tree(xml.format(extralang1, extralang2, extralang3))
+


### PR DESCRIPTION
#### O que esse PR faz?
Cria um módulo article_renditions.py que contém as classes ArticleRenditions e Rendition. Essas classes são responsáveis por inferir, a partir de um lxml.etree, quais são os idiomas (e portanto, arquivos PDF) esperados para um documento (etree).

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
```python
from packtools.sps.models.article_renditions import ArticleRenditions
from packtools.sps.utils import xml_utils

fin = open('arquivo.xml')
xmltree = xml_utils.get_xml_tree(fin.read())

ar = ArticleRenditions(xmltree)

for i in ar.article_renditions:
    print(i.language, i.is_main_language)
```

#### Algum cenário de contexto que queira dar?
Poderia ser interessante tentar inferir qual seria o nome do arquivo em si, para cada idioma, no entanto, isto depende dos outros campos estarem preenchidos (ISSN, Ano, etc...). Também poderia ser com base no nome do arquivo, mas acredito que isto esteja fora do escopo do momento. A app que for usar esse módulo pode ficar responsável por isso.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A