### PR TITLE
Corrige situação de validador de xml:lang sem atributo

### DIFF
--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -28,7 +28,7 @@ def validate_language(xml):
                 line=i.get('line_number'),
             ))
 
-        if not tag_is_valid(_lang):
+        elif not tag_is_valid(_lang):
             _message = f'XML {_article_type} has an invalid language: {_lang}'
             errors.append(exceptions.ValidationArticleAndSubArticlesHasInvalidLanguage(
                 message=_message,

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.16'
+__version__ = '2.16.1'

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -4,7 +4,7 @@ from packtools.sps.utils.xml_utils import get_xml_tree
 from packtools.sps.validation.article_and_subarticles import validate_language
 
 
-class ArticleTest(TestCase):        
+class ArticleAndSubarticlesTest(TestCase):
     def test_article_has_valid_language(self):
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -5,6 +5,30 @@ from packtools.sps.validation.article_and_subarticles import validate_language
 
 
 class ArticleAndSubarticlesTest(TestCase):
+    def test_article_has_no_language_attribute(self):
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+            <front>
+                <article-meta>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v3">zTn4sYXBrfSTMNVPF5Dm7jr</article-id>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0103-50532014001202258</article-id>
+                    <article-id pub-id-type="doi">10.5935/0103-5053.20140192</article-id>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        result, errors = validate_language(xml_tree)
+
+        self.assertFalse(result)
+
+        self.assertListEqual(
+            ['XML research-article has no language.'],
+            [e.message for e in errors]
+        )
+
+
     def test_article_has_valid_language(self):
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -126,6 +126,30 @@ class ArticleAndSubarticlesTest(TestCase):
             [e.line for e in errors]
         )
 
+    def test_article_and_subarticles_with_one_valid_language_one_empty_and_one_invalid(self):
+        xml_str = """
+        <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <sub-article article-type="translation" id="s1">
+            </sub-article>
+            <sub-article article-type="translation" id="s2" xml:lang="">
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+        result, errors = validate_language(xml_tree)
+        
+        self.assertFalse(result)
+
+        self.assertListEqual(
+            ['XML translation has no language.', 'XML translation has an invalid language: '],
+            [e.message for e in errors]
+        )
+
+        self.assertListEqual(
+            [3, 5],
+            [e.line for e in errors]
+        )
+
 
     def test_article_and_subarticles_with_two_invalid_languages(self):
         xml_str = """


### PR DESCRIPTION
#### O que esse PR faz?
Corrige caso em que não há parâmetro xml:lang definido em <article> ou <sub-article>.

#### Onde a revisão poderia começar?
Por commits.

#### Como este poderia ser testado manualmente?
Como na PR anterior relacionado a validação de xml:lang.

#### Algum cenário de contexto que queira dar?
Foi preciso fazer esse ajuste para melhor acomodar essa validação na aplicação scms-upload.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A