### PR TITLE
Corrige validação de códigos ISSN

### DIFF
--- a/packtools/sps/models/front_journal_meta.py
+++ b/packtools/sps/models/front_journal_meta.py
@@ -27,11 +27,11 @@ class ISSN:
 
     @property
     def epub(self):
-        return self.xmltree.findtext('.//journal-meta//issn[@pub-type="epub"]')
+        return self.xmltree.findtext('.//journal-meta//issn[@pub-type="epub"]') or ''
 
     @property
     def ppub(self):
-        return self.xmltree.findtext('.//journal-meta//issn[@pub-type="ppub"]')
+        return self.xmltree.findtext('.//journal-meta//issn[@pub-type="ppub"]') or ''
  
 
 class Acronym:

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.15'
+__version__ = '2.15.1'

--- a/tests/sps/validation/test_journal.py
+++ b/tests/sps/validation/test_journal.py
@@ -39,6 +39,27 @@ class JournalTest(TestCase):
         with self.assertRaises(exceptions.ArticleHasIncompatibleJournalISSNError):
             journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic)
 
+    def test_are_journal_issns_compatible_with_one_xml_issn_and_one_empty_issn_is_true(self):
+        # Um dos códigos ISSN do XML não está na lista padrão
+        xml_article_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
+            <front>
+                <journal-meta>
+                    <issn pub-type="epub">1678-4790</issn>
+                </journal-meta>
+            </front>
+        </article>
+        """
+        # XML possui apenas um código ISSN
+        xml_article = get_xml_tree(xml_article_str)
+
+        # Base de dados ou data possui um ISSN vazio e outro válido
+        issn_print = ''
+        issn_electronic = '1678-4790'
+        
+        # Espera-se que o método que compara os dados decida por True, pois há apenas um ISSN válido
+        journal.are_journal_issns_compatible(xml_article, issn_print, issn_electronic)
+
     def test_are_journal_issns_compatible_one_different_issn_raises_exception(self):
         # Um dos códigos ISSN da lista padrão é diferente do que está no XML
         xml_article_str = """


### PR DESCRIPTION
#### O que esse PR faz?
Corrige método que valida se os códigos ISSN que existem num XML são compatíveis com aqueles esperados.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
O método que recupera ISSN de um XML retorna None quando este campo não existe no XML. A correção passou por fazer esse método retornar string vazia.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A