### PR TITLE
Adiciona validação de conteúdo de xml com dados de periódico

### DIFF
--- a/packtools/sps/exceptions.py
+++ b/packtools/sps/exceptions.py
@@ -86,3 +86,35 @@ class SPSAssetOrRenditionFileError(Exception):
 class SPSMakePackageFromPathsMissingKeyError(Exception):
     """ To handle missing paths.
     """
+
+
+class ArticleHasInvalidInstanceError(Exception):
+    """ To handle invalid instance.
+    """
+
+
+class ArticleIncompatibleDataError(Exception):
+    """ The root of incompatible Article data exceptions.
+    """
+
+class ArticleHasIncompatibleJournalAcronymError(ArticleIncompatibleDataError):
+    """ To handle incompatible Article and JournalAcronym data.
+    """
+    def __init__(self, *args: object, data):
+        super().__init__(*args)
+        self.data = data
+
+
+class ArticleHasIncompatibleJournalISSNError(ArticleIncompatibleDataError):
+    """ To handle incompatible Article and JournalISSN data.
+    """
+    def __init__(self, *args: object, data):
+        super().__init__(*args)
+        self.data = data
+
+class ArticleHasIncompatibleJournalTitleError(ArticleIncompatibleDataError):
+    """ To handle incompatible Article and JournalTitle data.
+    """
+    def __init__(self, *args: object, data):
+        super().__init__(*args)
+        self.data = data

--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -42,3 +42,29 @@ class Acronym:
     def text(self):
         return self.xmltree.findtext('.//journal-meta//journal-id[@journal-id-type="publisher-id"]')
 
+class Title:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def data(self):
+        _data = []
+
+        _data.append({
+            'type': 'main',
+            'value': self.journal_title,
+        })
+        _data.append({
+            'type': 'abbreviated',
+            'value': self.abbreviated_journal_title,
+        })
+
+        return _data
+
+    @property
+    def abbreviated_journal_title(self):
+        return self.xmltree.findtext('.//journal-meta//journal-title-group//abbrev-journal-title[@abbrev-type="publisher"]')
+
+    @property
+    def journal_title(self):
+        return self.xmltree.findtext('.//journal-meta//journal-title-group//journal-title')

--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -68,3 +68,11 @@ class Title:
     @property
     def journal_title(self):
         return self.xmltree.findtext('.//journal-meta//journal-title-group//journal-title')
+
+class Publisher:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def publisher_name(self):
+        return self.xmltree.findtext('.//journal-meta//publisher//publisher-name')

--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -1,3 +1,18 @@
+"""
+<journal-meta>
+    <journal-id journal-id-type="publisher-id">tinf</journal-id>
+    <journal-title-group>
+        <journal-title>Transinformação</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Transinformação</abbrev-journal-title>
+    </journal-title-group>
+    <issn pub-type="ppub">0103-3786</issn>
+    <issn pub-type="epub">2318-0889</issn>
+    <publisher>
+        <publisher-name>Pontifícia Universidade Católica de Campinas</publisher-name>
+    </publisher>
+</journal-meta>
+"""
+
 
 class ISSN:
     def __init__(self, xmltree):

--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -69,10 +69,14 @@ class Title:
     def journal_title(self):
         return self.xmltree.findtext('.//journal-meta//journal-title-group//journal-title')
 
+
 class Publisher:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
     @property
-    def publisher_name(self):
-        return self.xmltree.findtext('.//journal-meta//publisher//publisher-name')
+    def publishers_names(self):
+        names = []
+        for node in self.xmltree.xpath('.//journal-meta//publisher//publisher-name'):
+            names.append(node.text)
+        return names

--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -33,3 +33,12 @@ class ISSN:
     def ppub(self):
         return self.xmltree.findtext('.//journal-meta//issn[@pub-type="ppub"]')
  
+
+class Acronym:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def text(self):
+        return self.xmltree.findtext('.//journal-meta//journal-id[@journal-id-type="publisher-id"]')
+

--- a/packtools/sps/validation/article.py
+++ b/packtools/sps/validation/article.py
@@ -1,15 +1,18 @@
 from lxml import etree
+from packtools.sps import exceptions
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
 from packtools.sps.models.front_journal_meta import ISSN
 
 
-class InvalidXMLTreeError(Exception):
-    ...
-
-
 def are_similar_articles(xml1, xml2):
-    if not isinstance(xml1, etree.ElementTree) or not isinstance(xml2, etree.ElementTree):
-        raise InvalidXMLTreeError()
+    """
+    Params
+    ------
+    xml1: ElementTree
+    xml2: ElementTree
+    """
+    if not isinstance(xml1, etree._Element) or not isinstance(xml2, etree._Element):
+        raise exceptions.ArticleHasInvalidInstanceError()
 
     if not have_similar_issn_codes(xml1, xml2):
         return False
@@ -21,6 +24,12 @@ def are_similar_articles(xml1, xml2):
 
 
 def have_similar_doi_codes(xml1, xml2):
+    """
+    Params
+    ------
+    xml1: ElementTree
+    xml2: ElementTree
+    """
     a1_doi_list = [d['value'] for d in DoiWithLang(xml1).data]
     a2_doi_list = [d['value'] for d in DoiWithLang(xml2).data]
 
@@ -31,6 +40,12 @@ def have_similar_doi_codes(xml1, xml2):
 
 
 def have_similar_issn_codes(xml1, xml2):
+    """
+    Params
+    ------
+    xml1: ElementTree
+    xml2: ElementTree
+    """
     a1_issn = ISSN(xml1)
     a2_issn = ISSN(xml2)
     

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -16,3 +16,18 @@ def are_journal_issns_compatible(xml_article, issns):
             raise exceptions.ArticleHasIncompatibleJournalISSNError(data={'xml': i, 'issns': issns})
     return True
 
+
+def are_journal_titles_compatible(xml_article, titles):
+    """
+    Params
+    ------
+    xml_article: ElementTree
+    titles: list
+    """
+    obj_journal_title_values = [d['value'] for d in Title(xml_article).data]
+    for t in obj_journal_title_values:
+        if t in titles:
+            return True
+    raise exceptions.ArticleHasIncompatibleJournalTitleError(data={'xml': obj_journal_title_values, 'titles': titles})
+
+

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -3,3 +3,16 @@ from packtools.sps import exceptions
 from packtools.sps.models.front_journal_meta import Acronym, ISSN, Title
 
 
+def are_journal_issns_compatible(xml_article, issns):
+    """
+    Params
+    ------
+    xml_article: ElementTree
+    issns: list
+    """
+    obj_journal_issn = ISSN(xml_article)
+    for i in [j for j in [obj_journal_issn.epub, obj_journal_issn.ppub] if j != '']:
+        if i not in issns:
+            raise exceptions.ArticleHasIncompatibleJournalISSNError(data={'xml': i, 'issns': issns})
+    return True
+

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -1,0 +1,5 @@
+from lxml import etree
+from packtools.sps import exceptions
+from packtools.sps.models.front_journal_meta import Acronym, ISSN, Title
+
+

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -3,6 +3,37 @@ from packtools.sps import exceptions
 from packtools.sps.models.front_journal_meta import Acronym, ISSN, Title
 
 
+def are_article_and_journal_data_compatible(xml_article, journal_issns, journal_titles, journal_acronym=None):
+    """
+    Params
+    ------
+    xml_article: ElementTree
+    journal_issns: list
+    journal_titles: list
+    journal_acronym: str
+    """
+    if not isinstance(xml_article, etree._Element):
+        raise exceptions.ArticleHasInvalidInstanceError()
+
+    try:
+        are_journal_issns_compatible(xml_article, journal_issns)
+    except exceptions.ArticleHasIncompatibleJournalISSNError:
+        raise
+    
+    try:
+        are_journal_titles_compatible(xml_article, journal_titles)
+    except exceptions.ArticleHasIncompatibleJournalTitleError:
+        raise
+
+    if journal_acronym is not None:
+        try:
+            are_journal_acronyms_compatible(xml_article, journal_acronym)
+        except exceptions.ArticleHasIncompatibleJournalAcronymError:
+            raise
+
+    return True
+    
+
 def are_journal_issns_compatible(xml_article, issns):
     """
     Params

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -31,3 +31,14 @@ def are_journal_titles_compatible(xml_article, titles):
     raise exceptions.ArticleHasIncompatibleJournalTitleError(data={'xml': obj_journal_title_values, 'titles': titles})
 
 
+def are_journal_acronyms_compatible(xml_article, acronym):
+    """
+    Params
+    ------
+    xml_article: ElementTree
+    acronym: str
+    """
+    xml_acronym = Acronym(xml_article).text
+    if xml_acronym != acronym:
+        raise exceptions.ArticleHasIncompatibleJournalAcronymError(data={'xml': xml_acronym, 'acronym': acronym})
+    return True

--- a/packtools/sps/validation/journal.py
+++ b/packtools/sps/validation/journal.py
@@ -57,11 +57,11 @@ def are_journal_titles_compatible(xml_article, titles):
     xml_article: ElementTree
     titles: list
     """
-    obj_journal_title_values = [d['value'] for d in Title(xml_article).data]
-    for t in obj_journal_title_values:
-        if t in titles:
-            return True
-    raise exceptions.ArticleHasIncompatibleJournalTitleError(data={'xml': obj_journal_title_values, 'titles': titles})
+    for d in Title(xml_article).data:
+        if d['value'] not in titles:
+            raise exceptions.ArticleHasIncompatibleJournalTitleError(data={'xml': d['value'], 'titles': titles})
+
+    return True
 
 
 def are_journal_acronyms_compatible(xml_article, acronym):
@@ -74,4 +74,5 @@ def are_journal_acronyms_compatible(xml_article, acronym):
     xml_acronym = Acronym(xml_article).text
     if xml_acronym != acronym:
         raise exceptions.ArticleHasIncompatibleJournalAcronymError(data={'xml': xml_acronym, 'acronym': acronym})
+
     return True

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.13'
+__version__ = '2.14'

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -1,0 +1,87 @@
+from unittest import TestCase
+
+from packtools.sps.utils.xml_utils import get_xml_tree
+from packtools.sps.validation import journal
+from packtools.sps import exceptions
+
+
+class JournalTest(TestCase):
+    def test_are_journal_issns_compatible_true_identical_issns(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        issns = ['0103-5053', '1678-4790']
+        self.assertTrue(journal.are_journal_issns_compatible(xml_article, issns))
+    
+    def test_are_journal_issns_compatible_missing_issn_raises_exception(self):
+        # Um dos códigos ISSN do XML não está na lista padrão
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        issns = ['0103-5053', '1678-4790']
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
+            journal.are_journal_issns_compatible(xml_article, issns)
+
+    def test_are_journal_issns_compatible_one_different_issn_raises_exception(self):
+        # Um dos códigos ISSN da lista padrão é diferente do que está no XML
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        issns = ['0103-5053', '2222-2222']
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
+            journal.are_journal_issns_compatible(xml_article, issns)
+
+    def test_are_journal_issns_compatible_false_two_different_issn_raises_exception(self):
+        # Nenhum código ISSN coincide
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        issns = ['0103-0000', '0000-4790']
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
+            journal.are_journal_issns_compatible(xml_article, issns)
+
+    def test_are_journal_issns_compatible_false_empty_issn_list_raises_exception(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
+            journal.are_journal_issns_compatible(xml_article, [])

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -198,9 +198,9 @@ class JournalTest(TestCase):
         xml_article = get_xml_tree(xml_article_str)
         self.assertTrue(journal.are_article_and_journal_data_compatible(
             xml_article,
-            journal_acronym='jbchs',
             journal_titles=['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.'],
-            journal_issns=['0103-5053', '1678-4790'] 
+            journal_print_issn='0103-5053',
+            journal_electronic_issn='1678-4790',
         ))
 
     def test_are_article_and_journal_data_compatible_raises_exception(self):
@@ -228,10 +228,12 @@ class JournalTest(TestCase):
         try:
             journal.are_article_and_journal_data_compatible(
                 xml_article,
-                journal_acronym='jbchz',
                 journal_titles=['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.'],
-                journal_issns=['0103-5053', '1678-4790'] 
+                journal_print_issn='0102-5053',
+                journal_electronic_issn='1678-4790',
             )
-        except exceptions.ArticleHasIncompatibleJournalAcronymError as e:
+            # alerta para indicar que o try/except não capturou exceção
+            self.assertTrue(False)
+        except exceptions.ArticleIncompatibleDataError as e:
             # os valores incompatíveis são registrados no campo e.data
-            self.assertDictEqual(e.data, {'xml': 'jbchs', 'acronym': 'jbchz'})
+            self.assertListEqual(e.data, [{'xml': '0103-5053', 'print_issn': '0102-5053'}])

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -107,8 +107,28 @@ class JournalTest(TestCase):
         xml_article = get_xml_tree(xml_article_str)
         titles = ['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.']
         self.assertTrue(journal.are_journal_titles_compatible(xml_article, titles))        
-        self.assertTrue(journal.are_journal_titles_compatible(xml_article, ['J. Braz. Chem. Soc.']))
-        self.assertTrue(journal.are_journal_titles_compatible(xml_article, ['Journal of the Brazilian Chemical Society']))
+
+
+    def test_are_journal_titles_compatible_missing_title_raises_exception(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                    <journal-title-group>
+                        <journal-title>Journal of the Brazilian Chemical Society</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">J. Braz. Chem. Soc.</abbrev-journal-title>
+                    </journal-title-group>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalTitleError):
+            journal.are_journal_titles_compatible(xml_article, ['J. Braz. Chem. Soc.'])
+
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalTitleError):
+            journal.are_journal_titles_compatible(xml_article, ['Journal of the Brazilian Chemical Society'])
 
 
     def test_are_journal_titles_compatible_title_different_raises_exception(self):

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -152,3 +152,62 @@ class JournalTest(TestCase):
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalAcronymError):
             journal.are_journal_acronyms_compatible(xml_article, 'jbch')
 
+    def test_are_article_and_journal_data_compatible_true(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                    <journal-title-group>
+                        <journal-title>Journal of the Brazilian Chemical Society</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">J. Braz. Chem. Soc.</abbrev-journal-title>
+                    </journal-title-group>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                    <publisher>
+                        <publisher-name>Sociedade Brasileira de Química</publisher-name>
+                    </publisher>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        self.assertTrue(journal.are_article_and_journal_data_compatible(
+            xml_article,
+            journal_acronym='jbchs',
+            journal_titles=['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.'],
+            journal_issns=['0103-5053', '1678-4790'] 
+        ))
+
+    def test_are_article_and_journal_data_compatible_raises_exception(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                    <journal-title-group>
+                        <journal-title>Journal of the Brazilian Chemical Society</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">J. Braz. Chem. Soc.</abbrev-journal-title>
+                    </journal-title-group>
+                    <issn pub-type="ppub">0103-5053</issn>
+                    <issn pub-type="epub">1678-4790</issn>
+                    <publisher>
+                        <publisher-name>Sociedade Brasileira de Química</publisher-name>
+                    </publisher>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+
+        # se qualquer um dos campos journal_* for distinto do esperado, uma exceção é gerada
+        try:
+            journal.are_article_and_journal_data_compatible(
+                xml_article,
+                journal_acronym='jbchz',
+                journal_titles=['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.'],
+                journal_issns=['0103-5053', '1678-4790'] 
+            )
+        except exceptions.ArticleHasIncompatibleJournalAcronymError as e:
+            # os valores incompatíveis são registrados no campo e.data
+            self.assertDictEqual(e.data, {'xml': 'jbchs', 'acronym': 'jbchz'})

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -85,3 +85,43 @@ class JournalTest(TestCase):
         xml_article = get_xml_tree(xml_article_str)
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
             journal.are_journal_issns_compatible(xml_article, [])
+
+    def test_are_journal_titles_compatible_true(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                    <journal-title-group>
+                        <journal-title>Journal of the Brazilian Chemical Society</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">J. Braz. Chem. Soc.</abbrev-journal-title>
+                    </journal-title-group>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        titles = ['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.']
+        self.assertTrue(journal.are_journal_titles_compatible(xml_article, titles))        
+        self.assertTrue(journal.are_journal_titles_compatible(xml_article, ['J. Braz. Chem. Soc.']))
+        self.assertTrue(journal.are_journal_titles_compatible(xml_article, ['Journal of the Brazilian Chemical Society']))
+
+
+    def test_are_journal_titles_compatible_title_different_raises_exception(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-title-group>
+                        <journal-title>Journal of the German Chemical Society</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">J. Ger. Chem. Soc.</abbrev-journal-title>
+                    </journal-title-group>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        titles = ['Journal of the Brazilian Chemical Society', 'J. Braz. Chem. Soc.']
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalTitleError):
+            journal.are_journal_titles_compatible(xml_article, titles)
+

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -18,8 +18,9 @@ class JournalTest(TestCase):
         </article>
         """
         xml_article = get_xml_tree(xml_article_str)
-        issns = ['0103-5053', '1678-4790']
-        self.assertTrue(journal.are_journal_issns_compatible(xml_article, issns))
+        issn_print = '0103-5053'
+        issn_electronic = '1678-4790'
+        self.assertTrue(journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic))
     
     def test_are_journal_issns_compatible_missing_issn_raises_exception(self):
         # Um dos códigos ISSN do XML não está na lista padrão
@@ -33,9 +34,10 @@ class JournalTest(TestCase):
         </article>
         """
         xml_article = get_xml_tree(xml_article_str)
-        issns = ['0103-5053', '1678-4790']
+        issn_print = '0103-5053'
+        issn_electronic = '1678-4790'
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
-            journal.are_journal_issns_compatible(xml_article, issns)
+            journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic)
 
     def test_are_journal_issns_compatible_one_different_issn_raises_exception(self):
         # Um dos códigos ISSN da lista padrão é diferente do que está no XML
@@ -50,9 +52,10 @@ class JournalTest(TestCase):
         </article>
         """
         xml_article = get_xml_tree(xml_article_str)
-        issns = ['0103-5053', '2222-2222']
+        issn_print = '0103-5053'
+        issn_electronic = '2222-2222'
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
-            journal.are_journal_issns_compatible(xml_article, issns)
+            journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic)
 
     def test_are_journal_issns_compatible_false_two_different_issn_raises_exception(self):
         # Nenhum código ISSN coincide
@@ -67,9 +70,10 @@ class JournalTest(TestCase):
         </article>
         """
         xml_article = get_xml_tree(xml_article_str)
-        issns = ['0103-0000', '0000-4790']
+        issn_print = '0103-0000'
+        issn_electronic = '0000-4790'
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
-            journal.are_journal_issns_compatible(xml_article, issns)
+            journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic)
 
     def test_are_journal_issns_compatible_false_empty_issn_list_raises_exception(self):
         xml_article_str = """
@@ -84,7 +88,7 @@ class JournalTest(TestCase):
         """
         xml_article = get_xml_tree(xml_article_str)
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
-            journal.are_journal_issns_compatible(xml_article, [])
+            journal.are_journal_issns_compatible(xml_article, '', '')
 
     def test_are_journal_titles_compatible_true(self):
         xml_article_str = """

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -125,3 +125,30 @@ class JournalTest(TestCase):
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalTitleError):
             journal.are_journal_titles_compatible(xml_article, titles)
 
+    def test_are_journal_acronyms_compatible_true(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        self.assertTrue(journal.are_journal_acronyms_compatible(xml_article, 'jbchs'))
+
+    def test_are_journal_acronyms_compatible_acronym_different_raises_error(self):
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="publisher-id">jbchs</journal-id>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        xml_article = get_xml_tree(xml_article_str)
+        with self.assertRaises(exceptions.ArticleHasIncompatibleJournalAcronymError):
+            journal.are_journal_acronyms_compatible(xml_article, 'jbch')
+


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validação relacionada a XML e dados de periódico.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
...

#### Algum cenário de contexto que queira dar?
Este PR faz parte das alterações necessárias para lidar com o envio de pacotes com conteúdo inédito na aplicação scms-upload. Alguns pontos devem ser considerados neste PR. Por exemplo, que critérios queremos adotar para indicar que um xml não correspondente ao que temos registrado. 
1. Caso um XML tenha um ISSN correto e outro estranho em relação à lista de issns questionada, devemos indicar que há algo errado? 
2. Isso vale para outros campos como acrônimo e título de periódico, quero dizer, o quão diferente podemos aceitar.


### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A