### PR TITLE
Adiciona função que retorna nome oficial de asset

### DIFF
--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -25,10 +25,10 @@ class ArticleAssets:
 
     def __init__(self, xmltree):
         self.xmltree = xmltree
-        self.create_parent_map()
+        self._create_parent_map()
 
-    def create_parent_map(self):
-        self.parent_map = dict(
+    def _create_parent_map(self):
+        self._parent_map = dict(
             (c, p) for p in self.xmltree.iter() for c in p
         )
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -121,9 +121,12 @@ class ArticleAssets:
 
 
 class Asset:
-    def __init__(self, node, parent_map):
+    def __init__(self, node, parent_map, parent_node_with_id=None, number=None):
         self.node = node
-        self.parent_map = parent_map
+        self._parent_map = parent_map
+        self._parent_node_with_id = parent_node_with_id
+        self._number = number
+
 
     @property
     def name(self):

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -35,6 +35,15 @@ class ArticleAssets:
 
     @property
     def article_assets(self):
+        return self.article_assets_which_have_id + self.article_assets_which_have_no_id
+
+    @property
+    def article_assets_which_have_id(self):
+        return self._assets_which_have_id
+
+    @property
+    def article_assets_which_have_no_id(self):
+        return self._assets_which_have_no_id
 
     def _discover_assets(self):
         self._discover_assets_which_have_id()

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -98,8 +98,7 @@ class Asset:
 
     @property
     def _suffix(self):
-        id_number = ''.join([i for i in self.id if i.isdigit()]).zfill(2)
-        return f"-{self._category_name_code}{id_number}{self._content_type or ''}"
+        return f"-{self._category_name_code}{self._id_str}{self._content_type}"
 
     @property
     def _ext(self):

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -127,6 +127,19 @@ class Asset:
         self._parent_node_with_id = parent_node_with_id
         self._number = number
 
+    @property
+    def id(self):
+        try:
+            return self.node.attrib['id']
+        except KeyError:
+            ...
+
+        try:
+            return self._parent_node_with_id.get('id')
+        except (AttributeError, TypeError):
+            ...
+
+        return ''
 
     @property
     def name(self):

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -105,6 +105,21 @@ class Asset:
         _, ext = os.path.splitext(self.name)
         return ext
 
+    @property
+    def _lang(self):
+        '''
+        Tenta obter lang de assets associados a sub-article, caso contrário, retorna string.
+        Assets cujo lang é representado por uma string vazia possuem um nome canônico sem o idioma.
+        '''
+        current_node = self.parent_map[self.node]
+        while current_node.tag != 'sub-article':
+            try:
+                current_node = self.parent_map[current_node]
+            except KeyError:
+                return ''
+
+        return f"-{current_node.get('{http://www.w3.org/XML/1998/namespace}lang')}" or ""
+
     def name_canonical(self, package_name):
         return f"{package_name}{self._suffix}{self._ext}"
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -71,6 +71,12 @@ class Asset:
         self.node.set("{http://www.w3.org/1999/xlink}href", value)
 
     @property
+    def _content_type(self):
+        ct = self.node.get('content-type')
+        if ct:
+            return f'-{ct}'
+        return ''
+
     def id(self):
         current_node = self.node
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -214,25 +214,20 @@ class Asset:
         return f"{package_name}{self._suffix}{self._lang}{self._ext}"
 
     @property
-    def id(self):
-        current_node = self.node
-
-        while current_node is not None and hasattr(current_node, 'attrib') and 'id' not in current_node.attrib:
-            current_node = self.parent_map.get(current_node)
-
-        if current_node is None or not hasattr(current_node, 'attrib'):
-            return
-
-        current_node_attrib = getattr(current_node, 'attrib')
-        if current_node_attrib:
-            return current_node_attrib.get('id')
+    def _id_str(self):
+        digits = [i for i in self.id if i.isdigit()]
+        if len(digits) > 0:
+            return ''.join(digits).zfill(2)
+        return ''
 
     @property
-    def _id_str(self):
-        try:
-            return ''.join([i for i in self.id if i.isdigit()]).zfill(2)
-        except TypeError:
-            return ''
+    def _number_str(self):
+        '''
+        Esta propriedade é utilizada em name_canonical quando o Asset não possui um nó próximo com ID, isto é, um _parent_node_with_id.
+        '''
+        if self._id_str == '':
+            return f'-n{str(self._number).zfill(2)}'
+        return ''
 
     @property
     def type(self):

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -157,6 +157,20 @@ class Asset:
         return ''
 
     @property
+    def tag(self):
+        if self._parent_node_with_id is not None:
+            return self._parent_node_with_id.tag
+        
+        current_node = self._parent_map[self.node]
+        while current_node.tag not in ArticleAssets.ASSET_EXTENDED_TAGS:
+            try:
+                current_node = self._parent_map[current_node]
+            except KeyError:
+                return ''
+
+        return current_node.tag
+
+    @property
     def _category_name_code(self):
         """
         -g: figure graphic
@@ -164,11 +178,11 @@ class Asset:
         -e: equation
         -s: supplementary data file
         """
-        if "display-formula" in self.node.tag:
+        if "disp-formula" in self.tag or "display-formula" in self.tag:
             return "e"
-        if "supplementary" in self.node.tag:
+        if "supplementary" in self.tag or "app" in self.tag:
             return "s"
-        if "inline" in self.node.tag:
+        if "inline" in self.tag:
             return "i"
         return "g"
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -14,6 +14,11 @@ class ArticleAssets:
         'inline-supplementary-material',
     )
 
+    ASSET_EXTENDED_TAGS = ASSET_TAGS + (
+        'disp-formula',
+        'display-formula',
+    )
+
     XPATH_FOR_IDENTIFYING_ASSETS = '|'.join([
         './/' + at + '[@xlink:href]' for at in ASSET_TAGS
     ])

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -123,6 +123,13 @@ class Asset:
             return current_node_attrib.get('id')
 
     @property
+    def _id_str(self):
+        try:
+            return ''.join([i for i in self.id if i.isdigit()]).zfill(2)
+        except TypeError:
+            return ''
+
+    @property
     def type(self):
         """
         <alternatives>

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -85,13 +85,17 @@ class ArticleAssets:
                     ))
                     _visited_nodes.append(child_node)
                     i += 1
+
+    def _asset_nodes(self, node=None):
         _assets = []
 
-        for node in self.xmltree.xpath(
+        source = node or self.xmltree
+
+        for node in source.xpath(
             ArticleAssets.XPATH_FOR_IDENTIFYING_ASSETS,
             namespaces={"xlink": "http://www.w3.org/1999/xlink"}
         ):
-            _assets.append(Asset(node, self.parent_map))
+            _assets.append(node)
 
         return _assets
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -16,7 +16,6 @@ class ArticleAssets:
 
     ASSET_EXTENDED_TAGS = ASSET_TAGS + (
         'disp-formula',
-        'display-formula',
     )
 
     XPATH_FOR_IDENTIFYING_ASSETS = '|'.join([
@@ -178,7 +177,7 @@ class Asset:
         -e: equation
         -s: supplementary data file
         """
-        if "disp-formula" in self.tag or "display-formula" in self.tag:
+        if "disp-formula" in self.tag:
             return "e"
         if "supplementary" in self.tag or "app" in self.tag:
             return "s"

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -48,6 +48,25 @@ class ArticleAssets:
     def _discover_assets(self):
         self._discover_assets_which_have_id()
         self._discover_assets_which_have_no_id()
+    
+    def _discover_assets_which_have_id(self):
+        self._assets_which_have_id = []
+        _visited_nodes = []
+        
+        for node in self.xmltree.xpath(".//*[@id]"):
+            if node.tag == "sub-article":
+                continue
+        
+            i = 0
+            for child_node in self._asset_nodes(node):
+                if child_node not in _visited_nodes:
+                    self._assets_which_have_id.append(Asset(
+                        node=child_node, 
+                        parent_map=self._parent_map,
+                        parent_node_with_id=node, 
+                        number=i))
+                    _visited_nodes.append(child_node)
+                    i += 1
         _assets = []
 
         for node in self.xmltree.xpath(

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -26,6 +26,7 @@ class ArticleAssets:
     def __init__(self, xmltree):
         self.xmltree = xmltree
         self._create_parent_map()
+        self._discover_assets()
 
     def _create_parent_map(self):
         self._parent_map = dict(
@@ -34,6 +35,10 @@ class ArticleAssets:
 
     @property
     def article_assets(self):
+
+    def _discover_assets(self):
+        self._discover_assets_which_have_id()
+        self._discover_assets_which_have_no_id()
         _assets = []
 
         for node in self.xmltree.xpath(

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -77,6 +77,22 @@ class Asset:
             return f'-{ct}'
         return ''
 
+    @property
+    def _category_name_code(self):
+        """
+        -g: figure graphic
+        -i: inline graphic
+        -e: equation
+        -s: supplementary data file
+        """
+        if "display-formula" in self.node.tag:
+            return "e"
+        if "supplementary" in self.node.tag:
+            return "s"
+        if "inline" in self.node.tag:
+            return "i"
+        return "g"
+
     def id(self):
         current_node = self.node
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -102,6 +102,11 @@ class Asset:
     def _ext(self):
         _, ext = os.path.splitext(self.name)
         return ext
+
+    def name_canonical(self, package_name):
+        return f"{package_name}{self._suffix}{self._ext}"
+
+    @property
     def id(self):
         current_node = self.node
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -98,6 +98,10 @@ class Asset:
         id_number = ''.join([i for i in self.id if i.isdigit()]).zfill(2)
         return f"-{self._category_name_code}{id_number}{self._content_type or ''}"
 
+    @property
+    def _ext(self):
+        _, ext = os.path.splitext(self.name)
+        return ext
     def id(self):
         current_node = self.node
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -198,13 +198,13 @@ class Asset:
     @property
     def _lang(self):
         '''
-        Tenta obter lang de assets associados a sub-article, caso contrário, retorna string.
-        Assets cujo lang é representado por uma string vazia possuem um nome canônico sem o idioma.
+        Tenta obter lang de asset associado a sub-article, caso contrário, retorna string vazia.
+        Asset cujo lang é representado por uma string vazia possui nome canônico sem o idioma.
         '''
-        current_node = self.parent_map[self.node]
+        current_node = self._parent_map[self.node]
         while current_node.tag != 'sub-article':
             try:
-                current_node = self.parent_map[current_node]
+                current_node = self._parent_map[current_node]
             except KeyError:
                 return ''
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -93,6 +93,11 @@ class Asset:
             return "i"
         return "g"
 
+    @property
+    def _suffix(self):
+        id_number = ''.join([i for i in self.id if i.isdigit()]).zfill(2)
+        return f"-{self._category_name_code}{id_number}{self._content_type or ''}"
+
     def id(self):
         current_node = self.node
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -121,7 +121,7 @@ class Asset:
         return f"-{current_node.get('{http://www.w3.org/XML/1998/namespace}lang')}" or ""
 
     def name_canonical(self, package_name):
-        return f"{package_name}{self._suffix}{self._ext}"
+        return f"{package_name}{self._suffix}{self._lang}{self._ext}"
 
     @property
     def id(self):

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -1,3 +1,6 @@
+import os
+
+
 class AssetReplacementError(Exception):
     ...
 

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -67,6 +67,24 @@ class ArticleAssets:
                         number=i))
                     _visited_nodes.append(child_node)
                     i += 1
+
+    def _discover_assets_which_have_no_id(self):
+        self._assets_which_have_no_id = []
+        _visited_nodes = []
+
+        nodes_which_have_id = [i.node for i in self._assets_which_have_id]
+
+        i = 0
+        for child_node in self._asset_nodes():
+            if child_node not in nodes_which_have_id:
+                if child_node not in _visited_nodes:
+                    self._assets_which_have_no_id.append(Asset(
+                        node=child_node,
+                        parent_map=self._parent_map,
+                        number=i
+                    ))
+                    _visited_nodes.append(child_node)
+                    i += 1
         _assets = []
 
         for node in self.xmltree.xpath(

--- a/packtools/sps/models/article_assets.py
+++ b/packtools/sps/models/article_assets.py
@@ -188,7 +188,7 @@ class Asset:
 
     @property
     def _suffix(self):
-        return f"-{self._category_name_code}{self._id_str}{self._content_type}"
+        return f"-{self._category_name_code}{self._id_str}{self._number_str}{self._content_type}"
 
     @property
     def _ext(self):

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -759,33 +759,33 @@ class ArticleAssetsTest(TestCase):
 
       expected = {
         'f1': [
-          {'name': '1676-0611-bn-2021-1306-g01.tif', 'type': 'original'},
-          {'name': '1676-0611-bn-2021-1306-g01.png', 'type': 'optimised'},
-          {'name': '1676-0611-bn-2021-1306-g01-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/256bcf2e607f18b0bb3842a31332f6b48620cb09.tif', 'name_canonical': '1676-0611-bn-2021-1306-g01.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c00655410885461df4a98dd77860b81b2e5baa2c.png', 'name_canonical': '1676-0611-bn-2021-1306-g01.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ebd30641f55d890debe55743b8e2946135c74140.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g01-scielo-267x140.jpg', 'type': 'thumbnail'},
         ],
         'f2': [
-          {'name': '1676-0611-bn-2021-1306-g02.tif', 'type': 'original'},
-          {'name': '1676-0611-bn-2021-1306-g02.png', 'type': 'optimised'},
-          {'name': '1676-0611-bn-2021-1306-g02-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b784533145d2f1557a7df00e05e5c6207fc57e2a.tif', 'name_canonical': '1676-0611-bn-2021-1306-g02.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b298055fb49aba04fa94a1287ed4c38c0680ccf7.png', 'name_canonical': '1676-0611-bn-2021-1306-g02.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c0a10dd209a9da0ef40f92f070ee6c77b0ca220b.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g02-scielo-267x140.jpg', 'type': 'thumbnail'},
         ],
         'f3': [
-          {'name': '1676-0611-bn-2021-1306-g03.tif', 'type': 'original'},
-          {'name': '1676-0611-bn-2021-1306-g03.png', 'type': 'optimised'},
-          {'name': '1676-0611-bn-2021-1306-g03-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/14717caba8b886eddbbc9e1e4a8c579631730187.tif', 'name_canonical': '1676-0611-bn-2021-1306-g03.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b0b01286ff114d6eda85f9a5afb1217d164e32b5.png', 'name_canonical': '1676-0611-bn-2021-1306-g03.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b03ad3e4bced80bf0a81dfe12fbe6e567982414b.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g03-scielo-267x140.jpg', 'type': 'thumbnail'},
         ],
         'f4': [
-          {'name': '1676-0611-bn-2021-1306-g04.tif', 'type': 'original'},
-          {'name': '1676-0611-bn-2021-1306-g04.png', 'type': 'optimised'},
-          {'name': '1676-0611-bn-2021-1306-g04-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/407a7771f32d6364ee6536278a011a2c05da3339.tif', 'name_canonical': '1676-0611-bn-2021-1306-g04.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c1ba665e5e0731d623095779a2d4099c808e776b.png', 'name_canonical': '1676-0611-bn-2021-1306-g04.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/f1da586984d4176883f92f2fb28e9abea946b8d2.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g04-scielo-267x140.jpg', 'type': 'thumbnail'},
         ],
         'suppl01': [
-          {'name': '1676-0611-bn-2021-1306-s01.pdf', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/e738857c8fb8bc085b766a812bbe73277c67d346.pdf', 'name_canonical': '1676-0611-bn-2021-1306-s01.pdf', 'type': 'original'},
         ],
         'suppl02': [
-          {'name': '1676-0611-bn-2021-1306-s02.xls', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b72942b47698183bf992f1ad8cebdf61d346e0cf.xls', 'name_canonical': '1676-0611-bn-2021-1306-s02.xls', 'type': 'original'},
         ],
         'suppl03': [
-          {'name': '1676-0611-bn-2021-1306-s03.pdf', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf', 'name_canonical': '1676-0611-bn-2021-1306-s03.pdf', 'type': 'original'},
         ]
       }
       obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='1676-0611-bn-2021-1306')

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -34,12 +34,15 @@ def generate_xmltree(snippet):
     return xml_utils.get_xml_tree(xml.format(snippet))
 
 
-def obtain_asset_dict(article_assets):
+def obtain_asset_dict(article_assets, package_name=None):
   assets_dict = {}
 
   for asset in article_assets:
     a_id = asset.id
-    a_name = asset.name
+    if not package_name:
+      a_name = asset.name
+    else:
+      a_name = asset.name_canonical(package_name)
     a_type = asset.type
 
     if a_id not in assets_dict:

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -38,17 +38,15 @@ def obtain_asset_dict(article_assets, package_name=None):
   assets_dict = {}
 
   for asset in article_assets:
-    a_id = asset.id
-    if not package_name:
-      a_name = asset.name
-    else:
-      a_name = asset.name_canonical(package_name)
-    a_type = asset.type
+    asset_metadata = {'name': asset.name, 'type': asset.type}
+    if package_name:
+      asset_metadata['name_canonical'] = asset.name_canonical(package_name)
 
+    a_id = asset.id
     if a_id not in assets_dict:
       assets_dict[a_id] = []
 
-    assets_dict[a_id].append({'name': a_name, 'type': a_type})
+    assets_dict[a_id].append(asset_metadata)
 
   return assets_dict
 

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -849,14 +849,17 @@ class ArticleAssetsTest(TestCase):
       xmltree = xml_utils.get_xml_tree(data)
 
       expected = {
-        # <graphic> sem id associado
-        None: [{'name': '0034-8910-rsp-48-2-0232-ee01', 'name_canonical': '0034-8910-rsp-48-2-0232-g', 'type': 'original'}],
-        # <graphic> sem id associado (o id do sub-article mais próximo é obtido)
-        'TRen': [{'name': '0034-8910-rsp-48-2-0232-ee01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-g00-en', 'type': 'original'}],
-        'app01': [{'name': '0034-8910-rsp-48-2-0232-app01', 'name_canonical': '0034-8910-rsp-48-2-0232-g01-en', 'type': 'original'}],
-        # <graphic> cujo id é f01
+        '': [
+          # <graphic> dentro de <disp-formula> sem id associado
+          {'name': '0034-8910-rsp-48-2-0232-ee01', 'name_canonical': '0034-8910-rsp-48-2-0232-e-n00', 'type': 'original'},
+          # <graphic> dentro de <disp-formula> sem id associado e em sub-article cujo lang é en
+          {'name': '0034-8910-rsp-48-2-0232-ee01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-e-n01-en', 'type': 'original'}
+        ],
+        # <graphic> dentro de <app> cujo id é app01 e em sub-article cujo lang é en
+        'app01': [{'name': '0034-8910-rsp-48-2-0232-app01', 'name_canonical': '0034-8910-rsp-48-2-0232-s01-en', 'type': 'original'}],
+        # <graphic> dentro de <fig> cujo id é f01
         'f01': [{'name': '0034-8910-rsp-48-2-0232-gf01', 'name_canonical': '0034-8910-rsp-48-2-0232-g01', 'type': 'original'}],
-        # <graphic> cujo id é f01_en
+        # <graphic> dentro de <fig> cujo id é f01_en e em sub-article cujo lang é en
         'f01_en': [{'name': '0034-8910-rsp-48-2-0232-gf01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-g01-en', 'type': 'original'}],
       }
       obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0232')
@@ -906,7 +909,7 @@ class SupplementaryMaterialsTest(TestCase):
         xmltree = xml_utils.get_xml_tree(data)
 
         expected = [
-            (None, 'https://minio.scielo.br/documentstore/1678-4790/LgRcS7ZYYQ5wSDKw8wKytSp/818bf2b94169513756c9f4734c24d9bc774a3795.pdf'),
+            ('', 'https://minio.scielo.br/documentstore/1678-4790/LgRcS7ZYYQ5wSDKw8wKytSp/818bf2b94169513756c9f4734c24d9bc774a3795.pdf'),
         ]
 
         for i, item in enumerate(SupplementaryMaterials(xmltree).items):
@@ -961,4 +964,3 @@ obtida por Einstein em 1905
             with self.subTest(i):
                 self.assertEqual(item.id, expected[i][0])
                 self.assertEqual(item.name, expected[i][1])
-

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -755,6 +755,47 @@ class ArticleAssetsTest(TestCase):
         self.assertEqual(not_found, ["figura2.jpg"])
 
 
+    def test_article_assets_canonical_name(self):
+      self.maxDiff = None
+      data = open('tests/sps/fixtures/document-with-supplementary-material.xml').read()
+      xmltree = xml_utils.get_xml_tree(data)
+
+      expected = {
+        'f1': [
+          {'name': '1676-0611-bn-2021-1306-g01.tif', 'type': 'original'},
+          {'name': '1676-0611-bn-2021-1306-g01.png', 'type': 'optimised'},
+          {'name': '1676-0611-bn-2021-1306-g01-scielo-267x140.jpg', 'type': 'thumbnail'},
+        ],
+        'f2': [
+          {'name': '1676-0611-bn-2021-1306-g02.tif', 'type': 'original'},
+          {'name': '1676-0611-bn-2021-1306-g02.png', 'type': 'optimised'},
+          {'name': '1676-0611-bn-2021-1306-g02-scielo-267x140.jpg', 'type': 'thumbnail'},
+        ],
+        'f3': [
+          {'name': '1676-0611-bn-2021-1306-g03.tif', 'type': 'original'},
+          {'name': '1676-0611-bn-2021-1306-g03.png', 'type': 'optimised'},
+          {'name': '1676-0611-bn-2021-1306-g03-scielo-267x140.jpg', 'type': 'thumbnail'},
+        ],
+        'f4': [
+          {'name': '1676-0611-bn-2021-1306-g04.tif', 'type': 'original'},
+          {'name': '1676-0611-bn-2021-1306-g04.png', 'type': 'optimised'},
+          {'name': '1676-0611-bn-2021-1306-g04-scielo-267x140.jpg', 'type': 'thumbnail'},
+        ],
+        'suppl01': [
+          {'name': '1676-0611-bn-2021-1306-s01.pdf', 'type': 'original'},
+        ],
+        'suppl02': [
+          {'name': '1676-0611-bn-2021-1306-s02.xls', 'type': 'original'},
+        ],
+        'suppl03': [
+          {'name': '1676-0611-bn-2021-1306-s03.pdf', 'type': 'original'},
+        ]
+      }
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='1676-0611-bn-2021-1306')
+
+      self.assertDictEqual(expected, obtained)
+
+
 class SupplementaryMaterialsTest(TestCase):
     def _get_xmltree(self, xml):
         return xml_utils.get_xml_tree(xml)

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -753,8 +753,7 @@ class ArticleAssetsTest(TestCase):
         self.assertEqual(not_found, ["figura2.jpg"])
 
 
-    def test_article_assets_canonical_name(self):
-      self.maxDiff = None
+    def test_assets_canonical_name_without_subarticles(self):
       data = open('tests/sps/fixtures/document-with-supplementary-material.xml').read()
       xmltree = xml_utils.get_xml_tree(data)
 

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -793,6 +793,24 @@ class ArticleAssetsTest(TestCase):
       self.assertDictEqual(expected, obtained)
 
 
+    def test_assets_canonical_name_with_subarticles_and_without_id(self):
+      data = open('tests/samples/0034-8910-rsp-48-2-0232.xml').read()
+      xmltree = xml_utils.get_xml_tree(data)
+
+      expected = {
+        # <graphic> sem id associado
+        None: [{'name': '0034-8910-rsp-48-2-0232-ee01', 'name_canonical': '0034-8910-rsp-48-2-0232-g', 'type': 'original'}],
+        # <graphic> sem id associado (o id do sub-article mais próximo é obtido)
+        'TRen': [{'name': '0034-8910-rsp-48-2-0232-ee01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-g00-en', 'type': 'original'}],
+        'app01': [{'name': '0034-8910-rsp-48-2-0232-app01', 'name_canonical': '0034-8910-rsp-48-2-0232-g01-en', 'type': 'original'}],
+        # <graphic> cujo id é f01
+        'f01': [{'name': '0034-8910-rsp-48-2-0232-gf01', 'name_canonical': '0034-8910-rsp-48-2-0232-g01', 'type': 'original'}],
+        # <graphic> cujo id é f01_en
+        'f01_en': [{'name': '0034-8910-rsp-48-2-0232-gf01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-g01-en', 'type': 'original'}],
+      }
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0232')
+
+      self.assertDictEqual(expected, obtained)
 class SupplementaryMaterialsTest(TestCase):
     def _get_xmltree(self, xml):
         return xml_utils.get_xml_tree(xml)

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -108,7 +108,12 @@ class ArticleAssetsTest(TestCase):
       self.assertDictEqual(expected, obtained)
 
 
-    def test_article_assets_images_outside_figure(self):
+    def test_article_assets_images_outside_figure_and_name_canonical(self):
+      # O XML é composto por:
+      #  um artigo principal em Inglês composto por 3 figuras (cada uma com original, otimizado e miniatura)
+      #  um subartigo em Espanhol com 3 figuras (cada uma com original, otimizado e miniatura)
+      #  um subartigo em Português com 3 figuras (cada uma com original, otimizado e miniatura)
+      # Há 27 assets sem ID
       data = open('tests/fixtures/htmlgenerator/alternatives/imagens_fora_de_fig.xml').read()
       xmltree = xml_utils.get_xml_tree(data)
 

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -784,6 +784,66 @@ class ArticleAssetsTest(TestCase):
       self.assertDictEqual(expected, obtained)
 
 
+    def test_assets_category_name_code(self):
+      data = """
+      <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="pt">
+        <body>
+          <sec sec-type="methods">
+            <disp-formula>
+              <graphic xlink:href="0034-8910-rsp-48-2-0232-ee01"/>
+            </disp-formula>
+          </sec>
+          <sec sec-type="results">
+            <p>
+              <fig id="f01">
+                <label>Figura. </label>
+                <caption>
+                  <title>Curva total da informação do instrumento de adesão ao tratamento da hipertensão arterial sistêmica. Fortaleza, CE, 2012.</title>
+                </caption>
+                <graphic xlink:href="0034-8910-rsp-48-2-0232-gf01"/>
+              </fig>
+            </p>
+          </sec>
+        </body>
+        <sub-article article-type="translation" xml:lang="en" id="TRen">
+          <body>
+            <sec sec-type="methods">
+              <disp-formula>
+                <graphic xlink:href="0034-8910-rsp-48-2-0232-ee01-en"/>
+              </disp-formula>
+            </sec>
+          </body>
+          <back>
+            <app-group>
+              <app id="app01">
+                <label>Annex</label>
+                <title>Questionnaire on adherence to treatment of systemic hypertension (QATSH). Fortaleza, CE, Northeastern Brazil, 2012.</title>
+                <graphic xlink:href="0034-8910-rsp-48-2-0232-app01"/>
+              </app>
+            </app-group>
+          </back>
+        </sub-article>
+      </article>
+      """
+      xmltree = xml_utils.get_xml_tree(data)
+
+      expected = [
+        # <graphic> com cujo parente possui id f01
+        ('g', 'f01', '0034-8910-rsp-48-2-0232-gf01'), 
+        # <supplementary-material> cujo parente possui id app01
+        ('s', 'app01', '0034-8910-rsp-48-2-0232-app01'),
+        # <display-formula> sem parente com id
+        ('e', '', '0034-8910-rsp-48-2-0232-ee01'),
+        # <display-formula> cujo parente com id é sub-article
+        ('e', '', '0034-8910-rsp-48-2-0232-ee01-en'),
+      ]
+
+      aa = ArticleAssets(xmltree).article_assets
+      obtained = [(i._category_name_code, i.id, i.name) for i in aa]
+      
+      self.assertListEqual(expected, obtained)
+
+
     def test_assets_canonical_name_with_subarticles_and_without_id(self):
       data = open('tests/samples/0034-8910-rsp-48-2-0232.xml').read()
       xmltree = xml_utils.get_xml_tree(data)

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -811,6 +811,27 @@ class ArticleAssetsTest(TestCase):
       obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0232')
 
       self.assertDictEqual(expected, obtained)
+
+
+    def test_assets_canonical_name_with_subarticles_and_ids_with_lang(self):
+      data = open('tests/samples/0034-8910-rsp-48-2-0240.xml').read()
+      xmltree = xml_utils.get_xml_tree(data)
+
+      expected = {
+        'f01': [{'name': '0034-8910-rsp-48-2-0240-gf01', 'name_canonical': '0034-8910-rsp-48-2-0240-g01', 'type': 'original'}],
+        'f02': [{'name': '0034-8910-rsp-48-2-0240-gf02', 'name_canonical': '0034-8910-rsp-48-2-0240-g02', 'type': 'original'}],
+        'f03': [{'name': '0034-8910-rsp-48-2-0240-gf03', 'name_canonical': '0034-8910-rsp-48-2-0240-g03', 'type': 'original'}],
+        'f04': [{'name': '0034-8910-rsp-48-2-0240-gf04', 'name_canonical': '0034-8910-rsp-48-2-0240-g04', 'type': 'original'}],
+        'f01_en': [{'name': '0034-8910-rsp-48-2-0240-gf01-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g01-en', 'type': 'original'}],
+        'f02_en': [{'name': '0034-8910-rsp-48-2-0240-gf02-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g02-en', 'type': 'original'}],
+        'f03_en': [{'name': '0034-8910-rsp-48-2-0240-gf03-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g03-en', 'type': 'original'}],
+        'f04_en': [{'name': '0034-8910-rsp-48-2-0240-gf04-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g04-en', 'type': 'original'}],
+      }
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0240')
+
+      self.assertDictEqual(expected, obtained)
+
+
 class SupplementaryMaterialsTest(TestCase):
     def _get_xmltree(self, xml):
         return xml_utils.get_xml_tree(xml)

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -120,41 +120,36 @@ class ArticleAssetsTest(TestCase):
       expected = {
 
         '': [
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/6c7e45494816692122f9467ee9b5ee7a88f86e01.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/7172c66d1c5fa56dc230efa7123dea014f21e62f.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'type': 'thumbnail'},
-        ],
-        # figures that belong to subarticle s1
-        's1': [
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/9a4a202884a687ad4858fc95fbf3be801e63215b.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/1fdbee345fae2065d9bd0fd0b4b09a4f77e99e90.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/aa495447d05a9156d0d15f5f95f8890ee1d55743.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'type': 'thumbnail'},
-        ],
-        # figures that belong to subarticle s2
-        's2': [
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/e971ae023bce641ced89dfbdc40d62be94c4c738.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/30d718ea67b77dd98bcda9d3acba9cb296fcba9e.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/b824ebf96bd03d51ee26edc6c3807c3092bf1901.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/8d6031a105ac49f92d2bac1dab55785ec62ed139.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n01.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n02-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/6c7e45494816692122f9467ee9b5ee7a88f86e01.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n03.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n04.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n05-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/7172c66d1c5fa56dc230efa7123dea014f21e62f.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n06.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n07.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n08-scielo-267x140.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/9a4a202884a687ad4858fc95fbf3be801e63215b.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n09-es.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n10-es.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n11-scielo-267x140-es.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/1fdbee345fae2065d9bd0fd0b4b09a4f77e99e90.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n12-es.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n13-es.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n14-scielo-267x140-es.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/aa495447d05a9156d0d15f5f95f8890ee1d55743.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n15-es.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n16-es.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n17-scielo-267x140-es.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/e971ae023bce641ced89dfbdc40d62be94c4c738.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n18-pt.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n19-pt.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n20-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/30d718ea67b77dd98bcda9d3acba9cb296fcba9e.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n21-pt.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n22-pt.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n23-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/b824ebf96bd03d51ee26edc6c3807c3092bf1901.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n24-pt.tif', 'type': 'original'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n25-pt.png', 'type': 'optimised'},
+          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n26-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
         ]
       }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
 
       self.assertDictEqual(expected, obtained)
 

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -164,7 +164,7 @@ class ArticleAssetsTest(TestCase):
       """
       xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {None: [{'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'}],}
+      expected = {'': [{'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'}],}
       obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
       self.assertDictEqual(expected, obtained)
@@ -211,7 +211,7 @@ class ArticleAssetsTest(TestCase):
       self.assertDictEqual(expected, obtained)
 
 
-    def test_article_assets_with_inline_graphic(self):
+    def test_article_assets_with_inline_graphic_and_name_canonical(self):
       data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <front>
@@ -221,10 +221,6 @@ class ArticleAssetsTest(TestCase):
         <body>
           <sec>
             <p>The Eh measurements... <xref ref-type="disp-formula" rid="e01">equation 1</xref>(in mV):</p>
-            <disp-formula id="e01">
-              {}
-            </disp-formula>
-            <p>We also used an... {}.</p>
           </sec>
           <p>We also used an ... based on the equation:<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e04.tif"/>.</p>
         </body>
@@ -234,10 +230,10 @@ class ArticleAssetsTest(TestCase):
 
       expected = {
         '': [
-          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original'},
+          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif'},
         ]
       }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
 
       self.assertDictEqual(expected, obtained)
 
@@ -250,24 +246,17 @@ class ArticleAssetsTest(TestCase):
           </article-meta>
         </front>
         <body>
-          <sec>
-            <p>The Eh measurements... <xref ref-type="disp-formula" rid="e01">equation 1</xref>(in mV):</p>
-            <disp-formula id="e01">
-              {}
-            </disp-formula>
-            <p>We also used an... {}.</p>
-          </sec>
           <fig id="f01">
             <label>Figura 1</label>
             <caption>
                 <title>Caption Figura 1</title>
             </caption>
             <disp-formula>
-            <alternatives>
-                <graphic xlink:href="original.tif" />
-                <graphic xlink:href="ampliada.png" specific-use="scielo-web" />
-                <graphic xlink:href="miniatura.jpg" specific-use="scielo-web" content-type="scielo-20x20" />
-            </alternatives>
+              <alternatives>
+                  <graphic xlink:href="original.tif" />
+                  <graphic xlink:href="ampliada.png" specific-use="scielo-web" />
+                  <graphic xlink:href="miniatura.jpg" specific-use="scielo-web" content-type="scielo-20x20" />
+              </alternatives>
             </disp-formula>
             <attrib>Fonte: Dados originais da pesquisa</attrib>
           </fig>
@@ -291,22 +280,22 @@ class ArticleAssetsTest(TestCase):
 
       expected = {
         'f01': [
-          {'name': 'original.tif', 'type': 'original'},
-          {'name': 'ampliada.png', 'type': 'optimised'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'},
+          {'name': 'original.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g01.tif'},
+          {'name': 'ampliada.png', 'type': 'optimised', 'name_canonical': 'NOME-DO-PACOTE-g01.png'},
+          {'name': 'miniatura.jpg', 'type': 'thumbnail', 'name_canonical': 'NOME-DO-PACOTE-g01-scielo-20x20.jpg'},
         ],
         'f03': [
-          {'name': '1234-5678-rctb-45-05-0110-gf03.tiff', 'type': 'original'},
-          {'name': '1234-5678-rctb-45-05-0110-gf03.png', 'type': 'optimised'},
-          {'name': '1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg', 'type': 'thumbnail'},
+          {'name': '1234-5678-rctb-45-05-0110-gf03.tiff', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g03.tiff'},
+          {'name': '1234-5678-rctb-45-05-0110-gf03.png', 'type': 'optimised', 'name_canonical': 'NOME-DO-PACOTE-g03.png'},
+          {'name': '1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg', 'type': 'thumbnail', 'name_canonical': 'NOME-DO-PACOTE-g03-scielo-267x140.jpg'},
         ],
         '': [
-          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original'},
-          {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
+          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif'},
+          {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n01.mp4'},
         ]
       }
 
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
 
       self.assertDictEqual(expected, obtained)
 
@@ -709,6 +698,7 @@ class ArticleAssetsTest(TestCase):
         self.assertEqual(updated[1].name, 'novo_miniatura.jpg')
         self.assertEqual(updated[2].name, 'novo_figura2.jpg')
 
+
     def test_replace_names(self):
         snippet = """
         <fig-group id="f01">
@@ -788,7 +778,8 @@ class ArticleAssetsTest(TestCase):
           {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf', 'name_canonical': '1676-0611-bn-2021-1306-s03.pdf', 'type': 'original'},
         ]
       }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='1676-0611-bn-2021-1306')
+      aa = ArticleAssets(xmltree).article_assets
+      obtained = obtain_asset_dict(aa, package_name='1676-0611-bn-2021-1306')
 
       self.assertDictEqual(expected, obtained)
 

--- a/tests/sps/test_article_assets.py
+++ b/tests/sps/test_article_assets.py
@@ -56,7 +56,7 @@ class ArticleAssetsTest(TestCase):
       data = open('tests/sps/fixtures/document3.xml').read()
       xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {None: [{'name': 'document3-xdadaf.jpg', 'type': 'original'}]}
+      expected = {'': [{'name': 'document3-xdadaf.jpg', 'type': 'original'}]}
       obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
       self.assertDictEqual(expected, obtained)
@@ -113,8 +113,8 @@ class ArticleAssetsTest(TestCase):
       xmltree = xml_utils.get_xml_tree(data)
 
       expected = {
-        None: [
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/8d6031a105ac49f92d2bac1dab55785ec62ed139.tif', 'type': 'original'},
+
+        '': [
           {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'type': 'optimised'},
           {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'type': 'thumbnail'},
           {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/6c7e45494816692122f9467ee9b5ee7a88f86e01.tif', 'type': 'original'},
@@ -197,7 +197,7 @@ class ArticleAssetsTest(TestCase):
       xmltree = xml_utils.get_xml_tree(data)
 
       expected = {
-        None: [
+        '': [
           {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
         ],
         'f01': [
@@ -233,7 +233,7 @@ class ArticleAssetsTest(TestCase):
       xmltree = xml_utils.get_xml_tree(data)
 
       expected = {
-        None: [
+        '': [
           {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original'},
         ]
       }
@@ -300,7 +300,7 @@ class ArticleAssetsTest(TestCase):
           {'name': '1234-5678-rctb-45-05-0110-gf03.png', 'type': 'optimised'},
           {'name': '1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg', 'type': 'thumbnail'},
         ],
-        None: [
+        '': [
           {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original'},
           {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
         ]
@@ -382,7 +382,7 @@ class ArticleAssetsTest(TestCase):
         'S1': [
           {'name': '1471-2105-1-1-s1.pdf', 'type': 'original'},
         ],
-        None: [
+        '': [
           {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
         ],
         'f01': [


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona uma função `name_canonical` que retorno nome de asset em formato padronizado ou canônico: package_name-sufixo-extensão.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
1. Ainda neste ponto do PR estamos lidando apenas com XML, por isso acho pertinente que a função nova fique em article_assets; Mas cabe mudança para outra estrutura/módulo, se assim julgarmos.
2. Este PR ajudará na implementação do milestone JOURNAL-2A  do scms-upload;

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A