### PR TITLE
Adiciona modelos ArticleErrata e Erratum

### DIFF
--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -28,3 +28,16 @@ class ArticleErrata:
 class Erratum:
     def __init__(self, node):
         self.node = node
+
+    @property
+    def label(self):
+        _label = ''
+        try:
+            fc = self.node.getchildren()[0]
+            if fc.tag == 'label':
+                _label = fc.text
+        except IndexError:
+            ...
+        finally:
+            return _label
+

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -16,11 +16,15 @@ class ArticleWithErrataNotes:
         self.xmltree = xmltree
 
     def footnotes(self, fn_types=None):
-    def article_errata(self):
         _errata = []
 
-        for node in self.xmltree.xpath(".//fn-group//fn[@fn-type='other']"):
-            _errata.append(Erratum(node))
+        if not fn_types:
+            xpath_pattern = ".//fn-group//fn[@fn-type='other']"
+        else:
+            xpath_pattern = "|".join([".//fn-group//fn[@fn-type='{0}']".format(i) for i in fn_types])
+
+        for node in self.xmltree.xpath(xpath_pattern):
+            _errata.append(Footnote(node))
 
         return _errata
 

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -14,3 +14,13 @@
 class ArticleErrata:
     def __init__(self, xmltree):
         self.xmltree = xmltree
+
+    @property
+    def article_errata(self):
+        _errata = []
+
+        for node in self.xmltree.xpath(".//fn-group//fn[@fn-type='other']"):
+            _errata.append(Erratum(node))
+
+        return _errata
+

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -41,3 +41,7 @@ class Erratum:
         finally:
             return _label
 
+
+    @property
+    def text(self):
+        return '\n'.join([t for t in self.node.itertext()])

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -24,3 +24,7 @@ class ArticleErrata:
 
         return _errata
 
+
+class Erratum:
+    def __init__(self, node):
+        self.node = node

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -11,11 +11,11 @@
 """
 
 
-class ArticleErrata:
+class ArticleWithErrataNotes:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    @property
+    def footnotes(self, fn_types=None):
     def article_errata(self):
         _errata = []
 
@@ -25,7 +25,7 @@ class ArticleErrata:
         return _errata
 
 
-class Erratum:
+class Footnote:
     def __init__(self, node):
         self.node = node
 
@@ -40,7 +40,6 @@ class Erratum:
             ...
         finally:
             return _label
-
 
     @property
     def text(self):

--- a/packtools/sps/models/article_errata.py
+++ b/packtools/sps/models/article_errata.py
@@ -1,0 +1,16 @@
+"""
+<fn-group>
+    <fn fn-type="other">
+        <label>Additions and Corrections</label>
+        <p>On page 10, where it was read:</p>
+        <p>“Joao da Silva”</p>
+        <p>Now reads:</p>
+        <p>“João da Silva Santos”</p>
+    </fn>
+</fn-group>
+"""
+
+
+class ArticleErrata:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.11.2'
+__version__ = '2.13'

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -83,3 +83,135 @@ class ArticleErrataTest(TestCase):
 
         self.assertEqual(expected_text, obtained_text)
     
+
+    def test_article_errata_with_table(self):
+        data = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Corrections</label>
+                <p>Article “Risk factors for site complications of intravenous therapy in children and adolescents with cancer”, with number of DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0034-7167-2019-0471">https://doi.org/10.1590/0034-7167-2019-0471</ext-link>, published in the journal Revista Brasileira de Enfermagem, 73(4):e20190471, on page 3:</p>
+                <p>Where to read:</p>
+                <p>In the multiple analysis, logistic regression was performed and modeling was achieved when all variables presented p ≤ 0.05.</p>
+                <p>Read:</p>
+                <p>In the multiple analysis, Poisson regression with robust variance was performed and modeling was achieved when all variables presented p ≤ 0.05.</p>
+                <p>On page 6, <xref ref-type="table" rid="t11">Table 5</xref>, where it read:</p>
+                <p>
+                    <table-wrap id="t11">
+                        <label>Tabela 5</label>
+                        <caption>
+                            <title>Regressão Logística das variáveis relacionadas à Terapia Intravenosa prévia associadas à ocorrência de complicação em crianças e adolescentes admitidos em unidades de clínica oncológica pediátrica, Feira de Santana, Bahia, Brasil, 2015 - 2016</title>
+                        </caption>
+                        <table frame="hsides" rules="groups">
+                            <colgroup>
+                                <col width="40%"/>
+                                <col width="20%"/>
+                                <col width="20%"/>
+                                <col width="20%"/>
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th align="left" rowspan="2">Variables</th>
+                                    <th align="center" colspan="2">Complicações da Terapia Intravenosa</th>
+                                    <th align="center" rowspan="2"><italic>p</italic><break/>value</th>
+                                </tr>
+                                <tr>
+                                    <th align="center">RR</th>
+                                    <th align="center">IC</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td align="left">Terapia Intravenosa periférica prolongada</td>
+                                    <td align="center">3.44</td>
+                                    <td align="center">1.58 - 7.50</td>
+                                    <td align="center">0.002</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Antecedente de complicações</td>
+                                    <td align="center">4.22</td>
+                                    <td align="center">2.84 - 6.26</td>
+                                    <td align="center">&lt;0.001</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Utilização de medicamentos não irritantes/vesicantes</td>
+                                    <td align="center">1.99</td>
+                                    <td align="center">1.26 - 3.15</td>
+                                    <td align="center">0.003</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Utilização de solução vesicante</td>
+                                    <td align="center">2.65</td>
+                                    <td align="center">1.69 - 4.17</td>
+                                    <td align="center">&lt;0.001</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </table-wrap>
+                </p>
+                <p>Read:</p>
+                <p>
+                    <table-wrap id="t12">
+                        <label>Table 5</label>
+                        <caption>
+                            <title>Poisson Regression of variables related to previous Intravenous Therapy associated with the occurrence of complications in children and adolescents admitted to pediatric oncology clinic units in the interior of Bahia, Brazil, Apr 2015 - Dec 2016</title>
+                        </caption>
+                        <table frame="hsides" rules="groups">
+                            <colgroup>
+                                <col width="40%"/>
+                                <col width="20%"/>
+                                <col width="20%"/>
+                                <col width="20%"/>
+                            </colgroup>
+                            <thead>
+                                <tr>
+                                    <th align="left" rowspan="2">Variables</th>
+                                    <th align="center" colspan="2">Intravenous Therapy Complications</th>
+                                    <th align="center" rowspan="2"><italic>p</italic><break/>value</th>
+                                </tr>
+                                <tr>
+                                    <th align="center">RR</th>
+                                    <th align="center">CI</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td align="left">Prolonged peripheral IVT</td>
+                                    <td align="center">3.44</td>
+                                    <td align="center">1.58 - 7.50</td>
+                                    <td align="center">0.002</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Hystory of complications</td>
+                                    <td align="center">4.22</td>
+                                    <td align="center">2.84 - 6.26</td>
+                                    <td align="center">&lt;0.001</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Use of non-irritating/vesicant medication</td>
+                                    <td align="center">1.99</td>
+                                    <td align="center">1.26 - 3.15</td>
+                                    <td align="center">0.003</td>
+                                </tr>
+                                <tr>
+                                    <td align="left">Use of vesicant solution</td>
+                                    <td align="center">2.65</td>
+                                    <td align="center">1.69 - 4.17</td>
+                                    <td align="center">&lt;00001</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </table-wrap>
+                </p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data)
+
+        expected_label = 'Corrections'
+        expected_text = 'Corrections\nArticle “Risk factors for site complications of intravenous therapy in children and adolescents with cancer”, with number of DOI: \nhttps://doi.org/10.1590/0034-7167-2019-0471\n, published in the journal Revista Brasileira de Enfermagem, 73(4):e20190471, on page 3:\nWhere to read:\nIn the multiple analysis, logistic regression was performed and modeling was achieved when all variables presented p ≤ 0.05.\nRead:\nIn the multiple analysis, Poisson regression with robust variance was performed and modeling was achieved when all variables presented p ≤ 0.05.\nOn page 6, \nTable 5\n, where it read:\nTabela 5\nRegressão Logística das variáveis relacionadas à Terapia Intravenosa prévia associadas à ocorrência de complicação em crianças e adolescentes admitidos em unidades de clínica oncológica pediátrica, Feira de Santana, Bahia, Brasil, 2015 - 2016\nVariables\nComplicações da Terapia Intravenosa\np\nvalue\nRR\nIC\nTerapia Intravenosa periférica prolongada\n3.44\n1.58 - 7.50\n0.002\nAntecedente de complicações\n4.22\n2.84 - 6.26\n<0.001\nUtilização de medicamentos não irritantes/vesicantes\n1.99\n1.26 - 3.15\n0.003\nUtilização de solução vesicante\n2.65\n1.69 - 4.17\n<0.001\nRead:\nTable 5\nPoisson Regression of variables related to previous Intravenous Therapy associated with the occurrence of complications in children and adolescents admitted to pediatric oncology clinic units in the interior of Bahia, Brazil, Apr 2015 - Dec 2016\nVariables\nIntravenous Therapy Complications\np\nvalue\nRR\nCI\nProlonged peripheral IVT\n3.44\n1.58 - 7.50\n0.002\nHystory of complications\n4.22\n2.84 - 6.26\n<0.001\nUse of non-irritating/vesicant medication\n1.99\n1.26 - 3.15\n0.003\nUse of vesicant solution\n2.65\n1.69 - 4.17\n<00001'
+
+        obtained = ArticleErrata(xmltree).article_errata.pop()
+
+        self.assertEqual(expected_label, obtained.label)
+        self.assertEqual(expected_text, obtained.text)
+

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -41,3 +41,24 @@ class ArticleErrataTest(TestCase):
 
         self.assertIsInstance(obtained, Erratum)
 
+
+    def test_article_erratum_label(self):
+        data = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Additions and Corrections</label>
+                <p>On page 100, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“João Silva Costa”</p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data)
+
+        expected_label = 'Additions and Corrections'
+        erratum = ArticleErrata(xmltree).article_errata.pop()
+        obtained_label = erratum.label
+
+        self.assertEqual(expected_label, obtained_label)
+

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -23,3 +23,21 @@ def generate_xmltree(erratum1, erratum2=None):
 
 
 class ArticleErrataTest(TestCase):
+    def test_article_erratum_presence(self):
+        data = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Additions and Corrections</label>
+                <p>On page 100, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“João Silva Costa”</p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data)
+
+        obtained = ArticleErrata(xmltree).article_errata.pop()
+
+        self.assertIsInstance(obtained, Erratum)
+

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+from packtools.sps.utils import xml_utils
+
+from packtools.sps.models.article_errata import ArticleErrata, Erratum
+
+
+def generate_xmltree(erratum1, erratum2=None):
+    xml = """
+    <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
+        <front>
+            <article-meta></article-meta>
+        </front>
+        <body>
+        </body>
+        <back>
+        {0}
+        {1}
+        </back>
+    </article>
+    """
+    return xml_utils.get_xml_tree(xml.format(erratum1, erratum2))
+
+
+class ArticleErrataTest(TestCase):

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -215,3 +215,38 @@ class ArticleErrataTest(TestCase):
         self.assertEqual(expected_label, obtained.label)
         self.assertEqual(expected_text, obtained.text)
 
+
+    def test_article_errata_two_errata(self):
+        data1 = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Erratum number 1</label>
+                <p>On page 10, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“João Silva Costa”</p>
+            </fn>
+        </fn-group>
+        """
+
+        data2 = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Erratum number 2</label>
+                <p>On page 23, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“SciELO Research Group”</p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data1, data2)
+
+        expected_labels = ['Erratum number 1', 'Erratum number 2']
+        obtained_labels = [ae.label for ae in ArticleErrata(xmltree).article_errata]
+
+        expected_texts = ['Erratum number 1\nOn page 10, where it was read:\n“Joao S. Costa”\nNow reads:\n“João Silva Costa”', 'Erratum number 2\nOn page 23, where it was read:\n“Joao S. Costa”\nNow reads:\n“SciELO Research Group”']
+        obtained_texts = [ae.text for ae in ArticleErrata(xmltree).article_errata]
+
+        self.assertListEqual(expected_labels, obtained_labels)
+        self.assertListEqual(expected_texts, obtained_texts)

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from packtools.sps.utils import xml_utils
 
-from packtools.sps.models.article_errata import ArticleErrata, Erratum
+from packtools.sps.models.article_errata import ArticleWithErrataNotes, Footnote
 
 
 def generate_xmltree(erratum1, erratum2=None):
@@ -23,7 +23,7 @@ def generate_xmltree(erratum1, erratum2=None):
 
 
 class ArticleErrataTest(TestCase):
-    def test_article_erratum_presence(self):
+    def test_footnote_presence(self):
         data = """
         <fn-group>
             <fn fn-type="other">
@@ -37,12 +37,12 @@ class ArticleErrataTest(TestCase):
         """
         xmltree = generate_xmltree(data)
 
-        obtained = ArticleErrata(xmltree).article_errata.pop()
+        obtained = ArticleWithErrataNotes(xmltree).footnotes().pop()
 
-        self.assertIsInstance(obtained, Erratum)
+        self.assertIsInstance(obtained, Footnote)
 
 
-    def test_article_erratum_label(self):
+    def test_footnote_label(self):
         data = """
         <fn-group>
             <fn fn-type="other">
@@ -57,13 +57,13 @@ class ArticleErrataTest(TestCase):
         xmltree = generate_xmltree(data)
 
         expected_label = 'Additions and Corrections'
-        erratum = ArticleErrata(xmltree).article_errata.pop()
-        obtained_label = erratum.label
+        fn = ArticleWithErrataNotes(xmltree).footnotes().pop()
+        obtained_label = fn.label
 
         self.assertEqual(expected_label, obtained_label)
 
 
-    def test_article_erratum_text(self):
+    def test_footnote_text(self):
         data = """
         <fn-group>
             <fn fn-type="other">
@@ -78,13 +78,13 @@ class ArticleErrataTest(TestCase):
         xmltree = generate_xmltree(data)
 
         expected_text = 'Additions and Corrections\nOn page 100, where it was read:\n“Joao S. Costa”\nNow reads:\n“João Silva Costa”'
-        erratum = ArticleErrata(xmltree).article_errata.pop()
-        obtained_text = erratum.text
+        fn = ArticleWithErrataNotes(xmltree).footnotes().pop()
+        obtained_text = fn.text
 
         self.assertEqual(expected_text, obtained_text)
     
 
-    def test_article_errata_with_table(self):
+    def test_footnote_with_table(self):
         data = """
         <fn-group>
             <fn fn-type="other">
@@ -210,13 +210,13 @@ class ArticleErrataTest(TestCase):
         expected_label = 'Corrections'
         expected_text = 'Corrections\nArticle “Risk factors for site complications of intravenous therapy in children and adolescents with cancer”, with number of DOI: \nhttps://doi.org/10.1590/0034-7167-2019-0471\n, published in the journal Revista Brasileira de Enfermagem, 73(4):e20190471, on page 3:\nWhere to read:\nIn the multiple analysis, logistic regression was performed and modeling was achieved when all variables presented p ≤ 0.05.\nRead:\nIn the multiple analysis, Poisson regression with robust variance was performed and modeling was achieved when all variables presented p ≤ 0.05.\nOn page 6, \nTable 5\n, where it read:\nTabela 5\nRegressão Logística das variáveis relacionadas à Terapia Intravenosa prévia associadas à ocorrência de complicação em crianças e adolescentes admitidos em unidades de clínica oncológica pediátrica, Feira de Santana, Bahia, Brasil, 2015 - 2016\nVariables\nComplicações da Terapia Intravenosa\np\nvalue\nRR\nIC\nTerapia Intravenosa periférica prolongada\n3.44\n1.58 - 7.50\n0.002\nAntecedente de complicações\n4.22\n2.84 - 6.26\n<0.001\nUtilização de medicamentos não irritantes/vesicantes\n1.99\n1.26 - 3.15\n0.003\nUtilização de solução vesicante\n2.65\n1.69 - 4.17\n<0.001\nRead:\nTable 5\nPoisson Regression of variables related to previous Intravenous Therapy associated with the occurrence of complications in children and adolescents admitted to pediatric oncology clinic units in the interior of Bahia, Brazil, Apr 2015 - Dec 2016\nVariables\nIntravenous Therapy Complications\np\nvalue\nRR\nCI\nProlonged peripheral IVT\n3.44\n1.58 - 7.50\n0.002\nHystory of complications\n4.22\n2.84 - 6.26\n<0.001\nUse of non-irritating/vesicant medication\n1.99\n1.26 - 3.15\n0.003\nUse of vesicant solution\n2.65\n1.69 - 4.17\n<00001'
 
-        obtained = ArticleErrata(xmltree).article_errata.pop()
+        obtained = ArticleWithErrataNotes(xmltree).footnotes().pop()
 
         self.assertEqual(expected_label, obtained.label)
         self.assertEqual(expected_text, obtained.text)
 
 
-    def test_article_errata_two_errata(self):
+    def test_two_footnotes(self):
         data1 = """
         <fn-group>
             <fn fn-type="other">
@@ -243,10 +243,10 @@ class ArticleErrataTest(TestCase):
         xmltree = generate_xmltree(data1, data2)
 
         expected_labels = ['Erratum number 1', 'Erratum number 2']
-        obtained_labels = [ae.label for ae in ArticleErrata(xmltree).article_errata]
+        obtained_labels = [ae.label for ae in ArticleWithErrataNotes(xmltree).footnotes()]
 
         expected_texts = ['Erratum number 1\nOn page 10, where it was read:\n“Joao S. Costa”\nNow reads:\n“João Silva Costa”', 'Erratum number 2\nOn page 23, where it was read:\n“Joao S. Costa”\nNow reads:\n“SciELO Research Group”']
-        obtained_texts = [ae.text for ae in ArticleErrata(xmltree).article_errata]
+        obtained_texts = [ae.text for ae in ArticleWithErrataNotes(xmltree).footnotes()]
 
         self.assertListEqual(expected_labels, obtained_labels)
         self.assertListEqual(expected_texts, obtained_texts)

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -62,3 +62,24 @@ class ArticleErrataTest(TestCase):
 
         self.assertEqual(expected_label, obtained_label)
 
+
+    def test_article_erratum_text(self):
+        data = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Additions and Corrections</label>
+                <p>On page 100, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“João Silva Costa”</p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data)
+
+        expected_text = 'Additions and Corrections\nOn page 100, where it was read:\n“Joao S. Costa”\nNow reads:\n“João Silva Costa”'
+        erratum = ArticleErrata(xmltree).article_errata.pop()
+        obtained_text = erratum.text
+
+        self.assertEqual(expected_text, obtained_text)
+    

--- a/tests/sps/test_article_errata.py
+++ b/tests/sps/test_article_errata.py
@@ -250,3 +250,46 @@ class ArticleErrataTest(TestCase):
 
         self.assertListEqual(expected_labels, obtained_labels)
         self.assertListEqual(expected_texts, obtained_texts)
+
+
+    def test_footnote_custom_fn_type(self):
+        data1 = """
+        <fn-group>
+            <fn fn-type="erratum-custom-type">
+                <label>Correction of a custom type</label>
+                <p>On page 100, where it was read:</p>
+                <p>“Joao S. Costa”</p>
+                <p>Now reads:</p>
+                <p>“João Silva Costa”</p>
+            </fn>
+        </fn-group>
+        """
+
+        data2 = """
+        <fn-group>
+            <fn fn-type="other">
+                <label>Default type</label>
+                <p>On page 1, where it was read:</p>
+                <p>Alberto Einstein</p>
+                <p>Now reads:</p>
+                <p>Albert Einstein</p>
+            </fn>
+        </fn-group>
+        """
+        xmltree = generate_xmltree(data1, data2)
+
+        expected_labels = [
+            'Correction of a custom type',
+            'Default type',
+        ]
+        expected_texts = [
+            'Correction of a custom type\nOn page 100, where it was read:\n“Joao S. Costa”\nNow reads:\n“João Silva Costa”', 
+            'Default type\nOn page 1, where it was read:\nAlberto Einstein\nNow reads:\nAlbert Einstein'
+        ]
+        
+        fn = ArticleWithErrataNotes(xmltree).footnotes(fn_types=['erratum-custom-type','other', ])
+        obtained_labels = [f.label for f in fn]
+        obtained_texts = [f.text for f in fn]
+
+        self.assertEqual(expected_labels, obtained_labels)
+        self.assertEqual(expected_texts, obtained_texts)


### PR DESCRIPTION
#### O que esse PR faz?
Cria modelos para representar elementos Erratum existentes em documentos XML corrigidos ou alterados por Errata.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
Esta alteração faz parte da issue 51 do repositório scms-upload. Especificamente, as alterações realizadas neste PR permitirão que os novos modelos sejam utilizados no scms-upload para enviar e avaliar XML com ArticleErrata e com RelatedArticle.

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/scms-upload/issues/51

### Referências
Modelagem esperada de uma errata: https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt_BR/latest/narr/errata.html