### PR TITLE
Adiciona ao menu lateral esquerdo da página do artigo, as notas de rodapé

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
@@ -33,7 +33,8 @@
     </xsl:template>
         
     <xsl:template match="fn">
-        <li>
+        <li class="articleSection">
+            <xsl:attribute name="data-anchor"><xsl:apply-templates select="label"/></xsl:attribute>
             <xsl:apply-templates select="*|text()"></xsl:apply-templates>
         </li>
     </xsl:template>
@@ -41,7 +42,7 @@
     <xsl:template match="fn/label">
         <xsl:choose>
             <xsl:when test="string-length(normalize-space(text())) &gt; 3">
-                <h3><span class="xref big"><xsl:apply-templates select="*|text()"></xsl:apply-templates></span></h3>
+                <h3><xsl:apply-templates select="*|text()"></xsl:apply-templates></h3>
             </xsl:when>
             <xsl:otherwise>
                 <span class="xref big"><xsl:apply-templates select="*|text()"></xsl:apply-templates></span>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.16.1'
+__version__ = '2.17.0'

--- a/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.en.html
+++ b/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.en.html
@@ -1,0 +1,1623 @@
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css">
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css" media="print">
+<link rel="alternate" type="application/rss+xml" title="SciELO" href="">
+</head>
+<body class="journal article">
+<a name="top"></a><div id="standalonearticle">
+<section class="articleCtt"><div class="container"><div class="articleTxt">
+<div class="articleBadge-editionMeta-doi-copyLink">
+<span class="_articleBadge">ARTICLE</span><span class="_separator"> • </span><span class="_editionMeta">Pap. Avulsos Zool. 62 <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.11606/1807-0205/2022.62.026" class="_doi" target="_blank">https://doi.org/10.11606/1807-0205/2022.62.026</a>
+         
+        <a class="copyLink" data-clipboard-text="https://doi.org/10.11606/1807-0205/2022.62.026"><span class="sci-ico-link"></span>copy</a></span>
+</div>
+<h1 class="article-title">
+<span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Composition and dynamics of mixed flocks of birds in a remnant of Submontane Atlantic Rain Forest in southern Brazil<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+</h1>
+<div class="articleMeta"></div>
+<div class="contribGroup">
+<span class="dropdown"><a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Gustavo Silveira da Luz </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+<strong></strong>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Ecologia de Paisagem e de Vertebrados (LABECO), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.<div class="corresp">
+					<h3><sup>3</sup></h3>E-mail: <a href="mailto:gustavoluzbio@gmail.com">gustavoluzbio@gmail.com</a>
+				</div>
+<a href="http://orcid.org/0000-0001-5757-1048" class="btnContribLinks orcid">http://orcid.org/0000-0001-5757-1048</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Fernando Carvalho </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+<strong></strong>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Zoologia e Ecologia de Vertebrados (LABZEV), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.<div class="corresp">
+					<h3><sup>4</sup></h3>E-mail: <a href="mailto:f.carvalho@unesc.net">f.carvalho@unesc.net</a>
+				</div>
+<a href="http://orcid.org/0000-0002-7216-7083" class="btnContribLinks orcid">http://orcid.org/0000-0002-7216-7083</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Jairo José Zocche </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+<strong></strong>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Ecologia de Paisagem e de Vertebrados (LABECO), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.<div class="corresp">
+					<h3><sup>5</sup></h3>E-mail: <a href="mailto:jjz@unesc.net">jjz@unesc.net</a> (corresponding author)</div>
+<a href="http://orcid.org/0000-0003-2291-3065" class="btnContribLinks orcid">http://orcid.org/0000-0003-2291-3065</a>
+</ul></span><a href="" class="outlineFadeLink" data-toggle="modal" data-target="#ModalTutors">About the authors</a>
+</div>
+<div class="row">
+<ul class="col-md-2 hidden-sm articleMenu"></ul>
+<article id="articleText" class="col-md-10 col-md-offset-2 col-sm-12 col-sm-offset-0"><div class="articleSection" data-anchor="Abstract">
+<h1 class="articleSectionTitle">Abstract</h1>
+<p>Mixed flocks are associations of two or more species that are formed and maintained through mutual behavioral responses, with advantages such as maximizing foraging and protecting against predation. This study aimed to evaluate the composition, temporal dynamics, and presence of core species in mixed flocks of birds in a remnant of the Submontane Atlantic Rain Forest in the Parque Nacional Aparados da Serra, southern Santa Catarina state, Brazil. Data collection took place from October 2016 to September 2017 through monthly campaigns, consisting of three consecutive observation days, with sampling sessions of six hours per day, resulting in a total effort of 216 h of observations. For each contact with the flocks, we recorded the species and number of individuals, stratum of occurrence, substrates of search, and agonistic interactions. We recorded 152 mixed flocks, with a total of 76 species belonging to 24 families, and five orders, with Thraupidae, Tyrannidae, Furnariidae, and Rhynchocyclidae being the richest. The flocks had an average of 4.5 ± 2.7 species and 8.7 ± 5.8 individuals, with richness and the number of individuals being positively correlated (R² = 0.8). Mixed flocks occurred throughout the year. There was a great variation in the number of contacts from October to February (from 5 to 20 contacts). Meanwhile from March to September, the coldest period of the year in the region, the number of contacts did not vary (from 9 to 14 contacts). However, there was no difference in the number of contacts between these months (z = 0.37; <i>p</i> = 0.691). <i>Basileuterus culicivorus</i> and <i>Habia rubica</i> were the core species because, in addition to their high participation (46.7 and 32.9%, respectively), they showed frequent and conspicuous movement and vocalization. Thus, a high capacity to enlist a greater number of individuals from different species for the flocks was demonstrated.</p>
+<p><strong>Keywords</strong><br>Passeriformes; Heterospecific associations; Core species; Ombrophilous Dense Forest; PARNA Aparados da Serra</p>
+</div>
+<div class="articleSection" data-anchor="Text">
+<h1 class="articleSectionTitle">INTRODUCTION</h1>
+<p>Individuals of multiple bird species can associate by forming mixed flocks, maintained by mutual behavioral responses (<span class="ref"><strong class="xref xrefblue">Moynihan, 1962</strong><span class="refCtt closed"><span>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					. Access: 16/08/2021.</span><br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">https://repository.si.edu/bitstream/hand...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). The evolution of this behavior is related to the advantages of maximizing foraging and protection against predation (<span class="ref"><strong class="xref xrefblue">Moynihan, 1962</strong><span class="refCtt closed"><span>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					. Access: 16/08/2021.</span><br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">https://repository.si.edu/bitstream/hand...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Powell, 1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Alves &amp; Cavalcanti, 1996</strong><span class="refCtt closed"><span>Alves, M.A.S. &amp; Cavalcanti, R.B. 1996. Sentinel behavior, seasonality, and the structure of bird flocks in Brazilian savanna. Neotropical Ornithology, 7: 43-51.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Machado &amp; Rodrigues, 2000</strong><span class="refCtt closed"><span>Machado, C.G. &amp; Rodrigues, N.M.R. 2000. Alteração de altura de forrageamento de espécies de aves quando associadas a bandos mistos. In: Alves, M.A.S.; Silva, J.M.C. &amp; Sluys, V.M. (Org.). Ornitologia brasileira: perspectivas, conservação e pesquisa. Rio de Janeiro, Ed. UERJ. p. 231-239.</span></span></span>). Although mixed flocks occur frequently in tropical forests (<span class="ref"><strong class="xref xrefblue">Powell, 1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Develey, 2001</strong><span class="refCtt closed"><span>Develey, P.F. 2001. The mixed flocks of birds in the Neotropical forests. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul . p. 39-48.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Mangini &amp; Areta, 2018</strong><span class="refCtt closed"><span>Mangini, G.G. &amp; Areta, J.I. 2018. Bird mixed-species flock formation is driven by low temperatures between and within seasons in a Subtropical Andean-foothill forest. Biotropica, 50(5): 816-825. https://doi.org/10.1111/btp.12551.</span><br><a href="https://doi.org/10.1111/btp.12551" target="_blank">https://doi.org/10.1111/btp.12551...
+            </a></span></span>), their composition, structure, and temporal dynamics remain poorly understood.</p>
+<p>The composition, size, and frequency of occurrence (FO) of mixed flocks is influenced by multiple factors, including the drop in the participation of species during reproductive periods, variations in the availability of food resources, and presence of migratory species (<span class="ref"><strong class="xref xrefblue">Alves &amp; Cavalcanti, 1996</strong><span class="refCtt closed"><span>Alves, M.A.S. &amp; Cavalcanti, R.B. 1996. Sentinel behavior, seasonality, and the structure of bird flocks in Brazilian savanna. Neotropical Ornithology, 7: 43-51.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>). These factors are generally associated with climatic variation (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Mangini &amp; Areta, 2018</strong><span class="refCtt closed"><span>Mangini, G.G. &amp; Areta, J.I. 2018. Bird mixed-species flock formation is driven by low temperatures between and within seasons in a Subtropical Andean-foothill forest. Biotropica, 50(5): 816-825. https://doi.org/10.1111/btp.12551.</span><br><a href="https://doi.org/10.1111/btp.12551" target="_blank">https://doi.org/10.1111/btp.12551...
+            </a></span></span>). In addition, other factors, such as habitat loss and fragmentation, edge effects, and successional vegetation stage, can also influence the composition and dynamics of mixed flocks in forest environments (<span class="ref"><strong class="xref xrefblue">Aleixo, 2001</strong><span class="refCtt closed"><span>Aleixo, A. 2001. Conservação da avifauna da Floresta Atlântica: efeitos da fragmentação e a importância de florestas secundárias. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul. p. 199-206.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Marini &amp; Garcia, 2005</strong><span class="refCtt closed"><span>Marini, M.Â. &amp; Garcia, F.I. 2005. Conservação de aves no Brasil. Megadiversidade, 1(1): 95-101.</span></span></span>).</p>
+<p>Species associated with mixed flocks present different patterns of interaction and can be categorized into core and assistant species (<span class="ref"><strong class="xref xrefblue">Powell, 1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>). Core species have a high frequency of participation and conspicuous patterns of movement and vocalization that stimulate the formation and cohesion of the flock (<span class="ref"><strong class="xref xrefblue">Develey, 2001</strong><span class="refCtt closed"><span>Develey, P.F. 2001. The mixed flocks of birds in the Neotropical forests. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul . p. 39-48.</span></span></span>). Meanwhile, the assistant species have a secondary role in the flock and can be divided into regular or occasional participants, depending on the frequency of interaction (<span class="ref"><strong class="xref xrefblue">Moynihan, 1962</strong><span class="refCtt closed"><span>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					. Access: 16/08/2021.</span><br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">https://repository.si.edu/bitstream/hand...
+            </a></span></span>).</p>
+<p>Although mixed flocks of birds occur in almost all vegetation types, they are far more common in Neotropical forests (<span class="ref"><strong class="xref xrefblue">Powell, 1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>). In Brazil, mixed flocks have been studied extensively in the Atlantic Forest and Amazon biomes, where more than 40% of birds participate in these associations, including species considered endemic and/or threatened (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>). Despite high environmental degradation, the frequency of mixed flocks in the Atlantic Rain Forest is still high (<span class="ref"><strong class="xref xrefblue">Aleixo, 1997</strong><span class="refCtt closed"><span>Aleixo, A. 1997. Composition of mixed-species bird flocks and abundance of flocking species in a semideciduous forest of southeastern Brazil. Ararajuba, 5(6): 11-18.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Batista <i>et al.,</i> 2013</strong><span class="refCtt closed"><span>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</span></span></span>). This biome is considered one of the most biodiverse and threatened ecosystems on the planet (<span class="ref"><strong class="xref xrefblue">Myers <i>et al.,</i> 2000</strong><span class="refCtt closed"><span>Myers, N.; Mittermeier, R.A.; Mittermeier, C.G.; da Fonseca, G.A.B. &amp; Kent, J. 2000. Biodiversity hotspots for conservation priorities. Nature, 403(6772): 853-858. https://doi.org/10.1038/35002501.</span><br><a href="https://doi.org/10.1038/35002501" target="_blank">https://doi.org/10.1038/35002501...
+            </a></span></span>) and is among the 36 global biodiversity hotspots (<span class="ref"><strong class="xref xrefblue">Merritt <i>et al.,</i> 2019</strong><span class="refCtt closed"><span>Merritt, M.; Maldaner, M.E. &amp; de Almeida, A.M.R. 2019. What are biodiversity hotspots? Frontiers for Young Minds, 7: 1-7. https://doi.org/10.3389/frym.2019.00029.</span><br><a href="https://doi.org/10.3389/frym.2019.00029" target="_blank">https://doi.org/10.3389/frym.2019.00029...
+            </a></span></span>). In this way, deforestation and loss of species not only represent the loss of taxonomic diversity but also the loss of interspecific interactions in which these species are involved.</p>
+<p>Studies on the composition and dynamics of heterospecific mixed flocks are vital for understanding the autoecology of the participating species, as they contribute to filling knowledge gaps in tropical environments. Moreover, they are essential for defining biodiversity conservation strategies in fragmented landscapes remaining in tropical forests (<span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Batista <i>et al.,</i> 2013</strong><span class="refCtt closed"><span>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</span></span></span>).</p>
+<p>In this study, we evaluated the composition, temporal dynamics, and presence of core species in mixed flocks of birds in a remnant of the Submontane Atlantic Rain Forest in the Parque Nacional Aparados da Serra, southern Santa Catarina state, Brazil. To the best of our knowledge, there are no previous studies on mixed flocks of birds in this region, and thus, the species involved in these associations, their structure, and their temporal dynamics remain unknown.</p>
+<h1 class="articleSectionTitle">MATERIAL AND METHODS</h1>
+<p>The present study was carried out in the Parque Nacional Aparados da Serra (29°12′18.92″S and 50°3′22.81″W), municipality of Praia Grande, south of Santa Catarina state, southern Brazil (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1"><span class="sci-ico-fileFigure"></span>Fig. 1</a>). The Parque Nacional Aparados da Serra is a protected area that covers 130,606 km², extending within the municipalities of Cambará do Sul in the Rio Grande do Sul state and Praia Grande in the Santa Catarina state (<span class="ref"><strong class="xref xrefblue">IBAMA-MMA, 2004</strong><span class="refCtt closed"><span>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA) &amp; Ministério do Meio Ambiente (MMA). 2004. Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC. Brasília, MMA.</span></span></span>).</p>
+<p>
+				<div class="row fig" id="f1">
+<a name="f1"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf1"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 1</strong><br>Location of the study area in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.<br>
+</div>
+</div>
+			</p>
+<p>The altitude of the study area ranges between 200 and 350 m above sea level (<span class="ref"><strong class="xref xrefblue">IBAMA-MMA, 2004</strong><span class="refCtt closed"><span>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA) &amp; Ministério do Meio Ambiente (MMA). 2004. Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC. Brasília, MMA.</span></span></span>). The Köppen climate classification is Cfa (humid subtropical, without a dry season, and hot summers), with a mean annual temperature of 19.0 °C. However, the study area is also influenced by the Köppen climate Cfb (humid subtropical, without a dry season, and temperate summers), with an annual average temperature of 16.0 °C (<span class="ref"><strong class="xref xrefblue">Alvares <i>et al.,</i> 2014</strong><span class="refCtt closed"><span>Alvares, C.A.; Starpe, J.L.; Sentelhas, P.C.; Gonçalves, J.L.M. &amp; Sparovek, G. 2014. Köppen’s climate classification map for Brazil. Meteorologische Zeitschrift, Garmisch-Partenkirchen, 22(6): 711-728. https://doi.org/10.1127/0941-2948/2013/0507.</span><br><a href="https://doi.org/10.1127/0941-2948/2013/0507" target="_blank">https://doi.org/10.1127/0941-2948/2013/0...
+            </a></span></span>). The mean temperature in the coldest periods (June-August) ranges close to 7.2°C and the annual rainfall ranges from 1,220 to 1,660 mm, with an annual total of 102-150 rainy days (<span class="ref"><strong class="xref xrefblue">EPAGRI, 2001</strong><span class="refCtt closed"><span>Empresa de Pesquisa Agropecuária e Extensão Rural de Santa Catarina (EPAGRI). 2001. Dados e informações biofísicas da unidade de planejamento regional litoral sul Catarinense - UPR 8. Florianópolis, EPAGRI.</span></span></span>).</p>
+<p>The study area was covered by a Submontane Atlantic Rain Forest (<span class="ref"><strong class="xref xrefblue">IBAMA-MMA, 2004</strong><span class="refCtt closed"><span>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA) &amp; Ministério do Meio Ambiente (MMA). 2004. Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC. Brasília, MMA.</span></span></span>; <span class="ref"><strong class="xref xrefblue">IBGE, 2012</strong><span class="refCtt closed"><span>Instituto Brasileiro de Geografia e Estatística (IBGE). 2012. Manual técnico da vegetação brasileira. Rio de Janeiro, IBGE.</span></span></span>) (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Fig. 2A</a>). The vegetation was in the secondary successional stage of regeneration, predominantly in the early and medium stages, where the canopy varies from 6-15 m in height from the ground (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Fig. 2B</a>). The understory is denser along the forest border, where Melastomataceae, Rubiaceae, Poaceae, and several pteridophytes predominate (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Fig. 2D</a>), and less dense inside the forest (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Fig. 2C</a>), where numerous lianas and epiphytes, especially bromeliads of the genus <i>Vriesea</i> persist (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Fig. 2E</a>).</p>
+<p>
+				<div class="row fig" id="f2">
+<a name="f2"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf2"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 2</strong><br>(A-E) Images of Atlantic Rain Forest in the lower part of Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil. (A) overview of Submontane Atlantic Rain Forest; (B) detail of canopy height; (C) detail of the understory within the forest; (D) detail of understory at the forest edge; (E) presence of lianas and bromeliads in the understory within the forest.<br>
+</div>
+</div>
+			</p>
+<p>Data on the detection of mixed flocks were collected between October 2016 and September 2017 in 12 monthly campaigns over three consecutive days. Sampling was carried out along a main trail of three kilometers, containing perpendicular trails ranging from 200 to 300 m (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf3"><span class="sci-ico-fileFigure"></span>Fig. 3</a>), covering inland environments and edges of the Submontane Forest. The group formed by the main and secondary trails was divided into three sectors (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf3"><span class="sci-ico-fileFigure"></span>Fig. 3</a>). Each sector was sampled in one day during sampling sessions of six hours each; 60% in the morning, starting after sunrise, and the remainder in the afternoon, ending before dusk (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span> adapted), totaling 216 h of data collection (36 d).</p>
+<p>
+				<div class="row fig" id="f3">
+<a name="f3"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf3"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 3</strong><br>Distribution of the three sampling sectors (I, II, and III) in the study area, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.<br>
+</div>
+</div>
+			</p>
+<p>Mixed flocks were detected through visual observations, aided by binoculars (8 × 42), contact calls, and aural records. Mixed flocks were defined as the association of two or more individuals of at least two distinct species following each other along the same route for a minimum period of five minutes while looking for food (<span class="ref"><strong class="xref xrefblue">Stotz, 1993</strong><span class="refCtt closed"><span>Stotz, D.F. 1993. Geographic variation in species composition of mixed species flocks in lowland humid forest in Brazil. Papéis Avulsos de Zoologia, 38(4): 61-75.</span></span></span>). Due to difficulties in access and movement in the area, because of the slope of the terrain and the dense understory, some groups were followed in the direction of displacement only when they moved close to the trails, as suggested by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>).</p>
+<p>Per the recommendations from <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>), when in contact with a mixed flock, we recorded the time and contact time (start and end time, with a maximum observation time of 15 min), species observed, number of individuals of each species, type of record (visual or aural), and stratum of occurrence (understory or canopy) occupied by each species. When possible, search substrates (soil, litter, trunks, branches, leaves, flowers, and air), types of food items consumed (arthropods, fruits, seeds, buds, leaves, nectar, and flowers), and agonistic interactions (physical aggression and flight chase) were recorded, as suggested by <span class="ref"><strong class="xref xrefblue">Fitzpatrick (1980</strong><span class="refCtt closed"><span>Fitzpatrick, J.W. 1980. Foraging behavior of neotropical tyrant flycatchers. Condor, 82(1): 43-57. https://doi.org/10.2307/1366784.</span><br><a href="https://doi.org/10.2307/1366784" target="_blank">https://doi.org/10.2307/1366784...
+            </a></span></span>). Taxonomic nomenclature followed the proposition adopted by the Brazilian Committee of Ornithological Records (<span class="ref"><strong class="xref xrefblue">Pacheco <i>et al.,</i> 2021</strong><span class="refCtt closed"><span>Pacheco, J.F.; Silveira, L.F.; Aleixo, A.; Agne, C.E.; Bencke, G.A.; Bravo, G.A; Brito, G.R.R.; Cohn-Haft, M.; Maurício, G.N.; Naka, L.N.; Olmos, F.; Posso, S.; Lees, A.C.; Figueiredo, L.F.A.; Carrano, E.; Guedes, R.C.; Cesari, E.; Franz, I.; Schunck, F. &amp; Piacentini, V.Q. 2021. Annotated checklist of the birds of Brazil by the Brazilian Ornithological Records Committee - second edition. Ornithology Research, 29(2): 94-105. https://doi.org/10.1007/s43388-021-00058-x.</span><br><a href="https://doi.org/10.1007/s43388-021-00058-x" target="_blank">https://doi.org/10.1007/s43388-021-00058...
+            </a></span></span>).</p>
+<p>The FO of a species in mixed flocks was defined as the proportion of flocks in which it was present among the total registered flocks. The species were then classified into the following categories: regular (FO ≥ 25%), common (10 ≤ FO ≤ 24.9%), unusual (3.0 ≤ FO ≤ 9.9%), and rare species (FO ≤ 2.9%) (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>).</p>
+<p>The relationship between species richness and the number of individuals in mixed flocks was assessed using simple linear regression. To analyze the temporal variation in the frequency of mixed flocks per campaign (number of contacts), size of the flocks (number of individuals), and richness of the flocks throughout the year, the Rayleigh test (Z) was used, with a significance level of 0.05, calculated using the Oriana software, version 4.3 (<span class="ref"><strong class="xref xrefblue">Kovach, 2011</strong><span class="refCtt closed"><span>Kovach, W.L. 2011. Oriana - Circular statistics for windows, ver. 4. Kovach Computing Services, Anglesey, Wales.</span></span></span>).</p>
+<p>To determine which of the recorded species acted as core species, the performance of each species in the formation and maintenance of the cohesion of the flocks was evaluated. In this case, the requirements proposed by <span class="ref"><strong class="xref xrefblue">Powell (1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>) and <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) were considered: (1) neutral color patterns (<i>e.g.,</i> olive, yellow, brown, black, and without spots) - these are considered less aggressive plumes which potentially facilitate interspecific association; (2) movement - species that move during foraging cause local disturbances that attract other individuals to the flock; (3) vocalization - species that vocalize strongly during foraging reinforce the attraction and keep individuals cohesive to the flock; (4) FO in flocks - core species participate with a high frequency in mixed flocks; (5) size of the intraspecific group within the flock - quantitative data that measures the natural tendency to gregariousness of the core species (s) in the flocks; and (6) the size of the interspecific group - the total number of individuals in the mixed flock. Species were selected if they met at least four of the six requirements listed above. Next, we used a Student’s t-test, with a significance level of 0.05, calculated using the PAST 3.25 software (<span class="ref"><strong class="xref xrefblue">Hammer <i>et al.,</i> 2001</strong><span class="refCtt closed"><span>Hammer, Ø.; Harper, D.A.T. &amp; Ryan, P.D. 2001. Past: paleontological statistics software package for education and data analysis. Palaeontologia Electronica, 4(1): 1-9. Available: Available: http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html
+					. Access: 10/08/2021.</span><br><a href="http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html" target="_blank">http://priede.bf.lu.lv/ftp/pub/TIS/datu_...
+            </a></span></span>), to assess whether mixed flocks are richer in the number of species due to the presence of the core species when they are aggregated or solitary among the mixed flocks. Data are presented as mean ± standard deviation (SD).</p>
+<h1 class="articleSectionTitle">RESULTS</h1>
+<p>We recorded 152 mixed flocks, with 76 participating species belonging to five orders and 24 families. Passeriformes (n = 68 species) had the highest richness, mostly represented by the families Thraupidae (n = 15), Tyrannidae (n = 8), Furnariidae (n = 6), and Rhynchocyclidae (n = 6). Cuculiformes and Apodiformes were recorded in only one species each, Trogoniformes in two, and Piciformes in four (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>).</p>
+<p>
+				<div class="row table" id="t1">
+<a name="t1"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Table 1</strong><br>Bird species participating in mixed flocks, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017. Frequency of occurrence of species in the mixed flocks (FO, %). Categories of frequency of occurrence of species (FC): Regular (RE) FO ≥ 25.0%, Common (COM) 10.0 ≤ FO ≤ 24.99%, Unusual (U) 3.0 ≤ FO ≤ 9.99%, and Rare (RA) FO ≤ 2.99%. Foraging stratum (FS): Understory (Und) and Canopy (Can).<br>
+</div>
+</div>
+			</p>
+<p>The mixed flocks comprised a mean 4.5 ± 2.7 species, with a minimum of 2 and a maximum of 14 species, while the mean number of individuals was 8.7 ± 5.8, ranging between 2 and 31. Flocks with a greater number of individuals had greater species richness (R² = 0.83%; <i>p</i> &lt; 0.05; <i>df</i> = 151; <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf4"><span class="sci-ico-fileFigure"></span>Fig. 4</a>). Regarding the FO, only three species were classified as regular: <i>Basileuterus culicivorus</i> (FO = 46.7%), <i>Habia rubica</i> (FO = 32.9%), and <i>Sittasomus griseicapillus</i> (FO = 25.7%), representing 3.9% of the total richness. Common species (n = 10 spp.) accounted for 13.1% of the species richness, whereas unusual species (n = 20 spp.) accounted for 26.3%. The remaining 43 species (56.5% of total richness) were rare (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>).</p>
+<p>
+				<div class="row fig" id="f4">
+<a name="f4"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf4"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 4</strong><br>Simple linear regression of the relationship between species richness and the number of individuals from mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</div>
+</div>
+			</p>
+<p>Six events of agonistic behavior between species were observed. Of these, three intraspecific species, including <i>H. rubica</i> (two events) and <i>Turdus subalaris</i> (one event), and three interspecific species, including <i>Lathrotriccus euleri</i> (two events), one against <i>Myiothlypis leucoblephara,</i> the other against <i>Platyrinchus mystaceus,</i> and finally, <i>Turdus albicollis</i> against an individual of <i>Turdus rufiventris,</i> who was not part of the flock.</p>
+<p>Mixed flocks occurred throughout the year, with variations in their frequencies. From October to February, a greater number of flocks were detected with a wide fluctuation in the number of contacts in October (n = 17), November (n = 12), December (n = 5), January (n = 20), and February (n = 18). Between March and September, fewer flocks were detected with less variation; March (n = 9), April (n = 14), May (n = 11), June (n = 12), July (n = 14), and August and September (n = 10, each). There were no differences observed in the number of contacts between months (z = 0.369; <i>p</i> = 0.691); therefore, no peak was observed (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf5"><span class="sci-ico-fileFigure"></span>Fig. 5</a>).</p>
+<p>
+				<div class="row fig" id="f5">
+<a name="f5"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf5"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 5</strong><br>Variation in the number of contacts of mixed flocks of birds per month, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</div>
+</div>
+			</p>
+<p>The average species richness in the mixed flocks (4.5 ± 2.7 species) did not differ throughout the year (z = 0.005; p = 0.995; <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf6"><span class="sci-ico-fileFigure"></span>Fig. 6</a>), and there was no difference in the average number of individuals per flock (z = 0.572; p = 0.564; <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf7"><span class="sci-ico-fileFigure"></span>Fig. 7</a>).</p>
+<p>
+				<div class="row fig" id="f6">
+<a name="f6"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf6"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 6</strong><br>Monthly variation in the average richness of mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</div>
+</div>
+			</p>
+<p>
+				<div class="row fig" id="f7">
+<a name="f7"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf7"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 7</strong><br>Monthly variation of the average size (in the number of individuals) of the mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina, Brazil, between October 2016 and September 2017.<br>
+</div>
+</div>
+			</p>
+<p>Among the 76 species participating in the mixed flocks, <i>B. culicivorus</i> and <i>H. rubica</i> had the highest frequency of participation (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>) and presented physical and behavioral characteristics that allowed them to be classified as core species (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet2"><span class="sci-ico-fileTable"></span>Table 2</a>). <i>Basileuterus culicivorus</i> was the most frequent species in the flocks (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>) and generally occurred at a frequency of two to four individuals, always exhibiting intense movement and strong vocalization. These individuals were present from the understory to the canopy and used different substrates, such as thin trunks, branches, and leaves, to forage for arthropods, seeds, insects, and small larvae. In addition, individuals of this species have been observed alone on a few occasions and are most commonly seen in pairs or in small monospecific flocks. <i>Habia rubica,</i> in turn, was the second most frequent species in the mixed flocks, always occurring in the understory and represented by groups of two to eight members (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>). Usually, <i>H. rubica</i> forages along branches, trunks, and leaves, where it preys upon small arthropods, insects, and larvae. The mixed flocks in which <i>B. culicivorus</i> and <i>H. rubica</i> occurred (n = 95) were richer (4.9 ± 2.8 species) than in those (n = 57) where they did not occur (3.6 ± 2.2 species; t = 2.845; <i>p</i> = 0.005).</p>
+<p>
+				<div class="row table" id="t2">
+<a name="t2"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Table 2</strong><br>Physical and behavioral characteristics of the two most frequent species in mixed flocks of birds (n = 152), recorded in PARNA of Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</div>
+</div>
+			</p>
+<h1 class="articleSectionTitle">DISCUSSION</h1>
+<p>The species richness recorded in the present study (76 species) was similar to that found in the Southeast Atlantic Rain Forest by <span class="ref"><strong class="xref xrefblue">Davis (1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>), <span class="ref"><strong class="xref xrefblue">Develey &amp; Peres (2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>), and <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini (2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>), who reported, 77, 72, and 78 species, respectively. In contrast, considering the studies conducted in the southern Atlantic Rain Forest region, the species richness recorded in our study was higher than that found by <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. &amp; Azevedo (2006</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. (2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>), who recorded 64 and 56 species, respectively, but lower than that recorded by <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.</i> (2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), who recorded 117 species. The highest richness of species in mixed flocks in the Atlantic Rain Forest biome was recorded by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>), in the upper region of Serra do Paranapiacaba, São Paulo state, where 120 species were recorded. However, in the study by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>), in addition to the diversity of sampled environments, the number of hours of sampling (n = 432 h) was much higher than that of the present study (n = 216 h). Therefore, the diversity detected in the present study can be considered representative as it covered all four seasons of the year and was conducted during both the reproductive and non-reproductive periods.</p>
+<p>Migratory species also contributed to the recorded species richness. Among these, <i>Vireo chivi</i> stands out, which, according to <span class="ref"><strong class="xref xrefblue">Machado (1997</strong><span class="refCtt closed"><span>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</span></span></span>), is recognized as a regular participant in mixed flocks within the Atlantic Rain Forest. This species remains in the southern region of Brazil (<span class="ref"><strong class="xref xrefblue">Sick, 1997</strong><span class="refCtt closed"><span>Sick, H. 1997. Ornitologia brasileira. Rio de Janeiro, Nova Fronteira.</span></span></span>) for only six to seven months and participated in the flocks from October 24, 2016, to April 20, 2017 (first and last records). However, it was among the most frequent in flocks, a result supported by the findings of <span class="ref"><strong class="xref xrefblue">Machado (1997</strong><span class="refCtt closed"><span>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</span></span></span>, <span class="ref"><sup class="xref xrefblue">1999</sup><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). Generally, <i>V. chivi</i> accompanies flocks in pairs through the canopy and sometimes within the medium understory where it uses various substrates such as thin trunks, branches, and leaves to forage for seeds and small fruits. Other registered migratory birds that caused seasonal displacement in the region were <i>T. subalaris, L. euleri, Myiarchus swainsoni, Haplospiza unicolor, Myiodynastes maculatus,</i> and <i>Pachyramphus polychopterus.</i> These last three species were also recorded by <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.</i> (2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>) and are considered potential members of mixed flocks by <span class="ref"><strong class="xref xrefblue">Machado (1997</strong><span class="refCtt closed"><span>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</span></span></span>). The low values found for the average richness of species in the flocks and average size of the flocks in relation to other studies carried out in Brazil can be explained by the diversity of species that is accompanied by changes along the latitudinal gradient between the Atlantic Rain Forest and Amazon biomes (<span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>). In addition to biogeographic factors, the successional stages of vegetation may also influence species composition, richness, and the size of registered flocks, as mentioned by <span class="ref"><strong class="xref xrefblue">Aleixo (1997</strong><span class="refCtt closed"><span>Aleixo, A. 1997. Composition of mixed-species bird flocks and abundance of flocking species in a semideciduous forest of southeastern Brazil. Ararajuba, 5(6): 11-18.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini (2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>).</p>
+<p>Neotropical mixed flocks are either primarily or exclusively composed of passerines (<span class="ref"><strong class="xref xrefblue">Moynihan, 1962</strong><span class="refCtt closed"><span>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					. Access: 16/08/2021.</span><br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">https://repository.si.edu/bitstream/hand...
+            </a></span></span>). They are stable flocks formed by a couple of species, mainly insectivorous and omnivorous birds (<span class="ref"><strong class="xref xrefblue">Powell, 1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>), which is justified by the observations made during the present study. However, this does not mean that other orders cannot be typical followers of mixed flocks, such as Cuculiformes, Trogoniformes, and Piciformes, which were recorded here and are commonly reported in other studies of mixed flocks in the Atlantic Rain Forest. <i>Piaya cayana</i> specimens were always observed alone, discreetly following the mixed flocks through the upper understory where they captured arthropods disturbed by the flocks. This was also observed in the middle understory of <i>Trogon surrucura</i> and <i>Trogon chrysochloros,</i> although the participation of trogonids in mixed flocks is considered rare (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). In the present study, these two species followed the flocks for long periods of time (more than 15 min). In contrast, <i>Picumnus temminckii, Veniliornis spilogaster,</i> and <i>Piculus aurulentus</i> benefited mainly from protection against predators, as their diets are composed of larvae and not arthropods disturbed by the flock (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). The participation of <i>Thalurania glaucopis</i> in mixed flocks may be related to a response to the aggregation instinct or even to the temporary protection obtained by the presence of a greater number of individuals (<span class="ref"><strong class="xref xrefblue">Moynihan, 1962</strong><span class="refCtt closed"><span>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					. Access: 16/08/2021.</span><br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">https://repository.si.edu/bitstream/hand...
+            </a></span></span>).</p>
+<p>Some of the richest families, such as Thraupidae, Tyrannidae, and Furnariidae, observed were also among the most frequent in other studies with mixed flocks of Atlantic Rain Forest birds. This is possibly because a large part of the species belonging to these families are insectivorous, small sized, and have a great capacity to adapt to forest environments (<span class="ref"><strong class="xref xrefblue">Sick, 1997</strong><span class="refCtt closed"><span>Sick, H. 1997. Ornitologia brasileira. Rio de Janeiro, Nova Fronteira.</span></span></span>), characteristics that facilitate participation in heterospecific associations (<span class="ref"><strong class="xref xrefblue">Develey &amp; Peres, 2000</strong><span class="refCtt closed"><span>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255.</span><br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">https://doi.org/10.1017/s026646740000125...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>).</p>
+<p>Among the “regular species,” <i>B. culicivorus</i> was the species with the highest FO; a same result was also found in the Brazilian Southeast Region by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) and in the Brazilian south region by <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. &amp; Azevedo (2006</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.</i> (2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>). The other two regular species, <i>H. rubica</i> and <i>S. griseicapillus,</i> also occurred with a high frequency in other studies (<i>e.g.,</i><span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr., 2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>). This fact was true for most of the registered “common species,” <i>Xiphorhynchus fuscus, Philydor atricapillus</i> (<span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), <i>Setophaga pitiayumi, Phylloscartes ventralis</i> (<span class="ref"><strong class="xref xrefblue">Ghizoni-Jr., 2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>), <i>Dysithamnus mentalis</i> (<span class="ref"><strong class="xref xrefblue">Davis, 1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), <i>Tachyphonus coronatus</i> (<span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. &amp; Azevedo, 2006</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), <i>Trichothraupis melanops</i> (<span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr., 2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>), <i>T. albicollis</i><span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), and <i>V. chivi</i> (<span class="ref"><strong class="xref xrefblue">Machado, 1997</strong><span class="refCtt closed"><span>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</span></span></span>, <span class="ref"><sup class="xref xrefblue">1999</sup><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). The exception was <i>P. mystaceus,</i> which in this study alone was among the most frequent.</p>
+<p>Previous studies on mixed flocks carried out in other regions of the Atlantic Rain Forest found that some of the species registered here as “uncommon” have a marked presence in heterospecific associations. These include <i>Lepidocolaptes falcinellus, Xenops rutilans, Dendroma rufa, Anabacerthia amaurotis, Heliobletus contaminatus, Leptopogon amaurocephalus, Tolmomyias sulphurescens, Hylophilus poicilotis,</i> and <i>Hemithraupis ruficapilla.</i> Individuals of these species were rarely seen outside the flocks and thus can be considered flock participants in this study.</p>
+<p>The rare species group accounted for 56.5% of the total richness recorded. This result was similar to that found by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) in the Serra de Paranapiacaba, southeast Brazil, which registered 53.3% of the species as rare. Thus, as observed in this study, these species do not contribute significantly to the cohesion and maintenance of the mixed flocks, while a large proportion of them eventually participated in the flocks. A good example of the latter includes records of <i>Chamaeza campanisona, Sclerurus scansor, Schiffornis virescens, Rhopias gularis,</i> and <i>Myrmoderus squamosus,</i> which forage in the lower understory and participate in the flocks only when they pass through their territory. The same can be mentioned for <i>Thamnophilus caerulescens, T. rufiventris, Phyllomyias virescens,</i> and <i>Tyranniscus burmeisteri</i> in the middle understory and <i>Troglodytes musculus</i> in border areas. The participation of <i>Celeus flavescens</i> and <i>Hemitriccus obsoletus</i> was purely accidental; on both occasions when these species were recorded, they were following a separate foraging route and accidentally entered the flock.</p>
+<p>The agonistic interactions recorded between species participating in mixed flocks, as mentioned by <span class="ref"><strong class="xref xrefblue">Powell (1985</strong><span class="refCtt closed"><span>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313.</span><br><a href="https://doi.org/10.2307/40168313" target="_blank">https://doi.org/10.2307/40168313...
+            </a></span></span>), may be related to the defense and demarcation of the foraging territory of the flock. Such behaviors structurally reinforce groups, as they prioritize group members to avoid further confrontations, which is beneficial due to the increase in efficiency of use of food resources (<span class="ref"><strong class="xref xrefblue">Lagory <i>et al.,</i> 1984</strong><span class="refCtt closed"><span>LaGory, K.E.; LaGory, M.K.; Meyers, D.M. &amp; Herman, S.G. 1984. Niche relationships in wintering mixed-species flocks in western Washington. Wilson Bulletin, 96(1): 108-116.</span></span></span>).</p>
+<p>In areas of the Atlantic Rain Forest in the southeast, <span class="ref"><strong class="xref xrefblue">Davis (1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) found that mixed flocks occur more frequently in the sub-dry season, from April to September, and may present peaks in the coldest months of the year such as July and August. However, this was not observed in the present study, as there were no high frequencies of contact with flocks in the winter months. Concurrently, certain variations in the number of contacts appeared to be similar to the pattern found by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) and <span class="ref"><strong class="xref xrefblue">Batista <i>et al.</i> (2013</strong><span class="refCtt closed"><span>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</span></span></span>). The decrease in the number of contacts with flocks observed between November and December was also recorded by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). This decrease may be linked to the reproductive period of the birds, where most species establish territory during this time of the year and participate with a lower frequency within mixed flocks. This justifies the various reproductive behaviors observed among birds in these months, such as cutting, nest building, and care for nestlings. Contrary to the findings of <span class="ref"><strong class="xref xrefblue">Davis (1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>), the greatest number of contacts with mixed flocks was obtained in the summer months of January and February in the present study. However, during these months, the flocks were less cohesive, with many young individuals present and greater distances between members, in addition to remaining united for short periods of time. Furthermore, it was observed on many occasions that the flocks disintegrate, either by dilution when the flock fragmented (but followed the same direction) or even by division, with two or more groups following different directions. This fact was also highlighted by <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>). The flocks remained stable between March and September. In the winter months of June and July, the flocks were cohesive with members remaining close to each other or being united for long periods.</p>
+<p>As for the variation in the average species richness and average size of the flocks, the decrease observed in the months of November and December may also be related to the reproductive period of the birds. The observed increases in these variables in the summer months of January, February, and March are similar to those found by <span class="ref"><strong class="xref xrefblue">Davis (1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>); however, in this study, the flocks were less frequent during this period. <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>) highlighted that the low frequency of flocks in these months may be due to the greater concentration of species in the few formed flocks, resulting in an increase in both the richness and size of the flocks. In this study, unlike <span class="ref"><strong class="xref xrefblue">Davis (1946</strong><span class="refCtt closed"><span>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Machado (1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>), the increase in the average species richness and average size of the flocks seemed to accompany the monthly flock frequency, mainly in the months of January and February, in which a greater contact number with flocks was registered. Concurrently, the possibility that the inverse relationship may occur in March is not ruled out, being precisely one of the months with the lowest number of contacts with flocks. However, it ranks among the months with the greatest richness and size of registered flocks.</p>
+<p>Another pattern observed was the increase in species richness and flock size during the winter months, especially in June and July, which was a result also found by <span class="ref"><strong class="xref xrefblue">Batista <i>et al.</i> (2013</strong><span class="refCtt closed"><span>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</span></span></span>) in areas of the Atlantic Rain Forest in the northeast. This increase may be related to the low availability of potential prey items in the winter months, and thus, the birds tend to participate more frequently in flocks to maximize foraging and increase protection against predation (<span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>).</p>
+<p>The dynamics of the flocks recorded in this study seem to follow the same trend observed in other studies carried out in the Atlantic Rain Forest (<i>e.g.,</i><span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Batista <i>et al.,</i> 2013</strong><span class="refCtt closed"><span>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</span></span></span>). Nevertheless, it is important to note that the results obtained for the frequency variation in flock occurrence, species richness, and flock size did not show differences in the respective values throughout the year.</p>
+<p><i>Basileuterus culicivorus</i> and <i>H. rubica,</i> due to their high frequency of participation as well as the conspicuous pattern of movement and vocalization, were responsible for the formation of 62.5% of the total registered flocks. In the Atlantic Rain Forest biome, <i>B. culicivorus</i> has been considered a nuclear species of mixed flocks in some studies (<i>e.g.,</i><span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2003</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001.</span><br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">https://doi.org/10.1590/S0031-1049200300...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. &amp; Azevedo, 2006</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>). This species is frequent throughout the year in the study area and exhibits conspicuous behavior and strong vocalization, which is why it was present in 46.7% of the registered flocks. In addition, flocks with the presence of <i>B. culicivorus</i> without other nuclear species had a higher average species richness compared to flocks with no nuclear species. These results reinforce the idea that in the Atlantic Forest, <i>B. culicivorus</i> plays a fundamental role in the cohesion and maintenance of mixed flocks. However, some authors (<i>e.g.,</i><span class="ref"><strong class="xref xrefblue">Machado, 1999</strong><span class="refCtt closed"><span>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010.</span><br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">https://doi.org/10.1590/s0034-7108199900...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini, 2004</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2004. Mixed-species bird flocks from Brazilian Atlantic forest: the effects of forest fragmentation and seasonality on their size, richness and stability. Biological Conservation, 116(1): 19-26. https://doi.org/10.1016/s0006-3207(03)00169-1.</span><br><a href="https://doi.org/10.1016/s0006-3207(03)00169-1" target="_blank">https://doi.org/10.1016/s0006-3207(03)00...
+            </a></span></span>) also cite <i>H. rubica</i> as an indispensable species for the cohesion and maintenance of mixed flocks in the Atlantic Rain Forest, noting that its absence can result in the disintegration of the group. <span class="ref"><strong class="xref xrefblue">Maldonado-Coelho &amp; Marini (2004</strong><span class="refCtt closed"><span>Maldonado-Coelho, M. &amp; Marini, M.Â. 2004. Mixed-species bird flocks from Brazilian Atlantic forest: the effects of forest fragmentation and seasonality on their size, richness and stability. Biological Conservation, 116(1): 19-26. https://doi.org/10.1016/s0006-3207(03)00169-1.</span><br><a href="https://doi.org/10.1016/s0006-3207(03)00169-1" target="_blank">https://doi.org/10.1016/s0006-3207(03)00...
+            </a></span></span>) also pointed out that the presence of <i>H. rubica</i> in mixed understory flocks in fragments of the Atlantic Rain Forest keeps individuals cohesive during foraging. This was clearly observed in the present study, in which the flocks registered with the presence of <i>H. rubica</i> were always cohesive and generally remained together for longer periods of time. Moreover, some species are typical followers of <i>H. rubica,</i> such as <i>P. atricapillus</i> (<span class="ref"><strong class="xref xrefblue">Cestari, 2007</strong><span class="refCtt closed"><span>Cestari, C. 2007. A atração de aves em resposta ao playback de Habia rubica: implicações complementares sobre o papel da espécie para coesão de bandos mistos na Estação Ecológica Juréia-Itatins - SP. Atualidades Ornitológicas, 136: 4-5. Available: Available: http://www.ao.com.br
+					. Access: 16/08/2021.</span><br><a href="http://www.ao.com.br" target="_blank">http://www.ao.com.br...
+            </a></span></span>), in addition to <i>S. griseicapillus</i> and <i>X. fuscus.</i> These species forage preferentially on trunks, branches, and leaves, where they capture arthropods, seeds, and small fruits, in addition to searching for epiphytic bromeliads which harbor many insects. Even so, the flocks where <i>H. rubica</i> occurred without the presence of the other core species (<i>B. culicivorus</i>) also had a higher average species richness than flocks without their presence. This shows the high capacity of this species to attract and retain individuals of different cohesive species, forming mixed flocks. It should be noted, however, that when considering studies with mixed flocks carried out in the southern region of Brazil (<i>e.g.,</i><span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. &amp; Azevedo, 2006</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr., 2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Brandt <i>et al.,</i> 2009</strong><span class="refCtt closed"><span>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013.</span><br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">https://doi.org/10.1590/s1984-4670200900...
+            </a></span></span>), <i>H. rubica</i> demonstrated the exercise function of nuclear species only in this study.</p>
+<p>It was observed that the mixed flocks formed during this study were dependent on the presence of <i>H. rubica</i> and <i>B. culicivorus.</i> Therefore, these species are considered vital for the cohesion and maintenance of the mixed flocks of the Submontane Atlantic Rain Forest in the southern region of Brazil. <span class="ref"><strong class="xref xrefblue">Machado (2002</strong><span class="refCtt closed"><span>Machado, C.G. 2002. As espécies-núcleo dos bandos mistos de aves da Mata Atlântica da serra de Paranapiacaba, no sudeste brasileiro. Sitientibus Série Ciências Biológicas, 2(1/2): 85-90.</span></span></span>), in the southeast Atlantic Rain Forest, found not only one or two core species, but a set of species responsible for the cohesion and maintenance of mixed flocks, which he termed the “core-complex.” <span class="ref"><strong class="xref xrefblue">Ghizoni-Jr. (2009</strong><span class="refCtt closed"><span>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143.</span><br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">https://doi.org/10.5007/2175-7925.2009v2...
+            </a></span></span>) also found evidence of this same pattern in a Mixed Ombrophilous Forest, in the southern region of Brazil. Thus, the flocks recorded in this study without the presence of the two nuclear species may have been formed by a core-complex. However, this consideration is not conclusive, because in addition to these flocks being less rich in species, they were less cohesive and remained united for shorter periods of time.</p>
+<h1 class="articleSectionTitle">CONCLUSIONS</h1>
+<p>The composition and richness of species in the bird assemblage within the mixed flocks were recognized by species already recorded in studies carried out in other areas of the Atlantic Rain Forest. However, the presence of migratory species, and the structure of the vegetation, may have influenced the number of recorded species, as most of the vegetation in the study area comprises plant species typical of the early and middle stages of regeneration. The low average species richness and flock size may be related not only to biogeographic factors but also to the successional stage of vegetation in the study area.</p>
+<p>The variation in the FO, species richness, and size (in the number of individuals) of the flocks throughout the year may be related to the reproductive period and availability of food resources that occur in the southern region of Brazil, depending on the seasonality present at these latitudes.</p>
+<p><i>Basileuterus culicivorus</i> and <i>H. rubica</i> behaved as typical nuclear species, a result that was expected due to their behavior, color pattern, and abundance in the Atlantic Rain Forest in southern Brazil. Thus, as suggested by previous studies on mixed flocks, we reinforce the importance of these two species for the cohesion and maintenance of mixed flocks in the Atlantic Rain Forest.</p>
+</div>
+<div class="articleSection" data-anchor="ACKNOWLEDGMENTS:">
+<h1 class="articleSectionTitle">ACKNOWLEDGMENTS:</h1>
+<p>The authors would like to thank Gustavo Piletti Plucenio, Bento Tadeu Leandro Junior, Gabriel Schmidt Gonzaga, and Cleiton Dias Teixeira for their kind assistance in fieldwork. Thanks are also due to Danrlei de Conto and Eduarda Fraga Olivo for their help in the final edition of the figures, and to Parque Nacional Aparados da Serra’s Administration for permission to carry out the investigation.</p>
+</div>
+<div class="articleSection" data-anchor="REFERENCES">
+<h1 class="articleSectionTitle">REFERENCES</h1>
+<div class="ref-list"><ul class="refList">
+<li><div>Aleixo, A. 1997. Composition of mixed-species bird flocks and abundance of flocking species in a semideciduous forest of southeastern Brazil. Ararajuba, 5(6): 11-18.</div></li>
+<li><div>Aleixo, A. 2001. Conservação da avifauna da Floresta Atlântica: efeitos da fragmentação e a importância de florestas secundárias. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul. p. 199-206.</div></li>
+<li><div>Alvares, C.A.; Starpe, J.L.; Sentelhas, P.C.; Gonçalves, J.L.M. &amp; Sparovek, G. 2014. Köppen’s climate classification map for Brazil. Meteorologische Zeitschrift, Garmisch-Partenkirchen, 22(6): 711-728. https://doi.org/10.1127/0941-2948/2013/0507<br><a href="https://doi.org/10.1127/0941-2948/2013/0507" target="_blank">» https://doi.org/10.1127/0941-2948/2013/0507</a>
+</div></li>
+<li><div>Alves, M.A.S. &amp; Cavalcanti, R.B. 1996. Sentinel behavior, seasonality, and the structure of bird flocks in Brazilian savanna. Neotropical Ornithology, 7: 43-51.</div></li>
+<li><div>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</div></li>
+<li><div>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. https://doi.org/10.1590/s1984-46702009000300013<br><a href="https://doi.org/10.1590/s1984-46702009000300013" target="_blank">» https://doi.org/10.1590/s1984-46702009000300013</a>
+</div></li>
+<li><div>Cestari, C. 2007. A atração de aves em resposta ao playback de Habia rubica: implicações complementares sobre o papel da espécie para coesão de bandos mistos na Estação Ecológica Juréia-Itatins - SP. Atualidades Ornitológicas, 136: 4-5. Available: Available: http://www.ao.com.br
+					 Access: 16/08/2021.<br><a href="http://www.ao.com.br" target="_blank">» http://www.ao.com.br</a>
+</div></li>
+<li><div>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</div></li>
+<li><div>Develey, P.F. 2001. The mixed flocks of birds in the Neotropical forests. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul . p. 39-48.</div></li>
+<li><div>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. https://doi.org/10.1017/s0266467400001255<br><a href="https://doi.org/10.1017/s0266467400001255" target="_blank">» https://doi.org/10.1017/s0266467400001255</a>
+</div></li>
+<li><div>Empresa de Pesquisa Agropecuária e Extensão Rural de Santa Catarina (EPAGRI). 2001. Dados e informações biofísicas da unidade de planejamento regional litoral sul Catarinense - UPR 8. Florianópolis, EPAGRI.</div></li>
+<li><div>Fitzpatrick, J.W. 1980. Foraging behavior of neotropical tyrant flycatchers. Condor, 82(1): 43-57. https://doi.org/10.2307/1366784<br><a href="https://doi.org/10.2307/1366784" target="_blank">» https://doi.org/10.2307/1366784</a>
+</div></li>
+<li><div>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. https://doi.org/10.5007/2175-7925.2009v22n3p143<br><a href="https://doi.org/10.5007/2175-7925.2009v22n3p143" target="_blank">» https://doi.org/10.5007/2175-7925.2009v22n3p143</a>
+</div></li>
+<li><div>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</div></li>
+<li><div>Hammer, Ø.; Harper, D.A.T. &amp; Ryan, P.D. 2001. Past: paleontological statistics software package for education and data analysis. Palaeontologia Electronica, 4(1): 1-9. Available: Available: http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html
+					 Access: 10/08/2021.<br><a href="http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html" target="_blank">» http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html</a>
+</div></li>
+<li><div>Instituto Brasileiro de Geografia e Estatística (IBGE). 2012. Manual técnico da vegetação brasileira. Rio de Janeiro, IBGE.</div></li>
+<li><div>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA) &amp; Ministério do Meio Ambiente (MMA). 2004. Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC. Brasília, MMA.</div></li>
+<li><div>Kovach, W.L. 2011. Oriana - Circular statistics for windows, ver. 4. Kovach Computing Services, Anglesey, Wales.</div></li>
+<li><div>LaGory, K.E.; LaGory, M.K.; Meyers, D.M. &amp; Herman, S.G. 1984. Niche relationships in wintering mixed-species flocks in western Washington. Wilson Bulletin, 96(1): 108-116.</div></li>
+<li><div>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</div></li>
+<li><div>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. https://doi.org/10.1590/s0034-71081999000100010<br><a href="https://doi.org/10.1590/s0034-71081999000100010" target="_blank">» https://doi.org/10.1590/s0034-71081999000100010</a>
+</div></li>
+<li><div>Machado, C.G. 2002. As espécies-núcleo dos bandos mistos de aves da Mata Atlântica da serra de Paranapiacaba, no sudeste brasileiro. Sitientibus Série Ciências Biológicas, 2(1/2): 85-90.</div></li>
+<li><div>Machado, C.G. &amp; Rodrigues, N.M.R. 2000. Alteração de altura de forrageamento de espécies de aves quando associadas a bandos mistos. In: Alves, M.A.S.; Silva, J.M.C. &amp; Sluys, V.M. (Org.). Ornitologia brasileira: perspectivas, conservação e pesquisa. Rio de Janeiro, Ed. UERJ. p. 231-239.</div></li>
+<li><div>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. https://doi.org/10.1590/S0031-10492003000300001<br><a href="https://doi.org/10.1590/S0031-10492003000300001" target="_blank">» https://doi.org/10.1590/S0031-10492003000300001</a>
+</div></li>
+<li><div>Maldonado-Coelho, M. &amp; Marini, M.Â. 2004. Mixed-species bird flocks from Brazilian Atlantic forest: the effects of forest fragmentation and seasonality on their size, richness and stability. Biological Conservation, 116(1): 19-26. https://doi.org/10.1016/s0006-3207(03)00169-1<br><a href="https://doi.org/10.1016/s0006-3207(03)00169-1" target="_blank">» https://doi.org/10.1016/s0006-3207(03)00169-1</a>
+</div></li>
+<li><div>Mangini, G.G. &amp; Areta, J.I. 2018. Bird mixed-species flock formation is driven by low temperatures between and within seasons in a Subtropical Andean-foothill forest. Biotropica, 50(5): 816-825. https://doi.org/10.1111/btp.12551<br><a href="https://doi.org/10.1111/btp.12551" target="_blank">» https://doi.org/10.1111/btp.12551</a>
+</div></li>
+<li><div>Marini, M.Â. &amp; Garcia, F.I. 2005. Conservação de aves no Brasil. Megadiversidade, 1(1): 95-101.</div></li>
+<li><div>Merritt, M.; Maldaner, M.E. &amp; de Almeida, A.M.R. 2019. What are biodiversity hotspots? Frontiers for Young Minds, 7: 1-7. https://doi.org/10.3389/frym.2019.00029<br><a href="https://doi.org/10.3389/frym.2019.00029" target="_blank">» https://doi.org/10.3389/frym.2019.00029</a>
+</div></li>
+<li><div>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: Available: https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y
+					 Access: 16/08/2021.<br><a href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y" target="_blank">» https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y</a>
+</div></li>
+<li><div>Myers, N.; Mittermeier, R.A.; Mittermeier, C.G.; da Fonseca, G.A.B. &amp; Kent, J. 2000. Biodiversity hotspots for conservation priorities. Nature, 403(6772): 853-858. https://doi.org/10.1038/35002501<br><a href="https://doi.org/10.1038/35002501" target="_blank">» https://doi.org/10.1038/35002501</a>
+</div></li>
+<li><div>Pacheco, J.F.; Silveira, L.F.; Aleixo, A.; Agne, C.E.; Bencke, G.A.; Bravo, G.A; Brito, G.R.R.; Cohn-Haft, M.; Maurício, G.N.; Naka, L.N.; Olmos, F.; Posso, S.; Lees, A.C.; Figueiredo, L.F.A.; Carrano, E.; Guedes, R.C.; Cesari, E.; Franz, I.; Schunck, F. &amp; Piacentini, V.Q. 2021. Annotated checklist of the birds of Brazil by the Brazilian Ornithological Records Committee - second edition. Ornithology Research, 29(2): 94-105. https://doi.org/10.1007/s43388-021-00058-x<br><a href="https://doi.org/10.1007/s43388-021-00058-x" target="_blank">» https://doi.org/10.1007/s43388-021-00058-x</a>
+</div></li>
+<li><div>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. https://doi.org/10.2307/40168313<br><a href="https://doi.org/10.2307/40168313" target="_blank">» https://doi.org/10.2307/40168313</a>
+</div></li>
+<li><div>Sick, H. 1997. Ornitologia brasileira. Rio de Janeiro, Nova Fronteira.</div></li>
+<li><div>Stotz, D.F. 1993. Geographic variation in species composition of mixed species flocks in lowland humid forest in Brazil. Papéis Avulsos de Zoologia, 38(4): 61-75.</div></li>
+</ul></div>
+</div>
+<div>
+<h1></h1>
+<div class="ref-list"><ul class="refList footnote"><li>
+<span class="xref big"><b>FUNDING INFORMATION:</b></span><div> The first author is grateful to Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES) - Finance Code 001, for the Master’s degree scholarship to support this research project. </div>
+</li></ul></div>
+</div>
+<div class="articleSection" data-anchor="Publication Dates">
+<h1 class="articleSectionTitle">Publication Dates</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Publication in this collection</strong><br>15 June 2022</li>
+<li>
+<strong>Date of issue</strong><br>2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="History">
+<h1 class="articleSectionTitle">History</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Received</strong><br>25 Aug 2021</li>
+<li>
+<strong>Accepted</strong><br>17 Mar 2022</li>
+<li>
+<strong>Published</strong><br>27 Apr 2022</li>
+</ul></div></div>
+</div>
+<section class="documentLicense"><div class="container-license"><div class="row">
+<div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+<div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">This is an open-access article distributed under the terms of the Creative Commons Attribution License</a></div>
+</div></div></section></article>
+</div>
+</div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">About the authors</h4>
+</div>
+<div class="modal-body">
+<div class="info">
+<div class="tutors">
+<strong> Gustavo Silveira da Luz </strong><strong>3</strong><br><div>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Ecologia de Paisagem e de Vertebrados (LABECO), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0001-5757-1048" class="btnContribLinks orcid">http://orcid.org/0000-0001-5757-1048</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Fernando Carvalho </strong><strong>4</strong><br><div>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Zoologia e Ecologia de Vertebrados (LABZEV), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-7216-7083" class="btnContribLinks orcid">http://orcid.org/0000-0002-7216-7083</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Jairo José Zocche </strong><strong>5</strong><br><div>Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Ecologia de Paisagem e de Vertebrados (LABECO), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-2291-3065" class="btnContribLinks orcid">http://orcid.org/0000-0003-2291-3065</a></li></ul>
+<div class="clearfix"></div>
+</div>
+</div>
+<div class="info">
+					<h3><sup>3</sup></h3>E-mail: <a href="mailto:gustavoluzbio@gmail.com">gustavoluzbio@gmail.com</a>
+				</div>
+<div class="info">
+					<h3><sup>4</sup></h3>E-mail: <a href="mailto:f.carvalho@unesc.net">f.carvalho@unesc.net</a>
+				</div>
+<div class="info">
+					<h3><sup>5</sup></h3>E-mail: <a href="mailto:jjz@unesc.net">jjz@unesc.net</a> (corresponding author)</div>
+<div class="info">
+<h3>Edited by:</h3>
+<div> Luís Fábio Silveira</div>
+</div>
+<div class="info">
+<h3><b>AUTHORS’ CONTRIBUTIONS:</b></h3>
+<div>
+<b>GSL:</b> Investigation; <b>GSL, JJZ:</b> Conceptualization, Methodology, Writing - review &amp; editing; <b>GSL, FC, JJZ:</b> Formal analysis, Writing - original draft. All authors actively participated in the discussion of the results and reviewed and approved the final version of the manuscript.</div>
+</div>
+<div class="info">
+<h3><b>CONFLICTS OF INTEREST:</b></h3>
+<div> Authors declare that there are no conflicts of interest.</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Figures | Tables</h4>
+</div>
+<div class="modal-body">
+<ul class="nav nav-tabs md-tabs" role="tablist">
+<li role="presentation" class="col-md-4 col-sm-4 active"><a href="#figures" aria-controls="figures" role="tab" data-toggle="tab">Figures
+                    (7)
+                </a></li>
+<li role="presentation" class="col-md-4 col-sm-4 "><a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">Tables
+                    (2)
+                </a></li>
+</ul>
+<div class="clearfix"></div>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="figures">
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 1</strong><br>Location of the study area in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 2</strong><br>(A-E) Images of Atlantic Rain Forest in the lower part of Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil. (A) overview of Submontane Atlantic Rain Forest; (B) detail of canopy height; (C) detail of the understory within the forest; (D) detail of understory at the forest edge; (E) presence of lianas and bromeliads in the understory within the forest.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf3"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 3</strong><br>Distribution of the three sampling sectors (I, II, and III) in the study area, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf4"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 4</strong><br>Simple linear regression of the relationship between species richness and the number of individuals from mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf5"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 5</strong><br>Variation in the number of contacts of mixed flocks of birds per month, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf6"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 6</strong><br>Monthly variation in the average richness of mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf7"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 7</strong><br>Monthly variation of the average size (in the number of individuals) of the mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina, Brazil, between October 2016 and September 2017.</div>
+</div>
+</div>
+<div role="tabpanel" class="tab-pane " id="tables">
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Table 1</strong><br>Bird species participating in mixed flocks, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017. Frequency of occurrence of species in the mixed flocks (FO, %). Categories of frequency of occurrence of species (FC): Regular (RE) FO ≥ 25.0%, Common (COM) 10.0 ≤ FO ≤ 24.99%, Unusual (U) 3.0 ≤ FO ≤ 9.99%, and Rare (RA) FO ≤ 2.99%. Foraging stratum (FS): Understory (Und) and Canopy (Can).</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Table 2</strong><br>Physical and behavioral characteristics of the two most frequent species in mixed flocks of birds (n = 152), recorded in PARNA of Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</div>
+</div>
+</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf1" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf1.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 1   Location of the study area in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf1.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf2" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf2.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 2   (A-E) Images of Atlantic Rain Forest in the lower part of Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil. (A) overview of Submontane Atlantic Rain Forest; (B) detail of canopy height; (C) detail of the understory within the forest; (D) detail of understory at the forest edge; (E) presence of lianas and bromeliads in the understory within the forest.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf2.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf3" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf3.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 3   Distribution of the three sampling sectors (I, II, and III) in the study area, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf3.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf4" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf4.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 4   Simple linear regression of the relationship between species richness and the number of individuals from mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf4.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf5" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf5.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 5   Variation in the number of contacts of mixed flocks of birds per month, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf5.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf6" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf6.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 6   Monthly variation in the average richness of mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf6.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf7" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1807-0205-paz-62-e202262026-gf7.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 7   Monthly variation of the average size (in the number of individuals) of the mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina, Brazil, between October 2016 and September 2017.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1807-0205-paz-62-e202262026-gf7.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet1" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Table 1</strong>    Bird species participating in mixed flocks, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017. Frequency of occurrence of species in the mixed flocks (FO, %). Categories of frequency of occurrence of species (FC): Regular (RE) FO ≥ 25.0%, Common (COM) 10.0 ≤ FO ≤ 24.99%, Unusual (U) 3.0 ≤ FO ≤ 9.99%, and Rare (RA) FO ≤ 2.99%. Foraging stratum (FS): Understory (Und) and Canopy (Can).<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Taxa</th>
+<th align="center">Range of Number of Individuals in the Flocks</th>
+<th align="center">Number of Contacts</th>
+<th align="center">FO (%)</th>
+<th align="center">FC</th>
+<th align="center">FS</th>
+</tr></thead>
+<tbody>
+<tr>
+<td align="left">
+<b>Cuculiformes</b> Wagler, 1830</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<b>Cuculidae</b> Leach, 1820</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Piaya cayana</i> (Linnaeus, 1766)</td>
+<td align="center">1</td>
+<td align="center">3</td>
+<td align="center">2.0</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Apodiformes</b> Peters, 1940</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<b>Trochilidae</b> Vigors, 1825</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Thalurania glaucopis</i> (Gmelin, 1788)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Trogoniformes</b> A.O.U., 1886</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<b>Trogonidae</b> Lesson, 1828</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Trogon surrucura</i> Vieillot, 1817</td>
+<td align="center">1-2</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Trogon chrysochloros</i> Pelzeln, 1856</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Piciformes</b> Meyer &amp; Wolf, 1810</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<b>Picidae</b> Leach, 1820</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Picumnus temminckii</i> Lafresnaye, 1845</td>
+<td align="center">1</td>
+<td align="center">3</td>
+<td align="center">2.0</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Veniliornis spilogaster</i> (Wagler, 1827)</td>
+<td align="center">1-2</td>
+<td align="center">8</td>
+<td align="center">5.3</td>
+<td align="center">U</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Celeus flavescens</i> (Gmelin, 1788)</td>
+<td align="center">2</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Piculus aurulentus</i> (Temminck, 1821)</td>
+<td align="center">1-2</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Passeriformes</b> Linnaeus, 1758</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<b>Thamnophilidae</b> Swainson, 1824</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Rhopias gularis</i> (Spix, 1825)</td>
+<td align="center">2-4</td>
+<td align="center">3</td>
+<td align="center">2.0</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Dysithamnus mentalis</i> (Temminck, 1823)</td>
+<td align="center">1-4</td>
+<td align="center">28</td>
+<td align="center">18.4</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Thamnophilus caerulescens</i> Vieillot, 1816</td>
+<td align="center">1-2</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Myrmoderus squamosus</i> (Pelzeln, 1868)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Conopophagidae</b> Sclater &amp; Salvin, 1873</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Conopophaga lineata</i> (Wied, 1831)</td>
+<td align="center">1</td>
+<td align="center">5</td>
+<td align="center">3.3</td>
+<td align="center">U</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Formicariidae</b> Gray, 1840</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Chamaeza campanisona</i> (Lichtenstein, 1823)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Scleruridae</b> Swainson, 1827</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Sclerurus scansor</i> (Ménétries, 1835)</td>
+<td align="center">1-2</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Dendrocolaptidae</b> Gray, 1840</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Sittasomus griseicapillus</i> (Vieillot, 1818)</td>
+<td align="center">1-3</td>
+<td align="center">39</td>
+<td align="center">25.7</td>
+<td align="center">RE</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Dendrocolaptes platyrostris</i> Spix, 1825</td>
+<td align="center">1</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Xiphorhynchus fuscus</i> (Vieillot, 1818)</td>
+<td align="center">1-2</td>
+<td align="center">37</td>
+<td align="center">24.3</td>
+<td align="center">COM</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Lepidocolaptes falcinellus</i> (Cabanis &amp; Heine, 1859)</td>
+<td align="center">1-2</td>
+<td align="center">5</td>
+<td align="center">3.3</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Xenopidae</b> Bonaparte, 1854</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Xenops rutilans</i> Temminck, 1821</td>
+<td align="center">1-2</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Furnariidae</b> Gray, 1840</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Heliobletus contaminatus</i> Pelzeln, 1859</td>
+<td align="center">1-2</td>
+<td align="center">7</td>
+<td align="center">4.6</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Philydor atricapillus</i> (Wied, 1821)</td>
+<td align="center">1-4</td>
+<td align="center">29</td>
+<td align="center">19.1</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Anabacerthia amaurotis</i> (Temminck, 1823)</td>
+<td align="center">1-3</td>
+<td align="center">11</td>
+<td align="center">7.2</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Syndactyla rufosuperciliata</i> (Lafresnaye, 1832)</td>
+<td align="center">1</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Dendroma rufa</i> (Vieillot, 1818)</td>
+<td align="center">1-6</td>
+<td align="center">15</td>
+<td align="center">9.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Synallaxis ruficapilla</i> Vieillot, 1819</td>
+<td align="center">1-2</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Pipridae</b> Rafinesque, 1815</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Chiroxiphia caudata</i> (Shaw &amp; Nodder, 1793)</td>
+<td align="center">1-4</td>
+<td align="center">13</td>
+<td align="center">8.6</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Tityridae</b> Gray, 1840</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Schiffornis virescens</i> (Lafresnaye, 1838)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Pachyramphus castaneus</i> (Jardine &amp; Selby, 1827)</td>
+<td align="center">1-4</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Pachyramphus polychopterus</i> (Vieillot, 1818)</td>
+<td align="center">1-2</td>
+<td align="center">7</td>
+<td align="center">4.6</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Pachyramphus validus</i> (Lichtenstein, 1823)</td>
+<td align="center">1-6</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Platyrinchidae</b> Bonaparte, 1854</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Platyrinchus mystaceus</i> Vieillot, 1818</td>
+<td align="center">1-4</td>
+<td align="center">17</td>
+<td align="center">11.2</td>
+<td align="center">COM</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Rhynchocyclidae</b> Berlepsch, 1907</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Mionectes rufiventris</i> Cabanis, 1846</td>
+<td align="center">1</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Leptopogon amaurocephalus</i> Tschudi, 1846</td>
+<td align="center">1-2</td>
+<td align="center">15</td>
+<td align="center">9.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Phylloscartes ventralis</i> (Temminck, 1824)</td>
+<td align="center">1-5</td>
+<td align="center">20</td>
+<td align="center">13.2</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Tolmomyias sulphurescens</i> (Spix, 1825)</td>
+<td align="center">1</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Poecilotriccus plumbeiceps</i> (Lafresnaye, 1846)</td>
+<td align="center">3</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Hemitriccus obsoletus</i> (Miranda-Ribeiro, 1906)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Tyrannidae</b> Vigors, 1825</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Tyranniscus burmeisteri</i> (Cabanis &amp; Heine, 1859)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Camptostoma obsoletum</i> (Temminck, 1824)</td>
+<td align="center">1-2</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Phyllomyias virescens</i> (Temminck, 1824)</td>
+<td align="center">1</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Attila rufus</i> (Vieillot, 1819)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Myiarchus swainsoni</i> Cabanis &amp; Heine, 1859</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Myiodynastes maculatus</i> (Statius Muller, 1776)</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Megarynchus pitangua</i> (Linnaeus, 1766)</td>
+<td align="center">1</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Lathrotriccus euleri</i> (Cabanis, 1868)</td>
+<td align="center">1-2</td>
+<td align="center">7</td>
+<td align="center">4.6</td>
+<td align="center">U</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Vireonidae</b> Swainson, 1837</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Cyclarhis gujanensis</i> (Gmelin, 1789)</td>
+<td align="center">1</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Ca</td>
+</tr>
+<tr>
+<td align="left">
+<i>Hylophilus poicilotis</i> Temminck, 1822</td>
+<td align="center">1-3</td>
+<td align="center">9</td>
+<td align="center">5.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Vireo chivi</i> (Vieillot, 1817)</td>
+<td align="center">1-4</td>
+<td align="center">23</td>
+<td align="center">15.1</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Troglodytidae</b> Swainson, 1831</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Troglodytes musculus</i> Naumann, 1823</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Turdidae</b> Rafinesque, 1815</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Turdus rufiventris</i> Vieillot, 1818</td>
+<td align="center">1-3</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Turdus subalaris</i> (Seebohm, 1887)</td>
+<td align="center">2-5</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Turdus albicollis</i> Vieillot, 1818</td>
+<td align="center">1-4</td>
+<td align="center">22</td>
+<td align="center">14.5</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Fringillidae</b> Leach, 1820</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Euphonia violacea</i> (Linnaeus, 1758)</td>
+<td align="center">1-4</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Euphonia pectoralis</i> (Latham, 1801)</td>
+<td align="center">1-2</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Icteridae</b> Vigors, 1825</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Cacicus chrysopterus</i> (Vigors, 1825)</td>
+<td align="center">1-3</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Icterus pyrrhopterus</i> (Vieillot, 1819)</td>
+<td align="center">4-4</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Parulidae</b> Wetmore, Friedmann, Lincoln, Miller, Peters, van Rossem, Van Tyne &amp; Zimmer, 1947</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Setophaga pitiayumi</i> (Vieillot, 1817)</td>
+<td align="center">1-4</td>
+<td align="center">33</td>
+<td align="center">21.7</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Myiothlypis leucoblephara</i> (Vieillot, 1817)</td>
+<td align="center">1-3</td>
+<td align="center">12</td>
+<td align="center">7.9</td>
+<td align="center">U</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Basileuterus culicivorus</i> (Deppe, 1830)</td>
+<td align="center">1-8</td>
+<td align="center">71</td>
+<td align="center">46.7</td>
+<td align="center">RE</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<b>Cardinalidae</b> Ridgway, 1901</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Habia rubica</i> (Vieillot, 1817)</td>
+<td align="center">1-8</td>
+<td align="center">50</td>
+<td align="center">32.9</td>
+<td align="center">RE</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<b>Thraupidae</b> Cabanis, 1847</td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+<td align="left"> </td>
+</tr>
+<tr>
+<td align="left">
+<i>Hemithraupis ruficapilla</i> (Vieillot, 1818)</td>
+<td align="center">2-5</td>
+<td align="center">11</td>
+<td align="center">7.2</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Tersina viridis</i> (Illiger, 1811)</td>
+<td align="center">2-5</td>
+<td align="center">4</td>
+<td align="center">2.6</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Dacnis cayana</i> (Linnaeus, 1766)</td>
+<td align="center">1-2</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Saltator similis</i> d’Orbigny &amp; Lafresnaye, 1837</td>
+<td align="center">1</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Coereba flaveola</i> (Linnaeus, 1758)</td>
+<td align="center">1</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Trichothraupis melanops</i> (Vieillot, 1818)</td>
+<td align="center">1-8</td>
+<td align="center">21</td>
+<td align="center">13.8</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Tachyphonus coronatus</i> (Vieillot, 1822)</td>
+<td align="center">1-4</td>
+<td align="center">23</td>
+<td align="center">15.1</td>
+<td align="center">COM</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Haplospiza unicolor</i> Cabanis, 1851</td>
+<td align="center">1-4</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Pipraeidea melanonota</i> (Vieillot, 1819)</td>
+<td align="center">1-6</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Stephanophorus diadematus</i> (Temminck, 1823)</td>
+<td align="center">1-2</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Thraupis sayaca</i> (Linnaeus, 1766)</td>
+<td align="center">1-4</td>
+<td align="center">6</td>
+<td align="center">3.9</td>
+<td align="center">U</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Thraupis cyanoptera</i> (Vieillot, 1817)</td>
+<td align="center">1-4</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+<tr>
+<td align="left">
+<i>Stilpnia preciosa</i> (Cabanis, 1850)</td>
+<td align="center">1-5</td>
+<td align="center">3</td>
+<td align="center">2</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Tangara seledon</i> (Statius Muller, 1776)</td>
+<td align="center">3-6</td>
+<td align="center">2</td>
+<td align="center">1.3</td>
+<td align="center">RA</td>
+<td align="center">Und, Can</td>
+</tr>
+<tr>
+<td align="left">
+<i>Tangara cyanocephala</i> (Statius Muller, 1776)</td>
+<td align="center">2-2</td>
+<td align="center">1</td>
+<td align="center">0.7</td>
+<td align="center">RA</td>
+<td align="center">Und</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet2" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Table 2</strong>    Physical and behavioral characteristics of the two most frequent species in mixed flocks of birds (n = 152), recorded in PARNA of Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col span="2">
+</colgroup>
+<thead>
+<tr>
+<th align="center" rowspan="2">Physical and Behavioral Characteristics</th>
+<th align="center" colspan="2">Species </th>
+</tr>
+<tr>
+<th align="center"><b>
+ <i>B. culicivorus</i> 
+</b></th>
+<th align="center"><b>
+ <i>H. rubica</i> 
+</b></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">Neutral coloring</td>
+<td align="center">Yes</td>
+<td align="center">Yes</td>
+</tr>
+<tr>
+<td align="left">Vocalization</td>
+<td align="center">Conspicuous</td>
+<td align="center">Conspicuous</td>
+</tr>
+<tr>
+<td align="left">Movement intensity</td>
+<td align="center">High</td>
+<td align="center">High</td>
+</tr>
+<tr>
+<td align="left">Frequency of occurrence</td>
+<td align="center">Regular</td>
+<td align="center">Regular</td>
+</tr>
+<tr>
+<td align="left">Number of contacts</td>
+<td align="center">71</td>
+<td align="center">50</td>
+</tr>
+<tr>
+<td align="left">Number of individuals in the intraspecific groups</td>
+<td align="center">2.9 ± 1.5</td>
+<td align="center">3.6 ± 1.3</td>
+</tr>
+<tr>
+<td align="left">Richness of flocks without the presence of the other species</td>
+<td align="center">4.0 ± 2.2 (n = 47)</td>
+<td align="center">4.8 ± 2.7 (n = 26)</td>
+</tr>
+<tr>
+<td align="left">Richness of flocks without the presence of the two species</td>
+<td align="center" colspan="2">3.6 ± 2.2 (n = 57)</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"></div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">How to cite</h4>
+</div>
+<div class="modal-body">
+<p id="citation"></p>
+<input id="citationCut" type="text" value=""><a class="copyLink" data-clipboard-target="#citationCut"><span class="glyphBtn copyIcon"></span>copy</a>
+</div>
+</div></div></div>
+<script type="text/javascript">
+            function currentDate() {
+            var today = new Date();
+            var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+            today.setTime(today.getTime());
+            return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+            }
+            var citation = 'Luz, Gustavo Silveira da, Carvalho, Fernando and Zocche, Jairo JoséComposition and dynamics of mixed flocks of birds in a remnant of Submontane Atlantic Rain Forest in southern Brazil. Papéis Avulsos de Zoologia [online]. 2022, v. 62 [Accessed CURRENTDATE] , e202262026. Available from: &lt;https://doi.org/10.11606/1807-0205/2022.62.026&gt;. Epub 15 June 2022. ISSN 1807-0205. https://doi.org/10.11606/1807-0205/2022.62.026.'.replace('CURRENTDATE', currentDate());
+            document.getElementById('citation').innerHTML = citation;
+            document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+        </script>
+</div>
+<ul class="floatingMenu fm-slidein" data-fm-toogle="hover"><li class="fm-wrap">
+<a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a><ul class="fm-list">
+<li><a class="fm-button-child" data-fm-label="Figures | Tables" data-toggle="modal" data-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+<li><a class="fm-button-child" data-toggle="modal" data-target="#ModalArticles" data-fm-label="How to
+                                          cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+</ul>
+</li></ul>
+<script src="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js"></script>
+</body>
+</html>

--- a/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.xml
+++ b/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.xml
@@ -1,0 +1,2084 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article
+  PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="publisher-id">paz</journal-id>
+			<journal-title-group>
+				<journal-title>Papéis Avulsos de Zoologia</journal-title>
+				<abbrev-journal-title abbrev-type="publisher">Pap. Avulsos Zool.</abbrev-journal-title>
+			</journal-title-group>
+			<issn pub-type="ppub">0031-1049</issn>
+			<issn pub-type="epub">1807-0205</issn>
+			<publisher>
+				<publisher-name>Museu de Zoologia da Universidade de São Paulo</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="doi">10.11606/1807-0205/2022.62.026</article-id>
+			<article-id pub-id-type="other">00226</article-id>
+			<article-categories>
+				<subj-group subj-group-type="heading">
+					<subject>ARTICLE</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>Composition and dynamics of mixed flocks of birds in a remnant of Submontane Atlantic Rain Forest in southern Brazil</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0001-5757-1048</contrib-id>
+					<name>
+						<surname>Luz</surname>
+						<given-names>Gustavo Silveira da</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+					<xref ref-type="corresp" rid="c1"><sup>3</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-7216-7083</contrib-id>
+					<name>
+						<surname>Carvalho</surname>
+						<given-names>Fernando</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff2"><sup>2</sup></xref>
+					<xref ref-type="corresp" rid="c2"><sup>4</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0003-2291-3065</contrib-id>
+					<name>
+						<surname>Zocche</surname>
+						<given-names>Jairo José</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+					<xref ref-type="corresp" rid="c3"><sup>5</sup></xref>
+				</contrib>
+			</contrib-group>
+			<aff id="aff1">
+				<label>1</label>
+				<institution content-type="original">Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Ecologia de Paisagem e de Vertebrados (LABECO), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.</institution>
+				<institution content-type="orgname">Universidade do Extremo Sul Catarinense</institution>
+				<institution content-type="orgdiv1">Laboratório de Ecologia de Paisagem e de Vertebrados</institution>
+				<institution content-type="orgdiv2">Programa de Pós-Graduação em Ciências Ambientais</institution>
+				<addr-line>
+					<city>Criciúma</city>
+					<state>SC</state>
+				</addr-line>
+				<country country="BR">Brasil</country>
+			</aff>
+			<aff id="aff2">
+				<label>2</label>
+				<institution content-type="original">Universidade do Extremo Sul Catarinense (UNESC), Laboratório de Zoologia e Ecologia de Vertebrados (LABZEV), Programa de Pós-Graduação em Ciências Ambientais (PPGCA). Criciúma, SC, Brasil.</institution>
+				<institution content-type="orgname">Universidade do Extremo Sul Catarinense</institution>
+				<institution content-type="orgdiv1">Laboratório de Zoologia e Ecologia de Vertebrados</institution>
+				<institution content-type="orgdiv2">Programa de Pós-Graduação em Ciências Ambientais</institution>
+				<addr-line>
+					<city>Criciúma</city>
+					<state>SC</state>
+				</addr-line>
+				<country country="BR">Brasil</country>
+			</aff>
+			<author-notes>
+				<corresp id="c1">
+					<label><sup>3</sup></label>E-mail: <email>gustavoluzbio@gmail.com</email>
+				</corresp>
+				<corresp id="c2">
+					<label><sup>4</sup></label>E-mail: <email>f.carvalho@unesc.net</email>
+				</corresp>
+				<corresp id="c3">
+					<label><sup>5</sup></label>E-mail: <email>jjz@unesc.net</email> (corresponding author)</corresp>
+				<fn fn-type="edited-by" id="fn1">
+					<label>Edited by:</label>
+					<p> Luís Fábio Silveira</p>
+				</fn>
+				<fn fn-type="con" id="fn2">
+					<label><bold>AUTHORS’ CONTRIBUTIONS:</bold></label>
+					<p><bold>GSL:</bold> Investigation; <bold>GSL, JJZ:</bold> Conceptualization, Methodology, Writing - review &amp; editing; <bold>GSL, FC, JJZ:</bold> Formal analysis, Writing - original draft. All authors actively participated in the discussion of the results and reviewed and approved the final version of the manuscript.</p>
+				</fn>
+				<fn fn-type="conflict" id="fn3">
+					<label><bold>CONFLICTS OF INTEREST:</bold></label>
+					<p> Authors declare that there are no conflicts of interest.</p>
+				</fn>
+			</author-notes>
+			<pub-date date-type="pub" publication-format="electronic">
+				<day>15</day>
+				<month>06</month>
+				<year>2022</year>
+			</pub-date>
+			<pub-date date-type="collection" publication-format="electronic">
+				<year>2022</year>
+			</pub-date>
+			<volume>62</volume>
+			<elocation-id>e202262026</elocation-id>
+			<history>
+				<date date-type="received">
+					<day>25</day>
+					<month>08</month>
+					<year>2021</year>
+				</date>
+				<date date-type="accepted">
+					<day>17</day>
+					<month>03</month>
+					<year>2022</year>
+				</date>
+				<date date-type="pub">
+					<day>27</day>
+					<month>04</month>
+					<year>2022</year>
+				</date>
+			</history>
+			<permissions>
+				<license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/" xml:lang="en">
+					<license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License</license-p>
+				</license>
+			</permissions>
+			<abstract>
+				<title>Abstract</title>
+				<p>Mixed flocks are associations of two or more species that are formed and maintained through mutual behavioral responses, with advantages such as maximizing foraging and protecting against predation. This study aimed to evaluate the composition, temporal dynamics, and presence of core species in mixed flocks of birds in a remnant of the Submontane Atlantic Rain Forest in the Parque Nacional Aparados da Serra, southern Santa Catarina state, Brazil. Data collection took place from October 2016 to September 2017 through monthly campaigns, consisting of three consecutive observation days, with sampling sessions of six hours per day, resulting in a total effort of 216 h of observations. For each contact with the flocks, we recorded the species and number of individuals, stratum of occurrence, substrates of search, and agonistic interactions. We recorded 152 mixed flocks, with a total of 76 species belonging to 24 families, and five orders, with Thraupidae, Tyrannidae, Furnariidae, and Rhynchocyclidae being the richest. The flocks had an average of 4.5 ± 2.7 species and 8.7 ± 5.8 individuals, with richness and the number of individuals being positively correlated (R² = 0.8). Mixed flocks occurred throughout the year. There was a great variation in the number of contacts from October to February (from 5 to 20 contacts). Meanwhile from March to September, the coldest period of the year in the region, the number of contacts did not vary (from 9 to 14 contacts). However, there was no difference in the number of contacts between these months (z = 0.37; <italic>p</italic> = 0.691). <italic>Basileuterus culicivorus</italic> and <italic>Habia rubica</italic> were the core species because, in addition to their high participation (46.7 and 32.9%, respectively), they showed frequent and conspicuous movement and vocalization. Thus, a high capacity to enlist a greater number of individuals from different species for the flocks was demonstrated.</p>
+			</abstract>
+			<kwd-group xml:lang="en">
+				<title>Keywords</title>
+				<kwd>Passeriformes</kwd>
+				<kwd>Heterospecific associations</kwd>
+				<kwd>Core species</kwd>
+				<kwd>Ombrophilous Dense Forest</kwd>
+				<kwd>PARNA Aparados da Serra</kwd>
+			</kwd-group>
+			<funding-group>
+				<award-group award-type="contract">
+					<funding-source>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES)</funding-source>
+					<award-id>001</award-id>
+				</award-group>
+				<funding-statement>The first author is grateful to Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES) - Finance Code 001, for the Master’s degree scholarship to support this research project. </funding-statement>
+			</funding-group>
+			<counts>
+				<fig-count count="7"/>
+				<table-count count="2"/>
+				<equation-count count="0"/>
+				<ref-count count="34"/>
+			</counts>
+		</article-meta>
+	</front>
+	<body>
+		<sec sec-type="intro">
+			<title>INTRODUCTION</title>
+			<p>Individuals of multiple bird species can associate by forming mixed flocks, maintained by mutual behavioral responses (<xref ref-type="bibr" rid="B29">Moynihan, 1962</xref>; <xref ref-type="bibr" rid="B21">Machado, 1999</xref>). The evolution of this behavior is related to the advantages of maximizing foraging and protection against predation (<xref ref-type="bibr" rid="B29">Moynihan, 1962</xref>; <xref ref-type="bibr" rid="B32">Powell, 1985</xref>; <xref ref-type="bibr" rid="B4">Alves &amp; Cavalcanti, 1996</xref>; <xref ref-type="bibr" rid="B23">Machado &amp; Rodrigues, 2000</xref>). Although mixed flocks occur frequently in tropical forests (<xref ref-type="bibr" rid="B32">Powell, 1985</xref>; <xref ref-type="bibr" rid="B9">Develey, 2001</xref>; <xref ref-type="bibr" rid="B26">Mangini &amp; Areta, 2018</xref>), their composition, structure, and temporal dynamics remain poorly understood.</p>
+			<p>The composition, size, and frequency of occurrence (FO) of mixed flocks is influenced by multiple factors, including the drop in the participation of species during reproductive periods, variations in the availability of food resources, and presence of migratory species (<xref ref-type="bibr" rid="B4">Alves &amp; Cavalcanti, 1996</xref>; <xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>). These factors are generally associated with climatic variation (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>; <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini, 2003</xref>; <xref ref-type="bibr" rid="B26">Mangini &amp; Areta, 2018</xref>). In addition, other factors, such as habitat loss and fragmentation, edge effects, and successional vegetation stage, can also influence the composition and dynamics of mixed flocks in forest environments (<xref ref-type="bibr" rid="B2">Aleixo, 2001</xref>; <xref ref-type="bibr" rid="B27">Marini &amp; Garcia, 2005</xref>).</p>
+			<p>Species associated with mixed flocks present different patterns of interaction and can be categorized into core and assistant species (<xref ref-type="bibr" rid="B32">Powell, 1985</xref>). Core species have a high frequency of participation and conspicuous patterns of movement and vocalization that stimulate the formation and cohesion of the flock (<xref ref-type="bibr" rid="B9">Develey, 2001</xref>). Meanwhile, the assistant species have a secondary role in the flock and can be divided into regular or occasional participants, depending on the frequency of interaction (<xref ref-type="bibr" rid="B29">Moynihan, 1962</xref>).</p>
+			<p>Although mixed flocks of birds occur in almost all vegetation types, they are far more common in Neotropical forests (<xref ref-type="bibr" rid="B32">Powell, 1985</xref>). In Brazil, mixed flocks have been studied extensively in the Atlantic Forest and Amazon biomes, where more than 40% of birds participate in these associations, including species considered endemic and/or threatened (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>). Despite high environmental degradation, the frequency of mixed flocks in the Atlantic Rain Forest is still high (<xref ref-type="bibr" rid="B1">Aleixo, 1997</xref>; <xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>; <xref ref-type="bibr" rid="B5">Batista <italic>et al.,</italic> 2013</xref>). This biome is considered one of the most biodiverse and threatened ecosystems on the planet (<xref ref-type="bibr" rid="B30">Myers <italic>et al.,</italic> 2000</xref>) and is among the 36 global biodiversity hotspots (<xref ref-type="bibr" rid="B28">Merritt <italic>et al.,</italic> 2019</xref>). In this way, deforestation and loss of species not only represent the loss of taxonomic diversity but also the loss of interspecific interactions in which these species are involved.</p>
+			<p>Studies on the composition and dynamics of heterospecific mixed flocks are vital for understanding the autoecology of the participating species, as they contribute to filling knowledge gaps in tropical environments. Moreover, they are essential for defining biodiversity conservation strategies in fragmented landscapes remaining in tropical forests (<xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>; <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini, 2003</xref>; <xref ref-type="bibr" rid="B5">Batista <italic>et al.,</italic> 2013</xref>).</p>
+			<p>In this study, we evaluated the composition, temporal dynamics, and presence of core species in mixed flocks of birds in a remnant of the Submontane Atlantic Rain Forest in the Parque Nacional Aparados da Serra, southern Santa Catarina state, Brazil. To the best of our knowledge, there are no previous studies on mixed flocks of birds in this region, and thus, the species involved in these associations, their structure, and their temporal dynamics remain unknown.</p>
+		</sec>
+		<sec sec-type="materials|methods">
+			<title>MATERIAL AND METHODS</title>
+			<p>The present study was carried out in the Parque Nacional Aparados da Serra (29°12′18.92″S and 50°3′22.81″W), municipality of Praia Grande, south of Santa Catarina state, southern Brazil (<xref ref-type="fig" rid="f1">Fig. 1</xref>). The Parque Nacional Aparados da Serra is a protected area that covers 130,606 km², extending within the municipalities of Cambará do Sul in the Rio Grande do Sul state and Praia Grande in the Santa Catarina state (<xref ref-type="bibr" rid="B17">IBAMA-MMA, 2004</xref>).</p>
+			<p>
+				<fig id="f1">
+					<label>Figure 1</label>
+					<caption>
+						<title>Location of the study area in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf1.tif"/>
+				</fig>
+			</p>
+			<p>The altitude of the study area ranges between 200 and 350 m above sea level (<xref ref-type="bibr" rid="B17">IBAMA-MMA, 2004</xref>). The Köppen climate classification is Cfa (humid subtropical, without a dry season, and hot summers), with a mean annual temperature of 19.0 °C. However, the study area is also influenced by the Köppen climate Cfb (humid subtropical, without a dry season, and temperate summers), with an annual average temperature of 16.0 °C (<xref ref-type="bibr" rid="B3">Alvares <italic>et al.,</italic> 2014</xref>). The mean temperature in the coldest periods (June-August) ranges close to 7.2°C and the annual rainfall ranges from 1,220 to 1,660 mm, with an annual total of 102-150 rainy days (<xref ref-type="bibr" rid="B11">EPAGRI, 2001</xref>).</p>
+			<p>The study area was covered by a Submontane Atlantic Rain Forest (<xref ref-type="bibr" rid="B17">IBAMA-MMA, 2004</xref>; <xref ref-type="bibr" rid="B16">IBGE, 2012</xref>) (<xref ref-type="fig" rid="f2">Fig. 2A</xref>). The vegetation was in the secondary successional stage of regeneration, predominantly in the early and medium stages, where the canopy varies from 6-15 m in height from the ground (<xref ref-type="fig" rid="f2">Fig. 2B</xref>). The understory is denser along the forest border, where Melastomataceae, Rubiaceae, Poaceae, and several pteridophytes predominate (<xref ref-type="fig" rid="f2">Fig. 2D</xref>), and less dense inside the forest (<xref ref-type="fig" rid="f2">Fig. 2C</xref>), where numerous lianas and epiphytes, especially bromeliads of the genus <italic>Vriesea</italic> persist (<xref ref-type="fig" rid="f2">Fig. 2E</xref>).</p>
+			<p>
+				<fig id="f2">
+					<label>Figure 2</label>
+					<caption>
+						<title>(A-E) Images of Atlantic Rain Forest in the lower part of Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil. (A) overview of Submontane Atlantic Rain Forest; (B) detail of canopy height; (C) detail of the understory within the forest; (D) detail of understory at the forest edge; (E) presence of lianas and bromeliads in the understory within the forest.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf2.tif"/>
+				</fig>
+			</p>
+			<p>Data on the detection of mixed flocks were collected between October 2016 and September 2017 in 12 monthly campaigns over three consecutive days. Sampling was carried out along a main trail of three kilometers, containing perpendicular trails ranging from 200 to 300 m (<xref ref-type="fig" rid="f3">Fig. 3</xref>), covering inland environments and edges of the Submontane Forest. The group formed by the main and secondary trails was divided into three sectors (<xref ref-type="fig" rid="f3">Fig. 3</xref>). Each sector was sampled in one day during sampling sessions of six hours each; 60% in the morning, starting after sunrise, and the remainder in the afternoon, ending before dusk (<xref ref-type="bibr" rid="B21">Machado, 1999</xref> adapted), totaling 216 h of data collection (36 d).</p>
+			<p>
+				<fig id="f3">
+					<label>Figure 3</label>
+					<caption>
+						<title>Distribution of the three sampling sectors (I, II, and III) in the study area, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf3.tif"/>
+				</fig>
+			</p>
+			<p>Mixed flocks were detected through visual observations, aided by binoculars (8 × 42), contact calls, and aural records. Mixed flocks were defined as the association of two or more individuals of at least two distinct species following each other along the same route for a minimum period of five minutes while looking for food (<xref ref-type="bibr" rid="B34">Stotz, 1993</xref>). Due to difficulties in access and movement in the area, because of the slope of the terrain and the dense understory, some groups were followed in the direction of displacement only when they moved close to the trails, as suggested by <xref ref-type="bibr" rid="B21">Machado (1999</xref>).</p>
+			<p>Per the recommendations from <xref ref-type="bibr" rid="B21">Machado (1999</xref>), when in contact with a mixed flock, we recorded the time and contact time (start and end time, with a maximum observation time of 15 min), species observed, number of individuals of each species, type of record (visual or aural), and stratum of occurrence (understory or canopy) occupied by each species. When possible, search substrates (soil, litter, trunks, branches, leaves, flowers, and air), types of food items consumed (arthropods, fruits, seeds, buds, leaves, nectar, and flowers), and agonistic interactions (physical aggression and flight chase) were recorded, as suggested by <xref ref-type="bibr" rid="B12">Fitzpatrick (1980</xref>). Taxonomic nomenclature followed the proposition adopted by the Brazilian Committee of Ornithological Records (<xref ref-type="bibr" rid="B31">Pacheco <italic>et al.,</italic> 2021</xref>).</p>
+			<p>The FO of a species in mixed flocks was defined as the proportion of flocks in which it was present among the total registered flocks. The species were then classified into the following categories: regular (FO ≥ 25%), common (10 ≤ FO ≤ 24.9%), unusual (3.0 ≤ FO ≤ 9.9%), and rare species (FO ≤ 2.9%) (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>).</p>
+			<p>The relationship between species richness and the number of individuals in mixed flocks was assessed using simple linear regression. To analyze the temporal variation in the frequency of mixed flocks per campaign (number of contacts), size of the flocks (number of individuals), and richness of the flocks throughout the year, the Rayleigh test (Z) was used, with a significance level of 0.05, calculated using the Oriana software, version 4.3 (<xref ref-type="bibr" rid="B18">Kovach, 2011</xref>).</p>
+			<p>To determine which of the recorded species acted as core species, the performance of each species in the formation and maintenance of the cohesion of the flocks was evaluated. In this case, the requirements proposed by <xref ref-type="bibr" rid="B32">Powell (1985</xref>) and <xref ref-type="bibr" rid="B21">Machado (1999</xref>) were considered: (1) neutral color patterns (<italic>e.g.,</italic> olive, yellow, brown, black, and without spots) - these are considered less aggressive plumes which potentially facilitate interspecific association; (2) movement - species that move during foraging cause local disturbances that attract other individuals to the flock; (3) vocalization - species that vocalize strongly during foraging reinforce the attraction and keep individuals cohesive to the flock; (4) FO in flocks - core species participate with a high frequency in mixed flocks; (5) size of the intraspecific group within the flock - quantitative data that measures the natural tendency to gregariousness of the core species (s) in the flocks; and (6) the size of the interspecific group - the total number of individuals in the mixed flock. Species were selected if they met at least four of the six requirements listed above. Next, we used a Student’s t-test, with a significance level of 0.05, calculated using the PAST 3.25 software (<xref ref-type="bibr" rid="B15">Hammer <italic>et al.,</italic> 2001</xref>), to assess whether mixed flocks are richer in the number of species due to the presence of the core species when they are aggregated or solitary among the mixed flocks. Data are presented as mean ± standard deviation (SD).</p>
+		</sec>
+		<sec sec-type="results">
+			<title>RESULTS</title>
+			<p>We recorded 152 mixed flocks, with 76 participating species belonging to five orders and 24 families. Passeriformes (n = 68 species) had the highest richness, mostly represented by the families Thraupidae (n = 15), Tyrannidae (n = 8), Furnariidae (n = 6), and Rhynchocyclidae (n = 6). Cuculiformes and Apodiformes were recorded in only one species each, Trogoniformes in two, and Piciformes in four (<xref ref-type="table" rid="t1">Table 1</xref>).</p>
+			<p>
+				<table-wrap id="t1">
+					<label>Table 1</label>
+					<caption>
+						<title>Bird species participating in mixed flocks, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017. Frequency of occurrence of species in the mixed flocks (FO, %). Categories of frequency of occurrence of species (FC): Regular (RE) FO ≥ 25.0%, Common (COM) 10.0 ≤ FO ≤ 24.99%, Unusual (U) 3.0 ≤ FO ≤ 9.99%, and Rare (RA) FO ≤ 2.99%. Foraging stratum (FS): Understory (Und) and Canopy (Can).</title>
+					</caption>
+					<table>
+						<colgroup>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+						</colgroup>
+						<thead>
+							<tr>
+								<th align="center">Taxa</th>
+								<th align="center">Range of Number of Individuals in the Flocks</th>
+								<th align="center">Number of Contacts</th>
+								<th align="center">FO (%)</th>
+								<th align="center">FC</th>
+								<th align="center">FS</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="left"><bold>Cuculiformes</bold> Wagler, 1830</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Cuculidae</bold> Leach, 1820</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Piaya cayana</italic> (Linnaeus, 1766)</td>
+								<td align="center">1</td>
+								<td align="center">3</td>
+								<td align="center">2.0</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Apodiformes</bold> Peters, 1940</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Trochilidae</bold> Vigors, 1825</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Thalurania glaucopis</italic> (Gmelin, 1788)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Trogoniformes</bold> A.O.U., 1886</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Trogonidae</bold> Lesson, 1828</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Trogon surrucura</italic> Vieillot, 1817</td>
+								<td align="center">1-2</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Trogon chrysochloros</italic> Pelzeln, 1856</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Piciformes</bold> Meyer &amp; Wolf, 1810</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Picidae</bold> Leach, 1820</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Picumnus temminckii</italic> Lafresnaye, 1845</td>
+								<td align="center">1</td>
+								<td align="center">3</td>
+								<td align="center">2.0</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Veniliornis spilogaster</italic> (Wagler, 1827)</td>
+								<td align="center">1-2</td>
+								<td align="center">8</td>
+								<td align="center">5.3</td>
+								<td align="center">U</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Celeus flavescens</italic> (Gmelin, 1788)</td>
+								<td align="center">2</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Piculus aurulentus</italic> (Temminck, 1821)</td>
+								<td align="center">1-2</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Passeriformes</bold> Linnaeus, 1758</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Thamnophilidae</bold> Swainson, 1824</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Rhopias gularis</italic> (Spix, 1825)</td>
+								<td align="center">2-4</td>
+								<td align="center">3</td>
+								<td align="center">2.0</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Dysithamnus mentalis</italic> (Temminck, 1823)</td>
+								<td align="center">1-4</td>
+								<td align="center">28</td>
+								<td align="center">18.4</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Thamnophilus caerulescens</italic> Vieillot, 1816</td>
+								<td align="center">1-2</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Myrmoderus squamosus</italic> (Pelzeln, 1868)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Conopophagidae</bold> Sclater &amp; Salvin, 1873</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Conopophaga lineata</italic> (Wied, 1831)</td>
+								<td align="center">1</td>
+								<td align="center">5</td>
+								<td align="center">3.3</td>
+								<td align="center">U</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Formicariidae</bold> Gray, 1840</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Chamaeza campanisona</italic> (Lichtenstein, 1823)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Scleruridae</bold> Swainson, 1827</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Sclerurus scansor</italic> (Ménétries, 1835)</td>
+								<td align="center">1-2</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Dendrocolaptidae</bold> Gray, 1840</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Sittasomus griseicapillus</italic> (Vieillot, 1818)</td>
+								<td align="center">1-3</td>
+								<td align="center">39</td>
+								<td align="center">25.7</td>
+								<td align="center">RE</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Dendrocolaptes platyrostris</italic> Spix, 1825</td>
+								<td align="center">1</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Xiphorhynchus fuscus</italic> (Vieillot, 1818)</td>
+								<td align="center">1-2</td>
+								<td align="center">37</td>
+								<td align="center">24.3</td>
+								<td align="center">COM</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Lepidocolaptes falcinellus</italic> (Cabanis &amp; Heine, 1859)</td>
+								<td align="center">1-2</td>
+								<td align="center">5</td>
+								<td align="center">3.3</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Xenopidae</bold> Bonaparte, 1854</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Xenops rutilans</italic> Temminck, 1821</td>
+								<td align="center">1-2</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Furnariidae</bold> Gray, 1840</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Heliobletus contaminatus</italic> Pelzeln, 1859</td>
+								<td align="center">1-2</td>
+								<td align="center">7</td>
+								<td align="center">4.6</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Philydor atricapillus</italic> (Wied, 1821)</td>
+								<td align="center">1-4</td>
+								<td align="center">29</td>
+								<td align="center">19.1</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Anabacerthia amaurotis</italic> (Temminck, 1823)</td>
+								<td align="center">1-3</td>
+								<td align="center">11</td>
+								<td align="center">7.2</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Syndactyla rufosuperciliata</italic> (Lafresnaye, 1832)</td>
+								<td align="center">1</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Dendroma rufa</italic> (Vieillot, 1818)</td>
+								<td align="center">1-6</td>
+								<td align="center">15</td>
+								<td align="center">9.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Synallaxis ruficapilla</italic> Vieillot, 1819</td>
+								<td align="center">1-2</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Pipridae</bold> Rafinesque, 1815</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Chiroxiphia caudata</italic> (Shaw &amp; Nodder, 1793)</td>
+								<td align="center">1-4</td>
+								<td align="center">13</td>
+								<td align="center">8.6</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Tityridae</bold> Gray, 1840</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Schiffornis virescens</italic> (Lafresnaye, 1838)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Pachyramphus castaneus</italic> (Jardine &amp; Selby, 1827)</td>
+								<td align="center">1-4</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Pachyramphus polychopterus</italic> (Vieillot, 1818)</td>
+								<td align="center">1-2</td>
+								<td align="center">7</td>
+								<td align="center">4.6</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Pachyramphus validus</italic> (Lichtenstein, 1823)</td>
+								<td align="center">1-6</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Platyrinchidae</bold> Bonaparte, 1854</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Platyrinchus mystaceus</italic> Vieillot, 1818</td>
+								<td align="center">1-4</td>
+								<td align="center">17</td>
+								<td align="center">11.2</td>
+								<td align="center">COM</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Rhynchocyclidae</bold> Berlepsch, 1907</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Mionectes rufiventris</italic> Cabanis, 1846</td>
+								<td align="center">1</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Leptopogon amaurocephalus</italic> Tschudi, 1846</td>
+								<td align="center">1-2</td>
+								<td align="center">15</td>
+								<td align="center">9.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Phylloscartes ventralis</italic> (Temminck, 1824)</td>
+								<td align="center">1-5</td>
+								<td align="center">20</td>
+								<td align="center">13.2</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tolmomyias sulphurescens</italic> (Spix, 1825)</td>
+								<td align="center">1</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Poecilotriccus plumbeiceps</italic> (Lafresnaye, 1846)</td>
+								<td align="center">3</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Hemitriccus obsoletus</italic> (Miranda-Ribeiro, 1906)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Tyrannidae</bold> Vigors, 1825</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tyranniscus burmeisteri</italic> (Cabanis &amp; Heine, 1859)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Camptostoma obsoletum</italic> (Temminck, 1824)</td>
+								<td align="center">1-2</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Phyllomyias virescens</italic> (Temminck, 1824)</td>
+								<td align="center">1</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Attila rufus</italic> (Vieillot, 1819)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Myiarchus swainsoni</italic> Cabanis &amp; Heine, 1859</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Myiodynastes maculatus</italic> (Statius Muller, 1776)</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Megarynchus pitangua</italic> (Linnaeus, 1766)</td>
+								<td align="center">1</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Lathrotriccus euleri</italic> (Cabanis, 1868)</td>
+								<td align="center">1-2</td>
+								<td align="center">7</td>
+								<td align="center">4.6</td>
+								<td align="center">U</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Vireonidae</bold> Swainson, 1837</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Cyclarhis gujanensis</italic> (Gmelin, 1789)</td>
+								<td align="center">1</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Ca</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Hylophilus poicilotis</italic> Temminck, 1822</td>
+								<td align="center">1-3</td>
+								<td align="center">9</td>
+								<td align="center">5.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Vireo chivi</italic> (Vieillot, 1817)</td>
+								<td align="center">1-4</td>
+								<td align="center">23</td>
+								<td align="center">15.1</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Troglodytidae</bold> Swainson, 1831</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Troglodytes musculus</italic> Naumann, 1823</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Turdidae</bold> Rafinesque, 1815</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Turdus rufiventris</italic> Vieillot, 1818</td>
+								<td align="center">1-3</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Turdus subalaris</italic> (Seebohm, 1887)</td>
+								<td align="center">2-5</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Turdus albicollis</italic> Vieillot, 1818</td>
+								<td align="center">1-4</td>
+								<td align="center">22</td>
+								<td align="center">14.5</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Fringillidae</bold> Leach, 1820</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Euphonia violacea</italic> (Linnaeus, 1758)</td>
+								<td align="center">1-4</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Euphonia pectoralis</italic> (Latham, 1801)</td>
+								<td align="center">1-2</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Icteridae</bold> Vigors, 1825</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Cacicus chrysopterus</italic> (Vigors, 1825)</td>
+								<td align="center">1-3</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Icterus pyrrhopterus</italic> (Vieillot, 1819)</td>
+								<td align="center">4-4</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Parulidae</bold> Wetmore, Friedmann, Lincoln, Miller, Peters, van Rossem, Van Tyne &amp; Zimmer, 1947</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Setophaga pitiayumi</italic> (Vieillot, 1817)</td>
+								<td align="center">1-4</td>
+								<td align="center">33</td>
+								<td align="center">21.7</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Myiothlypis leucoblephara</italic> (Vieillot, 1817)</td>
+								<td align="center">1-3</td>
+								<td align="center">12</td>
+								<td align="center">7.9</td>
+								<td align="center">U</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Basileuterus culicivorus</italic> (Deppe, 1830)</td>
+								<td align="center">1-8</td>
+								<td align="center">71</td>
+								<td align="center">46.7</td>
+								<td align="center">RE</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Cardinalidae</bold> Ridgway, 1901</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Habia rubica</italic> (Vieillot, 1817)</td>
+								<td align="center">1-8</td>
+								<td align="center">50</td>
+								<td align="center">32.9</td>
+								<td align="center">RE</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><bold>Thraupidae</bold> Cabanis, 1847</td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+								<td align="left"> </td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Hemithraupis ruficapilla</italic> (Vieillot, 1818)</td>
+								<td align="center">2-5</td>
+								<td align="center">11</td>
+								<td align="center">7.2</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tersina viridis</italic> (Illiger, 1811)</td>
+								<td align="center">2-5</td>
+								<td align="center">4</td>
+								<td align="center">2.6</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Dacnis cayana</italic> (Linnaeus, 1766)</td>
+								<td align="center">1-2</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Saltator similis</italic> d’Orbigny &amp; Lafresnaye, 1837</td>
+								<td align="center">1</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Coereba flaveola</italic> (Linnaeus, 1758)</td>
+								<td align="center">1</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Trichothraupis melanops</italic> (Vieillot, 1818)</td>
+								<td align="center">1-8</td>
+								<td align="center">21</td>
+								<td align="center">13.8</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tachyphonus coronatus</italic> (Vieillot, 1822)</td>
+								<td align="center">1-4</td>
+								<td align="center">23</td>
+								<td align="center">15.1</td>
+								<td align="center">COM</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Haplospiza unicolor</italic> Cabanis, 1851</td>
+								<td align="center">1-4</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Pipraeidea melanonota</italic> (Vieillot, 1819)</td>
+								<td align="center">1-6</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Stephanophorus diadematus</italic> (Temminck, 1823)</td>
+								<td align="center">1-2</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Thraupis sayaca</italic> (Linnaeus, 1766)</td>
+								<td align="center">1-4</td>
+								<td align="center">6</td>
+								<td align="center">3.9</td>
+								<td align="center">U</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Thraupis cyanoptera</italic> (Vieillot, 1817)</td>
+								<td align="center">1-4</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Stilpnia preciosa</italic> (Cabanis, 1850)</td>
+								<td align="center">1-5</td>
+								<td align="center">3</td>
+								<td align="center">2</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tangara seledon</italic> (Statius Muller, 1776)</td>
+								<td align="center">3-6</td>
+								<td align="center">2</td>
+								<td align="center">1.3</td>
+								<td align="center">RA</td>
+								<td align="center">Und, Can</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>Tangara cyanocephala</italic> (Statius Muller, 1776)</td>
+								<td align="center">2-2</td>
+								<td align="center">1</td>
+								<td align="center">0.7</td>
+								<td align="center">RA</td>
+								<td align="center">Und</td>
+							</tr>
+						</tbody>
+					</table>
+				</table-wrap>
+			</p>
+			<p>The mixed flocks comprised a mean 4.5 ± 2.7 species, with a minimum of 2 and a maximum of 14 species, while the mean number of individuals was 8.7 ± 5.8, ranging between 2 and 31. Flocks with a greater number of individuals had greater species richness (R² = 0.83%; <italic>p</italic> &lt; 0.05; <italic>df</italic> = 151; <xref ref-type="fig" rid="f4">Fig. 4</xref>). Regarding the FO, only three species were classified as regular: <italic>Basileuterus culicivorus</italic> (FO = 46.7%), <italic>Habia rubica</italic> (FO = 32.9%), and <italic>Sittasomus griseicapillus</italic> (FO = 25.7%), representing 3.9% of the total richness. Common species (n = 10 spp.) accounted for 13.1% of the species richness, whereas unusual species (n = 20 spp.) accounted for 26.3%. The remaining 43 species (56.5% of total richness) were rare (<xref ref-type="table" rid="t1">Table 1</xref>).</p>
+			<p>
+				<fig id="f4">
+					<label>Figure 4</label>
+					<caption>
+						<title>Simple linear regression of the relationship between species richness and the number of individuals from mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf4.tif"/>
+				</fig>
+			</p>
+			<p>Six events of agonistic behavior between species were observed. Of these, three intraspecific species, including <italic>H. rubica</italic> (two events) and <italic>Turdus subalaris</italic> (one event), and three interspecific species, including <italic>Lathrotriccus euleri</italic> (two events), one against <italic>Myiothlypis leucoblephara,</italic> the other against <italic>Platyrinchus mystaceus,</italic> and finally, <italic>Turdus albicollis</italic> against an individual of <italic>Turdus rufiventris,</italic> who was not part of the flock.</p>
+			<p>Mixed flocks occurred throughout the year, with variations in their frequencies. From October to February, a greater number of flocks were detected with a wide fluctuation in the number of contacts in October (n = 17), November (n = 12), December (n = 5), January (n = 20), and February (n = 18). Between March and September, fewer flocks were detected with less variation; March (n = 9), April (n = 14), May (n = 11), June (n = 12), July (n = 14), and August and September (n = 10, each). There were no differences observed in the number of contacts between months (z = 0.369; <italic>p</italic> = 0.691); therefore, no peak was observed (<xref ref-type="fig" rid="f5">Fig. 5</xref>).</p>
+			<p>
+				<fig id="f5">
+					<label>Figure 5</label>
+					<caption>
+						<title>Variation in the number of contacts of mixed flocks of birds per month, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf5.tif"/>
+				</fig>
+			</p>
+			<p>The average species richness in the mixed flocks (4.5 ± 2.7 species) did not differ throughout the year (z = 0.005; p = 0.995; <xref ref-type="fig" rid="f6">Fig. 6</xref>), and there was no difference in the average number of individuals per flock (z = 0.572; p = 0.564; <xref ref-type="fig" rid="f7">Fig. 7</xref>).</p>
+			<p>
+				<fig id="f6">
+					<label>Figure 6</label>
+					<caption>
+						<title>Monthly variation in the average richness of mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf6.tif"/>
+				</fig>
+			</p>
+			<p>
+				<fig id="f7">
+					<label>Figure 7</label>
+					<caption>
+						<title>Monthly variation of the average size (in the number of individuals) of the mixed flocks of birds, in Parque Nacional Aparados da Serra, municipality of Praia Grande, southern Santa Catarina, Brazil, between October 2016 and September 2017.</title>
+					</caption>
+					<graphic xlink:href="1807-0205-paz-62-e202262026-gf7.tif"/>
+				</fig>
+			</p>
+			<p>Among the 76 species participating in the mixed flocks, <italic>B. culicivorus</italic> and <italic>H. rubica</italic> had the highest frequency of participation (<xref ref-type="table" rid="t1">Table 1</xref>) and presented physical and behavioral characteristics that allowed them to be classified as core species (<xref ref-type="table" rid="t2">Table 2</xref>). <italic>Basileuterus culicivorus</italic> was the most frequent species in the flocks (<xref ref-type="table" rid="t1">Table 1</xref>) and generally occurred at a frequency of two to four individuals, always exhibiting intense movement and strong vocalization. These individuals were present from the understory to the canopy and used different substrates, such as thin trunks, branches, and leaves, to forage for arthropods, seeds, insects, and small larvae. In addition, individuals of this species have been observed alone on a few occasions and are most commonly seen in pairs or in small monospecific flocks. <italic>Habia rubica,</italic> in turn, was the second most frequent species in the mixed flocks, always occurring in the understory and represented by groups of two to eight members (<xref ref-type="table" rid="t1">Table 1</xref>). Usually, <italic>H. rubica</italic> forages along branches, trunks, and leaves, where it preys upon small arthropods, insects, and larvae. The mixed flocks in which <italic>B. culicivorus</italic> and <italic>H. rubica</italic> occurred (n = 95) were richer (4.9 ± 2.8 species) than in those (n = 57) where they did not occur (3.6 ± 2.2 species; t = 2.845; <italic>p</italic> = 0.005).</p>
+			<p>
+				<table-wrap id="t2">
+					<label>Table 2</label>
+					<caption>
+						<title>Physical and behavioral characteristics of the two most frequent species in mixed flocks of birds (n = 152), recorded in PARNA of Aparados da Serra, municipality of Praia Grande, southern Santa Catarina state, Brazil, between October 2016 and September 2017.</title>
+					</caption>
+					<table>
+						<colgroup>
+							<col/>
+							<col span="2"/>
+						</colgroup>
+						<thead>
+							<tr>
+								<th align="center" rowspan="2">Physical and Behavioral Characteristics</th>
+								<th align="center" colspan="2">Species </th>
+							</tr>
+							<tr>
+								<th align="center"><bold>
+ <italic>B. culicivorus</italic> 
+</bold></th>
+								<th align="center"><bold>
+ <italic>H. rubica</italic> 
+</bold></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="left">Neutral coloring</td>
+								<td align="center">Yes</td>
+								<td align="center">Yes</td>
+							</tr>
+							<tr>
+								<td align="left">Vocalization</td>
+								<td align="center">Conspicuous</td>
+								<td align="center">Conspicuous</td>
+							</tr>
+							<tr>
+								<td align="left">Movement intensity</td>
+								<td align="center">High</td>
+								<td align="center">High</td>
+							</tr>
+							<tr>
+								<td align="left">Frequency of occurrence</td>
+								<td align="center">Regular</td>
+								<td align="center">Regular</td>
+							</tr>
+							<tr>
+								<td align="left">Number of contacts</td>
+								<td align="center">71</td>
+								<td align="center">50</td>
+							</tr>
+							<tr>
+								<td align="left">Number of individuals in the intraspecific groups</td>
+								<td align="center">2.9 ± 1.5</td>
+								<td align="center">3.6 ± 1.3</td>
+							</tr>
+							<tr>
+								<td align="left">Richness of flocks without the presence of the other species</td>
+								<td align="center">4.0 ± 2.2 (n = 47)</td>
+								<td align="center">4.8 ± 2.7 (n = 26)</td>
+							</tr>
+							<tr>
+								<td align="left">Richness of flocks without the presence of the two species</td>
+								<td align="center" colspan="2">3.6 ± 2.2 (n = 57)</td>
+							</tr>
+						</tbody>
+					</table>
+				</table-wrap>
+			</p>
+		</sec>
+		<sec sec-type="discussion">
+			<title>DISCUSSION</title>
+			<p>The species richness recorded in the present study (76 species) was similar to that found in the Southeast Atlantic Rain Forest by <xref ref-type="bibr" rid="B8">Davis (1946</xref>), <xref ref-type="bibr" rid="B10">Develey &amp; Peres (2000</xref>), and <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini (2003</xref>), who reported, 77, 72, and 78 species, respectively. In contrast, considering the studies conducted in the southern Atlantic Rain Forest region, the species richness recorded in our study was higher than that found by <xref ref-type="bibr" rid="B14">Ghizoni-Jr. &amp; Azevedo (2006</xref>) and <xref ref-type="bibr" rid="B13">Ghizoni-Jr. (2009</xref>), who recorded 64 and 56 species, respectively, but lower than that recorded by <xref ref-type="bibr" rid="B6">Brandt <italic>et al.</italic> (2009</xref>), who recorded 117 species. The highest richness of species in mixed flocks in the Atlantic Rain Forest biome was recorded by <xref ref-type="bibr" rid="B21">Machado (1999</xref>), in the upper region of Serra do Paranapiacaba, São Paulo state, where 120 species were recorded. However, in the study by <xref ref-type="bibr" rid="B21">Machado (1999</xref>), in addition to the diversity of sampled environments, the number of hours of sampling (n = 432 h) was much higher than that of the present study (n = 216 h). Therefore, the diversity detected in the present study can be considered representative as it covered all four seasons of the year and was conducted during both the reproductive and non-reproductive periods.</p>
+			<p>Migratory species also contributed to the recorded species richness. Among these, <italic>Vireo chivi</italic> stands out, which, according to <xref ref-type="bibr" rid="B20">Machado (1997</xref>), is recognized as a regular participant in mixed flocks within the Atlantic Rain Forest. This species remains in the southern region of Brazil (<xref ref-type="bibr" rid="B33">Sick, 1997</xref>) for only six to seven months and participated in the flocks from October 24, 2016, to April 20, 2017 (first and last records). However, it was among the most frequent in flocks, a result supported by the findings of <xref ref-type="bibr" rid="B20">Machado (1997</xref>, <xref ref-type="bibr" rid="B21">1999</xref>). Generally, <italic>V. chivi</italic> accompanies flocks in pairs through the canopy and sometimes within the medium understory where it uses various substrates such as thin trunks, branches, and leaves to forage for seeds and small fruits. Other registered migratory birds that caused seasonal displacement in the region were <italic>T. subalaris, L. euleri, Myiarchus swainsoni, Haplospiza unicolor, Myiodynastes maculatus,</italic> and <italic>Pachyramphus polychopterus.</italic> These last three species were also recorded by <xref ref-type="bibr" rid="B6">Brandt <italic>et al.</italic> (2009</xref>) and are considered potential members of mixed flocks by <xref ref-type="bibr" rid="B20">Machado (1997</xref>). The low values found for the average richness of species in the flocks and average size of the flocks in relation to other studies carried out in Brazil can be explained by the diversity of species that is accompanied by changes along the latitudinal gradient between the Atlantic Rain Forest and Amazon biomes (<xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>). In addition to biogeographic factors, the successional stages of vegetation may also influence species composition, richness, and the size of registered flocks, as mentioned by <xref ref-type="bibr" rid="B1">Aleixo (1997</xref>) and <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini (2003</xref>).</p>
+			<p>Neotropical mixed flocks are either primarily or exclusively composed of passerines (<xref ref-type="bibr" rid="B29">Moynihan, 1962</xref>). They are stable flocks formed by a couple of species, mainly insectivorous and omnivorous birds (<xref ref-type="bibr" rid="B32">Powell, 1985</xref>), which is justified by the observations made during the present study. However, this does not mean that other orders cannot be typical followers of mixed flocks, such as Cuculiformes, Trogoniformes, and Piciformes, which were recorded here and are commonly reported in other studies of mixed flocks in the Atlantic Rain Forest. <italic>Piaya cayana</italic> specimens were always observed alone, discreetly following the mixed flocks through the upper understory where they captured arthropods disturbed by the flocks. This was also observed in the middle understory of <italic>Trogon surrucura</italic> and <italic>Trogon chrysochloros,</italic> although the participation of trogonids in mixed flocks is considered rare (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>). In the present study, these two species followed the flocks for long periods of time (more than 15 min). In contrast, <italic>Picumnus temminckii, Veniliornis spilogaster,</italic> and <italic>Piculus aurulentus</italic> benefited mainly from protection against predators, as their diets are composed of larvae and not arthropods disturbed by the flock (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>). The participation of <italic>Thalurania glaucopis</italic> in mixed flocks may be related to a response to the aggregation instinct or even to the temporary protection obtained by the presence of a greater number of individuals (<xref ref-type="bibr" rid="B29">Moynihan, 1962</xref>).</p>
+			<p>Some of the richest families, such as Thraupidae, Tyrannidae, and Furnariidae, observed were also among the most frequent in other studies with mixed flocks of Atlantic Rain Forest birds. This is possibly because a large part of the species belonging to these families are insectivorous, small sized, and have a great capacity to adapt to forest environments (<xref ref-type="bibr" rid="B33">Sick, 1997</xref>), characteristics that facilitate participation in heterospecific associations (<xref ref-type="bibr" rid="B10">Develey &amp; Peres, 2000</xref>; <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini, 2003</xref>).</p>
+			<p>Among the “regular species,” <italic>B. culicivorus</italic> was the species with the highest FO; a same result was also found in the Brazilian Southeast Region by <xref ref-type="bibr" rid="B21">Machado (1999</xref>) and in the Brazilian south region by <xref ref-type="bibr" rid="B14">Ghizoni-Jr. &amp; Azevedo (2006</xref>) and <xref ref-type="bibr" rid="B6">Brandt <italic>et al.</italic> (2009</xref>). The other two regular species, <italic>H. rubica</italic> and <italic>S. griseicapillus,</italic> also occurred with a high frequency in other studies (<italic>e.g.,</italic><xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini, 2003</xref>; <xref ref-type="bibr" rid="B13">Ghizoni-Jr., 2009</xref>). This fact was true for most of the registered “common species,” <italic>Xiphorhynchus fuscus, Philydor atricapillus</italic> (<xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>), <italic>Setophaga pitiayumi, Phylloscartes ventralis</italic> (<xref ref-type="bibr" rid="B13">Ghizoni-Jr., 2009</xref>), <italic>Dysithamnus mentalis</italic> (<xref ref-type="bibr" rid="B8">Davis, 1946</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>), <italic>Tachyphonus coronatus</italic> (<xref ref-type="bibr" rid="B14">Ghizoni-Jr. &amp; Azevedo, 2006</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>), <italic>Trichothraupis melanops</italic> (<xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>; <xref ref-type="bibr" rid="B13">Ghizoni-Jr., 2009</xref>), <italic>T. albicollis</italic><xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>), and <italic>V. chivi</italic> (<xref ref-type="bibr" rid="B20">Machado, 1997</xref>, <xref ref-type="bibr" rid="B21">1999</xref>). The exception was <italic>P. mystaceus,</italic> which in this study alone was among the most frequent.</p>
+			<p>Previous studies on mixed flocks carried out in other regions of the Atlantic Rain Forest found that some of the species registered here as “uncommon” have a marked presence in heterospecific associations. These include <italic>Lepidocolaptes falcinellus, Xenops rutilans, Dendroma rufa, Anabacerthia amaurotis, Heliobletus contaminatus, Leptopogon amaurocephalus, Tolmomyias sulphurescens, Hylophilus poicilotis,</italic> and <italic>Hemithraupis ruficapilla.</italic> Individuals of these species were rarely seen outside the flocks and thus can be considered flock participants in this study.</p>
+			<p>The rare species group accounted for 56.5% of the total richness recorded. This result was similar to that found by <xref ref-type="bibr" rid="B21">Machado (1999</xref>) in the Serra de Paranapiacaba, southeast Brazil, which registered 53.3% of the species as rare. Thus, as observed in this study, these species do not contribute significantly to the cohesion and maintenance of the mixed flocks, while a large proportion of them eventually participated in the flocks. A good example of the latter includes records of <italic>Chamaeza campanisona, Sclerurus scansor, Schiffornis virescens, Rhopias gularis,</italic> and <italic>Myrmoderus squamosus,</italic> which forage in the lower understory and participate in the flocks only when they pass through their territory. The same can be mentioned for <italic>Thamnophilus caerulescens, T. rufiventris, Phyllomyias virescens,</italic> and <italic>Tyranniscus burmeisteri</italic> in the middle understory and <italic>Troglodytes musculus</italic> in border areas. The participation of <italic>Celeus flavescens</italic> and <italic>Hemitriccus obsoletus</italic> was purely accidental; on both occasions when these species were recorded, they were following a separate foraging route and accidentally entered the flock.</p>
+			<p>The agonistic interactions recorded between species participating in mixed flocks, as mentioned by <xref ref-type="bibr" rid="B32">Powell (1985</xref>), may be related to the defense and demarcation of the foraging territory of the flock. Such behaviors structurally reinforce groups, as they prioritize group members to avoid further confrontations, which is beneficial due to the increase in efficiency of use of food resources (<xref ref-type="bibr" rid="B19">Lagory <italic>et al.,</italic> 1984</xref>).</p>
+			<p>In areas of the Atlantic Rain Forest in the southeast, <xref ref-type="bibr" rid="B8">Davis (1946</xref>) and <xref ref-type="bibr" rid="B21">Machado (1999</xref>) found that mixed flocks occur more frequently in the sub-dry season, from April to September, and may present peaks in the coldest months of the year such as July and August. However, this was not observed in the present study, as there were no high frequencies of contact with flocks in the winter months. Concurrently, certain variations in the number of contacts appeared to be similar to the pattern found by <xref ref-type="bibr" rid="B21">Machado (1999</xref>) and <xref ref-type="bibr" rid="B5">Batista <italic>et al.</italic> (2013</xref>). The decrease in the number of contacts with flocks observed between November and December was also recorded by <xref ref-type="bibr" rid="B21">Machado (1999</xref>). This decrease may be linked to the reproductive period of the birds, where most species establish territory during this time of the year and participate with a lower frequency within mixed flocks. This justifies the various reproductive behaviors observed among birds in these months, such as cutting, nest building, and care for nestlings. Contrary to the findings of <xref ref-type="bibr" rid="B8">Davis (1946</xref>) and <xref ref-type="bibr" rid="B21">Machado (1999</xref>), the greatest number of contacts with mixed flocks was obtained in the summer months of January and February in the present study. However, during these months, the flocks were less cohesive, with many young individuals present and greater distances between members, in addition to remaining united for short periods of time. Furthermore, it was observed on many occasions that the flocks disintegrate, either by dilution when the flock fragmented (but followed the same direction) or even by division, with two or more groups following different directions. This fact was also highlighted by <xref ref-type="bibr" rid="B21">Machado (1999</xref>). The flocks remained stable between March and September. In the winter months of June and July, the flocks were cohesive with members remaining close to each other or being united for long periods.</p>
+			<p>As for the variation in the average species richness and average size of the flocks, the decrease observed in the months of November and December may also be related to the reproductive period of the birds. The observed increases in these variables in the summer months of January, February, and March are similar to those found by <xref ref-type="bibr" rid="B8">Davis (1946</xref>) and <xref ref-type="bibr" rid="B21">Machado (1999</xref>); however, in this study, the flocks were less frequent during this period. <xref ref-type="bibr" rid="B21">Machado (1999</xref>) highlighted that the low frequency of flocks in these months may be due to the greater concentration of species in the few formed flocks, resulting in an increase in both the richness and size of the flocks. In this study, unlike <xref ref-type="bibr" rid="B8">Davis (1946</xref>) and <xref ref-type="bibr" rid="B21">Machado (1999</xref>), the increase in the average species richness and average size of the flocks seemed to accompany the monthly flock frequency, mainly in the months of January and February, in which a greater contact number with flocks was registered. Concurrently, the possibility that the inverse relationship may occur in March is not ruled out, being precisely one of the months with the lowest number of contacts with flocks. However, it ranks among the months with the greatest richness and size of registered flocks.</p>
+			<p>Another pattern observed was the increase in species richness and flock size during the winter months, especially in June and July, which was a result also found by <xref ref-type="bibr" rid="B5">Batista <italic>et al.</italic> (2013</xref>) in areas of the Atlantic Rain Forest in the northeast. This increase may be related to the low availability of potential prey items in the winter months, and thus, the birds tend to participate more frequently in flocks to maximize foraging and increase protection against predation (<xref ref-type="bibr" rid="B21">Machado, 1999</xref>).</p>
+			<p>The dynamics of the flocks recorded in this study seem to follow the same trend observed in other studies carried out in the Atlantic Rain Forest (<italic>e.g.,</italic><xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B5">Batista <italic>et al.,</italic> 2013</xref>). Nevertheless, it is important to note that the results obtained for the frequency variation in flock occurrence, species richness, and flock size did not show differences in the respective values throughout the year.</p>
+			<p><italic>Basileuterus culicivorus</italic> and <italic>H. rubica,</italic> due to their high frequency of participation as well as the conspicuous pattern of movement and vocalization, were responsible for the formation of 62.5% of the total registered flocks. In the Atlantic Rain Forest biome, <italic>B. culicivorus</italic> has been considered a nuclear species of mixed flocks in some studies (<italic>e.g.,</italic><xref ref-type="bibr" rid="B24">Maldonado-Coelho &amp; Marini, 2003</xref>; <xref ref-type="bibr" rid="B14">Ghizoni-Jr. &amp; Azevedo, 2006</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>). This species is frequent throughout the year in the study area and exhibits conspicuous behavior and strong vocalization, which is why it was present in 46.7% of the registered flocks. In addition, flocks with the presence of <italic>B. culicivorus</italic> without other nuclear species had a higher average species richness compared to flocks with no nuclear species. These results reinforce the idea that in the Atlantic Forest, <italic>B. culicivorus</italic> plays a fundamental role in the cohesion and maintenance of mixed flocks. However, some authors (<italic>e.g.,</italic><xref ref-type="bibr" rid="B21">Machado, 1999</xref>; <xref ref-type="bibr" rid="B25">Maldonado-Coelho &amp; Marini, 2004</xref>) also cite <italic>H. rubica</italic> as an indispensable species for the cohesion and maintenance of mixed flocks in the Atlantic Rain Forest, noting that its absence can result in the disintegration of the group. <xref ref-type="bibr" rid="B25">Maldonado-Coelho &amp; Marini (2004</xref>) also pointed out that the presence of <italic>H. rubica</italic> in mixed understory flocks in fragments of the Atlantic Rain Forest keeps individuals cohesive during foraging. This was clearly observed in the present study, in which the flocks registered with the presence of <italic>H. rubica</italic> were always cohesive and generally remained together for longer periods of time. Moreover, some species are typical followers of <italic>H. rubica,</italic> such as <italic>P. atricapillus</italic> (<xref ref-type="bibr" rid="B7">Cestari, 2007</xref>), in addition to <italic>S. griseicapillus</italic> and <italic>X. fuscus.</italic> These species forage preferentially on trunks, branches, and leaves, where they capture arthropods, seeds, and small fruits, in addition to searching for epiphytic bromeliads which harbor many insects. Even so, the flocks where <italic>H. rubica</italic> occurred without the presence of the other core species (<italic>B. culicivorus</italic>) also had a higher average species richness than flocks without their presence. This shows the high capacity of this species to attract and retain individuals of different cohesive species, forming mixed flocks. It should be noted, however, that when considering studies with mixed flocks carried out in the southern region of Brazil (<italic>e.g.,</italic><xref ref-type="bibr" rid="B14">Ghizoni-Jr. &amp; Azevedo, 2006</xref>; <xref ref-type="bibr" rid="B13">Ghizoni-Jr., 2009</xref>; <xref ref-type="bibr" rid="B6">Brandt <italic>et al.,</italic> 2009</xref>), <italic>H. rubica</italic> demonstrated the exercise function of nuclear species only in this study.</p>
+			<p>It was observed that the mixed flocks formed during this study were dependent on the presence of <italic>H. rubica</italic> and <italic>B. culicivorus.</italic> Therefore, these species are considered vital for the cohesion and maintenance of the mixed flocks of the Submontane Atlantic Rain Forest in the southern region of Brazil. <xref ref-type="bibr" rid="B22">Machado (2002</xref>), in the southeast Atlantic Rain Forest, found not only one or two core species, but a set of species responsible for the cohesion and maintenance of mixed flocks, which he termed the “core-complex.” <xref ref-type="bibr" rid="B13">Ghizoni-Jr. (2009</xref>) also found evidence of this same pattern in a Mixed Ombrophilous Forest, in the southern region of Brazil. Thus, the flocks recorded in this study without the presence of the two nuclear species may have been formed by a core-complex. However, this consideration is not conclusive, because in addition to these flocks being less rich in species, they were less cohesive and remained united for shorter periods of time.</p>
+		</sec>
+		<sec sec-type="conclusions">
+			<title>CONCLUSIONS</title>
+			<p>The composition and richness of species in the bird assemblage within the mixed flocks were recognized by species already recorded in studies carried out in other areas of the Atlantic Rain Forest. However, the presence of migratory species, and the structure of the vegetation, may have influenced the number of recorded species, as most of the vegetation in the study area comprises plant species typical of the early and middle stages of regeneration. The low average species richness and flock size may be related not only to biogeographic factors but also to the successional stage of vegetation in the study area.</p>
+			<p>The variation in the FO, species richness, and size (in the number of individuals) of the flocks throughout the year may be related to the reproductive period and availability of food resources that occur in the southern region of Brazil, depending on the seasonality present at these latitudes.</p>
+			<p><italic>Basileuterus culicivorus</italic> and <italic>H. rubica</italic> behaved as typical nuclear species, a result that was expected due to their behavior, color pattern, and abundance in the Atlantic Rain Forest in southern Brazil. Thus, as suggested by previous studies on mixed flocks, we reinforce the importance of these two species for the cohesion and maintenance of mixed flocks in the Atlantic Rain Forest.</p>
+		</sec>
+	</body>
+	<back>
+		<ack>
+			<title>ACKNOWLEDGMENTS:</title>
+			<p>The authors would like to thank Gustavo Piletti Plucenio, Bento Tadeu Leandro Junior, Gabriel Schmidt Gonzaga, and Cleiton Dias Teixeira for their kind assistance in fieldwork. Thanks are also due to Danrlei de Conto and Eduarda Fraga Olivo for their help in the final edition of the figures, and to Parque Nacional Aparados da Serra’s Administration for permission to carry out the investigation.</p>
+		</ack>
+		<ref-list>
+			<title>REFERENCES</title>
+			<ref id="B1">
+				<mixed-citation>Aleixo, A. 1997. Composition of mixed-species bird flocks and abundance of flocking species in a semideciduous forest of southeastern Brazil. Ararajuba, 5(6): 11-18.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Aleixo</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>1997</year>
+					<article-title>Composition of mixed-species bird flocks and abundance of flocking species in a semideciduous forest of southeastern Brazil</article-title>
+					<source>Ararajuba</source>
+					<volume>5</volume>
+					<issue>6</issue>
+					<fpage>11</fpage>
+					<lpage>18</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B2">
+				<mixed-citation>Aleixo, A. 2001. Conservação da avifauna da Floresta Atlântica: efeitos da fragmentação e a importância de florestas secundárias. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul. p. 199-206.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Aleixo</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2001</year>
+					<chapter-title>Conservação da avifauna da Floresta Atlântica: efeitos da fragmentação e a importância de florestas secundárias</chapter-title>
+					<person-group person-group-type="compiler">
+						<name>
+							<surname>Albuquerque</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Cândido-Jr.</surname>
+							<given-names>J.F.</given-names>
+						</name>
+						<name>
+							<surname>Straube</surname>
+							<given-names>F.C.</given-names>
+						</name>
+						<name>
+							<surname>Roos</surname>
+							<given-names>A.L.</given-names>
+						</name>
+					</person-group>
+					<source>Ornitologia e Conservação: da ciência às estratégias</source>
+					<publisher-loc>Tubarão</publisher-loc>
+					<publisher-name>Ed. Unisul</publisher-name>
+					<fpage>199</fpage>
+					<lpage>206</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B3">
+				<mixed-citation>Alvares, C.A.; Starpe, J.L.; Sentelhas, P.C.; Gonçalves, J.L.M. &amp; Sparovek, G. 2014. Köppen’s climate classification map for Brazil. Meteorologische Zeitschrift, Garmisch-Partenkirchen, 22(6): 711-728. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1127/0941-2948/2013/0507">https://doi.org/10.1127/0941-2948/2013/0507</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Alvares</surname>
+							<given-names>C.A.</given-names>
+						</name>
+						<name>
+							<surname>Starpe</surname>
+							<given-names>J.L.</given-names>
+						</name>
+						<name>
+							<surname>Sentelhas</surname>
+							<given-names>P.C.</given-names>
+						</name>
+						<name>
+							<surname>Gonçalves</surname>
+							<given-names>J.L.M.</given-names>
+						</name>
+						<name>
+							<surname>Sparovek</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<year>2014</year>
+					<article-title>Köppen’s climate classification map for Brazil</article-title>
+					<source>Meteorologische Zeitschrift, Garmisch-Partenkirchen</source>
+					<volume>22</volume>
+					<issue>6</issue>
+					<fpage>711</fpage>
+					<lpage>728</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1127/0941-2948/2013/0507">https://doi.org/10.1127/0941-2948/2013/0507</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B4">
+				<mixed-citation>Alves, M.A.S. &amp; Cavalcanti, R.B. 1996. Sentinel behavior, seasonality, and the structure of bird flocks in Brazilian savanna. Neotropical Ornithology, 7: 43-51.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Alves</surname>
+							<given-names>M.A.S.</given-names>
+						</name>
+						<name>
+							<surname>Cavalcanti</surname>
+							<given-names>R.B.</given-names>
+						</name>
+					</person-group>
+					<year>1996</year>
+					<article-title>Sentinel behavior, seasonality, and the structure of bird flocks in Brazilian savanna</article-title>
+					<source>Neotropical Ornithology</source>
+					<volume>7</volume>
+					<fpage>43</fpage>
+					<lpage>51</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B5">
+				<mixed-citation>Batista, R.O; Machado, C.G. &amp; Miguel, R.S. 2013. Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia. Bioscience Journal, 29(6): 2001-2012.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Batista</surname>
+							<given-names>R.O</given-names>
+						</name>
+						<name>
+							<surname>Machado</surname>
+							<given-names>C.G.</given-names>
+						</name>
+						<name>
+							<surname>Miguel</surname>
+							<given-names>R.S.</given-names>
+						</name>
+					</person-group>
+					<year>2013</year>
+					<article-title>Composition of mixed flocks of birds in an Atlantic Forest fragment in the northern coast of Bahia</article-title>
+					<source>Bioscience Journal</source>
+					<volume>29</volume>
+					<issue>6</issue>
+					<fpage>2001</fpage>
+					<lpage>2012</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B6">
+				<mixed-citation>Brandt, C.S.; Hasenack, H.; Laps, R.R.; &amp; Hartz, S.M. 2009. Composition of mixed-species bird flocks in forest fragments of southern Brazil. Zoologia, Curitiba, 26(3): 488-498. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/s1984-46702009000300013">https://doi.org/10.1590/s1984-46702009000300013</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Brandt</surname>
+							<given-names>C.S.</given-names>
+						</name>
+						<name>
+							<surname>Hasenack</surname>
+							<given-names>H.</given-names>
+						</name>
+						<name>
+							<surname>Laps</surname>
+							<given-names>R.R.</given-names>
+						</name>
+						<name>
+							<surname>Hartz</surname>
+							<given-names>S.M.</given-names>
+						</name>
+					</person-group>
+					<year>2009</year>
+					<article-title>Composition of mixed-species bird flocks in forest fragments of southern Brazil</article-title>
+					<source>Zoologia</source>
+					<publisher-loc>Curitiba</publisher-loc>
+					<volume>26</volume>
+					<issue>3</issue>
+					<fpage>488</fpage>
+					<lpage>498</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/s1984-46702009000300013">https://doi.org/10.1590/s1984-46702009000300013</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B7">
+				<mixed-citation>Cestari, C. 2007. A atração de aves em resposta ao playback de Habia rubica: implicações complementares sobre o papel da espécie para coesão de bandos mistos na Estação Ecológica Juréia-Itatins - SP. Atualidades Ornitológicas, 136: 4-5. Available: <comment>Available: <ext-link ext-link-type="uri" xlink:href="http://www.ao.com.br">http://www.ao.com.br</ext-link>
+					</comment>. Access: 16/08/2021.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Cestari</surname>
+							<given-names>C.</given-names>
+						</name>
+					</person-group>
+					<year>2007</year>
+					<article-title>A atração de aves em resposta ao playback de Habia rubica: implicações complementares sobre o papel da espécie para coesão de bandos mistos na Estação Ecológica Juréia-Itatins - SP</article-title>
+					<source>Atualidades Ornitológicas</source>
+					<volume>136</volume>
+					<fpage>4</fpage>
+					<lpage>5</lpage>
+					<comment>Available: <ext-link ext-link-type="uri" xlink:href="http://www.ao.com.br">http://www.ao.com.br</ext-link>
+					</comment>
+					<date-in-citation content-type="access-date" iso-8601-date="2021-08-16">Access: 16/08/2021</date-in-citation>
+				</element-citation>
+			</ref>
+			<ref id="B8">
+				<mixed-citation>Davis, D.E. 1946. A seasonal analysis of mixed flocks of birds in Brazil. Ecology, 27(2): 168-181.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Davis</surname>
+							<given-names>D.E.</given-names>
+						</name>
+					</person-group>
+					<year>1946</year>
+					<article-title>A seasonal analysis of mixed flocks of birds in Brazil</article-title>
+					<source>Ecology</source>
+					<volume>27</volume>
+					<issue>2</issue>
+					<fpage>168</fpage>
+					<lpage>181</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B9">
+				<mixed-citation>Develey, P.F. 2001. The mixed flocks of birds in the Neotropical forests. In: Albuquerque, J.; Cândido-Jr., J.F.; Straube, F.C. &amp; Roos, A.L. (Org.). Ornitologia e Conservação: da ciência às estratégias. Tubarão, Ed. Unisul . p. 39-48.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Develey</surname>
+							<given-names>P.F.</given-names>
+						</name>
+					</person-group>
+					<year>2001</year>
+					<chapter-title>The mixed flocks of birds in the Neotropical forests</chapter-title>
+					<person-group person-group-type="compiler">
+						<name>
+							<surname>Albuquerque</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Cândido-Jr.</surname>
+							<given-names>J.F.</given-names>
+						</name>
+						<name>
+							<surname>Straube</surname>
+							<given-names>F.C.</given-names>
+						</name>
+						<name>
+							<surname>Roos</surname>
+							<given-names>A.L.</given-names>
+						</name>
+					</person-group>
+					<source>Ornitologia e Conservação: da ciência às estratégias</source>
+					<publisher-loc>Tubarão</publisher-loc>
+					<publisher-name>Ed. Unisul</publisher-name>
+					<fpage>39</fpage>
+					<lpage>48</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B10">
+				<mixed-citation>Develey, P.F. &amp; Peres, C.A. 2000. Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil. Journal of Tropical Ecology, 16(1): 33-53. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/s0266467400001255">https://doi.org/10.1017/s0266467400001255</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Develey</surname>
+							<given-names>P.F.</given-names>
+						</name>
+						<name>
+							<surname>Peres</surname>
+							<given-names>C.A.</given-names>
+						</name>
+					</person-group>
+					<year>2000</year>
+					<article-title>Resource seasonality and the structure of mixed species bird flocks in a coastal Atlantic forest of southeastern Brazil</article-title>
+					<source>Journal of Tropical Ecology</source>
+					<volume>16</volume>
+					<issue>1</issue>
+					<fpage>33</fpage>
+					<lpage>53</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/s0266467400001255">https://doi.org/10.1017/s0266467400001255</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B11">
+				<mixed-citation>Empresa de Pesquisa Agropecuária e Extensão Rural de Santa Catarina (EPAGRI). 2001. Dados e informações biofísicas da unidade de planejamento regional litoral sul Catarinense - UPR 8. Florianópolis, EPAGRI.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<collab>Empresa de Pesquisa Agropecuária e Extensão Rural de Santa Catarina (EPAGRI)</collab>
+					</person-group>
+					<year>2001</year>
+					<source>Dados e informações biofísicas da unidade de planejamento regional litoral sul Catarinense - UPR 8</source>
+					<publisher-loc>Florianópolis</publisher-loc>
+					<publisher-name>EPAGRI</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B12">
+				<mixed-citation>Fitzpatrick, J.W. 1980. Foraging behavior of neotropical tyrant flycatchers. Condor, 82(1): 43-57. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/1366784">https://doi.org/10.2307/1366784</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Fitzpatrick</surname>
+							<given-names>J.W.</given-names>
+						</name>
+					</person-group>
+					<year>1980</year>
+					<article-title>Foraging behavior of neotropical tyrant flycatchers</article-title>
+					<source>Condor</source>
+					<volume>82</volume>
+					<issue>1</issue>
+					<fpage>43</fpage>
+					<lpage>57</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/1366784">https://doi.org/10.2307/1366784</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B13">
+				<mixed-citation>Ghizoni-Jr., I.R. 2009. Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil. Biotemas, 22(3): 143-148. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5007/2175-7925.2009v22n3p143">https://doi.org/10.5007/2175-7925.2009v22n3p143</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ghizoni-Jr.</surname>
+							<given-names>I.R.</given-names>
+						</name>
+					</person-group>
+					<year>2009</year>
+					<article-title>Composição de bandos mistos de aves no Parque Estadual das Araucárias, oeste de Santa Catarina, Brasil</article-title>
+					<source>Biotemas</source>
+					<volume>22</volume>
+					<issue>3</issue>
+					<fpage>143</fpage>
+					<lpage>148</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5007/2175-7925.2009v22n3p143">https://doi.org/10.5007/2175-7925.2009v22n3p143</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B14">
+				<mixed-citation>Ghizoni-Jr., I.R. &amp; Azevedo, M.A.G. 2006. Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil. Biotemas, 19(2): 47-53.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ghizoni-Jr.</surname>
+							<given-names>I.R.</given-names>
+						</name>
+						<name>
+							<surname>Azevedo</surname>
+							<given-names>M.A.G.</given-names>
+						</name>
+					</person-group>
+					<year>2006</year>
+					<article-title>Composição de bandos mistos de aves florestais de sub-bosque em áreas de encosta e planície da Floresta Atlântica de Santa Catarina, sul do Brasil</article-title>
+					<source>Biotemas</source>
+					<volume>19</volume>
+					<issue>2</issue>
+					<fpage>47</fpage>
+					<lpage>53</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B15">
+				<mixed-citation>Hammer, Ø.; Harper, D.A.T. &amp; Ryan, P.D. 2001. Past: paleontological statistics software package for education and data analysis. Palaeontologia Electronica, 4(1): 1-9. Available: <comment>Available: <ext-link ext-link-type="uri" xlink:href="http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html">http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html</ext-link>
+					</comment>. Access: 10/08/2021.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hammer</surname>
+							<given-names>Ø.</given-names>
+						</name>
+						<name>
+							<surname>Harper</surname>
+							<given-names>D.A.T.</given-names>
+						</name>
+						<name>
+							<surname>Ryan</surname>
+							<given-names>P.D.</given-names>
+						</name>
+					</person-group>
+					<year>2001</year>
+					<article-title>Past: paleontological statistics software package for education and data analysis</article-title>
+					<source>Palaeontologia Electronica</source>
+					<volume>4</volume>
+					<issue>1</issue>
+					<fpage>1</fpage>
+					<lpage>9</lpage>
+					<comment>Available: <ext-link ext-link-type="uri" xlink:href="http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html">http://priede.bf.lu.lv/ftp/pub/TIS/datu_analiize/PAST/2.17c/download.html</ext-link>
+					</comment>
+					<date-in-citation content-type="access-date" iso-8601-date="2021-08-10">Access: 10/08/2021</date-in-citation>
+				</element-citation>
+			</ref>
+			<ref id="B16">
+				<mixed-citation>Instituto Brasileiro de Geografia e Estatística (IBGE). 2012. Manual técnico da vegetação brasileira. Rio de Janeiro, IBGE.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<collab>Instituto Brasileiro de Geografia e Estatística (IBGE)</collab>
+					</person-group>
+					<year>2012</year>
+					<source>Manual técnico da vegetação brasileira</source>
+					<publisher-loc>Rio de Janeiro</publisher-loc>
+					<publisher-name>IBGE</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B17">
+				<mixed-citation>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA) &amp; Ministério do Meio Ambiente (MMA). 2004. Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC. Brasília, MMA.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<collab>Instituto Brasileiro do Meio Ambiente e dos Recursos Naturais Renováveis (IBAMA)</collab>
+						<collab>Ministério do Meio Ambiente (MMA)</collab>
+					</person-group>
+					<year>2004</year>
+					<source>Plano de Manejo do Parque Nacional de Aparados da Serra e Serra Geral. Encarte 3 - Contextualização da UC</source>
+					<publisher-loc>Brasília</publisher-loc>
+					<publisher-name>MMA</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B18">
+				<mixed-citation>Kovach, W.L. 2011. Oriana - Circular statistics for windows, ver. 4. Kovach Computing Services, Anglesey, Wales.</mixed-citation>
+				<element-citation publication-type="software">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Kovach</surname>
+							<given-names>W.L.</given-names>
+						</name>
+					</person-group>
+					<year>2011</year>
+					<source>Oriana - Circular statistics for windows, ver. 4</source>
+					<publisher-name>Kovach Computing Services</publisher-name>
+					<publisher-loc>Anglesey, Wales</publisher-loc>
+				</element-citation>
+			</ref>
+			<ref id="B19">
+				<mixed-citation>LaGory, K.E.; LaGory, M.K.; Meyers, D.M. &amp; Herman, S.G. 1984. Niche relationships in wintering mixed-species flocks in western Washington. Wilson Bulletin, 96(1): 108-116.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>LaGory</surname>
+							<given-names>K.E.</given-names>
+						</name>
+						<name>
+							<surname>LaGory</surname>
+							<given-names>M.K.</given-names>
+						</name>
+						<name>
+							<surname>Meyers</surname>
+							<given-names>D.M.</given-names>
+						</name>
+						<name>
+							<surname>Herman</surname>
+							<given-names>S.G.</given-names>
+						</name>
+					</person-group>
+					<year>1984</year>
+					<article-title>Niche relationships in wintering mixed-species flocks in western Washington</article-title>
+					<source>Wilson Bulletin</source>
+					<volume>96</volume>
+					<issue>1</issue>
+					<fpage>108</fpage>
+					<lpage>116</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B20">
+				<mixed-citation>Machado, C.G. 1997. Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro. Ararajuba, 5(1): 62-65.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Machado</surname>
+							<given-names>C.G.</given-names>
+						</name>
+					</person-group>
+					<year>1997</year>
+					<article-title>Vireo olivaceus (Vireonidae): uma espécie migratória nos bandos mistos da Mata Atlântica do sudeste brasileiro</article-title>
+					<source>Ararajuba</source>
+					<volume>5</volume>
+					<issue>1</issue>
+					<fpage>62</fpage>
+					<lpage>65</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B21">
+				<mixed-citation>Machado, C.G. 1999. A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro. Revista Brasileira de Biologia, 59(1): 75-85. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/s0034-71081999000100010">https://doi.org/10.1590/s0034-71081999000100010</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Machado</surname>
+							<given-names>C.G.</given-names>
+						</name>
+					</person-group>
+					<year>1999</year>
+					<article-title>A composição dos bandos mistos de aves na Mata Atlântica da Serra de Paranapiacaba, no sudeste brasileiro</article-title>
+					<source>Revista Brasileira de Biologia</source>
+					<volume>59</volume>
+					<issue>1</issue>
+					<fpage>75</fpage>
+					<lpage>85</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/s0034-71081999000100010">https://doi.org/10.1590/s0034-71081999000100010</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B22">
+				<mixed-citation>Machado, C.G. 2002. As espécies-núcleo dos bandos mistos de aves da Mata Atlântica da serra de Paranapiacaba, no sudeste brasileiro. Sitientibus Série Ciências Biológicas, 2(1/2): 85-90.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Machado</surname>
+							<given-names>C.G.</given-names>
+						</name>
+					</person-group>
+					<year>2002</year>
+					<article-title>As espécies-núcleo dos bandos mistos de aves da Mata Atlântica da serra de Paranapiacaba, no sudeste brasileiro</article-title>
+					<source>Sitientibus Série Ciências Biológicas</source>
+					<volume>2</volume>
+					<issue>1/2</issue>
+					<fpage>85</fpage>
+					<lpage>90</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B23">
+				<mixed-citation>Machado, C.G. &amp; Rodrigues, N.M.R. 2000. Alteração de altura de forrageamento de espécies de aves quando associadas a bandos mistos. In: Alves, M.A.S.; Silva, J.M.C. &amp; Sluys, V.M. (Org.). Ornitologia brasileira: perspectivas, conservação e pesquisa. Rio de Janeiro, Ed. UERJ. p. 231-239.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Machado</surname>
+							<given-names>C.G.</given-names>
+						</name>
+						<name>
+							<surname>Rodrigues</surname>
+							<given-names>N.M.R.</given-names>
+						</name>
+					</person-group>
+					<year>2000</year>
+					<chapter-title>Alteração de altura de forrageamento de espécies de aves quando associadas a bandos mistos</chapter-title>
+					<person-group person-group-type="compiler">
+						<name>
+							<surname>Alves</surname>
+							<given-names>M.A.S.</given-names>
+						</name>
+						<name>
+							<surname>Silva</surname>
+							<given-names>J.M.C.</given-names>
+						</name>
+						<name>
+							<surname>Sluys</surname>
+							<given-names>V.M.</given-names>
+						</name>
+					</person-group>
+					<source>Ornitologia brasileira: perspectivas, conservação e pesquisa</source>
+					<publisher-loc>Rio de Janeiro</publisher-loc>
+					<publisher-name>Ed. UERJ</publisher-name>
+					<fpage>231</fpage>
+					<lpage>239</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B24">
+				<mixed-citation>Maldonado-Coelho, M. &amp; Marini, M.Â. 2003. Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil. Papéis Avulsos de Zoologia, 43(3): 31-54. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/S0031-10492003000300001">https://doi.org/10.1590/S0031-10492003000300001</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Maldonado-Coelho</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Marini</surname>
+							<given-names>M.Â.</given-names>
+						</name>
+					</person-group>
+					<year>2003</year>
+					<article-title>Composição de bandos mistos de aves em fragmentos de Mata Atlântica no sudeste do Brasil</article-title>
+					<source>Papéis Avulsos de Zoologia</source>
+					<volume>43</volume>
+					<issue>3</issue>
+					<fpage>31</fpage>
+					<lpage>54</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/S0031-10492003000300001">https://doi.org/10.1590/S0031-10492003000300001</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B25">
+				<mixed-citation>Maldonado-Coelho, M. &amp; Marini, M.Â. 2004. Mixed-species bird flocks from Brazilian Atlantic forest: the effects of forest fragmentation and seasonality on their size, richness and stability. Biological Conservation, 116(1): 19-26. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/s0006-3207(03)00169-1">https://doi.org/10.1016/s0006-3207(03)00169-1</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Maldonado-Coelho</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Marini</surname>
+							<given-names>M.Â.</given-names>
+						</name>
+					</person-group>
+					<year>2004</year>
+					<article-title>Mixed-species bird flocks from Brazilian Atlantic forest: the effects of forest fragmentation and seasonality on their size, richness and stability</article-title>
+					<source>Biological Conservation</source>
+					<volume>116</volume>
+					<issue>1</issue>
+					<fpage>19</fpage>
+					<lpage>26</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/s0006-3207(03)00169-1">https://doi.org/10.1016/s0006-3207(03)00169-1</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B26">
+				<mixed-citation>Mangini, G.G. &amp; Areta, J.I. 2018. Bird mixed-species flock formation is driven by low temperatures between and within seasons in a Subtropical Andean-foothill forest. Biotropica, 50(5): 816-825. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/btp.12551">https://doi.org/10.1111/btp.12551</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Mangini</surname>
+							<given-names>G.G.</given-names>
+						</name>
+						<name>
+							<surname>Areta</surname>
+							<given-names>J.I.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>Bird mixed-species flock formation is driven by low temperatures between and within seasons in a Subtropical Andean-foothill forest</article-title>
+					<source>Biotropica</source>
+					<volume>50</volume>
+					<issue>5</issue>
+					<fpage>816</fpage>
+					<lpage>825</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/btp.12551">https://doi.org/10.1111/btp.12551</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B27">
+				<mixed-citation>Marini, M.Â. &amp; Garcia, F.I. 2005. Conservação de aves no Brasil. Megadiversidade, 1(1): 95-101.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Marini</surname>
+							<given-names>M.Â.</given-names>
+						</name>
+						<name>
+							<surname>Garcia</surname>
+							<given-names>F.I.</given-names>
+						</name>
+					</person-group>
+					<year>2005</year>
+					<article-title>Conservação de aves no Brasil</article-title>
+					<source>Megadiversidade</source>
+					<volume>1</volume>
+					<issue>1</issue>
+					<fpage>95</fpage>
+					<lpage>101</lpage>
+				</element-citation>
+			</ref>
+			<ref id="B28">
+				<mixed-citation>Merritt, M.; Maldaner, M.E. &amp; de Almeida, A.M.R. 2019. What are biodiversity hotspots? Frontiers for Young Minds, 7: 1-7. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/frym.2019.00029">https://doi.org/10.3389/frym.2019.00029</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Merritt</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Maldaner</surname>
+							<given-names>M.E.</given-names>
+						</name>
+						<name>
+							<surname>de Almeida</surname>
+							<given-names>A.M.R.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>What are biodiversity hotspots?</article-title>
+					<source>Frontiers for Young Minds</source>
+					<volume>7</volume>
+					<fpage>1</fpage>
+					<lpage>7</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/frym.2019.00029">https://doi.org/10.3389/frym.2019.00029</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B29">
+				<mixed-citation>Moynihan, M. 1962. The organization and probable evolution of some mixed species flocks of Neotropical birds. Smithsonian Miscellaneous Collections, 143(7): 1-140. Available: <comment>Available: <ext-link ext-link-type="uri" xlink:href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y">https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y</ext-link>
+					</comment>. Access: 16/08/2021.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Moynihan</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>1962</year>
+					<article-title>The organization and probable evolution of some mixed species flocks of Neotropical birds</article-title>
+					<source>Smithsonian Miscellaneous Collections</source>
+					<volume>143</volume>
+					<issue>7</issue>
+					<fpage>1</fpage>
+					<lpage>140</lpage>
+					<comment>Available: <ext-link ext-link-type="uri" xlink:href="https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y">https://repository.si.edu/bitstream/handle/10088/22974/SMC_143_Moynihan_1-140.pdf?sequence=1&amp;isAllowed=y</ext-link>
+					</comment>
+					<date-in-citation content-type="access-date" iso-8601-date="2021-08-16">Access: 16/08/2021</date-in-citation>
+				</element-citation>
+			</ref>
+			<ref id="B30">
+				<mixed-citation>Myers, N.; Mittermeier, R.A.; Mittermeier, C.G.; da Fonseca, G.A.B. &amp; Kent, J. 2000. Biodiversity hotspots for conservation priorities. Nature, 403(6772): 853-858. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1038/35002501">https://doi.org/10.1038/35002501</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Myers</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name>
+							<surname>Mittermeier</surname>
+							<given-names>R.A.</given-names>
+						</name>
+						<name>
+							<surname>Mittermeier</surname>
+							<given-names>C.G.</given-names>
+						</name>
+						<name>
+							<surname>da Fonseca</surname>
+							<given-names>G.A.B.</given-names>
+						</name>
+						<name>
+							<surname>Kent</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2000</year>
+					<article-title>Biodiversity hotspots for conservation priorities</article-title>
+					<source>Nature</source>
+					<volume>403</volume>
+					<issue>6772</issue>
+					<fpage>853</fpage>
+					<lpage>858</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1038/35002501">https://doi.org/10.1038/35002501</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B31">
+				<mixed-citation>Pacheco, J.F.; Silveira, L.F.; Aleixo, A.; Agne, C.E.; Bencke, G.A.; Bravo, G.A; Brito, G.R.R.; Cohn-Haft, M.; Maurício, G.N.; Naka, L.N.; Olmos, F.; Posso, S.; Lees, A.C.; Figueiredo, L.F.A.; Carrano, E.; Guedes, R.C.; Cesari, E.; Franz, I.; Schunck, F. &amp; Piacentini, V.Q. 2021. Annotated checklist of the birds of Brazil by the Brazilian Ornithological Records Committee - second edition. Ornithology Research, 29(2): 94-105. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s43388-021-00058-x">https://doi.org/10.1007/s43388-021-00058-x</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Pacheco</surname>
+							<given-names>J.F.</given-names>
+						</name>
+						<name>
+							<surname>Silveira</surname>
+							<given-names>L.F.</given-names>
+						</name>
+						<name>
+							<surname>Aleixo</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Agne</surname>
+							<given-names>C.E.</given-names>
+						</name>
+						<name>
+							<surname>Bencke</surname>
+							<given-names>G.A.</given-names>
+						</name>
+						<name>
+							<surname>Bravo</surname>
+							<given-names>G.A</given-names>
+						</name>
+						<name>
+							<surname>Brito</surname>
+							<given-names>G.R.R.</given-names>
+						</name>
+						<name>
+							<surname>Cohn-Haft</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Maurício</surname>
+							<given-names>G.N.</given-names>
+						</name>
+						<name>
+							<surname>Naka</surname>
+							<given-names>L.N.</given-names>
+						</name>
+						<name>
+							<surname>Olmos</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name>
+							<surname>Posso</surname>
+							<given-names>S.</given-names>
+						</name>
+						<name>
+							<surname>Lees</surname>
+							<given-names>A.C.</given-names>
+						</name>
+						<name>
+							<surname>Figueiredo</surname>
+							<given-names>L.F.A.</given-names>
+						</name>
+						<name>
+							<surname>Carrano</surname>
+							<given-names>E.</given-names>
+						</name>
+						<name>
+							<surname>Guedes</surname>
+							<given-names>R.C.</given-names>
+						</name>
+						<name>
+							<surname>Cesari</surname>
+							<given-names>E.</given-names>
+						</name>
+						<name>
+							<surname>Franz</surname>
+							<given-names>I.</given-names>
+						</name>
+						<name>
+							<surname>Schunck</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name>
+							<surname>Piacentini</surname>
+							<given-names>V.Q.</given-names>
+						</name>
+					</person-group>
+					<year>2021</year>
+					<article-title>Annotated checklist of the birds of Brazil by the Brazilian Ornithological Records Committee - second edition</article-title>
+					<source>Ornithology Research</source>
+					<volume>29</volume>
+					<issue>2</issue>
+					<fpage>94</fpage>
+					<lpage>105</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s43388-021-00058-x">https://doi.org/10.1007/s43388-021-00058-x</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B32">
+				<mixed-citation>Powell, G.V.N. 1985. Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics. Ornithological Monographs, 36: 713-732. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/40168313">https://doi.org/10.2307/40168313</ext-link>.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Powell</surname>
+							<given-names>G.V.N.</given-names>
+						</name>
+					</person-group>
+					<year>1985</year>
+					<article-title>Sociobiology and adaptive significance of interspecific foraging flocks in the Neotropics</article-title>
+					<source>Ornithological Monographs</source>
+					<volume>36</volume>
+					<fpage>713</fpage>
+					<lpage>732</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/40168313">https://doi.org/10.2307/40168313</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B33">
+				<mixed-citation>Sick, H. 1997. Ornitologia brasileira. Rio de Janeiro, Nova Fronteira.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sick</surname>
+							<given-names>H.</given-names>
+						</name>
+					</person-group>
+					<year>1997</year>
+					<source>Ornitologia brasileira</source>
+					<publisher-loc>Rio de Janeiro</publisher-loc>
+					<publisher-name>Nova Fronteira</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B34">
+				<mixed-citation>Stotz, D.F. 1993. Geographic variation in species composition of mixed species flocks in lowland humid forest in Brazil. Papéis Avulsos de Zoologia, 38(4): 61-75.</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Stotz</surname>
+							<given-names>D.F.</given-names>
+						</name>
+					</person-group>
+					<year>1993</year>
+					<article-title>Geographic variation in species composition of mixed species flocks in lowland humid forest in Brazil</article-title>
+					<source>Papéis Avulsos de Zoologia</source>
+					<volume>38</volume>
+					<issue>4</issue>
+					<fpage>61</fpage>
+					<lpage>75</lpage>
+				</element-citation>
+			</ref>
+		</ref-list>
+		<fn-group>
+			<fn fn-type="financial-disclosure" id="fn4">
+				<label><bold>FUNDING INFORMATION:</bold></label>
+				<p> The first author is grateful to Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES) - Finance Code 001, for the Master’s degree scholarship to support this research project. </p>
+			</fn>
+		</fn-group>
+	</back>
+</article>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
@@ -1,0 +1,1973 @@
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css">
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css" media="print">
+<link rel="alternate" type="application/rss+xml" title="SciELO" href="">
+</head>
+<body class="journal article">
+<a name="top"></a><div id="standalonearticle">
+<section class="articleCtt"><div class="container"><div class="articleTxt">
+<div class="articleBadge-editionMeta-doi-copyLink">
+<span class="_articleBadge">Theoretical-empirical Article</span><span class="_separator"> • </span><span class="_editionMeta">Rev. adm. contemp. 26 
+                (06)
+            <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.1590/1982-7849rac2022190379.en" class="_doi" target="_blank">https://doi.org/10.1590/1982-7849rac2022190379.en</a>
+         
+        <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/1982-7849rac2022190379.en"><span class="sci-ico-link"></span>copy</a></span>
+</div>
+<h1 class="article-title">
+<span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Analysis of Scales and Measures of Moral Virtues: A Systematic Review<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+</h1>
+<div class="articleMeta"></div>
+<div class="contribGroup">
+<span class="dropdown"><a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Maria Clara F. Dalla Costa Ames </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.<div class="corresp">
+					* Corresponding Author</div>
+<a href="http://orcid.org/0000-0002-0444-8764" class="btnContribLinks orcid">http://orcid.org/0000-0002-0444-8764</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Mauricio C. Serafim </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.<a href="http://orcid.org/0000-0002-4852-5119" class="btnContribLinks orcid">http://orcid.org/0000-0002-4852-5119</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Felipe Flôres Martins </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.<a href="http://orcid.org/0000-0003-2987-5479" class="btnContribLinks orcid">http://orcid.org/0000-0003-2987-5479</a>
+</ul></span><a href="" class="outlineFadeLink" data-toggle="modal" data-target="#ModalTutors">About the authors</a>
+</div>
+<div class="row">
+<ul class="col-md-2 hidden-sm articleMenu"></ul>
+<article id="articleText" class="col-md-10 col-md-offset-2 col-sm-12 col-sm-offset-0"><div class="articleSection" data-anchor="ABSTRACT">
+<h1 class="articleSectionTitle">ABSTRACT</h1>
+<h2>Objective:</h2>
+<p> to investigate how scales for the concept of moral virtues are constructed and measured, in studies associated with business ethics and the tradition of virtue ethics. </p>
+<h2>Methods:</h2>
+<p> a systematic literature review was conducted to select empirical articles on moral virtues that design or apply scales. Based on search, selection, and analysis criteria, five databases were consulted, and 37 papers were selected, with subsequent analysis of the scales development and measurement procedure (items, sample, factor analysis) and emerging factors. </p>
+<h2>Results:</h2>
+<p> the study gathers scales of multiple moral virtues (19) and of specific virtues (18), showing limitations in the generation of items, and in the item-sample proportion in some scales, as well as theoretical contributions in leadership and relationship strengthening, making a theoretical and methodological discussion in the light of the assumptions of virtue ethics in the Aristotelian-Thomistic tradition. </p>
+<h2>Conclusions:</h2>
+<p> the article intends to contribute to a better understanding of moral virtues in management, by discussing the scales from the unity of virtues and the phronesis-moral virtues connection, with implications for human behavior and business ethics. Procedures are recommended for future qualitative and quantitative studies in new research contexts.</p>
+<p><strong>Keywords:</strong><br>moral virtues; scale analysis; virtue ethics; business ethics</p>
+</div>
+<div class="articleSection" data-anchor="RESUMO">
+<h1 class="articleSectionTitle">RESUMO</h1>
+<h2>Objetivo:</h2>
+<p> investigar como as escalas para o conceito de virtudes morais são construídas e mensuradas, em estudos associados à ética empresarial e à tradição da ética das virtudes. </p>
+<h2>Métodos:</h2>
+<p> realizou-se uma revisão sistemática da literatura para selecionar artigos empíricos sobre virtudes morais que elaboram ou aplicam escalas. Com base em critérios de busca, seleção e análise, foram consultadas cinco bases de dados e selecionados 37 trabalhos, analisando-se o procedimento de desenvolvimento e mensuração de escalas (itens, amostra, análise fatorial) e fatores emergentes. </p>
+<h2>Resultados:</h2>
+<p> o estudo reúne escalas de múltiplas virtudes morais (19) e de virtudes específicas (18), evidenciando limitações na geração de itens e na proporção item-amostra em algumas escalas, como também contribuições teóricas em liderança e fortalecimento de relações, fazendo uma discussão teórico-metodológica, à luz dos pressupostos da ética das virtudes na tradição aristotélico-tomista. </p>
+<h2>Conclusões:</h2>
+<p> o artigo intenciona contribuir para uma melhor compreensão sobre as virtudes morais em administração, ao discutir as escalas a partir da unidade das virtudes e da conexão <i>phronesis</i>-virtudes morais, com implicações no comportamento humano e na ética empresarial. Recomendam-se procedimentos para estudos futuros qualitativos e quantitativos em novos contextos de pesquisa.</p>
+<p><strong>Palavras-chave:</strong><br>virtudes morais; análise de escalas; ética das virtudes; ética empresarial</p>
+</div>
+<div class="articleSection" data-anchor="Text">
+<h1 class="articleSectionTitle">INTRODUCTION</h1>
+<p>Virtue ethics has proved to be an influential tradition in business ethics studies in recent years (<span class="ref"><strong class="xref xrefblue">Alzola, Hennig, &amp; Romar, 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>). The interest in the topic has intensified since authors of moral philosophy such as <span class="ref"><strong class="xref xrefblue">Anscombe (1958</strong><span class="refCtt closed"><span>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				</span><br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">https://doi.org/10.1017/S003181910003794...
+            </a></span></span>) and MacIntyre (2007) reinterpreted <span class="ref"><strong class="xref xrefblue">Aristotle (2009</strong><span class="refCtt closed"><span>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</span></span></span>). The ethical problems of organizational reality have been discussed based on different perspectives and traditions related to virtues (<span class="ref"><strong class="xref xrefblue">Sison, Ferrero, &amp; Guitián, 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>). Such perspectives and traditions are alternatives to consequentialists and deontological ethics, and empirical and quantitative studies have been a prominent theme in the field since the turn of the millennium (Sison &amp; Ferrero, 2015).</p>
+<p>Empirical and quantitative studies have elaborated scales and measures based on the lists of moral virtues by <span class="ref"><strong class="xref xrefblue">Solomon (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>; 1999) and <span class="ref"><strong class="xref xrefblue">Murphy (1999</strong><span class="refCtt closed"><span>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				</span><br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">https://doi.org/10.1023/A:1006072413165...
+            </a></span></span>). Such studies aim to identify and measure moral virtues in administration and business. However, the use of certain scientific methods from social sciences to address moral virtues - a philosophical concept valued in many cultures - has been criticized (<span class="ref"><strong class="xref xrefblue">Beadle, Sison, &amp; Fontrodona, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). These methods may reduce the elements and assumptions to mere observable behaviors, hindering a better understanding of virtues (Sison &amp; Ferrero, 2015; <span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). This process has reinforced the need for a solid theoretical basis on the moral virtues construct, considering its multidimensionality (<span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker, Hyman, &amp; Shanahan, 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>).</p>
+<p>Another concept that has been developed in addition to individual moral virtues refers to organizational moral virtues, or virtuousness (<span class="ref"><strong class="xref xrefblue">Huhtala, Kangas, Kaptein, &amp; Feldt, 2018</strong><span class="refCtt closed"><span>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				</span><br><a href="https://doi.org/10.1111/beer.12184" target="_blank">https://doi.org/10.1111/beer.12184...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Gomide, Vieira, &amp; Oliveira, 2016</strong><span class="refCtt closed"><span>Gomide, S. Jr., Vieira, L. E., &amp; Oliveira, A. F. (2016). Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro. Psicologia: Organizações e Trabalho, 16(3), 298-307. http://dx.doi.org/10.17652/rpot/2016.3.10417
+				</span><br><a href="http://dx.doi.org/10.17652/rpot/2016.3.10417" target="_blank">http://dx.doi.org/10.17652/rpot/2016.3.1...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Rego &amp; Cunha, 2015</strong><span class="refCtt closed"><span>Rego, A., &amp; Cunha, M. P. (2015). As virtudes nas organizações. Análise Psicológica, 4(33), 349-359. https://doi.org/10.14417/ap.1022
+				</span><br><a href="https://doi.org/10.14417/ap.1022" target="_blank">https://doi.org/10.14417/ap.1022...
+            </a></span></span>). Despite their strict relationship, the concepts of moral virtue and virtuousness are not identical: the first refers to the individual, while the second to the organization, to what can be externally verified (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Thus, there are moral virtues scales at the individual level, and virtuousness scales at the group and organizational levels, such as those revisited by <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>) and <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker, Hyman e Shanahan (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). This article is limited to investigating moral virtues scales at an individual level - characteristics of a single individual - leaving the virtuousness scales for future research.</p>
+<p>The topic has different theoretical traditions (<span class="ref"><strong class="xref xrefblue">Sison et al., 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>) and extensive lists of virtues. Although the conception of virtues encompasses components or dimensions (<span class="ref"><strong class="xref xrefblue">Newstead, Macklin, Dawkins, &amp; Martin, 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>), empirical research has been restricted to observable traits or behaviors, revealing a methodological impasse in the relationship between the virtue ethics, originating in moral philosophy, and the experimental sciences, with certain ramifications in psychology. Given the development of new scales on virtues, this research seeks to answer the following question: ‘How are the scales for the moral virtues construct elaborated and measured in studies related to virtue ethics?’ This article seeks to analyze the scales and measures of the individual (personal) moral virtues construct, based on a systematic literature review (<span class="ref"><strong class="xref xrefblue">Snyder, 2019</strong><span class="refCtt closed"><span>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">https://doi.org/10.1016/j.jbusres.2019.0...
+            </a></span></span>).</p>
+<p>This study builds on two previous research works. One of them is the study by <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al. (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) who address challenges, possibilities, and best practices for the development of scales, describing scales, items, and psychometric aspects. The other is <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>), who lists individual, group, and organizational moral virtues scales.</p>
+<p>The intention is to continue these works offering a systematic review of articles that develop or apply scales based on the Preferred Reporting Items for Systematic Reviews and Meta-Analyses (PRISMA) by <span class="ref"><strong class="xref xrefblue">Moher, Liberati, Tetslaff and Altman (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>). Also, we conduct a statistical analysis following the recommendations by <span class="ref"><strong class="xref xrefblue">Fávero, Belfiore, Silva and Chan (2009</strong><span class="refCtt closed"><span>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</span></span></span>), <span class="ref"><strong class="xref xrefblue">Hair, Babin, Money and Samouel (2005</strong><span class="refCtt closed"><span>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</span></span></span>) and Hair, Black, Babin, Anderson and Tathan (2009).</p>
+<p>Finally, this study seeks to contribute to the analysis of methods used to elaborate and apply moral virtues scales, given the methodological impasse for empirical research on virtue ethics. The analysis is conducted through a methodological and theoretical discussion, considering Aristotelian-Thomistic assumptions of virtue ethics (<span class="ref"><strong class="xref xrefblue">Sison, Beabout, &amp; Ferrero, 2017</strong><span class="refCtt closed"><span>Sison, A. J. G., Beabout, G. R., &amp; Ferrero, I. (Eds.). (2017). Handbook of virtue ethics in business and management. Dordrecht, the Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>).</p>
+<p>After this introduction, the second section below presents the concept of moral virtues, considering assumptions of virtue ethics and perspectives seeking to measure virtues. The subsequent section describes the methodological procedures and the analysis criteria adopted in this systematic review, followed by the fourth section presenting the results and discussions about measures and scales found in the literature, analyzing methods and theoretical assumptions. Lastly, we offer suggestions for future studies and present the final considerations, including the research limitations and conclusions.</p>
+<h1 class="articleSectionTitle">MORAL VIRTUES ACCORDING TO THE TRADITION OF VIRTUES ETHICS IN BUSINESS ETHICS</h1>
+<p>The work of authors such as Elizabeth <span class="ref"><strong class="xref xrefblue">Anscombe (1958</strong><span class="refCtt closed"><span>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				</span><br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">https://doi.org/10.1017/S003181910003794...
+            </a></span></span>), Philippa <span class="ref"><strong class="xref xrefblue">Foot (1967</strong><span class="refCtt closed"><span>Foot, P. (1967). The problem of abortion and the doctrine of double effect. Oxford Reviews, 5, 5-15. Retrieved from https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf
+				</span><br><a href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf" target="_blank">https://spot.colorado.edu/~heathwoo/phil...
+            </a></span></span>), and Alasdair MacIntyre (2007), who return to Aristotelian and Thomistic concepts, were responsible for the resumption or reinterpretation of moral virtues in philosophy, psychology, education, and business ethics. Virtue ethics has been developed through both Western and Eastern perspectives (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>), that unfolded from moral traditions related to organizations’ ethical issues and different functions of Administration (<span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). </p>
+<p>The interest in virtue ethics has been observed in conferences, thematic symposia and special calls for paper (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beadle et al., 2015</strong><span class="refCtt closed"><span>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				</span><br><a href="https://doi.org/10.1111/beer.12098" target="_blank">https://doi.org/10.1111/beer.12098...
+            </a></span></span>; Hühn, Habisch, <span class="ref"><strong class="xref xrefblue">Hartmann, &amp; Sison, 2020</strong><span class="refCtt closed"><span>Hühn, M. P., Habish, A., Hartmann, E. M., &amp; Sison, A. J. G. (2020). Practicing management wisely. Business Ethics: A European Review, 29(S1), 1-5. https://doi.org/10.1111/beer.12321
+				</span><br><a href="https://doi.org/10.1111/beer.12321" target="_blank">https://doi.org/10.1111/beer.12321...
+            </a></span></span>), handbooks on virtue ethics in administration (Sison et al., 2017), book publishing (Hartmann, 2020; <span class="ref"><strong class="xref xrefblue">Moore, 2017</strong><span class="refCtt closed"><span>Moore, G. (2017). Virtue at work: Ethics for individuals, managers, and organizations. Oxford, UK: Oxford University Press.</span></span></span>; Sison et al., 2018) and by the emergence of new research groups, such as Virtue Ethics in Business (VEiB), from University of Navarre. Also, scientific journals such as the Journal of Business Ethics, the Business Ethics Quarterly, and Business Ethics: Environment and Responsibility bring together many issues that address virtue ethics.</p>
+<p>Studies on virtues can be linked to two distinct perspectives: virtue theory and virtue ethics (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Virtue theory refers to studies on virtues within the deontological and consequentialist models. In contrast, virtue ethics is adopted as a third perspective in moral philosophy to represent studies focused on character and anchored in the three elements <i>arête</i> (virtue or excellence), <i>phronesis</i> (prudence or practical wisdom), and <i>eudaimonia</i> (human flourishing). While the deontological and consequentialist perspectives refer to the action, virtue ethics focuses on the agent, considering particularities of the context regarding community life (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>).</p>
+<p>
+				<span class="ref"><strong class="xref xrefblue">Solomon (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>) and <span class="ref"><strong class="xref xrefblue">Moberg (1999</strong><span class="refCtt closed"><span>Moberg, D. J. (1999). The big five and organizational virtue. Business Ethics Quarterly, 9(2), 245-272. https://doi.org/10.2307/3857474
+				</span><br><a href="https://doi.org/10.2307/3857474" target="_blank">https://doi.org/10.2307/3857474...
+            </a></span></span>) were pioneers in considering virtue ethics in business ethics. Solomon (1992) attempted to address the gap between ethics and business practices through an Aristotle-based perspective (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>), with the idea that people and corporations are part of the community. Moberg (1999) explored the connection between virtue ethics and personality psychology, paving the way for empirical research on virtue ethics in business ethics.</p>
+<p>Moral virtues are usually described as character dispositions that indicate the correct ends of actions, while prudence or practical wisdom (phronesis) is the virtue responsible for indicating the means to achieve such ends (<span class="ref"><strong class="xref xrefblue">Ames &amp; Serafim, 2019</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., &amp; Serafim, M. C. (2019). Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review. Revista de Administração Contemporânea, 23(4), 564-586. https://doi.org/10.1590/1982-7849rac2019180301
+				</span><br><a href="https://doi.org/10.1590/1982-7849rac2019180301" target="_blank">https://doi.org/10.1590/1982-7849rac2019...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Aristotle, 2009</strong><span class="refCtt closed"><span>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). The moment virtuous actions, such as courage and humility, are repeated, they turn into habits, and, in the long run, these habits determine their character. The virtuous agent expresses virtues in their actions, and therefore their actions and personal traits can serve as a reference for others (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). Such actions result from a will or intention with an end (or <i>telos</i>), seeking to achieve <i>eudaimonia</i>. The human being improves themselves and their future practices by performing virtuous actions. Thus, “the core of virtue ethics is the causal relationship it establishes between what the agent does and what the agent becomes through the acquisition of virtues and the development of character” (Ferrero, 2020, p. 11).</p>
+<p>Among the main traditions of virtue ethics, the neo-Aristotelian tradition, the Thomist school, and the contributions of MacIntyre (2007), who delve into the ethics of Aristotle and Thomas Aquinas (<span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>), stand out. Recent studies share the notion of cardinal virtues - hinges of virtues - inherited from these traditions (<span class="ref"><strong class="xref xrefblue">Morales-Sánchez &amp; Cabello-Medina, 2013</strong><span class="refCtt closed"><span>Morales-Sánchez, R., &amp; Cabello-Medina, C. (2013). The role of four moral competencies in Ethical Decision-making. Journal of Business Ethics, 116(4), 717-734. https://doi.org/10.1007/s10551-013-1817-9
+				</span><br><a href="https://doi.org/10.1007/s10551-013-1817-9" target="_blank">https://doi.org/10.1007/s10551-013-1817-...
+            </a></span></span>). There are four cardinal virtues: (1) temperance, also known as self-control or moderation (<span class="ref"><strong class="xref xrefblue">Sanz &amp; Fontrodona, 2019</strong><span class="refCtt closed"><span>Sanz, P., &amp; Fontrodona, J. (2019). Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace. Journal of Business Ethics, 155, 981-994. https://doi.org/10.1007/s10551-018-3899-x
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3899-x" target="_blank">https://doi.org/10.1007/s10551-018-3899-...
+            </a></span></span>); (2) fortitude; (3) justice (Morales-Sánchez &amp; Cabello-Medina, 2013); and (4) prudence or practical wisdom; originally from the Greek term <i>phronesis</i> (<span class="ref"><strong class="xref xrefblue">Ames, Serafim, &amp; Zappellini, 2020</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				</span><br><a href="https://doi.org/10.1111/beer.12296" target="_blank">https://doi.org/10.1111/beer.12296...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Bachmann, Habisch, &amp; Dierksmeier, 2017</strong><span class="refCtt closed"><span>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">https://doi.org/10.1007/s10551-016-3417-...
+            </a></span></span>). Such traditions consider that virtues can be learned, especially through lived experience (Aristotle, 2009).</p>
+<p>Assuming that other agents can perceive someone’s virtuous action, studies that use scales seek to measure the perception of moral virtues about the action of colleagues, leaders, and managers in general. <span class="ref"><strong class="xref xrefblue">Solomon's (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>; 1999) list of virtues contributed in this regard. Its framework considers six dimensions: community, excellence, role identity, integrity, judgment, and holism. The author suggests a list of virtues related to business - such as honesty, loyalty, courage, trustworthiness, benevolence, cooperation, civility - which underpin <span class="ref"><strong class="xref xrefblue">Shanahan and Hyman's (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>). moral virtues scale. However, the extent to which a set of virtues can be associated with administration and business is discussed without considering the context and the administrators’ own perception about the virtues to be cultivated (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>).</p>
+<p>In addition to this empirical problem, positive psychology and positive organizational scholarship (POS) limit the definition of virtues in terms of behavior and based on aspects external to the individual (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al., 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). According to <span class="ref"><strong class="xref xrefblue">Sison and Ferrero (2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>) virtues cannot be reduced to the cognitive and emotional aspects of character, as they encompass other fundamental elements and assumptions, such as the interrelationship between actions, habits, character, and life trajectory. This context suggests that human nature has an end (<i>telos</i>), which is happiness (<i>eudaimonia</i>) or human flourishing.</p>
+<p>There is no unanimous concept of virtue, given the contributions of different traditions and fields of knowledge. Notwithstanding, it tends to be considered “the human inclination to feel, think, and act in ways that express moral excellence and contribute to the common good.” (<span class="ref"><strong class="xref xrefblue">Newstead et al., 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>, p. 446). According to <span class="ref"><strong class="xref xrefblue">Alzola (2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>), the “virtues are traits of character” whose intellectual, emotional, motivational and behavioral components “cannot be reduced to any of the others,” (Alzola, 2015, p. 306), which is something similar to the multi-components perceived by <span class="ref"><strong class="xref xrefblue">Morgan, Gulliford and Kristjánsson (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>). In virtue ethics, they are understood as personal inclinations or dispositions expressed by a range of other dispositions such as actions, habits, character, and lifestyle (way of living), with a view to the common good (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Therefore, it has been admitted that the behavioral manifestation of action is not enough to infer the presence of virtue (Alzola, 2015; <span class="ref"><strong class="xref xrefblue">Robson, 2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>).</p>
+<p>
+				<span class="ref"><strong class="xref xrefblue">Newstead, Macklin, Dawkins and Martin (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) develop the concept of virtue (inclination toward good). The authors present the notion of virtues and virtuous, which represent the perception of a virtuous event, understood as a subjective experience, an interpretation an agent does about a virtue someone expresses (virtues) in an event/moment.</p>
+<p>As observed in this section, the framework of virtue ethics brings together theoretical elements and fundamental assumptions. Among its elements are: the human agent and its nature, reiterated moral actions and habits that shape its character, the practice of moral virtues, coordinated by practical wisdom or prudence, an ultimate end aimed at human flourishing or eudaimonia, in a community context in which one contributes to the common good. As for the assumptions, two of them are worth highlighting, related to (1) the connection or interdependence between the virtue of phronesis and the moral virtues - for example, prudence in decision-making implies that temperance will manage the impulses that would affect such a decision, like anger or impatience; and, (2) the unity of the virtues: in the agent, the virtues are linked to each other - that is, there is no isolated virtue - which means that if a person has one virtue, this same person also has the others (<span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>).</p>
+<h2>Perspectives that seek to measure moral virtues</h2>
+<p>In administration, studies of virtue ethics have formed a line of research that adopts quantitative and statistical methods to measure virtues and their positive impacts on organizations (<span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). Such a line of research is inserted in positive psychology and is called Positive Organizational Scholarship (POS) (<span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>; Sison &amp; Ferrero, 2015). It is divided into two perspectives that seek to measure virtues: (1) one linked to the positive psychology of <span class="ref"><strong class="xref xrefblue">Peterson and Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) adopting an individual-level approach and corresponding to a positive movement in social sciences (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>); and (2) studies that assume the concept of virtuousness to access virtues at an organizational level (Meyer, 2018; <span class="ref"><strong class="xref xrefblue">Huhtala et al., 2018</strong><span class="refCtt closed"><span>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				</span><br><a href="https://doi.org/10.1111/beer.12184" target="_blank">https://doi.org/10.1111/beer.12184...
+            </a></span></span>).</p>
+<p>These two lines of research aim to measure virtues, adopting methods and assumptions that are different from those shared by the Aristotelian-Thomist tradition of virtue ethics (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>).</p>
+<p>The first is linked to positive psychology and considers character strengths as individuals’ positive traits. <span class="ref"><strong class="xref xrefblue">Peterson and Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) model was developed from reading classic texts from different cultures. The documents were reviewed by a research group that inductively brought together the human characteristics that lead to flourishing. There are differences between the concept of virtues and strengths of character (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). The VIA model - virtues in action - is composed of six main characteristics (virtues) and 24 strengths. However, this model has been methodologically and philosophically questioned. It does not assume the unity of virtues (<span class="ref"><strong class="xref xrefblue">Robson, 2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>). <span class="ref"><strong class="xref xrefblue">Kinghorn (2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>) explained how the model was built and argued that the cultural context is crucial to indicate if the model is valid or universal. It embraces the values of a modern democratic society that privileges the individuals’ self-determination, rights, and liberties (Kinghorn, 2017). For the author, there is no way for a set of virtues to transcend the particular political community in which they were conceived, which implies that the particular context matters and future instruments should consider the culture of the analyzed context and community.</p>
+<p>The second line of research is positive organizational studies (POS), which adopts the concept of virtuousness that is not identical to the notion of virtue (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Virtuousness is manifested in structures, processes, attributes, and cultures and in individual and collective action and is expressed in and through organizations (<span class="ref"><strong class="xref xrefblue">Cameron, Bright, &amp; Caza, 2004</strong><span class="refCtt closed"><span>Cameron, K., Bright, D., &amp; Caza, A. (2004). Exploring the relationships between organizational virtuousness and performance. American Behavioral Scientist, 47(6), 1-14. https://doi.org/10.1177/0002764203260209
+				</span><br><a href="https://doi.org/10.1177/0002764203260209" target="_blank">https://doi.org/10.1177/0002764203260209...
+            </a></span></span>; Sison &amp; Ferrero, 2015). It is understood as an aspect that contributes to organizational performance, which can be used instrumentally to achieve good indicators of commitment, satisfaction, and social capital (Sison &amp; Ferrero, 2015). In this approach, the concept of virtuousness is examined predominantly by quantitative methods and at an organizational level (<span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). Furthermore, this line of research does not address the role of phronesis in its framework for understanding organizations’ virtuousness (Sison &amp; Ferrero, 2015). </p>
+<p>
+					<span class="ref"><strong class="xref xrefblue">Sison and Ferrero (2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>) also refer to conceptual differences. The authors claim that the assumptions about human nature, the ultimate end, <i>phronesis</i> and <i>eudaimonia</i> underlying virtuousness are very different from virtue ethics and the locus of achievement. Virtues are found in people and only by analogy are associated with concepts such as corporate character. On the other hand, virtuousness refers to organizations primarily and only secondarily to individuals (<span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). </p>
+<p>Among critics of virtue ethics, <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al. (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) state that situationist criticism does not recognize the need to know internal factors inherent to behavior. In contrast, <span class="ref"><strong class="xref xrefblue">Alzola (2017</strong><span class="refCtt closed"><span>Alzola, M. (2017). Virtues and their explanatory and predictive power in the workplace. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) argues that moral virtues can help understand individuals’ actions. Despite the diversity and empirical challenges, adaptations for different contexts and cultures are still needed (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). Moreover, after all, can virtues be measured? There is no consensus on this issue. <span class="ref"><strong class="xref xrefblue">Robson (2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>) argues that positive psychology is able to measure personality traits and behavior tendencies, but it is not able to coordinate virtues because it cannot propose a substantive architecture to support a virtues approach based on a tradition, like virtue ethics.</p>
+<h1 class="articleSectionTitle">METHODOLOGICAL PROCEDURES</h1>
+<p>This section presents the systematic review and the procedures used to synthesize and compare evidence (Mendes-da-Silva, 2019; <span class="ref"><strong class="xref xrefblue">Snyder, 2019</strong><span class="refCtt closed"><span>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">https://doi.org/10.1016/j.jbusres.2019.0...
+            </a></span></span>). The steps carried out and the criteria and method adopted to search and select studies are described below, together with the procedures adopted in the methodological-theoretical analysis and the presentation of results. The study was conducted after formulating a central research question (Mendes-da-Silva, 2019), and the main elements and eligibility criteria adopted sought replicable and transparent procedures (<span class="ref"><strong class="xref xrefblue">Moher, Liberati, Tetslaff, &amp; Altman, 2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>). The eligibility criteria are:</p>
+<div>
+				<ol type="1">
+<li><p>Type of study: empirical research that develops or applies moral virtues scales and measures at an individual level - this being the selection criterion;</p></li>
+<li><p>Exclusion criteria: (a) research from other areas, such as medical and legal; (b) works that do not directly address virtues; (c) theoretical or empirical studies that do not address the construct through scales; (d) empirical research that develops or applies virtues scales at an organizational level (virtuousness);</p></li>
+<li><p>Topic: the process of identifying and selecting the articles is conducted by reading the titles, abstracts, keywords, and the name of the journal;</p></li>
+<li><p>Research design: empirical studies that report the development, application, and results obtained using virtues scales at the individual level;</p></li>
+<li><p>Period researched: The study did not define a specific period;</p></li>
+<li><p>Language: the review considered articles in Portuguese, English, and Spanish;</p></li>
+<li><p>Publication status: peer-reviewed scientific articles;</p></li>
+<li><p>Search criteria: consulting electronic databases and including studies cited in the selected articles (if they were not already part of the sample). The first stage took place in June 2017, and updates were carried out in 2018 and February 2021. The search was carried out in five databases: <i>EBSCOhost, Science Direct, Scopus, Web of Science</i> and <i>Wiley</i>.</p></li>
+</ol>
+			</div>
+<p>Five different queries consisting of two terms were used to expand the scope of the searches. The first term referred to scales and measurement, and the second to virtues, as detailed in <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1"><span class="sci-ico-fileTable"></span>Table 1</a>.</p>
+<div>
+				<div class="row table" id="t1">
+<a name="t1"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Table 1</strong><br>Number of references per database, query, and search format.<br>
+</div>
+</div>
+			</div>
+<p>Until 2018, 517 articles were selected. In February 2021, 248 articles were added, completing a sample of 765 references. The experience gained with the selection carried out in 2018 offered elements to improve the process. Thus, the update in references in 2021 was conducted based only on the abstracts. Also, some articles were manually added to the sample of references (n=3), found during the search and reading work indicated in Step 2 of the selection process (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1"><span class="sci-ico-fileFigure"></span>Figure 1</a>). The following journals were carefully searched to ensure the selection of articles in the area: <i>Journal of Business Ethics</i>, <i>Business Ethics: Environment and Responsibilty</i> and <i>Business Ethics Quarterly</i>.</p>
+<p>
+				<div class="row fig" id="f1">
+<a name="f1"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf1"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 1</strong><br>Selection process, according to the model by <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).<br>
+</div>
+</div>
+			</p>
+<p>The references were exported to the Endnote 8 reference organizer in the first step and Mendeley in the last selection. The selection process during the stages was the same: first, the removal of duplicated articles; second, the reading of titles, abstracts, keywords, and name of the journal, applying the eligibility criteria. <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1"><span class="sci-ico-fileFigure"></span>Figure 1</a> shows the flow of the selection process until reaching the number of 37 articles that develop or apply moral virtues at an individual level, forming the sample.</p>
+<p>As shown in <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1"><span class="sci-ico-fileFigure"></span>Figure 1</a>, sixteen references were excluded after being submitted to the eligibility analysis. Eight articles addressed other constructs, while another eight worked with virtuousness scales or virtue at an organizational level. The articles adopting the virtuousness scale were excluded since, based on virtue ethics, there are different assumptions between virtuousness and moral virtues (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). Studies referring to the organizational level - focusing on objectively verifiable elements expressed in or through organizations (such as structural and cultural elements) (Meyer, 2018) - were excluded since this research focuses on the individual level.</p>
+<p>For a theoretical-methodological discussion on the development of virtues scales and measures, the articles were first thoroughly read and their primary data organized in Excel spreadsheets, containing information on (a) how the scale is constructed or applied, item generation, pre-tests, sample and respondents, item treatment; (b) statistical analysis adopted, statistical techniques, adjustment factors, analysis techniques, emerging factors; (c) eliminations of items, types of validations and related topics and; (d) country of application, to analyze possible limitations and the rigor used in creation and validation. For the analysis of the use of Exploratory Factor Analysis (EFA), Confirmatory Factor Analysis (CFA), and other techniques, we considered the guidelines by <span class="ref"><strong class="xref xrefblue">Fávero et al. (2009</strong><span class="refCtt closed"><span>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Hair et al. (2005</strong><span class="refCtt closed"><span>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</span></span></span>). </p>
+<p>After analyzing the scales, the contributions of the articles to the knowledge on moral virtues were examined. In this case, the analysis observed the articles listing a set of virtues and those exploring a single virtue in-depth. Methodological challenges to accessing moral virtues are discussed, especially for researchers who are part of a tradition of virtue ethics. The discussion examines how virtues are defined, operationalized, and accessed in order to discuss theoretical implications and methodological issues in a broader scope, as the debate on measuring virtues is an open question for which researchers in business ethics and psychology may have different positions on possibilities and relevance.</p>
+<h1 class="articleSectionTitle">PRESENTATION AND DISCUSSION OF RESULTS</h1>
+<p>The 37 empirical articles selected show the contributions of two areas interested in virtues or virtue ethics: business ethics and psychology. The articles were published in 21 different journals. In the area of administration and business, the <i>Journal of Business Ethics</i> (JBE) published 11 articles on scales and measuring moral virtues at an individual level, followed by other journals in the area that published only one article each: <i>Asian Journal of Business &amp; Accounting, Business Ethics: A European Review, Canadian Journal of Administrative Sciences, Journal of Business Research, Leadership &amp; Organization Development Journal</i> and <i>Organizational Dynamics.</i> In the area of psychology, the journals <i>Personality and Individual Differences</i> (four articles), <i>Current Psychology</i> (three articles) and <i>Frontiers in Psychology</i> (two articles) stood out.</p>
+<p>Studies that develop or apply virtues scales follow two predominant formats, focusing on (1) multiple virtues analyzed together or (2) a single moral virtue. In administration journals, the research works are mostly based on lists proposed by <span class="ref"><strong class="xref xrefblue">Solomon (1999</strong><span class="refCtt closed"><span>Solomon, R. (1999). A better way to think about business: how personal integrity leads to corporate success. New York, NY: Oxford University Press.</span></span></span>) and <span class="ref"><strong class="xref xrefblue">Murphy (1999</strong><span class="refCtt closed"><span>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				</span><br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">https://doi.org/10.1023/A:1006072413165...
+            </a></span></span>). As for psychology journals, the articles are based on the positive psychology developed by <span class="ref"><strong class="xref xrefblue">Peterson and Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) or attempts to link psychology and moral philosophy (e.g., <span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>). Of the 37 articles, 19 refer to the use and development of scales on multiple virtues, which we chose to call multiple moral virtues, and 18 address scales and measures of specific moral virtues (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet2"><span class="sci-ico-fileTable"></span>Table 2</a>).</p>
+<div>
+				<div class="row table" id="t2">
+<a name="t2"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Table 2</strong><br>Moral virtue scales at the individual level - multiple and specific moral virtues.<br>
+</div>
+</div>
+			</div>
+<p>The articles published in the first decade of the current millennium adopted multiple virtue scales, covering a list of character traits. In the following decade, there was a methodological discussion about changing the concept to address the organizational level, with discussions about organizational virtuousness and assumptions and positive psychology methods. Over the past three years, empirical studies have predominantly focused on measuring a specific virtue, seeking to address components such as thinking, feelings, and behaviors expressing virtues. However, it is noteworthy that these questions remain open, and there are different positions on the feasibility or not of coordinating moral philosophy and psychology to broaden the understanding of moral virtues (<span class="ref"><strong class="xref xrefblue">Beadle et al., 2015</strong><span class="refCtt closed"><span>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				</span><br><a href="https://doi.org/10.1111/beer.12098" target="_blank">https://doi.org/10.1111/beer.12098...
+            </a></span></span>). Authors such as <span class="ref"><strong class="xref xrefblue">Newstead et al. (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) and <span class="ref"><strong class="xref xrefblue">Snow, Whright and Warren (2020</strong><span class="refCtt closed"><span>Snow, N. E., Wright, J. C., &amp; Warren, M. T. (2020). Virtue Measurement: Theory and Applications. Ethical Theory and Moral Practice, 23, 277-293. https://doi.org/10.1007/s10677-019-10050-6
+				</span><br><a href="https://doi.org/10.1007/s10677-019-10050-6" target="_blank">https://doi.org/10.1007/s10677-019-10050...
+            </a></span></span>) consider that such coordination is possible.</p>
+<p>It is crucial to emphasize that moral virtues scales, multiple or specific, access the perception of virtues, whether the respondent’s self-perception or the 'perception' in relation to other people (manager, employee, leadership, for instance), something similar to what <span class="ref"><strong class="xref xrefblue">Newstead et al. (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) called virtues. However, such studies do not consider these perceptions as originated from an event. They are limited to an abstract opinion on a list of attributes, disconnected from an action context. This is verified in most of the measurement instruments in the list of items.</p>
+<p>Articles that addressed specific moral virtues empirically observed one or two virtues: appreciation of virtues and their links with status (<span class="ref"><strong class="xref xrefblue">Bai, Ho, &amp; Yan, 2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>), self-consideration and consideration for others (<span class="ref"><strong class="xref xrefblue">Grappi, Romani, &amp; Bagozzi, 2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>), moral courage (<span class="ref"><strong class="xref xrefblue">Mansur, Sobral, &amp; Islam, 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>), gratitude (<span class="ref"><strong class="xref xrefblue">Bernabe-Valero, Blasco-Magraner, &amp; García-March, 2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Gulliford, Morgan, Hemming, &amp; Abbott, 2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Hudecek, Blabst, Morgan, &amp; Lermer, 2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>; Morgan, Gulliford, &amp; Kristjánsson, 2017), gratitude and love (<span class="ref"><strong class="xref xrefblue">Diessner, Iyer, Smith, &amp; Haidt, 2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>), humility (<span class="ref"><strong class="xref xrefblue">Colombo, Strangmann, Houkes, Kostadinova, &amp; Brandt, 2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Qin, Liu, Brown, Zheng, &amp; Owens, 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>), integrity (<span class="ref"><strong class="xref xrefblue">Castro-González, Bande, Fernández-Ferrín, &amp; Kimura, 2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>), justice (<span class="ref"><strong class="xref xrefblue">Beekun, Westerman, &amp; Barghouti, 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beugré, 2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>), self-forgiveness (Kim, Volk, &amp; Enright, 2021), respect and responsibility (<span class="ref"><strong class="xref xrefblue">Manly, Leonard, &amp; Riemenschneider, 2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>), good and bad character traits (<span class="ref"><strong class="xref xrefblue">Jiao, Yang, Guo, Xu, Zhang, &amp; Jiang, 2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>), resilience (<span class="ref"><strong class="xref xrefblue">Lasota, Tomaszek, &amp; Bosacki, 2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>) and temperance (<span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>).</p>
+<p>In addition to scales for specific virtues, several scales associated with leadership were developed (<span class="ref"><strong class="xref xrefblue">Mansur et al., 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Qin et al., 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Riggio, Zhu, Reina, &amp; Maroosis, 2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Thun &amp; Kelloway, 2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Sarros, Cooper, &amp; Hartican, 2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Seijts, Gands, Crossan, &amp; Reno, 2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Wang &amp; Hackett, 2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>).</p>
+<h2>Development and application of scales on moral virtues</h2>
+<p>
+					<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet3"><span class="sci-ico-fileTable"></span>Table 3</a> summarizes the information about the scales used in the articles analyzed. It is possible to observe the number of initial and final items, the item-sample ratio, the country, and the profile of respondents in the studies (mostly university students and practitioners). The scales found in the systematic review use items with a Likert response grid (strongly disagree - strongly agree) or adjective rating scales, ranging from four to ten-point scales.</p>
+<div>
+					<div class="row table" id="t3">
+<a name="t3"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet3"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Table 3</strong><br>Items, samples, and measures on moral virtues scales at the individual level.<br>
+</div>
+</div>
+				</div>
+<p>As for the context, the articles portray research works carried out in 15 different countries. The United States (11 studies), China (3 studies), and the United Kingdom (3 studies) stand out. Some articles discussed research results referring to two countries (<span class="ref"><strong class="xref xrefblue">Bai et al., 2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beekun et al., 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Hudecek et al., 2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Seijts et al., 2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>). Some studies recruited respondents via platforms, such as remote workers on Amazon Mturk (<span class="ref"><strong class="xref xrefblue">Bernabe-Valero et al., 2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Colombo et al., 2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Kim et al., 2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Mansur et al., 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>). In the selected article by Mansur et al. (2020), the authors did not specify the research context when describing the sample, even though the authors are affiliated with a Brazilian university. The literature shows that virtues depend on the context of action and, therefore, exploratory analysis in a new context is essential (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Newstead et al., 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>). For example, the virtue of temperance may be harder to develop depending on the country, and different virtues can be cultivated in each context. Also, choice of scales or adapting and developing scales are tasks that require analysis of the context, observing other cultures (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). </p>
+<p>In the item-sample size ratio, some studies (n=11) did not reach the 5:1 ratio as recommended by <span class="ref"><strong class="xref xrefblue">Hair et al. (2009</strong><span class="refCtt closed"><span>Hair, J., Jr., Black, W., Babin, B., Anderson, R., &amp; Tathan, R. (2009) Análise multivariada de dados. (6th ed.). Porto Alegre, RS: Bookman.</span></span></span>, p. 108). In contrast, <span class="ref"><strong class="xref xrefblue">Bai et al. (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>) seek a ratio of 10:1, which is a practice followed by most recent articles. For Hair et al. (2009), researchers should interpret any finding with caution when dealing with smaller samples or small proportions. In addition, the generation of more items through theoretical deepening, lexical analysis (<span class="ref"><strong class="xref xrefblue">Jiao et al., 2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>), consultation with experts (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>), and potential respondents (pre-tests) are measures that could reveal items more aligned with virtues from specific contexts (<span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al., 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). In this sense, the work by <span class="ref"><strong class="xref xrefblue">Shanahan and Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>) is an example of a study that conducted focus groups for pre-test among the few articles that used pre-testing (<span class="ref"><strong class="xref xrefblue">Libby &amp; Thorne, 2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>; Shanahan &amp; Hyman, 2003).</p>
+<p>The concepts adopted in the articles and their findings - both referring to elements of virtue ethics - were considered to illustrate the analysis of the scales’ development. Studies on virtues in leadership suggest that the leader’s character is still an essential attribute for ethics in administration, which could broaden the discussion on leadership traits and leadership as a process and expand the debate between heroic and post-heroic perspectives (<span class="ref"><strong class="xref xrefblue">Sobral &amp; Furtado, 2019</strong><span class="refCtt closed"><span>Sobral, F., &amp; Furtado, L. (2019). A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança. Revista de Administração de Empresas, 59(3), 209-214. http://dx.doi.org/10.1590/S0034-759020190306
+				</span><br><a href="http://dx.doi.org/10.1590/S0034-759020190306" target="_blank">http://dx.doi.org/10.1590/S0034-75902019...
+            </a></span></span>). </p>
+<p>
+					<span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>) suggest that integrity is a key attribute for a leader’s character. The article by <span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>) explores the cardinal virtues of temperance, fortitude, justice, and prudence related to leadership, based on assumptions by Thomas Aquinas and Aristotle. It is one of the few studies that seek to address the assumption of the unity of virtues. The authors carried out two stages of exploratory factor analysis and obtained results that suggest a single explanatory factor for the model, which Riggio et al. (2010) consider evidence of the unity of virtues.</p>
+<p>
+					<span class="ref"><strong class="xref xrefblue">Wang and Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>) found support on Aristotelian and Confucian concepts to develop the Virtuous Leadership Questionnaire. They started from six virtues - courage, prudence, justice, temperance, humanity, and truthfulness and, by factor analysis, reach five factors: courage (4), temperance (4), justice (3), prudence (4), and humanity (3).</p>
+<p>In their Character Strengths in Leadership scale, <span class="ref"><strong class="xref xrefblue">Thun and Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>) find the factors humanity (4 items), wisdom (5), and temperance (5), while <span class="ref"><strong class="xref xrefblue">Seijts et al. (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>) discuss character as an amalgamation of virtues, personality traits, and values, describing 11 elements of character and their importance to the leadership. Finally, <span class="ref"><strong class="xref xrefblue">Mansur et al. (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>) suggest that moral courage contributes to ethical leadership and group citizenship behavior.</p>
+<p>Further evidence of the role of moral virtues was observed in topics such as the relationships between buyer-seller (<span class="ref"><strong class="xref xrefblue">Donada, Mothe, Nogatchewsky, &amp; Ribeiro, 2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>); leader-led (<span class="ref"><strong class="xref xrefblue">Qin et al., 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>); managers-salespeople (<span class="ref"><strong class="xref xrefblue">Shanahan &amp; Hopkins, 2019</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">https://doi.org/10.1007/s10551-018-3813-...
+            </a></span></span>); the professionals’ character (<span class="ref"><strong class="xref xrefblue">Arthur et al., 2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>); and responsible consumption (<span class="ref"><strong class="xref xrefblue">Song &amp; Kim, 2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>).</p>
+<p>Although elaborated with statistical rigor, leadership scales are specific to this role, i.e., they are elaborated from specific cultural, moral, and political contexts. Thus, these scales need re-elaboration when applied to other organizational contexts or inserted in a community with its particular culture. Such adaptation accommodates particularities in terms of moral virtues and the notion of human flourishing.</p>
+<p>When applying <span class="ref"><strong class="xref xrefblue">Peterson and Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>), character strengths model, some studies partially or fully employ the items of character strengths: (a) <span class="ref"><strong class="xref xrefblue">Park and Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>) address moral competence as good character, using 198 out of the model’s 240 items. However, the authors’ sample consists of 250 adolescent students, making the item-sample ratio lower than statistically recommended. Park and Peterson (2006) apply the exploratory factor analysis (EFA), obtaining four factors - temperance (4 items), intellectual (6), theological (10), and other strengths (4); (b) <span class="ref"><strong class="xref xrefblue">Song and Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>) approach nine virtues of the model to verify how positive consumer traits explain their responsible consumption; and, (c) <span class="ref"><strong class="xref xrefblue">Arthur et al. (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>) address professionals’ self-perception regarding the most important virtues of the model. Although there are differences and similarities between moral virtues and character strengths (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>), the paths to understanding them within organizations go through theoretical deepening and research strategies that allow reaching more than a single “picture” of virtues, recognizing that they are cultivated throughout life.</p>
+<h2>Discussion</h2>
+<p>Virtue is a concept with a philosophical root and is considered in the virtue ethics tradition as the middle ground between two vices: the lack of virtue and the excess of virtue (<span class="ref"><strong class="xref xrefblue">Aristotle, 2009</strong><span class="refCtt closed"><span>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</span></span></span>). In this sense, the virtuous agent constantly reflects on their conduct, mistakes, and successes, seeking a path toward good. In this sense, self-education or self-improvement is a key element. Therefore, the importance of context, of action within a broader perspective (in life’s trajectory), is highlighted. After making a few or several mistakes, one learns the virtues, such as self-forgiveness (<span class="ref"><strong class="xref xrefblue">Kim et al., 2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>). Thus, a comprehensive ethical framework is desirable, a framework capable of considering negative and positive aspects of character, mistakes and successes, vices and virtues, as seems to be the case with virtue ethics.</p>
+<p>A form of reaching a more detailed understanding of a virtue’s multi-components is choosing the strategy of examining only one virtue, as recent studies have done. For example, the emerging factors indicated from the EFAs represent a set of perceptions of virtues or character traits, even though they result from the operationalization from different areas and ethical assumptions. Some factors appear more than once, such as temperance (<span class="ref"><strong class="xref xrefblue">Park &amp; Peterson, 2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Riggio et al., 2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Thun &amp; Kelloway, 2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Wang &amp; Hackett, 2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>), justice (<span class="ref"><strong class="xref xrefblue">Beekun et al., 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; Riggio et al., 2010; Wang &amp; Hackett, 2016) and resourcefulness (<span class="ref"><strong class="xref xrefblue">Cawley, Martin, &amp; Johnson, 2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Yang, Stoeber &amp; Wang, 2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). The virtue of prudence is found in the studies by Riggio et al. (2010) and Wang and Hackett (2016), while <span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>) and Thun and Kelloway (2011) define the factor as wisdom.</p>
+<p>On the other hand, it would be a limitation not to consider, for example, the role of <i>phronesis</i> linked to moral virtues (<span class="ref"><strong class="xref xrefblue">Ames et al., 2020</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				</span><br><a href="https://doi.org/10.1111/beer.12296" target="_blank">https://doi.org/10.1111/beer.12296...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Bachmann et al., 2017</strong><span class="refCtt closed"><span>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">https://doi.org/10.1007/s10551-016-3417-...
+            </a></span></span>). The unity of virtues recognizes the connection between them, i.e., to be virtuous, someone expresses more than one virtue. It is the case, for example, of honesty and justice to communicate in the best possible way; courage and prudence to make good decisions in the face of environmental risks.</p>
+<p>As for the assumptions regarding the participation of prudence in each virtue and the unity of virtues (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>), most articles do not consider them in the development or use of scales. Among the few exceptions is the attempt by <span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>). Some works rely on authors of virtue ethics - such as <span class="ref"><strong class="xref xrefblue">Aristotle (2009</strong><span class="refCtt closed"><span>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</span></span></span>), MacIntyre (2007) and Sison and Ferrero (2015) - while others connect virtue ethics to positive psychology (e.g., <span class="ref"><strong class="xref xrefblue">Arthur et al., 2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Donada et al., 2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>). </p>
+<p>What would the possible research strategies be, considering the need for further theoretical development on virtues in administration? Based on this question, we resume some theoretical-methodological aspects to gather suggestions for future studies.</p>
+<h1 class="articleSectionTitle">SUGGESTIONS FOR FUTURE STUDIES</h1>
+<p>From a theoretical-methodological perspective, four points are worth mentioning: learning of virtues, their presence in different social roles, subjective-objective duality, and judgment-action. The first is that the cultivation and learning of virtues take place throughout life, based on experience (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Methods that occasionally consult respondents at a specific time, without a contextualized analysis of their life trajectories, cannot access the context and circumstance of action, which is considered in the tradition of virtue ethics (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>). It is also worth bearing in mind the respondents’ age or experience, which can make a difference in moral maturity.</p>
+<p>The second point is connected to the first as it refers to someone’s reflection on their life as a whole. Thus, research must include the professional dimension and the harmony among the individuals’ different social roles (<span class="ref"><strong class="xref xrefblue">Sison et al., 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>). The third point refers to the subjective-objective duality related to the concept of virtue, which needs to be addressed by approaches focused on observable behaviors or in the use of scales on the perception of virtues. Such duality is important because a moral virtue expresses harmony between subjective-objective, will and action, something complex to access through scales and measures. Finally, the fourth point raises the question of the judgment-action gap that separates the moment of answering a test/scale on a given hypothetical question from the experience of an ethical question. Accessing the virtues from someone’s life trajectory could find reliable evidence of the participant’s experience.</p>
+<p>Therefore, some interpretative research strategies and qualitative approaches could achieve a deeper understanding of the virtues in a specific national and organizational context, considering the assumptions of the unity of virtues and the crucial role of <i>phronesis</i> (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>). Possible contributions from oral history, narrative approaches, case studies, ethnography, and phenomenology can be considered. Exploratory strategies usually precede quantitative approaches to subsidize future studies using scales, such as step 1, suggested in <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Figure 2</a>.</p>
+<p>
+				<div class="row fig" id="f2">
+<a name="f2"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf2"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figure 2</strong><br>Suggestions of steps in future studies on moral virtues.<br>
+</div>
+</div>
+			</p>
+<p>The review of works that seek to measure virtues requires a methodological and theoretical discussion. As for the method, this article a) questions why the studies have been seeking to measure virtues, b) tries to understand the limitations and possibilities based on the articles reviewed, and c) seeks to engage in discussions about which methods can be considered for empirical studies of virtue ethics. Against this backdrop, possible procedures in future studies are suggested, as pointed out in <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Figure 2</a>.</p>
+<p>Steps 1 and 2 are understood as a route to studies on moral virtues. Step 2 follows basic guidelines for the development of scales, as proposed by <span class="ref"><strong class="xref xrefblue">DeVellis (2016</strong><span class="refCtt closed"><span>DeVellis, R. F. (2016). Scale development: Theory and applications. (4th ed). Thousand Oaks, CA: Sage Publications.</span></span></span>). </p>
+<p>Future studies facing concerns about the instrumentation of the construct to improve performance or productivity may address its contribution to human flourishing and interpersonal relationships. The perception of virtues may allow us to understand how people associate these attributes with other organizational issues, such as leadership, decision-making, or organizational culture. From a theoretical perspective, there is still a debate about using scales to expand or deepen the understanding of moral virtues in the organizational and business environments while bearing in mind the assumptions and elements of the tradition of virtue ethics as a framework for the study of ethics in Administration.</p>
+<p>Among the research limitations, this study focuses on analyzing moral virtue scales at the individual level. Therefore, the virtuousness scales (at the organizational level) can be approached in future studies. Also, the studies were selected for the systematic review based on a search limited to terms such as virtue ethics and moral virtues. Thus, further studies may look for a specific virtue. Finally, the research reports do not describe how convergent and discriminant validations were carried out in relation to other concepts. The article was organized to offer a general analysis in the light of virtue ethics, discussing only some of the assumptions.</p>
+<h1 class="articleSectionTitle">FINAL CONSIDERATIONS</h1>
+<p>This study carried out a systematic review and analyzed how scales on moral virtues are constructed and measured in studies associated with virtue ethics in administration. The 37 articles used in the analysis were retrieved from five databases. They were published in 21 journals, most of them in business ethics, and portray studies that developed or applied scales related to the perception of moral virtues at the individual level. Nineteen articles covered multiple moral virtues, and 18 articles sought a specific moral virtue.</p>
+<p>The Aristotelian-Thomistic virtue ethics assumptions and statistical recommendations for the development and application of scales supported the analysis offered in this article. The research analyzed the construction of scales in the studies examined, presenting numbers on the generation of items before and after factor analysis, the proportion of respondents per item (sample-item), the respondents’ profile in each study, the research context (given by the 15 countries represented in the articles selected), and the types of statistical analyses adopted (such as exploratory and confirmatory factor analysis and emerging factors, structural equation modeling, Anova, Manova).</p>
+<p>The selected studies illustrate areas in the field of administration related to the theme of virtues, such as leadership, manager-employee relationship, and responsible consumption. As a portion of respondents is university students, further studies are required to access practitioners working in the field. Virtues such as courage, gratitude, humility, integrity, forgiveness, respect, resilience, and temperance were discussed.</p>
+<p>The results were discussed theoretically and methodologically, considering the use of scales in relation to the conceptual deepening of the area, and the assumptions regarding the particularities of the contexts, the unity of virtues, and their interconnection with phronesis (practical wisdom). Learning, presence in different roles, and judgment-action duality were also discussed to elucidate theoretical and practical implications of the limitations found in conceptual deepening and operationalization.</p>
+<p>Therefore, it was possible to suggest procedures for future studies on moral virtues, organized in successive stages. The intention is to coordinate the first step with qualitative exploratory studies - which grants conceptual precision and data on the context and targeted participants - and the second step, with recommendations for the development of scales on the perception of virtues, obtaining larger sets of items, the better item-sample ratio in accessing the field, validation with experts and potential respondents, and pre-testing.</p>
+<p>Conceptual deepening encompasses Western and Eastern traditions for virtue ethics, and it is necessary to reflect on the reasons for trying to measure virtues in the field of administration. An alternative path can be analyzing and identifying organizational aspects that help people cultivate virtues, such as practices and institutions, organizational culture, and administrative functions. </p>
+</div>
+<div class="articleSection" data-anchor="REFERENCES">
+<h1 class="articleSectionTitle">REFERENCES</h1>
+<div class="ref-list"><ul class="refList">
+<li><div>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				<br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">» https://doi.org/10.1017/beq.2015.24</a>
+</div></li>
+<li><div>Alzola, M. (2017). Virtues and their explanatory and predictive power in the workplace. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				<br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">» https://doi.org/10.1007/s10551-019-04317-2</a>
+</div></li>
+<li><div>Ames, M. C. F. D. C., &amp; Serafim, M. C. (2019). Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review. Revista de Administração Contemporânea, 23(4), 564-586. https://doi.org/10.1590/1982-7849rac2019180301
+				<br><a href="https://doi.org/10.1590/1982-7849rac2019180301" target="_blank">» https://doi.org/10.1590/1982-7849rac2019180301</a>
+</div></li>
+<li><div>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				<br><a href="https://doi.org/10.1111/beer.12296" target="_blank">» https://doi.org/10.1111/beer.12296</a>
+</div></li>
+<li><div>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				<br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">» https://doi.org/10.1017/S0031819100037943</a>
+</div></li>
+<li><div>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</div></li>
+<li><div>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				<br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">» https://doi.org/10.1007/s10551-019-04269-7</a>
+</div></li>
+<li><div>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				<br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">» https://doi.org/10.1007/s10551-016-3417-y</a>
+</div></li>
+<li><div>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				<br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">» http://doi.org/10.0.4.13/pspi0000192</a>
+</div></li>
+<li><div>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				<br><a href="https://doi.org/10.1111/beer.12098" target="_blank">» https://doi.org/10.1111/beer.12098</a>
+</div></li>
+<li><div>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				<br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">» https://doi.org/10.1007/s10551-005-4772-2</a>
+</div></li>
+<li><div>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				<br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">» https://doi.org/10.3389/fpsyg.2020.626330</a>
+</div></li>
+<li><div>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				<br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">» https://doi.org/10.1111/j.1559-1816.2012.00935.x</a>
+</div></li>
+<li><div>Cameron, K., Bright, D., &amp; Caza, A. (2004). Exploring the relationships between organizational virtuousness and performance. American Behavioral Scientist, 47(6), 1-14. https://doi.org/10.1177/0002764203260209
+				<br><a href="https://doi.org/10.1177/0002764203260209" target="_blank">» https://doi.org/10.1177/0002764203260209</a>
+</div></li>
+<li><div>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				<br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">» https://doi.org/10.1016/j.jclepro.2019.05.238</a>
+</div></li>
+<li><div>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				<br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">» https://doi.org/10.1016/s0191-8869(99)00207-x</a>
+</div></li>
+<li><div>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				<br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">» https://doi.org/10.1007/s13164-020-00496-4</a>
+</div></li>
+<li><div>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				<br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">» https://doi.org/10.1007/s10551-017-3505-7</a>
+</div></li>
+<li><div>DeVellis, R. F. (2016). Scale development: Theory and applications. (4th ed). Thousand Oaks, CA: Sage Publications.</div></li>
+<li><div>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				<br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">» http://dx.doi.org/10.1080/03057240.2013.785941</a>
+</div></li>
+<li><div>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				<br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">» https://doi.org/10.1007/s10551-016-3418-x</a>
+</div></li>
+<li><div>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</div></li>
+<li><div>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				<br><a href="https://doi.org/10.1111/beer.12057" target="_blank">» https://doi.org/10.1111/beer.12057</a>
+</div></li>
+<li><div>Ferrero, I. Prefácio. In M. C. Serafim (Org.). (2020). Virtudes e dilemas morais na Administração. (pp. 9-14). Florianópolis: Admethics.</div></li>
+<li><div>Foot, P. (1967). The problem of abortion and the doctrine of double effect. Oxford Reviews, 5, 5-15. Retrieved from https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf
+				<br><a href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf" target="_blank">» https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf</a>
+</div></li>
+<li><div>Gomide, S. Jr., Vieira, L. E., &amp; Oliveira, A. F. (2016). Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro. Psicologia: Organizações e Trabalho, 16(3), 298-307. http://dx.doi.org/10.17652/rpot/2016.3.10417
+				<br><a href="http://dx.doi.org/10.17652/rpot/2016.3.10417" target="_blank">» http://dx.doi.org/10.17652/rpot/2016.3.10417</a>
+</div></li>
+<li><div>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				<br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">» https://doi.org/10.1007/s12144-019-00330-w</a>
+</div></li>
+<li><div>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				<br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">» https://doi.org/10.1016/j.jbusres.2013.02.002</a>
+</div></li>
+<li><div>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</div></li>
+<li><div>Hair, J., Jr., Black, W., Babin, B., Anderson, R., &amp; Tathan, R. (2009) Análise multivariada de dados. (6th ed.). Porto Alegre, RS: Bookman.</div></li>
+<li><div>Hartmann, E. M. (2020). Arriving where we started: Aristotle and business ethics (E-book, Vol. 51). Cham: Switzerland: Springer. https://doi.org/10.1007/978-3-030-44089-3
+				<br><a href="https://doi.org/10.1007/978-3-030-44089-3" target="_blank">» https://doi.org/10.1007/978-3-030-44089-3</a>
+</div></li>
+<li><div>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				<br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">» https://doi.org/10.3389/fpsyg.2020.590108</a>
+</div></li>
+<li><div>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				<br><a href="https://doi.org/10.1111/beer.12184" target="_blank">» https://doi.org/10.1111/beer.12184</a>
+</div></li>
+<li><div>Hühn, M. P., Habish, A., Hartmann, E. M., &amp; Sison, A. J. G. (2020). Practicing management wisely. Business Ethics: A European Review, 29(S1), 1-5. https://doi.org/10.1111/beer.12321
+				<br><a href="https://doi.org/10.1111/beer.12321" target="_blank">» https://doi.org/10.1111/beer.12321</a>
+</div></li>
+<li><div>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				<br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">» https://doi.org/10.1111/sjop.12696</a>
+</div></li>
+<li><div>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				<br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">» https://doi.org/10.1007/s12144-020-01248-4</a>
+</div></li>
+<li><div>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				<br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">» https://doi.org/10.1080/17439760.2016.1228009</a>
+</div></li>
+<li><div>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				<br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">» https://doi.org/10.12711/TJBE.2016.9.0016</a>
+</div></li>
+<li><div>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				<br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">» https://doi.org/10.1007/s12144-020-01178-1</a>
+</div></li>
+<li><div>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				<br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">» https://doi.org/10.1007/s10551-006-9127-0</a>
+</div></li>
+<li><div>Macintyre, A. (2007). After virtue: A study in moral theory (3rd ed.). Notre Dame, IN: University of Notre Dame Press.</div></li>
+<li><div>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				<br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">» https://doi.org/10.1007/s10551-014-2060-8</a>
+</div></li>
+<li><div>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				<br><a href="https://doi.org/10.1111/beer.12270" target="_blank">» https://doi.org/10.1111/beer.12270</a>
+</div></li>
+<li><div>Mendes-Da-Silva, W. (2019). Contribuições e limitações de revisões narrativas e revisões sistemáticas na área de negócios. Revista de Administração Contemporânea, 23(2), https://doi.org/10.1590/1982-7849rac2019190094
+				<br><a href="https://doi.org/10.1590/1982-7849rac2019190094" target="_blank">» https://doi.org/10.1590/1982-7849rac2019190094</a>
+</div></li>
+<li><div>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				<br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">» https://doi.org/10.1007/s10551-016-3388-z</a>
+</div></li>
+<li><div>Moberg, D. J. (1999). The big five and organizational virtue. Business Ethics Quarterly, 9(2), 245-272. https://doi.org/10.2307/3857474
+				<br><a href="https://doi.org/10.2307/3857474" target="_blank">» https://doi.org/10.2307/3857474</a>
+</div></li>
+<li><div>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				<br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">» https://doi.org/10.1371/journal.pmed.1000097</a>
+</div></li>
+<li><div>Moore, G. (2017). Virtue at work: Ethics for individuals, managers, and organizations. Oxford, UK: Oxford University Press.</div></li>
+<li><div>Morales-Sánchez, R., &amp; Cabello-Medina, C. (2013). The role of four moral competencies in Ethical Decision-making. Journal of Business Ethics, 116(4), 717-734. https://doi.org/10.1007/s10551-013-1817-9
+				<br><a href="https://doi.org/10.1007/s10551-013-1817-9" target="_blank">» https://doi.org/10.1007/s10551-013-1817-9</a>
+</div></li>
+<li><div>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				<br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">» https://doi.org/10.1016/j.paid.2016.11.044</a>
+</div></li>
+<li><div>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				<br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">» https://doi.org/10.1023/A:1006072413165</a>
+</div></li>
+<li><div>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				<br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">» https://doi.org/10.5465/amp.2016.0162</a>
+</div></li>
+<li><div>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				<br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">» https://doi.org/10.1016/j.adolescence.2006.04.011</a>
+</div></li>
+<li><div>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</div></li>
+<li><div>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				<br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">» https://doi.org/10.1007/s10551-019-04250-4</a>
+</div></li>
+<li><div>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				<br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">» https://ajba.um.edu.my/article/view/2664</a>
+</div></li>
+<li><div>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				<br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">» https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens</a>
+</div></li>
+<li><div>Rego, A., &amp; Cunha, M. P. (2015). As virtudes nas organizações. Análise Psicológica, 4(33), 349-359. https://doi.org/10.14417/ap.1022
+				<br><a href="https://doi.org/10.14417/ap.1022" target="_blank">» https://doi.org/10.14417/ap.1022</a>
+</div></li>
+<li><div>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				<br><a href="https://doi.org/10.1037/a0022286" target="_blank">» https://doi.org/10.1037/a0022286</a>
+</div></li>
+<li><div>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				<br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">» https://doi.org/ 10.1111/beer.12103</a>
+</div></li>
+<li><div>Sanz, P., &amp; Fontrodona, J. (2019). Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace. Journal of Business Ethics, 155, 981-994. https://doi.org/10.1007/s10551-018-3899-x
+				<br><a href="https://doi.org/10.1007/s10551-018-3899-x" target="_blank">» https://doi.org/10.1007/s10551-018-3899-x</a>
+</div></li>
+<li><div>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				<br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">» https://doi.org/10.1108/01437730610709291</a>
+</div></li>
+<li><div>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				<br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">» https://doi.org/10.1016/j.orgdyn.2014.11.008</a>
+</div></li>
+<li><div>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				<br><a href="https://doi.org/10.1002/pchj.394" target="_blank">» https://doi.org/10.1002/pchj.394</a>
+</div></li>
+<li><div>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				<br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">» https://doi.org/10.1023/A:1021914218659</a>
+</div></li>
+<li><div>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				<br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">» https://doi.org/10.1007/s10551-018-3813-6</a>
+</div></li>
+<li><div>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				<br><a href="https://doi.org/10.1111/beer.12099" target="_blank">» https://doi.org/10.1111/beer.12099</a>
+</div></li>
+<li><div>Sison, A. J. G., Beabout, G. R., &amp; Ferrero, I. (Eds.). (2017). Handbook of virtue ethics in business and management. Dordrecht, the Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</div></li>
+<li><div>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				<br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">» https://doi.org/10.1016/j.jbusres.2019.07.039</a>
+</div></li>
+<li><div>Snow, N. E., Wright, J. C., &amp; Warren, M. T. (2020). Virtue Measurement: Theory and Applications. Ethical Theory and Moral Practice, 23, 277-293. https://doi.org/10.1007/s10677-019-10050-6
+				<br><a href="https://doi.org/10.1007/s10677-019-10050-6" target="_blank">» https://doi.org/10.1007/s10677-019-10050-6</a>
+</div></li>
+<li><div>Sobral, F., &amp; Furtado, L. (2019). A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança. Revista de Administração de Empresas, 59(3), 209-214. http://dx.doi.org/10.1590/S0034-759020190306
+				<br><a href="http://dx.doi.org/10.1590/S0034-759020190306" target="_blank">» http://dx.doi.org/10.1590/S0034-759020190306</a>
+</div></li>
+<li><div>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				<br><a href="https://doi.org/10.2307/3857536" target="_blank">» https://doi.org/10.2307/3857536</a>
+</div></li>
+<li><div>Solomon, R. (1999). A better way to think about business: how personal integrity leads to corporate success. New York, NY: Oxford University Press.</div></li>
+<li><div>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				<br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">» https://doi.org/10.1007/s10551-016-3331-3</a>
+</div></li>
+<li><div>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				<br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">» https://doi.org/10.1016/j.paid.2015.08.031</a>
+</div></li>
+<li><div>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				<br><a href="https://doi.org/10.1002/cjas.216" target="_blank">» https://doi.org/10.1002/cjas.216</a>
+</div></li>
+<li><div>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				<br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">» https://doi.org/10.1007/s10551-015-2560-1</a>
+</div></li>
+<li><div>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				<br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">» https://doi.org/10.1016/j.paid.2014.11.040</a>
+</div></li>
+<li><div>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</div></li>
+</ul></div>
+</div>
+<div>
+<h1></h1>
+<div class="ref-list"><ul class="refList footnote">
+<li>
+<h3><span class="xref big">JEL Code:</span></h3>
+<div>M1, M10.</div>
+</li>
+<li>
+<h3><span class="xref big">Peer Review Report:</span></h3>
+<div>The Peer Review Report is available at this <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">external URL</a>.</div>
+</li>
+<li>
+<h3><span class="xref big">Funding</span></h3>
+<div> The authors thank the Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development (CNPq) (CHSSA, Process nr. 445434/2015-5) for the financial support to the research project, from which this study was developed.</div>
+</li>
+<li>
+<h3><span class="xref big">Plagiarism Check</span></h3>
+<div> The RAC maintains the practice of submitting all documents approved for publication to the plagiarism check, using specific tools, e.g.: iThenticate.</div>
+</li>
+<li>
+<h3><span class="xref big">Copyrights</span></h3>
+<div> RAC owns the copyright to this content.</div>
+</li>
+<li>
+<h3><span class="xref big">Peer Review Method</span></h3>
+<div> This content was evaluated using the double-blind peer review process. The disclosure of the reviewers' information on the first page, as well as the Peer Review Report, is made only after concluding the evaluation process, and with the voluntary consent of the respective reviewers and authors.</div>
+</li>
+<li>
+<h3><span class="xref big">Data Availability</span></h3>
+<div>The authors claim that all data used in the research have been made publicly available through the Harvard Dataverse platform and can be accessed at:</div>
+<div>
+<img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>
+<div>RAC encourages data sharing but, in compliance with ethical principles, it does not demand the disclosure of any means of identifying research subjects, preserving the privacy of research subjects. The practice of open data is to enable the reproducibility of results, and to ensure the unrestricted transparency of the results of the published research, without requiring the identity of research subjects. </div>
+</li>
+</ul></div>
+</div>
+<div class="articleSection" data-anchor="Publication Dates">
+<h1 class="articleSectionTitle">Publication Dates</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Publication in this collection</strong><br>18 July 2022</li>
+<li>
+<strong>Date of issue</strong><br>2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="History">
+<h1 class="articleSectionTitle">History</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Received</strong><br>17 Nov 2019</li>
+<li>
+<strong>Reviewed</strong><br>15 June 2021</li>
+<li>
+<strong>Accepted</strong><br>16 June 2021</li>
+</ul></div></div>
+</div>
+<section class="documentLicense"><div class="container-license"><div class="row">
+<div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+<div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">This is an open-access article distributed under the terms of the Creative Commons Attribution License</a></div>
+</div></div></section></article>
+</div>
+</div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">About the authors</h4>
+</div>
+<div class="modal-body">
+<div class="info">
+<div class="tutors">
+<strong> Maria Clara F. Dalla Costa Ames </strong><strong>*</strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-0444-8764" class="btnContribLinks orcid">http://orcid.org/0000-0002-0444-8764</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Mauricio C. Serafim </strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-4852-5119" class="btnContribLinks orcid">http://orcid.org/0000-0002-4852-5119</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Felipe Flôres Martins </strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-2987-5479" class="btnContribLinks orcid">http://orcid.org/0000-0003-2987-5479</a></li></ul>
+<div class="clearfix"></div>
+</div>
+</div>
+<div class="info">
+					* Corresponding Author</div>
+<div class="info">
+<h3>Editors-in-chief:</h3>
+<div>Wesley Mendes-da-Silva (Fundação Getulio Vargas, EAESP, Brazil)</div>
+<div>Marcelo de Souza Bispo (Universidade Federal da Paraíba, PPGA, Brazil)</div>
+</div>
+<div class="info">
+<h3>Reviewers:</h3>
+<div>Janaína Cássia Grossi (Fundação Getulio Vargas, EAESP, Brazil)</div>
+<div>Claudio Zancan (Universidade Federal do Paraná, Brazil)</div>
+</div>
+<div class="info">
+<h3>Authorship</h3>
+<div>Maria Clara Figueiredo Dalla Costa Ames*</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</div>
+<div>E-mail: mariaclaraames@gmail.com</div>
+<div> https://orcid.org/0000-0002-0444-8764</div>
+<div>Mauricio C. Serafim</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</div>
+<div>E-mail: serafim.esag@gmail.com</div>
+<div> https://orcid.org/0000-0002-4852-5119</div>
+<div>Felipe Flôres Martins</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</div>
+<div>E-mail: martins.felipef@gmail.com</div>
+<div> https://orcid.org/0000-0003-2987-5479</div>
+</div>
+<div class="info">
+<h3>Conflict of Interests</h3>
+<div> The authors have stated that there is no conflict of interest.</div>
+</div>
+<div class="info">
+<h3>Authors' Contributions</h3>
+<div>1<sup>st</sup> author: conceptualization (lead); data curation (lead); formal analysis (lead); investigation (equal); methodology (lead); resources (equal); software (equal); supervision (equal); validation (equal); writing-original draft (equal); writing-review &amp; editing (equal).</div>
+<div>2<sup>nd</sup> author: conceptualization (supporting); data curation (supporting); formal analysis (supporting); investigation (supporting); methodology (supporting); project administration (supporting); supervision (supporting); validation (equal); writing-original draft (supporting); writing-review &amp; editing (equal).</div>
+<div>3<sup>rd</sup> author: conceptualization (supporting); formal analysis (supporting); investigation (supporting); methodology (supporting); validation (supporting); writing-original draft (equal); writing-review &amp; editing (supporting).</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Figures | Tables</h4>
+</div>
+<div class="modal-body">
+<ul class="nav nav-tabs md-tabs" role="tablist">
+<li role="presentation" class="col-md-4 col-sm-4 active"><a href="#figures" aria-controls="figures" role="tab" data-toggle="tab">Figures
+                    (2)
+                </a></li>
+<li role="presentation" class="col-md-4 col-sm-4 "><a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">Tables
+                    (3)
+                </a></li>
+</ul>
+<div class="clearfix"></div>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="figures">
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 1</strong><br>Selection process, according to the model by <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figure 2</strong><br>Suggestions of steps in future studies on moral virtues.</div>
+</div>
+</div>
+<div role="tabpanel" class="tab-pane " id="tables">
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet1"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Table 1</strong><br>Number of references per database, query, and search format.</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet2"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Table 2</strong><br>Moral virtue scales at the individual level - multiple and specific moral virtues.</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet3"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Table 3</strong><br>Items, samples, and measures on moral virtues scales at the individual level.</div>
+</div>
+</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf1" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1982-7849-rac-26-06-e190379-gf1.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 1   Selection process, according to the model by <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1982-7849-rac-26-06-e190379-gf1.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf2" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Open new window" href="1982-7849-rac-26-06-e190379-gf2.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figure 2   Suggestions of steps in future studies on moral virtues.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1982-7849-rac-26-06-e190379-gf2.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet1" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Table 1</strong>    Number of references per database, query, and search format.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Form</th>
+<th align="center">Search query</th>
+<th align="center"><i>Ebsco</i></th>
+<th align="center"><i>Science Direct</i></th>
+<th align="center"><i>Scopus</i></th>
+<th align="center"><i>Web of Science</i></th>
+<th align="center"><i>Wiley</i></th>
+<th align="center">Total</th>
+</tr></thead>
+<tbody>
+<tr>
+<td align="center" rowspan="5">All content</td>
+<td align="left">1 <i>“Scale development” AND “virtue* ethic*”</i>
+</td>
+<td align="center">3</td>
+<td align="center">0</td>
+<td align="center">2</td>
+<td align="center">2</td>
+<td align="center">100</td>
+<td align="center">107</td>
+</tr>
+<tr>
+<td align="left">2<i>. “scale*” AND “virtue* ethic*”</i>
+</td>
+<td align="center">11</td>
+<td align="center">1</td>
+<td align="center">16</td>
+<td align="center">14</td>
+<td align="center">-</td>
+<td align="center">42</td>
+</tr>
+<tr>
+<td align="left"><i>3. “scale*” AND “moral virtues”</i></td>
+<td align="center">-</td>
+<td align="center">116</td>
+<td align="center">5</td>
+<td align="center">34</td>
+<td align="center">-</td>
+<td align="center">155</td>
+</tr>
+<tr>
+<td align="left">4<i>. “scale development” AND “moral virtues”</i>
+</td>
+<td align="center">12</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center">8</td>
+<td align="center">65</td>
+<td align="center">86</td>
+</tr>
+<tr>
+<td align="left">5. <i>“measur*” AND “moral virtues”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">22</td>
+<td align="center">7</td>
+<td align="center">-</td>
+<td align="center">29</td>
+</tr>
+<tr>
+<td align="center" rowspan="5">Abstract</td>
+<td align="left">1. <i>“Scale development” AND “virtue* ethic*”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">4</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">6</td>
+</tr>
+<tr>
+<td align="left">2. <i>“scale*” AND “virtue* ethic*”</i>
+</td>
+<td align="center">2</td>
+<td align="center">3</td>
+<td align="center">66</td>
+<td align="center">14</td>
+<td align="center">17ª</td>
+<td align="center">102</td>
+</tr>
+<tr>
+<td align="left">3<i>. “scale*” AND “moral virtues”</i>
+</td>
+<td align="center">16ª</td>
+<td align="center">1</td>
+<td align="center">42</td>
+<td align="center">8</td>
+<td align="center">25ª </td>
+<td align="center">92</td>
+</tr>
+<tr>
+<td align="left">4<i>. “scale development” AND “moral virtues”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">4</td>
+<td align="center">2</td>
+<td align="center">1</td>
+<td align="center">7</td>
+</tr>
+<tr>
+<td align="left">5. <i>“measur*” AND “moral virtues”</i>
+</td>
+<td align="center">21ª </td>
+<td align="center">16ª </td>
+<td align="center">79</td>
+<td align="center">8</td>
+<td align="center">15</td>
+<td align="center">139</td>
+</tr>
+<tr>
+<td align="left"> </td>
+<td align="center">Total</td>
+<td align="center">65</td>
+<td align="center">138</td>
+<td align="center">240</td>
+<td align="center">98</td>
+<td align="center">224</td>
+<td align="center">765</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN1"><div>Note. <sup>a</sup> Searches with the first term of the search query applied to the abstract and the second to the article’s entire content.</div></li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet2" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Table 2</strong>    Moral virtue scales at the individual level - multiple and specific moral virtues.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Scale</th>
+<th align="center">Authors</th>
+<th align="center">Journal</th>
+<th align="right">Citations<sup>a</sup>
+</th>
+</tr></thead>
+<tbody>
+<tr><td align="center" colspan="4">Multiple moral virtues </td></tr>
+<tr>
+<td align="left">Virtue Scale (VS)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Cawley, Martin and Johnson (2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Stoeber and Yang (2016</strong><span class="refCtt closed"><span>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				</span><br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">https://doi.org/10.1016/j.paid.2015.08.0...
+            </a></span></span>)</td>
+<td align="center">PID<br>
+									 PID</td>
+<td align="right">245<br>
+									 27</td>
+</tr>
+<tr>
+<td align="left">Virtue Ethics Scale (VES)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Shanahan and Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Racelis (2013</strong><span class="refCtt closed"><span>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				</span><br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">https://ajba.um.edu.my/article/view/2664...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Racelis (2014</strong><span class="refCtt closed"><span>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				</span><br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">https://www.academia.edu/10525406/Examin...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Donada, Mothe, Nogatchewsky and Ribeiro (2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>)<br>
+									 Shanahan and Hopkins (2019)</td>
+<td align="center">JBE<br>
+									 AJBA<br>
+									 APSSR<br>
+									 JBE<br>
+									 JBE<br>
+									 JBE</td>
+<td align="right">152<br>
+									 18<br>
+									 3<br>
+									 8<br>
+									 15<br>
+									 7</td>
+</tr>
+<tr>
+<td align="left">VIA-Classification</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Park and Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Song and Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Arthur, Earl, Thompson and Ward (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>)</td>
+<td align="center">JA<br>
+									 JBE<br>
+									 JBE</td>
+<td align="right">775<br>
+									 27<br>
+									 3</td>
+</tr>
+<tr>
+<td align="left">Virtuous Leadership Scale (VLS)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Sarros, Cooper e Hartican (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Wang and Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">L&amp;ODJ<br>
+									 JBE</td>
+<td align="right">96<br>
+									 70</td>
+</tr>
+<tr>
+<td align="left">Measure of Auditor’s Virtue</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Libby and Thorne (2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">65</td>
+</tr>
+<tr>
+<td align="left">Leadership Virtues Questionnaire (LVQ)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Riggio, Zhu, Reina and Maroosis (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>)</td>
+<td align="center">CPJPR</td>
+<td align="right">256</td>
+</tr>
+<tr>
+<td align="left">Character Strengths Leadership Survey</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Thun and Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>)</td>
+<td align="center">CJAS</td>
+<td align="right">63</td>
+</tr>
+<tr>
+<td align="left">Virtue Adjective Rating Scale (VARS)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Yang, Stoeber and Wang (2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>)</td>
+<td align="center">PID</td>
+<td align="right">32</td>
+</tr>
+<tr>
+<td align="left">Leadership Character Insight Assessment (LCIA)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Seijts, Gandz, Crossan and Reno (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>)</td>
+<td align="center">OD</td>
+<td align="right">54</td>
+</tr>
+<tr>
+<td align="left">Ethical Tendencies Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Koçyiğit and Karadağ (2016</strong><span class="refCtt closed"><span>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				</span><br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">https://doi.org/10.12711/TJBE.2016.9.001...
+            </a></span></span>)</td>
+<td align="center">TJBE</td>
+<td align="right">9</td>
+</tr>
+<tr>
+<td align="left">Virtuous Leadership Questionnaire (VLQ)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Wang and Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">70</td>
+</tr>
+<tr>
+<td align="left">Individual Business Virtues (IBE) </td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">8</td>
+</tr>
+<tr><td align="center" colspan="4">Specific moral virtues </td></tr>
+<tr>
+<td align="left">Multidimensional Ethics Scale (MES)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Beekun, Westerman and Barghouti (2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Manly, Leonard and Riemenschneider (2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>)</td>
+<td align="center">JBE<br>
+									 JBE</td>
+<td align="right">56<br>
+									 36</td>
+</tr>
+<tr>
+<td align="left">Deontic Justice Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Beugré (2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>)</td>
+<td align="center">JASP</td>
+<td align="right">38</td>
+</tr>
+<tr>
+<td align="left">Specific scales correlated with Engagement Beauty Scale (EBS)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Diessner, Iyer, Smith and Haidt (2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>)</td>
+<td align="center">JME</td>
+<td align="right">104</td>
+</tr>
+<tr>
+<td align="left">Self-regarding and other regarding virtues</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Grappi, Romani and Bagozzi (2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>)</td>
+<td align="center">JBR</td>
+<td align="right">287</td>
+</tr>
+<tr>
+<td align="left">Multicomponent Gratitude Measure (MCGM)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Morgan et al. (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Gulliford, Morgan, Hemming and Abbott (2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Hudecek, Blabst, Morgan and Lermer (2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>)</td>
+<td align="center">PID<br>
+									 CP<br>
+									 FP</td>
+<td align="right">55<br>
+									 6<br>
+									 1</td>
+</tr>
+<tr>
+<td align="left">Moral Virtue Theory of Status Attainment (MVT)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Bai, Ho and Yan (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>)</td>
+<td align="center">JPSP</td>
+<td align="right">10</td>
+</tr>
+<tr>
+<td align="left">Consumer moral virtue of Integrity</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Castro-González, Bande, Fernández-Ferrín and Kimura (2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>)</td>
+<td align="center">JCP</td>
+<td align="right">29</td>
+</tr>
+<tr>
+<td align="left">Self-report Humility Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Qin, Liu, Brown, Zheng and Owens (2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">6</td>
+</tr>
+<tr>
+<td align="left">Gratitude Questionnaire (G-20)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Bernabe-Valero, Blasco-Magraner and García-March (2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>)</td>
+<td align="center">FP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">Intellectually Humble Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Colombo, Strangmann, Houkes, Kostadinova and Brandt (2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>)</td>
+<td align="center">RPP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">Good and Evil Character Traits (GECT) Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Jiao, Yang, Guo, Xu, Zhang and Jiang (2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>)</td>
+<td align="center">SJP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">Resilient Measurement Scale (SPP-25)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Lasota, Tomaszek and Bosacki (2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>)</td>
+<td align="center">CP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">Professional Moral Courage scale (PMC; Sekerka 2009, 2 items)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Mansur, Sobral and Islam (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>)</td>
+<td align="center">BEER</td>
+<td align="right">1</td>
+</tr>
+<tr>
+<td align="left">Temperance Scale</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Shahab and Adil (2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>)</td>
+<td align="center">PJ</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">Enright Self-Forgiveness Inventory (ESFI)</td>
+<td align="left">
+									<span class="ref"><strong class="xref xrefblue">Kim, Volk and Enright (2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>)</td>
+<td align="center">CP</td>
+<td align="right">-</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote">
+<li id="TFN2"><div>Note. <i>Personality and Individual Differences</i> (PID)<i>; Journal of Business Ethics</i> (JBE); <i>Asian Journal of Business &amp; Accounting</i> (AJBA); <i>Asia-Pacific Social Science Review</i> (APSSR); <i>Journal of Adolescence</i> (JA); <i>Leadership &amp; Organization Development Journal</i> (L&amp;ODJ); <i>Consulting Psychology Journal: Practice and Research</i> (CPJPR); <i>Canadian Journal of Administrative Science</i> (CJAS); <i>Organizational Dynamics; Turkish Journal of Business Ethics</i> (TJBE); <i>Journal of Applied Social Psychology</i> (JASP); <i>Journal of Moral Education</i> (JME); <i>Journal of Business Research</i> (JBR); <i>Journal of Personality &amp; Social Psychology</i> (JPSP); <i>Journal of Cleaner Production</i> (JCP); <i>Current Psychology</i> (CP); <i>Frontiers in Psychology</i> (FP); <i>Review of Philosophy and Psychology</i> (RPP)<i>; Scandinavian Journal of Psychology</i> (SJP); <i>Business Ethics: A European Review</i> (BEER)<i>; PsyCh Journal</i> (PJ).</div></li>
+<li id="TFN3">
+<sup class="xref big">a</sup><div> Search conducted on Google Scholar on March 2, 2021.</div>
+</li>
+</ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet3" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Table 3</strong>    Items, samples, and measures on moral virtues scales at the individual level.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Articles</th>
+<th align="center">Initial Items (A)</th>
+<th align="center">Sample (B)</th>
+<th align="center">Proportion (B/A)</th>
+<th align="center">Final Items</th>
+<th align="center">Statistical analyses</th>
+<th align="center">Country</th>
+<th align="center">Respondents’ profile</th>
+</tr></thead>
+<tbody>
+<tr><td align="center" colspan="8">Multiple moral virtues </td></tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Cawley et al. (2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>)</td>
+<td align="center">140</td>
+<td align="center">390(1), 181(2), 143(3)</td>
+<td align="center">2.8</td>
+<td align="center">48</td>
+<td align="center">EFA</td>
+<td align="center">US</td>
+<td align="center">Psychology students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Shanahan and Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>)</td>
+<td align="center">45</td>
+<td align="center">445</td>
+<td align="center">9.9</td>
+<td align="center">33</td>
+<td align="center">EFA</td>
+<td align="center">US</td>
+<td align="center">Marketing students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Park and Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>)</td>
+<td align="center">198</td>
+<td align="center">250</td>
+<td align="center">1.3</td>
+<td align="center">24</td>
+<td align="center">EFA</td>
+<td align="center">US</td>
+<td align="center">Students (10-17 years old)</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>)</td>
+<td align="center">7</td>
+<td align="center">238</td>
+<td align="center">34.0</td>
+<td align="center">7</td>
+<td align="center">ANOVA</td>
+<td align="center">Australia</td>
+<td align="center">Members of the Australian Institute of Management</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Libby and Thorne (2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>)</td>
+<td align="center">55</td>
+<td align="center">376</td>
+<td align="center">6.8</td>
+<td align="center">29</td>
+<td align="center">EFA</td>
+<td align="center">Canada</td>
+<td align="center">CICA members</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>)</td>
+<td align="center">36</td>
+<td align="center">200</td>
+<td align="center">5.6</td>
+<td align="center">19</td>
+<td align="center">EFA, CFA</td>
+<td align="center">US</td>
+<td align="center">Administrators</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Thun and Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>)</td>
+<td align="center">27</td>
+<td align="center">327</td>
+<td align="center">12.1</td>
+<td align="center">14</td>
+<td align="center">EFA</td>
+<td align="center"> Canada</td>
+<td align="center">University employees</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Racelis (2013</strong><span class="refCtt closed"><span>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				</span><br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">https://ajba.um.edu.my/article/view/2664...
+            </a></span></span>)</td>
+<td align="center">34</td>
+<td align="center">140</td>
+<td align="center">4.1</td>
+<td align="center">22</td>
+<td align="center">EFA</td>
+<td align="center">Philippines</td>
+<td align="center">University students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Racelis (2014</strong><span class="refCtt closed"><span>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				</span><br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">https://www.academia.edu/10525406/Examin...
+            </a></span></span>)</td>
+<td align="center">34</td>
+<td align="center">141</td>
+<td align="center">4.1</td>
+<td align="center">22</td>
+<td align="center">EFA</td>
+<td align="center">Philippines</td>
+<td align="center">Students who are managers</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Yang et al. (2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>)</td>
+<td align="center">90</td>
+<td align="center">348</td>
+<td align="center">3.9</td>
+<td align="center">90</td>
+<td align="center">EFA</td>
+<td align="center"> China</td>
+<td align="center">Students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Seijts et al. (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">364</td>
+<td align="center">36.4</td>
+<td align="center">10</td>
+<td align="center">-</td>
+<td align="center">Canada and the US</td>
+<td align="center">Organizations’ leaders</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Koçyiğit and Karadağ (2016</strong><span class="refCtt closed"><span>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				</span><br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">https://doi.org/10.12711/TJBE.2016.9.001...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">312</td>
+<td align="center">31.2</td>
+<td align="center">26</td>
+<td align="center">EFA, CFA</td>
+<td align="center">Turkey</td>
+<td align="center">Undergraduate students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Stoeber and Yang (2016</strong><span class="refCtt closed"><span>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				</span><br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">https://doi.org/10.1016/j.paid.2015.08.0...
+            </a></span></span>)</td>
+<td align="center">48</td>
+<td align="center">243</td>
+<td align="center">5.1</td>
+<td align="center">48</td>
+<td align="left"> </td>
+<td align="center">China</td>
+<td align="center">University students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Wang and Hacket (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">89</td>
+<td align="center">348</td>
+<td align="center">3.9</td>
+<td align="center">18</td>
+<td align="center">EFA, CFA</td>
+<td align="center">North America</td>
+<td align="center">MBA students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)</td>
+<td align="center">45</td>
+<td align="center">137</td>
+<td align="center">3.0</td>
+<td align="center">13</td>
+<td align="center">EFA, CFA</td>
+<td align="center">UK</td>
+<td align="center">HR professionals</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Song and Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>)</td>
+<td align="center">50</td>
+<td align="center">400</td>
+<td align="center">8</td>
+<td align="center">50</td>
+<td align="center">CFA</td>
+<td align="center">US</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Arthur et al. (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>)</td>
+<td align="center">24</td>
+<td align="center">2.340</td>
+<td align="center">97.5</td>
+<td align="center">24</td>
+<td align="center">ANOVA, CFA</td>
+<td align="center">US</td>
+<td align="center">Professionals in five different areas</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Donada et al. (2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>)</td>
+<td align="center">14</td>
+<td align="center">201</td>
+<td align="center">14.4</td>
+<td align="center">14</td>
+<td align="center">-</td>
+<td align="center">France</td>
+<td align="center">CEOs</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Shanahan and Hopkins (2019</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">https://doi.org/10.1007/s10551-018-3813-...
+            </a></span></span>)</td>
+<td align="center">3</td>
+<td align="center">129</td>
+<td align="center">43</td>
+<td align="center">3</td>
+<td align="center">CFA</td>
+<td align="center">US</td>
+<td align="center">Managers and salespeople</td>
+</tr>
+<tr><td align="center" colspan="8">Specific moral virtues </td></tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Beekun et al. (2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>)</td>
+<td align="center">14</td>
+<td align="center">165</td>
+<td align="center">11.8</td>
+<td align="center">14</td>
+<td align="center">EFA</td>
+<td align="center">US and Russia</td>
+<td align="center">MBA students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Beugré (2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>)</td>
+<td align="center">36</td>
+<td align="center">124(1) 101(2)</td>
+<td align="center">3.4 2.8</td>
+<td align="center">18</td>
+<td align="center">-</td>
+<td align="center">US</td>
+<td align="center">Employees of an electronics retail chain</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Diessner et al. (2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>)</td>
+<td align="center">18</td>
+<td align="center">5.380 (1) 542(2)</td>
+<td align="center">298.9</td>
+<td align="center">18</td>
+<td align="center">SEM</td>
+<td align="center">US (Idaho)</td>
+<td align="center">University students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Grappi et al. (2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>)</td>
+<td align="center">5</td>
+<td align="center">280</td>
+<td align="center">56.0</td>
+<td align="center">5</td>
+<td align="center">CFA</td>
+<td align="center">Italy</td>
+<td align="center">Consumers</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Manly et al. (2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>)</td>
+<td align="center">12</td>
+<td align="center">86</td>
+<td align="center">7.2</td>
+<td align="center">12</td>
+<td align="center">-</td>
+<td align="center">US</td>
+<td align="center">IT business students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Morgan et al. (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>)</td>
+<td align="center">119</td>
+<td align="center">477(1) 1.599(2)</td>
+<td align="center">4.0 55.1</td>
+<td align="center">29</td>
+<td align="center">EFA, CFA, ANOVA, MANOVA</td>
+<td align="center">UK</td>
+<td align="center">Online respondent</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Castro-González et al. (2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>)</td>
+<td align="center">2</td>
+<td align="center">252</td>
+<td align="center">126</td>
+<td align="center">2</td>
+<td align="center">CFA</td>
+<td align="center">Spain</td>
+<td align="center">Consumers</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Gulliford et al. (2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>)</td>
+<td align="center">6+29</td>
+<td align="center">311</td>
+<td align="center">8.9</td>
+<td align="center">6+29</td>
+<td align="center">ANOVA</td>
+<td align="center">UK</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Qin et al. (2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>)</td>
+<td align="center">9</td>
+<td align="center">487</td>
+<td align="center">54.1</td>
+<td align="center">9</td>
+<td align="center">EFA, CFA</td>
+<td align="center">China</td>
+<td align="center">Supervisors and employees</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Bai et al. (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>)</td>
+<td align="center">60</td>
+<td align="center">292(1), 167(2) 155(3)</td>
+<td align="center">4.9</td>
+<td align="center">15</td>
+<td align="center">EFA, CFA</td>
+<td align="center">US and China</td>
+<td align="center">Students Managers</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Bernabe-Valero et al. (2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>)</td>
+<td align="center">20</td>
+<td align="center">302</td>
+<td align="center">15.1</td>
+<td align="center">20</td>
+<td align="center">CFA</td>
+<td align="center">US</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Colombo et al. (2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>)</td>
+<td align="center">20</td>
+<td align="center">60(1), 301(2), 347(3), 431(4)</td>
+<td align="center">3</td>
+<td align="center">20</td>
+<td align="center">-</td>
+<td align="center">Netherlands</td>
+<td align="center">University students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Hudecek et al. (2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>)</td>
+<td align="center">6</td>
+<td align="center">508(1) 1.599(2)</td>
+<td align="center">84.7</td>
+<td align="center">6</td>
+<td align="center">CFA</td>
+<td align="center">Germany and UK</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Jiao et al. (2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>)</td>
+<td align="center">55</td>
+<td align="center">350</td>
+<td align="center">6.4</td>
+<td align="center">53</td>
+<td align="center">EFA, CFA</td>
+<td align="center">China</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Lasota et al. (2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>)</td>
+<td align="center">25</td>
+<td align="center">214</td>
+<td align="center">8.6</td>
+<td align="center">25</td>
+<td align="center">SEM</td>
+<td align="center">Poland</td>
+<td align="center">Students and employees</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Mansur et al. (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">202</td>
+<td align="center">20.2</td>
+<td align="center">9</td>
+<td align="center">EFA, CFA</td>
+<td align="center">Not informed</td>
+<td align="center">Adults</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Shahab and Adil (2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>)</td>
+<td align="center">24</td>
+<td align="center">250(1) 268(2)</td>
+<td align="center">10.4</td>
+<td align="center">24</td>
+<td align="center">EFA, CFA</td>
+<td align="center">Pakistan</td>
+<td align="center">University students</td>
+</tr>
+<tr>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Kim et al. (2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>)</td>
+<td align="center">60</td>
+<td align="center">252(1), 204(2), 343(3), 567(4) </td>
+<td align="center">4.2</td>
+<td align="center">30</td>
+<td align="center">EFA, CFA</td>
+<td align="center">USA</td>
+<td align="center">Students-parents; adults</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN4"><div>Note. Exploratory factor analysis (EFA), confirmatory factor analysis (CFA), structural equation modeling (SEM), univariate analysis of covariance (ANOVA), multivariate analysis of covariance (MANOVA).</div></li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">How to cite</h4>
+</div>
+<div class="modal-body">
+<p id="citation"></p>
+<input id="citationCut" type="text" value=""><a class="copyLink" data-clipboard-target="#citationCut"><span class="glyphBtn copyIcon"></span>copy</a>
+</div>
+</div></div></div>
+<script type="text/javascript">
+            function currentDate() {
+            var today = new Date();
+            var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+            today.setTime(today.getTime());
+            return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+            }
+            var citation = 'Ames, Maria Clara F. Dalla Costa, Serafim, Mauricio C. and Martins, Felipe FlôresAnalysis of Scales and Measures of Moral Virtues: A Systematic Review. Revista de Administração Contemporânea [online]. 2022, v. 26, n. 06 [Accessed CURRENTDATE] , e190379. Available from: &lt;https://doi.org/10.1590/1982-7849rac2022190379.en https://doi.org/10.1590/1982-7849rac2022190379.por&gt;. Epub 18 July 2022. ISSN 1982-7849. https://doi.org/10.1590/1982-7849rac2022190379.en.'.replace('CURRENTDATE', currentDate());
+            document.getElementById('citation').innerHTML = citation;
+            document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+        </script>
+</div>
+<ul class="floatingMenu fm-slidein" data-fm-toogle="hover"><li class="fm-wrap">
+<a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a><ul class="fm-list">
+<li><a class="fm-button-child" data-fm-label="Figures | Tables" data-toggle="modal" data-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+<li><a class="fm-button-child" data-toggle="modal" data-target="#ModalArticles" data-fm-label="How to
+                                          cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+</ul>
+</li></ul>
+<script src="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js"></script>
+</body>
+</html>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
@@ -745,32 +745,32 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote">
-<li>
-<h3><span class="xref big">JEL Code:</span></h3>
+<li class="articleSection" data-anchor="JEL Code:">
+<h3>JEL Code:</h3>
 <div>M1, M10.</div>
 </li>
-<li>
-<h3><span class="xref big">Peer Review Report:</span></h3>
+<li class="articleSection" data-anchor="Peer Review Report:">
+<h3>Peer Review Report:</h3>
 <div>The Peer Review Report is available at this <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">external URL</a>.</div>
 </li>
-<li>
-<h3><span class="xref big">Funding</span></h3>
+<li class="articleSection" data-anchor="Funding">
+<h3>Funding</h3>
 <div> The authors thank the Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development (CNPq) (CHSSA, Process nr. 445434/2015-5) for the financial support to the research project, from which this study was developed.</div>
 </li>
-<li>
-<h3><span class="xref big">Plagiarism Check</span></h3>
+<li class="articleSection" data-anchor="Plagiarism Check">
+<h3>Plagiarism Check</h3>
 <div> The RAC maintains the practice of submitting all documents approved for publication to the plagiarism check, using specific tools, e.g.: iThenticate.</div>
 </li>
-<li>
-<h3><span class="xref big">Copyrights</span></h3>
+<li class="articleSection" data-anchor="Copyrights">
+<h3>Copyrights</h3>
 <div> RAC owns the copyright to this content.</div>
 </li>
-<li>
-<h3><span class="xref big">Peer Review Method</span></h3>
+<li class="articleSection" data-anchor="Peer Review Method">
+<h3>Peer Review Method</h3>
 <div> This content was evaluated using the double-blind peer review process. The disclosure of the reviewers' information on the first page, as well as the Peer Review Report, is made only after concluding the evaluation process, and with the voluntary consent of the respective reviewers and authors.</div>
 </li>
-<li>
-<h3><span class="xref big">Data Availability</span></h3>
+<li class="articleSection" data-anchor="Data Availability">
+<h3>Data Availability</h3>
 <div>The authors claim that all data used in the research have been made publicly available through the Harvard Dataverse platform and can be accessed at:</div>
 <div>
 <img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
@@ -1,0 +1,1992 @@
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css">
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css" media="print">
+<link rel="alternate" type="application/rss+xml" title="SciELO" href="">
+</head>
+<body class="journal article">
+<a name="top"></a><div id="standalonearticle">
+<section class="articleCtt"><div class="container"><div class="articleTxt">
+<div class="articleBadge-editionMeta-doi-copyLink">
+<span class="_articleBadge">Artigo Teórico-empírico</span><span class="_separator"> • </span><span class="_editionMeta">Rev. adm. contemp. 26 
+                (06)
+            <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.1590/1982-7849rac2022190379.por" class="_doi" target="_blank">https://doi.org/10.1590/1982-7849rac2022190379.por</a>
+         
+        <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/1982-7849rac2022190379.por"><span class="sci-ico-link"></span>copiar</a></span>
+</div>
+<h1 class="article-title">
+<span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Análise de Escalas e Medidas de Virtudes Morais: Uma Revisão Sistemática<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+</h1>
+<div class="articleMeta"></div>
+<div class="contribGroup">
+<span class="dropdown"><a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Maria Clara F. Dalla Costa Ames </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.<div class="corresp">
+					* Autora Correspondente</div>
+<a href="http://orcid.org/0000-0002-0444-8764" class="btnContribLinks orcid">http://orcid.org/0000-0002-0444-8764</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Mauricio C. Serafim </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.<a href="http://orcid.org/0000-0002-4852-5119" class="btnContribLinks orcid">http://orcid.org/0000-0002-4852-5119</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Felipe Flôres Martins </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+<strong></strong>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.<a href="http://orcid.org/0000-0003-2987-5479" class="btnContribLinks orcid">http://orcid.org/0000-0003-2987-5479</a>
+</ul></span><a href="" class="outlineFadeLink" data-toggle="modal" data-target="#ModalTutors">Sobre os autores</a>
+</div>
+<div class="row">
+<ul class="col-md-2 hidden-sm articleMenu"></ul>
+<article id="articleText" class="col-md-10 col-md-offset-2 col-sm-12 col-sm-offset-0"><div class="articleSection" data-anchor="ABSTRACT">
+<h1 class="articleSectionTitle">ABSTRACT</h1>
+<h2>Objective:</h2>
+<p> to investigate how scales for the concept of moral virtues are constructed and measured, in studies associated with business ethics and the tradition of virtue ethics. </p>
+<h2>Methods:</h2>
+<p> a systematic literature review was conducted to select empirical articles on moral virtues that design or apply scales. Based on search, selection, and analysis criteria, five databases were consulted, and 37 papers were selected, with subsequent analysis of the scales development and measurement procedure (items, sample, factor analysis) and emerging factors. </p>
+<h2>Results:</h2>
+<p> the study gathers scales of multiple moral virtues (19) and of specific virtues (18), showing limitations in the generation of items, and in the item-sample proportion in some scales, as well as theoretical contributions in leadership and relationship strengthening, making a theoretical and methodological discussion in the light of the assumptions of virtue ethics in the Aristotelian-Thomistic tradition. </p>
+<h2>Conclusions:</h2>
+<p> the article intends to contribute to a better understanding of moral virtues in management, by discussing the scales from the unity of virtues and the phronesis-moral virtues connection, with implications for human behavior and business ethics. Procedures are recommended for future qualitative and quantitative studies in new research contexts.</p>
+<p><strong>Keywords:</strong><br>moral virtues; scale analysis; virtue ethics; business ethics</p>
+</div>
+<div class="articleSection" data-anchor="RESUMO">
+<h1 class="articleSectionTitle">RESUMO</h1>
+<h2>Objetivo:</h2>
+<p> investigar como as escalas para o conceito de virtudes morais são construídas e mensuradas, em estudos associados à ética empresarial e à tradição da ética das virtudes. </p>
+<h2>Métodos:</h2>
+<p> realizou-se uma revisão sistemática da literatura para selecionar artigos empíricos sobre virtudes morais que elaboram ou aplicam escalas. Com base em critérios de busca, seleção e análise, foram consultadas cinco bases de dados e selecionados 37 trabalhos, analisando-se o procedimento de desenvolvimento e mensuração de escalas (itens, amostra, análise fatorial) e fatores emergentes. </p>
+<h2>Resultados:</h2>
+<p> o estudo reúne escalas de múltiplas virtudes morais (19) e de virtudes específicas (18), evidenciando limitações na geração de itens e na proporção item-amostra em algumas escalas, como também contribuições teóricas em liderança e fortalecimento de relações, fazendo uma discussão teórico-metodológica, à luz dos pressupostos da ética das virtudes na tradição aristotélico-tomista. </p>
+<h2>Conclusões:</h2>
+<p> o artigo intenciona contribuir para uma melhor compreensão sobre as virtudes morais em administração, ao discutir as escalas a partir da unidade das virtudes e da conexão <i>phronesis</i>-virtudes morais, com implicações no comportamento humano e na ética empresarial. Recomendam-se procedimentos para estudos futuros qualitativos e quantitativos em novos contextos de pesquisa.</p>
+<p><strong>Palavras-chave:</strong><br>virtudes morais; análise de escalas; ética das virtudes; ética empresarial</p>
+</div>
+<div>
+<h1 class="articleSectionTitle">INTRODUÇÃO</h1>
+<p>A ética das virtudes tem se revelado nos últimos anos uma influente tradição nos estudos sobre ética empresarial (<span class="ref"><strong class="xref xrefblue">Alzola, Hennig, &amp; Romar, 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>). O interesse pelo tema tem se intensificado desde a reinterpretação de Aristóteles (2009) por autores da filosofia moral, como <span class="ref"><strong class="xref xrefblue">Anscombe (1958</strong><span class="refCtt closed"><span>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				</span><br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">https://doi.org/10.1017/S003181910003794...
+            </a></span></span>) e MacIntyre (2007). Os problemas éticos da realidade organizacional têm sido discutidos por diferentes perspectivas e tradições relacionadas às virtudes (<span class="ref"><strong class="xref xrefblue">Sison, Ferrero, &amp; Guitián, 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>), como alternativa às éticas consequencialistas e deontológicas, sendo a corrente de estudos empíricos e quantitativos um tema proeminente da área desde a virada do milênio (Sison &amp; Ferrero, 2015).</p>
+<p>Essa corrente tem elaborado escalas e medidas, tendo por base as listas de virtudes morais propostas por <span class="ref"><strong class="xref xrefblue">Solomon (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>; 1999) e <span class="ref"><strong class="xref xrefblue">Murphy (1999</strong><span class="refCtt closed"><span>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				</span><br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">https://doi.org/10.1023/A:1006072413165...
+            </a></span></span>). Tais estudos visam a identificar e mensurar virtudes morais no contexto da administração e negócios. No entanto, tem-se criticado o uso de certos métodos científicos das ciências sociais (<span class="ref"><strong class="xref xrefblue">Beadle, Sison, &amp; Fontrodona, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>), empregados para abordar virtudes morais, um conceito de raiz filosófica e valorado por muitas culturas. Nesse processo, elementos e pressupostos podem ser reduzidos a meros comportamentos observáveis, o que pode prejudicar uma melhor compreensão das virtudes (Sison &amp; Ferrero, 2015; <span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). Isso vem reforçando a necessidade de uma sólida base teórica sobre o construto virtudes morais em sua multidimensionalidade (<span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker, Hyman, &amp; Shanahan, 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>).</p>
+<p>Além de virtudes morais individuais, outro construto desenvolvido se refere às virtudes morais organizacionais, ou virtuosidade (<span class="ref"><strong class="xref xrefblue">Huhtala, Kangas, Kaptein, &amp; Feldt, 2018</strong><span class="refCtt closed"><span>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				</span><br><a href="https://doi.org/10.1111/beer.12184" target="_blank">https://doi.org/10.1111/beer.12184...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Gomide, Vieira, &amp; Oliveira, 2016</strong><span class="refCtt closed"><span>Gomide, S. Jr., Vieira, L. E., &amp; Oliveira, A. F. (2016). Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro. Psicologia: Organizações e Trabalho, 16(3), 298-307. http://dx.doi.org/10.17652/rpot/2016.3.10417
+				</span><br><a href="http://dx.doi.org/10.17652/rpot/2016.3.10417" target="_blank">http://dx.doi.org/10.17652/rpot/2016.3.1...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Rego &amp; Cunha, 2015</strong><span class="refCtt closed"><span>Rego, A., &amp; Cunha, M. P. (2015). As virtudes nas organizações. Análise Psicológica, 4(33), 349-359. https://doi.org/10.14417/ap.1022
+				</span><br><a href="https://doi.org/10.14417/ap.1022" target="_blank">https://doi.org/10.14417/ap.1022...
+            </a></span></span>). Apesar de sua estrita relação, os conceitos de virtude moral e virtuosidade não são idênticos: o primeiro se refere ao indivíduo, enquanto o segundo à organização, ao que pode ser externamente verificado (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Dessa maneira, há escalas de virtudes morais em âmbito individual e outras em âmbito de grupo e organizacional (<i>virtuousness</i>), como as revisitadas por <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>) e <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker, Hyman e Shanahan (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). Este artigo limita-se a investigar escalas de virtudes morais em âmbito individual, isto é, relacionadas às características de um único indivíduo, deixando as escalas de virtuosidade para uma futura pesquisa.</p>
+<p>O tema dispõe de diferentes tradições teóricas (<span class="ref"><strong class="xref xrefblue">Sison et al., 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>) e amplas listas de virtudes. Embora a concepção de virtudes contemple seus componentes ou dimensões (<span class="ref"><strong class="xref xrefblue">Newstead, Macklin, Dawkins, &amp; Martin, 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>), a pesquisa empírica tem se restringido a traços ou comportamentos observáveis, revelando um impasse metodológico na relação entre a ética das virtudes - com origem na filosofia moral - e as ciências experimentais, como certas ramificações na psicologia. Diante do desenvolvimento de novas escalas sobre virtudes, este trabalho se propõe a responder à seguinte pergunta: ‘Como as escalas para o construto virtudes morais são construídas e mensuradas em estudos associados à ética das virtudes?’ O presente artigo visa a analisar as escalas e medidas do construto virtudes morais individuais (pessoais), partindo de uma revisão sistemática da literatura (<span class="ref"><strong class="xref xrefblue">Snyder, 2019</strong><span class="refCtt closed"><span>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">https://doi.org/10.1016/j.jbusres.2019.0...
+            </a></span></span>).</p>
+<p>Dois trabalhos antecedentes contribuem nesse sentido. <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al. (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) abordam desafios, possibilidades e cuidados para o desenvolvimento de escalas, descrevendo escalas, itens e aspectos psicométricos, enquanto <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>) lista escalas de virtudes morais individuais, de grupo e organizacionais.</p>
+<p>O artigo em curso pretende dar continuidade a esses trabalhos ao fazer uma revisão sistemática de artigos que desenvolvem ou aplicam escalas a partir dos Principais Itens para Relatar Revisões Sistemáticas e Meta-Análises, de <span class="ref"><strong class="xref xrefblue">Moher, Liberati, Tetslaff e Altman (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>), seguida de uma análise estatística segundo recomendações de <span class="ref"><strong class="xref xrefblue">Fávero, Belfiore, Silva e Chan (2009</strong><span class="refCtt closed"><span>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</span></span></span>), <span class="ref"><strong class="xref xrefblue">Hair, Babin, Money e Samouel (2005</strong><span class="refCtt closed"><span>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</span></span></span>) e Hair, Black, Babin, Anderson e Tathan (2009).</p>
+<p>O trabalho procura contribuir com a análise de métodos empregados para elaboração e aplicação de escalas de virtudes morais, diante do impasse metodológico para pesquisas empíricas sobre a ética das virtudes. Isso é realizado e discutido metodológica e teoricamente, considerando pressupostos da ética das virtudes na tradição aristotélico-tomista (<span class="ref"><strong class="xref xrefblue">Sison, Beabout, &amp; Ferrero, 2017</strong><span class="refCtt closed"><span>Sison, A. J. G., Beabout, G. R., &amp; Ferrero, I. (Eds.). (2017). Handbook of virtue ethics in business and management. Dordrecht, the Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>).</p>
+<p>As próximas seções deste artigo estão assim organizadas. Primeiro, discute-se o conceito de virtudes morais, considerando pressupostos da ética das virtudes e perspectivas que buscam mensurar virtudes. Na sequência, descrevem-se os procedimentos para a revisão sistemática de artigos, bem como critérios de análise. Na seção seguinte são apresentados os resultados e análises das medidas e escalas encontradas, seguidos de uma discussão sobre métodos e pressupostos teóricos e de sugestões de estudos futuros. Ao final, consideram-se as limitações e conclusões de pesquisa. </p>
+<h1 class="articleSectionTitle"><b>VIRTUDES MORAIS SEGUNDO A TRADIÇÃO DA ÉTICA DAS VIRTUDES EM <i>BUSINESS ETHICS</i>
+</b></h1>
+<p>A retomada ou reinterpretação das virtudes morais na filosofia, psicologia, educação e ética empresarial é tributária ao trabalho de autores como Elizabeth <span class="ref"><strong class="xref xrefblue">Anscombe (1958</strong><span class="refCtt closed"><span>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				</span><br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">https://doi.org/10.1017/S003181910003794...
+            </a></span></span>), Philippa <span class="ref"><strong class="xref xrefblue">Foot (1967</strong><span class="refCtt closed"><span>Foot, P. (1967). The problem of abortion and the doctrine of double effect. Oxford Reviews, 5, 5-15. Retrieved from https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf
+				</span><br><a href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf" target="_blank">https://spot.colorado.edu/~heathwoo/phil...
+            </a></span></span>) e Alasdair MacIntyre (2007), os quais retomam conceitos aristotélicos e tomistas. A ética das virtudes tem sido desenvolvida por meio de várias perspectivas, tanto ocidentais como orientais (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>), que se desenvolveram a partir de tradições morais, relacionadas a questões éticas de organizações e de diferentes funções da administração (<span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). </p>
+<p>O interesse pela ética das virtudes tem se evidenciado em conferências, simpósios temáticos e chamadas especiais de trabalho (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beadle et al., 2015</strong><span class="refCtt closed"><span>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				</span><br><a href="https://doi.org/10.1111/beer.12098" target="_blank">https://doi.org/10.1111/beer.12098...
+            </a></span></span>; Hühn, Habisch, <span class="ref"><strong class="xref xrefblue">Hartmann, &amp; Sison, 2020</strong><span class="refCtt closed"><span>Hühn, M. P., Habish, A., Hartmann, E. M., &amp; Sison, A. J. G. (2020). Practicing management wisely. Business Ethics: A European Review, 29(S1), 1-5. https://doi.org/10.1111/beer.12321
+				</span><br><a href="https://doi.org/10.1111/beer.12321" target="_blank">https://doi.org/10.1111/beer.12321...
+            </a></span></span>), <i>handbooks</i> de ética das virtudes na Administração (Sison et al., 2017), publicação de livros (Hartmann, 2020; <span class="ref"><strong class="xref xrefblue">Moore, 2017</strong><span class="refCtt closed"><span>Moore, G. (2017). Virtue at work: Ethics for individuals, managers, and organizations. Oxford, UK: Oxford University Press.</span></span></span>; Sison et al., 2018) e na formação de grupos de pesquisa, como o <i>Virtue Ethics in Business</i> (VEiB), da Universidade de Navarra. Adicionalmente, revistas como o <i>Journal of Business Ethics</i>, o <i>Business Ethics Quarterly</i> e o <i>Business Ethics: Environment and Responsibility</i> reúnem muitas questões que abordam a ética das virtudes. </p>
+<p>Os estudos sobre as virtudes podem ser vinculados a duas distintas perspectivas: teoria da virtude e ética das virtudes (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). São chamados de teoria da virtude os estudos sobre virtudes internas aos modelos deontológicos e consequencialistas. Diferentemente, a ética das virtudes é adotada como uma terceira perspectiva na filosofia moral, para representar estudos centrados no caráter, ancorados no tripé <i>arête</i> (virtude ou excelência), <i>phronesis</i> (prudência ou sabedoria prática) e <i>eudaimonia</i> (florescimento humano). Enquanto as perspectivas dentológicas e consequencialistas têm como referência a ação, a ética das virtudes enfoca no agente, considerando as particularidades contextuais que vivencia em comunidade (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>).</p>
+<p>
+					<span class="ref"><strong class="xref xrefblue">Solomon (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>) e <span class="ref"><strong class="xref xrefblue">Moberg (1999</strong><span class="refCtt closed"><span>Moberg, D. J. (1999). The big five and organizational virtue. Business Ethics Quarterly, 9(2), 245-272. https://doi.org/10.2307/3857474
+				</span><br><a href="https://doi.org/10.2307/3857474" target="_blank">https://doi.org/10.2307/3857474...
+            </a></span></span>) foram precursores na consideração da ética das virtudes na ética empresarial. Solomon (1992) tentou abordar a lacuna entre ética e prática nos negócios por meio de uma perspectiva baseada em Aristóteles (<span class="ref"><strong class="xref xrefblue">Alzola et al., 2020</strong><span class="refCtt closed"><span>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">https://doi.org/10.1007/s10551-019-04317...
+            </a></span></span>), com a ideia de que as pessoas e as corporações fazem parte da comunidade. Moberg (1999) explorou a conexão entre ética das virtudes e psicologia da personalidade, abrindo caminho para as pesquisas empíricas sobre ética das virtudes na ética empresarial.</p>
+<p>As virtudes morais são geralmente descritas como disposições do caráter responsáveis por indicar os corretos fins das ações, enquanto a prudência ou <i>practical wisdom</i> (<i>phronesis</i>) é a virtude responsável por indicar os meios para a consecução de tais fins (<span class="ref"><strong class="xref xrefblue">Ames &amp; Serafim, 2019</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., &amp; Serafim, M. C. (2019). Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review. Revista de Administração Contemporânea, 23(4), 564-586. https://doi.org/10.1590/1982-7849rac2019180301
+				</span><br><a href="https://doi.org/10.1590/1982-7849rac2019180301" target="_blank">https://doi.org/10.1590/1982-7849rac2019...
+            </a></span></span>; Aristóteles, 2009; <span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). No momento em que ações virtuosas, como coragem e humildade, começam a ser repetidas, tornam-se hábitos de alguém, e no longo prazo isso determina o seu caráter. O agente virtuoso é aquele que expressa virtudes em suas ações, e por isso suas ações e seus traços pessoais podem servir como referência para os demais (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). Tais ações são fruto de uma vontade ou intenção, a qual tem um fim, ou <i>telos</i>, voltado para o alcance da <i>eudaimonia</i>. Ao realizar ações virtuosas, o ser humano se aprimora, assim como as suas ações. Dessa forma, “o núcleo central da ética das virtudes reside na relação causal que se estabelece entre o que o agente faz e o que o agente se torna, por meio da aquisição de virtudes e do desenvolvimento do caráter” (Ferrero, 2020, p. 11).</p>
+<p>Entre suas principais tradições, pode-se destacar a tradição neoaristotélica, a escola tomista e as contribuições de MacIntyre (2007), o qual se aprofunda na ética de Aristóteles e Tomás de Aquino (<span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>). Estudos recentes compartilham da noção de virtudes cardeais - um “eixo principal” de virtudes - herdadas dessas tradições (<span class="ref"><strong class="xref xrefblue">Morales-Sánchez &amp; Cabello-Medina, 2013</strong><span class="refCtt closed"><span>Morales-Sánchez, R., &amp; Cabello-Medina, C. (2013). The role of four moral competencies in Ethical Decision-making. Journal of Business Ethics, 116(4), 717-734. https://doi.org/10.1007/s10551-013-1817-9
+				</span><br><a href="https://doi.org/10.1007/s10551-013-1817-9" target="_blank">https://doi.org/10.1007/s10551-013-1817-...
+            </a></span></span>). As virtudes cardeais são um grupo de quatro virtudes: (1) temperança, também conhecida como autodomínio ou moderação (<span class="ref"><strong class="xref xrefblue">Sanz &amp; Fontrodona, 2019</strong><span class="refCtt closed"><span>Sanz, P., &amp; Fontrodona, J. (2019). Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace. Journal of Business Ethics, 155, 981-994. https://doi.org/10.1007/s10551-018-3899-x
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3899-x" target="_blank">https://doi.org/10.1007/s10551-018-3899-...
+            </a></span></span>); (2) fortaleza ou coragem; (3) justiça (Morales-Sánchez &amp; Cabello-Medina, 2013); e (4) prudência ou sabedoria prática, originalmente do grego <i>phronesis</i> (<span class="ref"><strong class="xref xrefblue">Ames, Serafim, &amp; Zappellini, 2020</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				</span><br><a href="https://doi.org/10.1111/beer.12296" target="_blank">https://doi.org/10.1111/beer.12296...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Bachmann, Habisch, &amp; Dierksmeier, 2017</strong><span class="refCtt closed"><span>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">https://doi.org/10.1007/s10551-016-3417-...
+            </a></span></span>). Tais tradições consideram que as virtudes podem ser aprendidas, especialmente pela experiência vivida (Aristóteles, 2009).</p>
+<p>Pressupondo que a ação virtuosa de alguém pode ser percebida pelos demais agentes, estudos que utilizam escalas buscam mensurar a percepção das virtudes morais sobre a ação de colegas, líderes e administradores de uma forma geral. A lista de virtudes de <span class="ref"><strong class="xref xrefblue">Solomon (1992</strong><span class="refCtt closed"><span>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				</span><br><a href="https://doi.org/10.2307/3857536" target="_blank">https://doi.org/10.2307/3857536...
+            </a></span></span>; 1999) contribuiu nesse sentido. Seu arcabouço considera seis dimensões: comunidade, excelência, identidade do papel ou cargo, integridade, julgamento e holismo. Ele sugere uma lista de virtudes relacionadas à esfera dos negócios - honestidade, lealdade, sinceridade, coragem, confiabilidade, benevolência, cooperação, civilidade, para citar algumas - as quais servem de base para a escala de virtudes morais de <span class="ref"><strong class="xref xrefblue">Shanahan e Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>). Contudo, discute-se em que medida um grupo de virtudes pode ser associado à administração e negócios, sem que se considere adicionalmente o contexto e a percepção dos próprios administradores sobre virtudes a cultivar (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>).</p>
+<p>Além desse problema empírico, a psicologia positiva e a <i>positive organizational scholarship</i> (POS) limitam a definição de virtudes em termos de comportamento e por aspectos externos ao indivíduo (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al., 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). <span class="ref"><strong class="xref xrefblue">Sison e Ferrero (2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>) argumentam que não se pode reduzi-las aos aspectos cognitivos e emocionais do caráter, pois envolvem outros elementos e pressupostos fundamentais, como a inter-relação entre ações, hábitos, caráter e trajetória de vida. Isso pressupõe uma natureza humana que tem por fim (<i>telos</i>) a felicidade (<i>eudaimonia</i>) ou florescimento humano.</p>
+<p>Não há um conceito unânime para a virtude, haja vista as contribuições de diferentes tradições e campos do saber. Ainda assim, ela tende a ser vista como “uma inclinação [ou disposição] humana para sentir, pensar e agir de forma a expressar a excelência moral e contribuir para o bem comum” (<span class="ref"><strong class="xref xrefblue">Newstead et al., 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>, p. 446, tradução nossa). Considera-se que seus componentes intelectual, emocional, motivacional e comportamental “não são redutíveis um ao outro” (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>, p. 306, tradução nossa), algo similar aos multicomponentes percebidos por <span class="ref"><strong class="xref xrefblue">Morgan, Gulliford e Kristjánsson (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>). Na ética das virtudes, são entendidas como inclinações ou disposições pessoais expressas por uma gama de disposições: ações, hábitos, caráter e estilo de vida (forma de viver), com vistas ao bem comum (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Por isso, tem-se admitido que a manifestação comportamental de uma ação não é suficiente para inferir a presença de virtude (Alzola, 2015; <span class="ref"><strong class="xref xrefblue">Robson, 2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>).</p>
+<p>
+					<span class="ref"><strong class="xref xrefblue">Newstead, Macklin, Dawkins e Martin (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) desdobram o conceito em <i>virtue</i> (a inclinação virtuosa em si), <i>virtues</i> e <i>virtuous</i>, este último correspondendo à percepção frente a um evento virtuoso, descrito como uma experiência subjetiva experienciada, uma interpretação que um agente faz sobre a virtude expressada por alguém (<i>virtues</i>) em um evento/momento.</p>
+<p>Como exposto, o arcabouço da ética das virtudes reúne elementos teóricos e pressupostos fundamentais. Entre seus elementos estão: o agente humano e sua natureza, ações e hábitos morais reiterados que formam o seu caráter, a prática de virtudes morais, coordenadas pela sabedoria prática ou prudência, um fim último voltado para o florescimento humano ou <i>eudaimonia</i>, em um contexto comunitário em que se contribui para o bem comum. Entre seus pressupostos, dois deles merecem destaque e estão relacionados: (1) a conexão ou interdependência entre a virtude da <i>phronesis</i> e as virtudes morais - por exemplo, para ser prudente em decisões é preciso que a temperança contenha os impulsos que afetariam tal decisão, como a raiva ou a impaciência; e (2) a unidade das virtudes: no agente as virtudes estão vinculadas umas às outras - isto é, não há virtude isolada -, o que significa que se uma pessoa tem uma virtude, ela também tem as outras (<span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>).</p>
+<h2>Perspectivas que buscam mensurar virtudes morais</h2>
+<p>Em administração, os estudos da ética das virtudes se ramificaram para uma corrente que emprega métodos quantitativos e estatísticos no intuito de mensurar virtudes e seus impactos positivos nas organizações (<span class="ref"><strong class="xref xrefblue">Ferrero &amp; Sison, 2014</strong><span class="refCtt closed"><span>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				</span><br><a href="https://doi.org/10.1111/beer.12057" target="_blank">https://doi.org/10.1111/beer.12057...
+            </a></span></span>). Tal corrente está inserida no campo da psicologia positiva e é chamada de <i>positive organizational scholarship</i> (POS) (Sison &amp; Ferrero, 2015; <span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). Essa corrente se ramifica em duas perspectivas que buscam mensurar virtudes: (1) uma atrelada à psicologia positiva de <span class="ref"><strong class="xref xrefblue">Peterson e Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) e de abordagem em nível individual, correspondente a um movimento positivo nas ciências sociais (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>); e (2) os estudos que assumem o conceito de <i>virtuousness</i> ou virtuosidade, para acessar virtudes em âmbito organizacional (Meyer, 2018; <span class="ref"><strong class="xref xrefblue">Huhtala et al., 2018</strong><span class="refCtt closed"><span>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				</span><br><a href="https://doi.org/10.1111/beer.12184" target="_blank">https://doi.org/10.1111/beer.12184...
+            </a></span></span>). </p>
+<p>Essas duas correntes buscam mensurar virtudes, adotando métodos e assumindo pressupostos distintos daqueles compartilhados pela tradição aristotélico-tomista da ética das virtudes (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>).</p>
+<p>A primeira é atrelada à psicologia positiva e considera as forças do caráter como traços positivos dos indivíduos. O modelo de <span class="ref"><strong class="xref xrefblue">Peterson e Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) foi desenvolvido a partir da leitura de textos clássicos de diferentes culturas, revisados pelo grupo de pesquisa dedicado a tais estudos, reunindo indutivamente as características humanas que levam ao florescimento. Há diferenças entre o conceito de virtudes e de forças do caráter (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>). O modelo VIA - virtudes em ação - é composto por seis principais características (virtudes) e 24 forças. Contudo, esse modelo tem sido metodológica e filosoficamente questionado. Ele não assume o pressuposto da unidade das virtudes (<span class="ref"><strong class="xref xrefblue">Robson, 2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>). <span class="ref"><strong class="xref xrefblue">Kinghorn (2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>) elucida como o modelo foi construído e argumenta que não oferece condições para se dizer universal ou válido independentemente do contexto cultural. Tal modelo acolhe valores da sociedade democrática moderna, na qual se privilegia a autodeterminação dos indivíduos, seus direitos e liberdades (Kinghorn, 2017). O autor conclui que não há como um grupo de virtudes transcender a comunidade política particular na qual foi pensado, o que implica que o contexto particular importa e futuros instrumentos deveriam considerar a cultura do contexto e comunidade em análise. </p>
+<p>A segunda é a corrente de estudos organizacionais positivos (EOP) e utiliza o conceito de virtuosidade, o qual não é idêntico à noção de virtude (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). A virtuosidade é manifesta em estruturas, processos, atributos e culturas, bem como na ação individual e coletiva, e é expresso na e por meio das organizações (<span class="ref"><strong class="xref xrefblue">Cameron, Bright, &amp; Caza, 2004</strong><span class="refCtt closed"><span>Cameron, K., Bright, D., &amp; Caza, A. (2004). Exploring the relationships between organizational virtuousness and performance. American Behavioral Scientist, 47(6), 1-14. https://doi.org/10.1177/0002764203260209
+				</span><br><a href="https://doi.org/10.1177/0002764203260209" target="_blank">https://doi.org/10.1177/0002764203260209...
+            </a></span></span>; Sison &amp; Ferrero, 2015). Ela é entendida como um aspecto que contribui para a performance organizacional, o que pode vir a ser usado instrumentalmente para alcançar bons indicadores de comprometimento, satisfação e capital social (Sison &amp; Ferrero, 2015). Nessa abordagem, o conceito de virtuosidade é investigado predominantemente por métodos quantitativos e em âmbito organizacional (<span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). Além disso, essa corrente não trata do papel da <i>phronesis</i> em seu arcabouço para compreender a virtuosidade em organizações (Sison &amp; Ferrero, 2015). </p>
+<p>
+						<span class="ref"><strong class="xref xrefblue">Sison e Ferrero (2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>) ainda remetem às diferenças conceituais. Afirmam que os pressupostos sobre a natureza humana, fim último, <i>phronesis</i> e <i>eudaimonia</i> subjacentes à virtuosidade são muito diferentes da ética das virtudes, bem como o <i>locus</i> de realização: as virtudes são encontradas nas pessoas e apenas por analogia se associam a conceitos como os de caráter corporativo. Por outro lado, a virtuosidade se refere a organizações primeiramente e apenas secundariamente a indivíduos (<span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>). </p>
+<p>Entre os críticos da ética das virtudes, <span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al. (2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) expõem que a crítica situacionista não reconhece a necessidade de se conhecer fatores internos inerentes ao comportamento. Diferentemente, <span class="ref"><strong class="xref xrefblue">Alzola (2017</strong><span class="refCtt closed"><span>Alzola, M. (2017). Virtues and their explanatory and predictive power in the workplace. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>) argumenta que as virtudes morais podem ajudar na compreensão das ações dos indivíduos. Apesar da diversidade e desafios empíricos, ainda são necessárias adaptações para diferentes contextos e culturas (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). E afinal, virtudes podem ser mensuradas? Não há consenso sobre essa questão. <span class="ref"><strong class="xref xrefblue">Robson (2015</strong><span class="refCtt closed"><span>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				</span><br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">https://doi.org/ 10.1111/beer.12103...
+            </a></span></span>) argumenta que a psicologia positiva é capaz de mensurar traços de personalidade e tendências de comportamento, mas não é capaz de articular virtudes, porque não pode propor um tipo de arquitetura substantiva, para dar suporte a uma abordagem de virtudes a partir de uma tradição, como a ética das virtudes.</p>
+<h1 class="articleSectionTitle">PROCEDIMENTOS METODOLÓGICOS</h1>
+<p>Esta seção apresenta os procedimentos de busca e análise desta revisão sistemática, empregados para sintetizar e comparar evidências (Mendes-da-Silva, 2019; <span class="ref"><strong class="xref xrefblue">Snyder, 2019</strong><span class="refCtt closed"><span>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">https://doi.org/10.1016/j.jbusres.2019.0...
+            </a></span></span>). São descritos etapas, procedimentos e critérios de busca e seleção de estudos, de análise metodológico-teórica e de apresentação dos resultados. Partiu-se da formulação da pergunta central sobre o fenômeno de interesse (Mendes-da-Silva, 2019). Os principais itens e os critérios de elegibilidade adotados para esta revisão sistemática visam a empregar um procedimento replicável e transparente (<span class="ref"><strong class="xref xrefblue">Moher, Liberati, Tetslaff, &amp; Altman, 2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>). Os critérios de elegibilidade são: </p>
+<div>
+					<ol type="1">
+<li><p>Tipo de estudo: pesquisas empíricas que desenvolvem ou aplicam escalas e medidas de virtudes morais em âmbito individual, sendo esse o critério de seleção. </p></li>
+<li><p>Critérios de exclusão: (a) pesquisas de outras áreas, como a médica e jurídica; (b) trabalhos que não abordam virtudes diretamente; (c) estudos teóricos ou empíricos que não abordam o construto por meio de escalas; (d) pesquisas empíricas que desenvolvam ou apliquem escalas de virtudes em âmbito organizacional (virtuosidade).</p></li>
+<li><p>Tópico: a identificação e seleção dos trabalhos é feita por uma leitura nos títulos e resumos, palavras-chave e revistas. </p></li>
+<li><p>Design de pesquisa: estudos empíricos que relatam o desenvolvimento, aplicação e resultados obtidos com o uso de escalas de virtudes em nível individual. </p></li>
+<li><p>Recorte temporal: sem recortes temporais. </p></li>
+<li><p>Idioma: acolhem-se trabalhos em português, inglês e espanhol. </p></li>
+<li><p>Status da publicação: artigos científicos revisados por pares.</p></li>
+<li><p>Critérios de busca: consultas às bases de dados eletrônicas e, complementarmente, inclusão de estudos citados pelos estudos selecionados, ainda não integrantes da amostra. A primeira etapa ocorreu no mês de junho de 2017 e atualizações foram realizadas em 2018 e fevereiro de 2021. A busca foi realizada em cinco bases de dados: <i>EBSCOhost, Science Direct, Scopus, Web of Science</i> e <i>Wiley</i>.</p></li>
+</ol>
+				</div>
+<p>Com o intuito de ampliar o alcance das buscas, empregaram-se cinco <i>queries</i> diferentes, compostos por dois termos: o primeiro referente a escalas e mensuração e o segundo às virtudes, conforme detalhado na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet1s"><span class="sci-ico-fileTable"></span>Tabela 1</a>.</p>
+<div>
+					<div class="row table" id="t1s">
+<a name="t1s"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet1s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 1</strong><br>Número de referências por base de dados, <i>query</i> e formato de busca.<br>
+</div>
+</div>
+				</div>
+<p>Até 2018 foram selecionadas 517 referências e, com a adição de 248 referências em fevereiro de 2021, foram totalizadas 765. Com a experiência das primeiras etapas, optou-se por fazer a atualização de 2021 restringindo-se a buscas no <i>abstract</i>. Além delas, alguns artigos foram adicionados à amostra manualmente (n=3), encontrados a partir do trabalho de buscas e leitura, indicado na Etapa 2 no fluxo do processo de seleção, na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1s"><span class="sci-ico-fileFigure"></span>Figura 1</a>. Atentou-se para as publicações das revistas <i>Journal of Business Ethics</i>, <i>Business Ethics: Environment and Responsibilty</i> e <i>Business Ethics Quarterly,</i> para assegurar a seleção de artigos da área.</p>
+<p>
+					<div class="row fig" id="f1s">
+<a name="f1s"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf1s"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figura 1</strong><br>Fluxo do processo de seleção, segundo modelo de <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).<br>
+</div>
+</div>
+				</p>
+<p>As referências foram exportadas para o organizador de referências EndNote 8, na primeira etapa, e Mendeley na última seleção. O processo de seleção durante as etapas foi o mesmo: primeiro, a retirada dos registros repetidos; segundo, a leitura de títulos, resumos, palavras-chave e nome da revista, aplicando os critérios de elegibilidade. A <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1s"><span class="sci-ico-fileFigure"></span>Figura 1</a> apresenta o fluxo do processo de seleção até chegar-se ao número de artigos incluídos na amostra, ou seja, 37 artigos que desenvolvem ou aplicam escalas de virtudes morais em nível individual.</p>
+<p>Conforme a <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf1s"><span class="sci-ico-fileFigure"></span>Figura 1</a>, oito artigos entre os disponíveis tratavam de outros construtos e outros oito abordavam escalas de virtuosidade, ou virtude em âmbito organizacional, que não é o foco desta revisão. As razões dessa opção remetem aos pressupostos distintos entre o conceito de virtuosidade e virtudes morais a partir do arcabouço da ética das virtudes (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Meyer, 2018</strong><span class="refCtt closed"><span>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">https://doi.org/10.1007/s10551-016-3388-...
+            </a></span></span>) e, além disso, seu foco de análise é em âmbito organizacional, ou seja, focam no que é objetivamente verificável, naquilo expresso na e por meio da organização, como nos elementos de estrutura e cultura (Meyer, 2018). </p>
+<p>Para uma discussão teórico-metodológica sobre o desenvolvimento de escalas e medidas de virtudes, primeiramente os artigos foram inteiramente lidos e seus dados principais organizados em planilhas do Excel, contendo informações sobre: (a) como a escala é construída ou aplicada, geração de itens, pré-testes, amostra e respondentes, tratamento dos itens; (b) análise estatística utilizada, técnicas estatísticas, fatores de ajuste, técnicas de análise, fatores emergentes; (c) eliminações de itens, tipos de validações e temas relacionados; e (d) país de aplicação, para analisar possíveis limitações e o rigor empregado na criação e validação. Para a análise do uso de análise fatorial exploratória (AFE), de análise fatorial confirmatória (AFC) e de outras técnicas, seguiram-se as orientações de <span class="ref"><strong class="xref xrefblue">Fávero et al. (2009</strong><span class="refCtt closed"><span>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</span></span></span>) e <span class="ref"><strong class="xref xrefblue">Hair et al. (2005</strong><span class="refCtt closed"><span>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</span></span></span>). </p>
+<p>Após a análise das escalas, buscou-se analisar as contribuições dos trabalhos para o conhecimento sobre virtudes morais, considerando os artigos que listam um conjunto de virtudes e aqueles que se aprofundam em uma única. Discutem-se desafios metodológicos para acessar virtudes morais, especialmente para pesquisadores que se inserem em uma tradição da ética das virtudes. Discute-se como são definidas, operacionalizadas e acessadas, de modo a discutir implicações teóricas e questões metodológicas em um escopo maior, pois o debate sobre mensuração de virtudes é uma questão em aberto, para a qual pesquisadores de ética empresarial e de psicologia podem ter posições diferentes sobre sua possibilidade, relevância e pertinência. </p>
+<h1 class="articleSectionTitle">APRESENTAÇÃO E DISCUSSÃO DOS RESULTADOS</h1>
+<p>Os 37 artigos empíricos selecionados refletem as contribuições de duas áreas com interesse em virtudes ou ética das virtudes: a ética empresarial e a psicologia. Os trabalhos foram publicados por 21 diferentes <i>journals</i>. Da área de administração e negócios, o <i>Journal of Business Ethics</i> (JBE) publicou 11 artigos sobre escalas e mensuração de virtudes morais em âmbito individual, seguido de outras revistas da área com um artigo: <i>Asian Journal of Business &amp; Accounting, Business Ethics: A European Review, Canadian Journal of Administrative Sciences, Journal of Business Research, Leadership &amp; Organization Development Journal</i> e <i>Organizational Dynamics.</i> Da área da psicologia destacam-se as revistas <i>Personality and Individual Differences</i> (4 artigos), <i>Current Psychology</i> (3) e <i>Frontiers in Psychology</i> (2).</p>
+<p>As investigações que desenvolvem ou aplicam escalas de virtudes seguem dois formatos predominantes: focam em múltiplas virtudes analisadas conjuntamente, ou em uma única virtude moral. Em revistas do campo da administração, os trabalhos partem, na sua maioria, de listas desenvolvidas a partir de <span class="ref"><strong class="xref xrefblue">Solomon (1999</strong><span class="refCtt closed"><span>Solomon, R. (1999). A better way to think about business: how personal integrity leads to corporate success. New York, NY: Oxford University Press.</span></span></span>) e <span class="ref"><strong class="xref xrefblue">Murphy (1999</strong><span class="refCtt closed"><span>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				</span><br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">https://doi.org/10.1023/A:1006072413165...
+            </a></span></span>). No campo da psicologia, os trabalhos se apoiam na psicologia positiva de <span class="ref"><strong class="xref xrefblue">Peterson e Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>) ou em tentativas de articulação entre psicologia e filosofia moral (ex.: <span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>). Dos 37 artigos, 19 se referem ao uso e desenvolvimento de escalas sobre múltiplas virtudes, que optamos por chamar de 'virtudes morais múltiplas'; e 18 abordam escalas e medidas de 'virtudes morais específicas', como exposto na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet2s"><span class="sci-ico-fileTable"></span>Tabela 2</a>.</p>
+<div>
+					<div class="row table" id="t2s">
+<a name="t2s"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet2s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 2</strong><br>Escalas relacionadas a virtudes morais em nível individual - múltiplas e específicas.<br>
+</div>
+</div>
+				</div>
+<p>Os trabalhos da primeira década do atual milênio optaram por escalas de múltiplas virtudes, abordando uma lista de traços do caráter. Na década seguinte, ocorre uma discussão metodológica sobre a mudança do conceito para o âmbito organizacional, com discussões sobre a virtuosidade organizacional, bem como sobre os pressupostos e métodos da psicologia positiva. Nos últimos três anos, os estudos empíricos focam predominantemente na mensuração de uma virtude específica, buscando abordar componentes como pensamento, sentimentos e comportamentos que expressam virtudes. Mas cabe ressaltar que essas questões permanecem em aberto e há posicionamentos distintos sobre a viabilidade ou não de articular a filosofia moral e a psicologia para ampliar o entendimento sobre virtudes morais (<span class="ref"><strong class="xref xrefblue">Beadle et al., 2015</strong><span class="refCtt closed"><span>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				</span><br><a href="https://doi.org/10.1111/beer.12098" target="_blank">https://doi.org/10.1111/beer.12098...
+            </a></span></span>). Possibilidades de articulação são consideradas por <span class="ref"><strong class="xref xrefblue">Newstead et al. (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) e <span class="ref"><strong class="xref xrefblue">Snow, Whright e Warren (2020</strong><span class="refCtt closed"><span>Snow, N. E., Wright, J. C., &amp; Warren, M. T. (2020). Virtue Measurement: Theory and Applications. Ethical Theory and Moral Practice, 23, 277-293. https://doi.org/10.1007/s10677-019-10050-6
+				</span><br><a href="https://doi.org/10.1007/s10677-019-10050-6" target="_blank">https://doi.org/10.1007/s10677-019-10050...
+            </a></span></span>).</p>
+<p>É importante ressaltar que as escalas de virtudes morais, múltiplas ou específicas, acessam a ‘percepção’ de virtudes, seja a autopercepção do respondente, seja a percepção em relação às outras pessoas (gestor, colaborador, liderança, etc.), algo próximo ao que <span class="ref"><strong class="xref xrefblue">Newstead et al. (2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>) chamaram de <i>virtues</i>. Mas tais estudos não as consideram a partir de um evento, limitando-se ao julgamento abstrato sobre lista de atributos, desconectado de um contexto de ação. Isso se verifica em boa parte dos instrumentos de medida no estilo de lista de itens. </p>
+<p>Os artigos que abordam virtudes morais específicas se dedicam a observar empiricamente uma ou duas virtudes: admiração às virtudes e sua relação com status (<span class="ref"><strong class="xref xrefblue">Bai, Ho, &amp; Yan, 2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>), autoconsideração e consideração pelos outros (<span class="ref"><strong class="xref xrefblue">Grappi, Romani, &amp; Bagozzi, 2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>), coragem moral (<span class="ref"><strong class="xref xrefblue">Mansur, Sobral, &amp; Islam, 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>), gratidão (<span class="ref"><strong class="xref xrefblue">Bernabe-Valero, Blasco-Magraner, &amp; García-March, 2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Gulliford, Morgan, Hemming, &amp; Abbott, 2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Hudecek, Blabst, Morgan, &amp; Lermer, 2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>; Morgan, Gulliford, &amp; Kristjánsson, 2017), gratidão e amor (<span class="ref"><strong class="xref xrefblue">Diessner, Iyer, Smith, &amp; Haidt, 2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>), humildade (<span class="ref"><strong class="xref xrefblue">Colombo, Strangmann, Houkes, Kostadinova, &amp; Brandt, 2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Qin, Liu, Brown, Zheng, &amp; Owens, 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>), integridade (<span class="ref"><strong class="xref xrefblue">Castro-González, Bande, Fernández-Ferrín, &amp; Kimura, 2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>), justiça (<span class="ref"><strong class="xref xrefblue">Beekun, Westerman, &amp; Barghouti, 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beugré, 2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>), perdão de si mesmo (Kim, Volk, &amp; Enright, 2021), respeito e responsabilidade (<span class="ref"><strong class="xref xrefblue">Manly, Leonard, &amp; Riemenschneider, 2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>), traços bons e maus do caráter (<span class="ref"><strong class="xref xrefblue">Jiao, Yang, Guo, Xu, Zhang, &amp; Jiang, 2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>), resiliência (<span class="ref"><strong class="xref xrefblue">Lasota, Tomaszek, &amp; Bosacki, 2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>) e temperança (<span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>).</p>
+<p>Além de virtudes específicas, virtudes associadas à liderança foram uma temática para a qual se desenvolveram várias escalas (<span class="ref"><strong class="xref xrefblue">Mansur et al., 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Qin et al., 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Riggio, Zhu, Reina, &amp; Maroosis, 2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Thun &amp; Kelloway, 2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Sarros, Cooper, &amp; Hartican, 2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Seijts, Gands, Crossan, &amp; Reno, 2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Wang &amp; Hackett, 2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>).</p>
+<h2>Desenvolvimento e aplicação de escalas sobre virtudes morais</h2>
+<p>A <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet3s"><span class="sci-ico-fileTable"></span>Tabela 3</a> resume as informações da construção de escalas. Nela é possível observar o número de itens iniciais e finais, a proporção item-amostra, o país e o perfil dos respondentes, em sua maioria universitários e profissionais da área. As escalas empregam itens com grade de respostas no formato Likert (‘discordo totalmente - concordo totalmente’) ou escalas adjetivais, variando entre escalas de quatro a dez pontos. </p>
+<div>
+						<div class="row table" id="t3s">
+<a name="t3s"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet3s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 3</strong><br>Itens, amostra e medidas em escalas relacionadas a virtudes morais em nível individual.<br>
+</div>
+</div>
+					</div>
+<p>Quanto ao contexto, as pesquisas foram realizadas em 15 diferentes países: Estados Unidos (11 estudos), China (3), Reino Unido (3), entre outros. Algumas analisam resultados de dois países (<span class="ref"><strong class="xref xrefblue">Bai et al., 2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Beekun et al., 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Hudecek et al., 2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Seijts et al., 2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>). Outras recrutaram respondentes em plataformas, como na Amazon MTurk, de trabalhadores remotos (<span class="ref"><strong class="xref xrefblue">Bernabe-Valero et al., 2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Colombo et al., 2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Kim et al., 2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Mansur et al., 2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>). Embora Mansur et al. (2020) tenham vínculo com universidade brasileira, a descrição de sua amostra não especifica o contexto de pesquisa. Análises exploratórias em um novo contexto são importantes, pois as virtudes dependem do contexto de ação (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Newstead et al., 2018</strong><span class="refCtt closed"><span>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				</span><br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">https://doi.org/10.5465/amp.2016.0162...
+            </a></span></span>). Por exemplo, ser temperante em um dado país pode exigir mais do que ser em outro, e diferentes virtudes podem ser cultivadas em cada contexto. No uso de escalas, isso requer desenvolver algo a partir do contexto, adaptando as desenvolvidas em outras culturas (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). </p>
+<p>Na proporção item-tamanho da amostra, alguns trabalhos (n=11) não alcançam a razão de 5:1 indicada por <span class="ref"><strong class="xref xrefblue">Hair et al. (2009</strong><span class="refCtt closed"><span>Hair, J., Jr., Black, W., Babin, B., Anderson, R., &amp; Tathan, R. (2009) Análise multivariada de dados. (6th ed.). Porto Alegre, RS: Bookman.</span></span></span>, p. 108). Diferentemente, <span class="ref"><strong class="xref xrefblue">Bai et al. (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>) buscam uma proporção de 10:1, algo acompanhado pela maioria dos artigos recentes. Hair et al. (2009) recomendam que o pesquisador deve interpretar qualquer descoberta com precaução, quando se lida com amostras menores ou com uma proporção pequena. Além disso, a geração de itens em maior número, mediante aprofundamento teórico, análise léxica (<span class="ref"><strong class="xref xrefblue">Jiao et al., 2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>), consulta com especialistas (<span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>) e potenciais respondentes (pré-testes), poderia reunir itens mais atrelados a virtudes de determinado contexto (<span class="ref"><strong class="xref xrefblue">Aguirre-Y-Luker et al., 2017</strong><span class="refCtt closed"><span>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				</span><br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">https://doi.org/10.1007/978-94-007-6510-...
+            </a></span></span>). Por exemplo, <span class="ref"><strong class="xref xrefblue">Shanahan e Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>) fizeram grupos focais, mas poucos trabalhos descrevem a realização de pré-testes (<span class="ref"><strong class="xref xrefblue">Libby &amp; Thorne, 2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>; Shanahan &amp; Hyman, 2003).</p>
+<p>Para ilustrar a análise do desenvolvimento de escalas, consideram-se conceitos e resultados encontrados, os quais remetem a elementos da ética das virtudes. Os estudos sobre virtudes na liderança sugerem que o caráter do líder ainda é um atributo de suma importância para a ética em administração, o que poderia ampliar a discussão sobre traços de liderança e liderança como processo e entre as perspectivas heroicas e pós-heroicas (<span class="ref"><strong class="xref xrefblue">Sobral &amp; Furtado, 2019</strong><span class="refCtt closed"><span>Sobral, F., &amp; Furtado, L. (2019). A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança. Revista de Administração de Empresas, 59(3), 209-214. http://dx.doi.org/10.1590/S0034-759020190306
+				</span><br><a href="http://dx.doi.org/10.1590/S0034-759020190306" target="_blank">http://dx.doi.org/10.1590/S0034-75902019...
+            </a></span></span>). </p>
+<p>
+						<span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>) sugerem que a integridade é um atributo-chave para o caráter de líderes. <span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>) investigam as virtudes cardeais da temperança, fortaleza, justiça e prudência relacionadas à liderança, baseados em premissas de Tomás de Aquino e Aristóteles, sendo um dos poucos estudos que procura abordar o pressuposto da unidade das virtudes. Os resultados de duas etapas de análise fatorial exploratória sugerem um único fator explicativo do modelo, o que Riggio et al. (2010) consideram uma evidência da unidade das virtudes.</p>
+<p>Apoiando-se em conceitos aristotélicos e confucianos para desenvolver o Questionário de Liderança Virtuosa, <span class="ref"><strong class="xref xrefblue">Wang e Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>) partem de seis virtudes - coragem, prudência, justiça, temperança, humanidade e confiabilidade e, pela análise fatorial, chegam a cinco fatores: coragem (4), temperança (4), justiça (3), prudência (4) e humanidade (3). </p>
+<p>Na Escala de Forças do Caráter da Liderança, <span class="ref"><strong class="xref xrefblue">Thun e Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>) encontram os fatores humanidade (4 itens), sabedoria (5) e temperança (5), enquanto <span class="ref"><strong class="xref xrefblue">Seijts et al. (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>) discutem o caráter como uma amálgama de virtudes, traços de personalidade e valores, descrevendo 11 elementos do caráter e sua importância para a liderança. Por fim, <span class="ref"><strong class="xref xrefblue">Mansur et al. (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>) sugerem que a coragem moral contribui para a liderança ética e o comportamento cidadão em grupo. </p>
+<p>Outras evidências do papel das virtudes morais aparecem nos seguintes temas: relações entre comprador-vendedor (<span class="ref"><strong class="xref xrefblue">Donada, Mothe, Nogatchewsky, &amp; Ribeiro, 2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>); líder-liderado (<span class="ref"><strong class="xref xrefblue">Qin et al., 2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>); gerentes-vendedores (<span class="ref"><strong class="xref xrefblue">Shanahan &amp; Hopkins, 2019</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">https://doi.org/10.1007/s10551-018-3813-...
+            </a></span></span>); caráter de profissionais (<span class="ref"><strong class="xref xrefblue">Arthur et al., 2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>); e consumo responsável (<span class="ref"><strong class="xref xrefblue">Song &amp; Kim, 2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>). </p>
+<p>Embora elaboradas com rigor estatístico, escalas de liderança são específicas para esse papel. Além disso, são elaboradas a partir de contextos culturais, morais e políticos específicos, o que requer reelaboração para outros contextos organizacionais, inseridos na cultura de uma comunidade, de forma a acolher as particularidades em termos de virtudes morais e da noção de florescimento humano. </p>
+<p>Considerando as aplicações do modelo de forças do caráter de <span class="ref"><strong class="xref xrefblue">Peterson e Seligman (2004</strong><span class="refCtt closed"><span>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</span></span></span>), alguns estudos empregam parcial ou integralmente os itens das forças do caráter: (a) <span class="ref"><strong class="xref xrefblue">Park e Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>) abordam a competência moral como bom caráter, utilizando 198 itens dentre os 240 do modelo. Sua amostra, porém, é de 250 estudantes adolescentes, fazendo com que a proporção item-amostra seja inferior ao indicado estatisticamente. Aplicando a análise fatorial exploratória (AFE), chegam a quatro fatores: temperança (4), intelectual (6), teológico (10), e outras forças (4); (b) <span class="ref"><strong class="xref xrefblue">Song e Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>) abordam nove virtudes do modelo para verificar como traços positivos dos consumidores explicam seu consumo responsável; e (c) <span class="ref"><strong class="xref xrefblue">Arthur et al. (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>) abordam a autopercepção de profissionais sobre as virtudes mais importantes do modelo. Embora haja diferenças e similaridades entre virtudes morais e forças do caráter (<span class="ref"><strong class="xref xrefblue">Alzola, 2015</strong><span class="refCtt closed"><span>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				</span><br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">https://doi.org/10.1017/beq.2015.24...
+            </a></span></span>), os caminhos para o seu entendimento no âmbito das organizações passam por aprofundamento teórico e estratégias de pesquisa que permitam alcançar mais que um 'retrato' instantâneo sobre virtudes, pois elas são cultivadas ao longo da vida.</p>
+<h2>Discussão</h2>
+<p>A virtude é um conceito de raiz filosófica e é considerada na tradição da ética das virtudes como o meio termo entre dois vícios: a sua falta, de um lado, e o seu excesso, do outro (Aristóteles, 2009). Nesse sentido, o agente virtuoso está em constante reflexão sobre sua conduta, seus erros e acertos, buscando nortear-se em vistas a um bem, sendo sua autoeducação ou autoaperfeiçoamento um elemento-chave. Por isso, destaca-se a importância do contexto, da ação dentro de uma perspectiva maior, na trajetória de vida. Muitas vezes é depois de cometidos alguns ou vários erros que se aprendem as virtudes, a exemplo do perdão de si mesmo (<span class="ref"><strong class="xref xrefblue">Kim et al., 2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>). Nesse sentido, caberia um arcabouço ético compreensivo, capaz de considerar aspectos negativos e positivos do caráter, erros e acertos, vícios e virtudes, como parece ser o caso da ética das virtudes. </p>
+<p>Optar por abordar somente uma virtude, como estudos recentes têm feito, seria uma maneira de alcançar um entendimento mais detalhado de seus multicomponentes. Por exemplo, os fatores emergentes indicados a partir das AFEs representam uma coletânea de percepções de virtudes ou traços do caráter, muito embora resultem da operacionalização a partir de diferentes áreas e pressupostos éticos. Alguns fatores aparecem mais de uma vez. É o caso de temperança (<span class="ref"><strong class="xref xrefblue">Park &amp; Peterson, 2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Riggio et al., 2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Thun &amp; Kelloway, 2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Wang &amp; Hackett, 2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>), justiça (<span class="ref"><strong class="xref xrefblue">Beekun et al., 2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>; Riggio et al., 2010; Wang &amp; Hackett, 2016) e desenvoltura (<span class="ref"><strong class="xref xrefblue">Cawley, Martin, &amp; Johnson, 2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Yang, Stoeber &amp; Wang, 2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Dawson, 2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>). A virtude da prudência é encontrada nos trabalhos de Riggio et al. (2010) e Wang e Hackett (2016), enquanto <span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>) e Thun e Kelloway (2011) definem o fator como sabedoria. </p>
+<p>Por outro lado, seria uma limitação não considerar, por exemplo, o papel da <i>phronesis</i> vinculada às virtudes morais (<span class="ref"><strong class="xref xrefblue">Ames et al., 2020</strong><span class="refCtt closed"><span>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				</span><br><a href="https://doi.org/10.1111/beer.12296" target="_blank">https://doi.org/10.1111/beer.12296...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Bachmann et al., 2017</strong><span class="refCtt closed"><span>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">https://doi.org/10.1007/s10551-016-3417-...
+            </a></span></span>). A unidade das virtudes reconhece a conexão entre elas, ou seja, que para ser virtuoso alguém expressa mais que uma virtude - por exemplo: honestidade e justiça, para comunicar da melhor forma possível; coragem e prudência, para tomar boas decisões frente aos riscos do ambiente. </p>
+<p>Considerando os pressupostos da participação da prudência em cada virtude e da unidade das virtudes (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>), percebe-se que a maioria dos artigos não considera tais pressupostos no desenvolvimento ou uso de escalas. Entre as poucas exceções, há a tentativa de <span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>). Alguns trabalhos se apoiam em autores da ética das virtudes - como em Aristóteles (2009), MacIntyre (2007) e Sison e Ferrero (2015) - enquanto outros a articulam à psicologia positiva (ex.: <span class="ref"><strong class="xref xrefblue">Arthur et al., 2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Donada et al., 2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Shahab &amp; Adil, 2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>). </p>
+<p>Quais estratégias de pesquisa seriam possíveis, considerando a necessidade de maior desenvolvimento teórico sobre virtudes em administração? Baseando-se nessa pergunta, é possível retomar alguns aspectos teórico-metodológicos para reunir sugestões a estudos futuros.</p>
+<h1 class="articleSectionTitle">SUGESTÕES PARA ESTUDOS FUTUROS</h1>
+<p>Do ponto de vista teórico-metodológico, quatro pontos cabem ser mencionados: aprendizagem de virtudes, sua presença em diferentes papéis sociais, dualidade subjetivo-objetivo e julgamento-ação. O primeiro deles é que o cultivo e a aprendizagem das virtudes se dão ao longo da vida, com a experiência (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>). Métodos que pontualmente consultam respondentes em um momento específico, sem uma análise contextualizada em suas trajetórias de vida, não conseguem acessar o contexto e a circunstância de ação, algo considerado na tradição da ética das virtudes (<span class="ref"><strong class="xref xrefblue">Kinghorn, 2017</strong><span class="refCtt closed"><span>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				</span><br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">https://doi.org/10.1080/17439760.2016.12...
+            </a></span></span>). Cabe ainda levar em conta a idade ou tempo de experiência dos pesquisados, o que pode fazer a diferença na maturidade moral. </p>
+<p>O segundo ponto está atrelado ao primeiro, pois remete à reflexão de alguém sobre a sua vida como um todo, o que envolve considerar em pesquisas não somente o trabalho no âmbito profissional, mas a harmonia entre os diferentes papéis sociais (<span class="ref"><strong class="xref xrefblue">Sison et al., 2018</strong><span class="refCtt closed"><span>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</span></span></span>). O terceiro ponto se refere à dualidade subjetivo-objetivo relacionada ao conceito de virtude, algo que precisa ser considerado pelas abordagens focadas em comportamentos observáveis, ou no uso de escalas de percepção sobre virtudes. Tal dualidade é importante porque uma virtude moral expressa uma harmonia entre subjetivo-objetivo, isto é, entre vontade e ação, algo complexo de se acessar por escalas e medidas. Finalmente, o quarto ponto levanta a questão da lacuna julgamento-ação que separa o momento de responder a um teste/escala, sobre uma dada questão hipotética, da vivência real de uma questão ética. Acessar as virtudes a partir da trajetória de vida de alguém poderia encontrar evidências fidedignas à experiência do participante. </p>
+<p>Diante disso, algumas estratégias de pesquisa interpretativas e de abordagens qualitativas poderiam alcançar um conhecimento mais aprofundado sobre as virtudes em um contexto nacional e organizacional específico, considerando os pressupostos da unidade das virtudes e do papel crucial da <i>phronesis</i> (<span class="ref"><strong class="xref xrefblue">Sison &amp; Ferrero, 2015</strong><span class="refCtt closed"><span>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				</span><br><a href="https://doi.org/10.1111/beer.12099" target="_blank">https://doi.org/10.1111/beer.12099...
+            </a></span></span>; <span class="ref"><strong class="xref xrefblue">Zyl, 2019</strong><span class="refCtt closed"><span>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</span></span></span>). Podem-se cogitar possíveis contribuições da história oral, de abordagens narrativas, estudo de caso, etnografia e fenomenologia. Estratégias exploratórias geralmente antecedem abordagens quantitativas, de modo a prover conhecimento para futuros estudos utilizando escalas, como a Etapa 1, sugerida na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2s"><span class="sci-ico-fileFigure"></span>Figura 2</a>. </p>
+<p>
+					<div class="row fig" id="f2s">
+<a name="f2s"></a><div class="col-md-4 col-sm-4"><a href="" data-toggle="modal" data-target="#ModalFigf2s"><div class="thumbOff"><div class="zoom"><span class="sci-ico-zoom"></span></div></div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Figura 2</strong><br>Sugestões de etapas futuras nos estudos sobre virtudes morais.<br>
+</div>
+</div>
+				</p>
+<p>A revisão de trabalhos que buscam mensurar virtudes requer uma discussão metodológica e teórica. Quanto ao método, essa discussão questiona por que as pesquisas buscam mensurar virtudes, as limitações e possibilidades a partir dos artigos revisados, e busca se inserir nas discussões sobre quais métodos podem ser considerados para estudos empíricos de ética das virtudes. A partir disso, sugerem-se possíveis procedimentos em estudos futuros, como pontuado na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalFigf2s"><span class="sci-ico-fileFigure"></span>Figura 2</a>.</p>
+<p>Entendem-se as Etapas 1 e 2 como um percurso para os estudos sobre virtudes morais. A Etapa 2 segue diretrizes básicas para o desenvolvimento de escalas, como propostas por <span class="ref"><strong class="xref xrefblue">DeVellis (2016</strong><span class="refCtt closed"><span>DeVellis, R. F. (2016). Scale development: Theory and applications. (4th ed). Thousand Oaks, CA: Sage Publications.</span></span></span>). </p>
+<p>Diante de preocupações sobre a instrumentalização do construto para a melhoria da performance ou produtividade, estudos futuros podem abordar a sua contribuição para o florescimento humano e o relacionamento interpessoal. A percepção de virtudes, por sua vez, pode permitir entender como as pessoas associam tais atributos a outras questões organizacionais, como liderança, tomada de decisão ou cultura organizacional. Do ponto de vista teórico, permanece a discussão sobre as contribuições do uso de escalas para a expansão ou aprofundamento do entendimento que se tem sobre as virtudes morais no ambiente organizacional e de negócios, tendo em mente os pressupostos e elementos da tradição da ética das virtudes como arcabouço para o estudo da ética em administração.</p>
+<p>Dentre as limitações de pesquisa, optou-se por analisar escalas de virtude morais no âmbito individual. Portanto, as escalas de virtuosidade (âmbito organizacional) podem ser revisadas em estudos futuros. Na busca por artigos, o estudo limitou-se aos termos como ética das virtudes e virtudes morais. Assim, estudos posteriores podem buscar por uma virtude específica. No relato desta pesquisa não se descreveu como se fizeram validações convergentes e discriminantes em relação a outros conceitos, e procurou-se fazer uma análise geral à luz da ética das virtudes, restringindo-se a discutir alguns de seus pressupostos.</p>
+<h1 class="articleSectionTitle">CONSIDERAÇÕES FINAIS</h1>
+<p>Este artigo buscou analisar como as escalas sobre virtudes morais são construídas e mensuradas em estudos associados à ética das virtudes em administração, a partir de uma revisão sistemática de artigos. Buscando-se em cinco bases de dados, foram selecionados 37 artigos, publicados em 21 <i>journals</i> das áreas de ética empresarial em sua maioria, que desenvolvem ou aplicam escalas relacionadas à percepção de virtudes morais em âmbito individual, dos quais 19 abrangem virtudes morais múltiplas e 18 buscam por uma virtude moral específica. </p>
+<p>Apoiando-se em pressupostos da ética das virtudes aristotélico-tomista e em recomendações estatísticas para o desenvolvimento e aplicação de escalas, este estudo analisou a sua construção, apresentando números sobre a geração de itens antes e depois de análises fatoriais, a proporção de respondentes por itens (amostra-item), o perfil dos respondentes, o contexto de pesquisa ilustrativo de 15 países, bem como os tipos de análises estatísticas empregadas (análises fatoriais exploratórias e confirmatórias e fatores emergentes, modelagem de equações estruturais, Manova, entre outras). </p>
+<p>Os estudos selecionados ilustram áreas do campo de administração relacionadas ao tema das virtudes, como liderança, relação gerentes-colaboradores, consumo responsável, entre outros campos. Uma parcela dos respondentes é público universitário, o que demanda novos estudos para acesso aos profissionais atuantes na área. Abordaram-se virtudes como coragem, gratidão, humildade, integridade, perdão, respeito, resiliência e temperança. </p>
+<p>Os resultados foram discutidos teórica e metodologicamente, considerando o uso de escalas em relação ao aprofundamento conceitual da área e levando-se em conta os pressupostos da particularidade contextual, da unidade das virtudes e de sua interconexão com a <i>phronesis</i> (sabedoria prática). Aprendizagem, presença em diversos papéis e dualidade julgamento-ação também foram discutidos para elucidar implicações teóricas e práticas de algumas limitações encontradas no aprofundamento e na operacionalização conceitual.</p>
+<p>Isso permitiu sugerir procedimentos para estudos futuros sobre virtudes morais, organizados em etapas sucessivas, de modo a articular estudos exploratórios qualitativos, inicialmente, para alcançar-se clareza conceitual, dados do contexto e dos participantes em foco, bem como recomendações para o desenvolvimento de escalas de percepção de virtudes como um passo subsequente: maiores conjuntos de itens, melhor proporção item-amostra no acesso ao campo, validação com especialistas e potenciais respondentes e realização de pré-testes. </p>
+<p>Os aprofundamentos conceituais dispõem de tradições ocidentais e orientais para a ética das virtudes, mas é necessário refletir sobre as razões de se tentar mensurar virtudes no campo da administração. Um caminho alternativo pode ser a análise e a identificação de aspectos organizacionais que contribuam para que as pessoas cultivem virtudes, como as práticas e instituições, a cultura organizacional e funções administrativas. </p>
+</div>
+<div class="articleSection" data-anchor="Referências bibliográficas">
+<h1 class="articleSectionTitle">Referências bibliográficas</h1>
+<div class="ref-list"><ul class="refList">
+<li><div>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. https://doi.org/10.1017/beq.2015.24
+				<br><a href="https://doi.org/10.1017/beq.2015.24" target="_blank">» https://doi.org/10.1017/beq.2015.24</a>
+</div></li>
+<li><div>Alzola, M. (2017). Virtues and their explanatory and predictive power in the workplace. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. https://doi.org/10.1007/s10551-019-04317-2
+				<br><a href="https://doi.org/10.1007/s10551-019-04317-2" target="_blank">» https://doi.org/10.1007/s10551-019-04317-2</a>
+</div></li>
+<li><div>Ames, M. C. F. D. C., &amp; Serafim, M. C. (2019). Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review. Revista de Administração Contemporânea, 23(4), 564-586. https://doi.org/10.1590/1982-7849rac2019180301
+				<br><a href="https://doi.org/10.1590/1982-7849rac2019180301" target="_blank">» https://doi.org/10.1590/1982-7849rac2019180301</a>
+</div></li>
+<li><div>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. https://doi.org/10.1111/beer.12296
+				<br><a href="https://doi.org/10.1111/beer.12296" target="_blank">» https://doi.org/10.1111/beer.12296</a>
+</div></li>
+<li><div>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. https://doi.org/10.1017/S0031819100037943
+				<br><a href="https://doi.org/10.1017/S0031819100037943" target="_blank">» https://doi.org/10.1017/S0031819100037943</a>
+</div></li>
+<li><div>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</div></li>
+<li><div>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				<br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">» https://doi.org/10.1007/s10551-019-04269-7</a>
+</div></li>
+<li><div>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. https://doi.org/10.1007/s10551-016-3417-y
+				<br><a href="https://doi.org/10.1007/s10551-016-3417-y" target="_blank">» https://doi.org/10.1007/s10551-016-3417-y</a>
+</div></li>
+<li><div>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				<br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">» http://doi.org/10.0.4.13/pspi0000192</a>
+</div></li>
+<li><div>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. https://doi.org/10.1111/beer.12098
+				<br><a href="https://doi.org/10.1111/beer.12098" target="_blank">» https://doi.org/10.1111/beer.12098</a>
+</div></li>
+<li><div>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				<br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">» https://doi.org/10.1007/s10551-005-4772-2</a>
+</div></li>
+<li><div>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				<br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">» https://doi.org/10.3389/fpsyg.2020.626330</a>
+</div></li>
+<li><div>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				<br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">» https://doi.org/10.1111/j.1559-1816.2012.00935.x</a>
+</div></li>
+<li><div>Cameron, K., Bright, D., &amp; Caza, A. (2004). Exploring the relationships between organizational virtuousness and performance. American Behavioral Scientist, 47(6), 1-14. https://doi.org/10.1177/0002764203260209
+				<br><a href="https://doi.org/10.1177/0002764203260209" target="_blank">» https://doi.org/10.1177/0002764203260209</a>
+</div></li>
+<li><div>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				<br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">» https://doi.org/10.1016/j.jclepro.2019.05.238</a>
+</div></li>
+<li><div>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				<br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">» https://doi.org/10.1016/s0191-8869(99)00207-x</a>
+</div></li>
+<li><div>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				<br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">» https://doi.org/10.1007/s13164-020-00496-4</a>
+</div></li>
+<li><div>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				<br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">» https://doi.org/10.1007/s10551-017-3505-7</a>
+</div></li>
+<li><div>DeVellis, R. F. (2016). Scale development: Theory and applications. (4th ed). Thousand Oaks, CA: Sage Publications.</div></li>
+<li><div>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				<br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">» http://dx.doi.org/10.1080/03057240.2013.785941</a>
+</div></li>
+<li><div>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				<br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">» https://doi.org/10.1007/s10551-016-3418-x</a>
+</div></li>
+<li><div>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</div></li>
+<li><div>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. https://doi.org/10.1111/beer.12057
+				<br><a href="https://doi.org/10.1111/beer.12057" target="_blank">» https://doi.org/10.1111/beer.12057</a>
+</div></li>
+<li><div>Ferrero, I. Prefácio. In M. C. Serafim (Org.). (2020). Virtudes e dilemas morais na Administração. (pp. 9-14). Florianópolis: Admethics.</div></li>
+<li><div>Foot, P. (1967). The problem of abortion and the doctrine of double effect. Oxford Reviews, 5, 5-15. Retrieved from https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf
+				<br><a href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf" target="_blank">» https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf</a>
+</div></li>
+<li><div>Gomide, S. Jr., Vieira, L. E., &amp; Oliveira, A. F. (2016). Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro. Psicologia: Organizações e Trabalho, 16(3), 298-307. http://dx.doi.org/10.17652/rpot/2016.3.10417
+				<br><a href="http://dx.doi.org/10.17652/rpot/2016.3.10417" target="_blank">» http://dx.doi.org/10.17652/rpot/2016.3.10417</a>
+</div></li>
+<li><div>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				<br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">» https://doi.org/10.1007/s12144-019-00330-w</a>
+</div></li>
+<li><div>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				<br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">» https://doi.org/10.1016/j.jbusres.2013.02.002</a>
+</div></li>
+<li><div>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</div></li>
+<li><div>Hair, J., Jr., Black, W., Babin, B., Anderson, R., &amp; Tathan, R. (2009) Análise multivariada de dados. (6th ed.). Porto Alegre, RS: Bookman.</div></li>
+<li><div>Hartmann, E. M. (2020). Arriving where we started: Aristotle and business ethics (E-book, Vol. 51). Cham: Switzerland: Springer. https://doi.org/10.1007/978-3-030-44089-3
+				<br><a href="https://doi.org/10.1007/978-3-030-44089-3" target="_blank">» https://doi.org/10.1007/978-3-030-44089-3</a>
+</div></li>
+<li><div>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				<br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">» https://doi.org/10.3389/fpsyg.2020.590108</a>
+</div></li>
+<li><div>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. https://doi.org/10.1111/beer.12184
+				<br><a href="https://doi.org/10.1111/beer.12184" target="_blank">» https://doi.org/10.1111/beer.12184</a>
+</div></li>
+<li><div>Hühn, M. P., Habish, A., Hartmann, E. M., &amp; Sison, A. J. G. (2020). Practicing management wisely. Business Ethics: A European Review, 29(S1), 1-5. https://doi.org/10.1111/beer.12321
+				<br><a href="https://doi.org/10.1111/beer.12321" target="_blank">» https://doi.org/10.1111/beer.12321</a>
+</div></li>
+<li><div>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				<br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">» https://doi.org/10.1111/sjop.12696</a>
+</div></li>
+<li><div>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				<br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">» https://doi.org/10.1007/s12144-020-01248-4</a>
+</div></li>
+<li><div>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. https://doi.org/10.1080/17439760.2016.1228009
+				<br><a href="https://doi.org/10.1080/17439760.2016.1228009" target="_blank">» https://doi.org/10.1080/17439760.2016.1228009</a>
+</div></li>
+<li><div>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				<br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">» https://doi.org/10.12711/TJBE.2016.9.0016</a>
+</div></li>
+<li><div>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				<br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">» https://doi.org/10.1007/s12144-020-01178-1</a>
+</div></li>
+<li><div>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				<br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">» https://doi.org/10.1007/s10551-006-9127-0</a>
+</div></li>
+<li><div>Macintyre, A. (2007). After virtue: A study in moral theory (3rd ed.). Notre Dame, IN: University of Notre Dame Press.</div></li>
+<li><div>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				<br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">» https://doi.org/10.1007/s10551-014-2060-8</a>
+</div></li>
+<li><div>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				<br><a href="https://doi.org/10.1111/beer.12270" target="_blank">» https://doi.org/10.1111/beer.12270</a>
+</div></li>
+<li><div>Mendes-Da-Silva, W. (2019). Contribuições e limitações de revisões narrativas e revisões sistemáticas na área de negócios. Revista de Administração Contemporânea, 23(2), https://doi.org/10.1590/1982-7849rac2019190094
+				<br><a href="https://doi.org/10.1590/1982-7849rac2019190094" target="_blank">» https://doi.org/10.1590/1982-7849rac2019190094</a>
+</div></li>
+<li><div>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. https://doi.org/10.1007/s10551-016-3388-z
+				<br><a href="https://doi.org/10.1007/s10551-016-3388-z" target="_blank">» https://doi.org/10.1007/s10551-016-3388-z</a>
+</div></li>
+<li><div>Moberg, D. J. (1999). The big five and organizational virtue. Business Ethics Quarterly, 9(2), 245-272. https://doi.org/10.2307/3857474
+				<br><a href="https://doi.org/10.2307/3857474" target="_blank">» https://doi.org/10.2307/3857474</a>
+</div></li>
+<li><div>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				<br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">» https://doi.org/10.1371/journal.pmed.1000097</a>
+</div></li>
+<li><div>Moore, G. (2017). Virtue at work: Ethics for individuals, managers, and organizations. Oxford, UK: Oxford University Press.</div></li>
+<li><div>Morales-Sánchez, R., &amp; Cabello-Medina, C. (2013). The role of four moral competencies in Ethical Decision-making. Journal of Business Ethics, 116(4), 717-734. https://doi.org/10.1007/s10551-013-1817-9
+				<br><a href="https://doi.org/10.1007/s10551-013-1817-9" target="_blank">» https://doi.org/10.1007/s10551-013-1817-9</a>
+</div></li>
+<li><div>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				<br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">» https://doi.org/10.1016/j.paid.2016.11.044</a>
+</div></li>
+<li><div>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. https://doi.org/10.1023/A:1006072413165
+				<br><a href="https://doi.org/10.1023/A:1006072413165" target="_blank">» https://doi.org/10.1023/A:1006072413165</a>
+</div></li>
+<li><div>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. https://doi.org/10.5465/amp.2016.0162
+				<br><a href="https://doi.org/10.5465/amp.2016.0162" target="_blank">» https://doi.org/10.5465/amp.2016.0162</a>
+</div></li>
+<li><div>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				<br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">» https://doi.org/10.1016/j.adolescence.2006.04.011</a>
+</div></li>
+<li><div>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</div></li>
+<li><div>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				<br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">» https://doi.org/10.1007/s10551-019-04250-4</a>
+</div></li>
+<li><div>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				<br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">» https://ajba.um.edu.my/article/view/2664</a>
+</div></li>
+<li><div>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				<br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">» https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens</a>
+</div></li>
+<li><div>Rego, A., &amp; Cunha, M. P. (2015). As virtudes nas organizações. Análise Psicológica, 4(33), 349-359. https://doi.org/10.14417/ap.1022
+				<br><a href="https://doi.org/10.14417/ap.1022" target="_blank">» https://doi.org/10.14417/ap.1022</a>
+</div></li>
+<li><div>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				<br><a href="https://doi.org/10.1037/a0022286" target="_blank">» https://doi.org/10.1037/a0022286</a>
+</div></li>
+<li><div>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. https://doi.org/ 10.1111/beer.12103
+				<br><a href="https://doi.org/%2010.1111/beer.12103" target="_blank">» https://doi.org/ 10.1111/beer.12103</a>
+</div></li>
+<li><div>Sanz, P., &amp; Fontrodona, J. (2019). Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace. Journal of Business Ethics, 155, 981-994. https://doi.org/10.1007/s10551-018-3899-x
+				<br><a href="https://doi.org/10.1007/s10551-018-3899-x" target="_blank">» https://doi.org/10.1007/s10551-018-3899-x</a>
+</div></li>
+<li><div>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				<br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">» https://doi.org/10.1108/01437730610709291</a>
+</div></li>
+<li><div>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				<br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">» https://doi.org/10.1016/j.orgdyn.2014.11.008</a>
+</div></li>
+<li><div>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				<br><a href="https://doi.org/10.1002/pchj.394" target="_blank">» https://doi.org/10.1002/pchj.394</a>
+</div></li>
+<li><div>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				<br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">» https://doi.org/10.1023/A:1021914218659</a>
+</div></li>
+<li><div>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				<br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">» https://doi.org/10.1007/s10551-018-3813-6</a>
+</div></li>
+<li><div>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. https://doi.org/10.1111/beer.12099
+				<br><a href="https://doi.org/10.1111/beer.12099" target="_blank">» https://doi.org/10.1111/beer.12099</a>
+</div></li>
+<li><div>Sison, A. J. G., Beabout, G. R., &amp; Ferrero, I. (Eds.). (2017). Handbook of virtue ethics in business and management. Dordrecht, the Netherlands: Springer. https://doi.org/10.1007/978-94-007-6510-8
+				<br><a href="https://doi.org/10.1007/978-94-007-6510-8" target="_blank">» https://doi.org/10.1007/978-94-007-6510-8</a>
+</div></li>
+<li><div>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</div></li>
+<li><div>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. https://doi.org/10.1016/j.jbusres.2019.07.039
+				<br><a href="https://doi.org/10.1016/j.jbusres.2019.07.039" target="_blank">» https://doi.org/10.1016/j.jbusres.2019.07.039</a>
+</div></li>
+<li><div>Snow, N. E., Wright, J. C., &amp; Warren, M. T. (2020). Virtue Measurement: Theory and Applications. Ethical Theory and Moral Practice, 23, 277-293. https://doi.org/10.1007/s10677-019-10050-6
+				<br><a href="https://doi.org/10.1007/s10677-019-10050-6" target="_blank">» https://doi.org/10.1007/s10677-019-10050-6</a>
+</div></li>
+<li><div>Sobral, F., &amp; Furtado, L. (2019). A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança. Revista de Administração de Empresas, 59(3), 209-214. http://dx.doi.org/10.1590/S0034-759020190306
+				<br><a href="http://dx.doi.org/10.1590/S0034-759020190306" target="_blank">» http://dx.doi.org/10.1590/S0034-759020190306</a>
+</div></li>
+<li><div>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. https://doi.org/10.2307/3857536
+				<br><a href="https://doi.org/10.2307/3857536" target="_blank">» https://doi.org/10.2307/3857536</a>
+</div></li>
+<li><div>Solomon, R. (1999). A better way to think about business: how personal integrity leads to corporate success. New York, NY: Oxford University Press.</div></li>
+<li><div>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				<br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">» https://doi.org/10.1007/s10551-016-3331-3</a>
+</div></li>
+<li><div>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				<br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">» https://doi.org/10.1016/j.paid.2015.08.031</a>
+</div></li>
+<li><div>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				<br><a href="https://doi.org/10.1002/cjas.216" target="_blank">» https://doi.org/10.1002/cjas.216</a>
+</div></li>
+<li><div>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				<br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">» https://doi.org/10.1007/s10551-015-2560-1</a>
+</div></li>
+<li><div>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				<br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">» https://doi.org/10.1016/j.paid.2014.11.040</a>
+</div></li>
+<li><div>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</div></li>
+</ul></div>
+</div>
+<div>
+<h1></h1>
+<div class="ref-list"><ul class="refList footnote">
+<li>
+<h3><span class="xref big">Classificação JEL:</span></h3>
+<div>M1, M10.</div>
+</li>
+<li>
+<h3><span class="xref big">Relatório de Revisão por Pares:</span></h3>
+<div>O Relatório de Revisão por Pares está disponível neste <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">link externo</a>.</div>
+</li>
+<li>
+<h3><span class="xref big">Financiamento</span></h3>
+<div> Os autores agradecem o Ministério da Ciência, Tecnologia e Inovação, Conselho Nacional de Desenvolvimento Científico e Tecnológico (CHSSA, Processo nr. 445434/2015-5) pelo suporte financeiro ao projeto de pesquisa, a partir do qual o presente estudo foi desenvolvido.</div>
+</li>
+<li>
+<h3><span class="xref big">Verificação de Plágio</span></h3>
+<div> A RAC mantém a prática de submeter todos os documentos aprovados para publicação à verificação de plágio, mediante o emprego de ferramentas específicas, e.g.: iThenticate.</div>
+</li>
+<li>
+<h3><span class="xref big">Direitos Autorais</span></h3>
+<div> A RAC detém os direitos autorais deste conteúdo.</div>
+</li>
+<li>
+<h3><span class="xref big">Método de Revisão por Pares</span></h3>
+<div> Este conteúdo foi avaliado utilizando o processo de revisão por pares duplo-cego (<i>double-blind peer-review</i>). A divulgação das informações dos pareceristas constantes na primeira página e do Relatório de Revisão por Pares (Peer Review Report) é feita somente após a conclusão do processo avaliativo, e com o consentimento voluntário dos respectivos pareceristas e autores.</div>
+</li>
+<li>
+<h3><span class="xref big">Disponibilidade dos Dados</span></h3>
+<div>Os autores afirmam que todos os dados utilizados na pesquisa foram disponibilizados publicamente, e podem ser acessados por meio da plataforma Harvard Dataverse:</div>
+<div>
+<img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr-pt.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>
+<div>A RAC incentiva o compartilhamento de dados mas, por observância a ditames éticos, não demanda a divulgação de qualquer meio de identificação de sujeitos de pesquisa, preservando a privacidade dos sujeitos de pesquisa. A prática de <i>open data</i> é viabilizar a reproducibilidade de resultados, e assegurar a irrestrita transparência dos resultados da pesquisa publicada, sem que seja demandada a identidade de sujeitos de pesquisa. </div>
+</li>
+</ul></div>
+</div>
+<div class="articleSection" data-anchor="Datas de Publicação ">
+<h1 class="articleSectionTitle">Datas de Publicação </h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Publicação nesta coleção</strong><br>18 Jul 2022</li>
+<li>
+<strong>Data do Fascículo</strong><br>2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="Histórico">
+<h1 class="articleSectionTitle">Histórico</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Recebido</strong><br>17 Nov 2019</li>
+<li>
+<strong>Revisado</strong><br>15 Jun 2021</li>
+<li>
+<strong>Aceito</strong><br>16 Jun 2021</li>
+</ul></div></div>
+</div>
+<section class="documentLicense"><div class="container-license"><div class="row">
+<div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+<div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">This is an open-access article distributed under the terms of the Creative Commons Attribution License</a></div>
+</div></div></section></article>
+</div>
+</div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Sobre os autores</h4>
+</div>
+<div class="modal-body">
+<div class="info">
+<div class="tutors">
+<strong> Maria Clara F. Dalla Costa Ames </strong><strong>*</strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-0444-8764" class="btnContribLinks orcid">http://orcid.org/0000-0002-0444-8764</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Mauricio C. Serafim </strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-4852-5119" class="btnContribLinks orcid">http://orcid.org/0000-0002-4852-5119</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Felipe Flôres Martins </strong><br><div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-2987-5479" class="btnContribLinks orcid">http://orcid.org/0000-0003-2987-5479</a></li></ul>
+<div class="clearfix"></div>
+</div>
+</div>
+<div class="info">
+					* Autora Correspondente</div>
+<div class="info">
+<h3>Editores-chefes:</h3>
+<div>Wesley Mendes-da-Silva (Fundação Getulio Vargas, EAESP, Brasil)</div>
+<div>Marcelo de Souza Bispo (Universidade Federal da Paraíba, PPGA, Brasil)</div>
+</div>
+<div class="info">
+<h3>Pareceristas:</h3>
+<div>Janaína Cássia Grossi (Fundação Getulio Vargas, EAESP, Brasil)</div>
+<div>Claudio Zancan (Universidade Federal do Paraná, Brasil)</div>
+</div>
+<div class="info">
+<h3>Autoria</h3>
+<div>Maria Clara Figueiredo Dalla Costa Ames*</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</div>
+<div>E-mail: mariaclaraames@gmail.com</div>
+<div>https://orcid.org/0000-0002-0444-8764</div>
+<div>Mauricio C. Serafim</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</div>
+<div>E-mail: serafim.esag@gmail.com</div>
+<div>https://orcid.org/0000-0002-4852-5119</div>
+<div>Felipe Flôres Martins</div>
+<div>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</div>
+<div>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</div>
+<div>E-mail: martins.felipef@gmail.com</div>
+<div>https://orcid.org/0000-0003-2987-5479</div>
+</div>
+<div class="info">
+<h3>Conflito de Interesses</h3>
+<div> Os autores informaram que não há conflito de interesses.</div>
+</div>
+<div class="info">
+<h3>Contribuições dos Autores</h3>
+<div>1<sup>ª</sup> autora: conceituação (liderança); curadoria de dados (liderança); análise formal (liderança); investigação (igual); metodologia (liderança); recursos (igual); software (igual); supervisão (igual); validação (igual); escrita - rascunho original (igual); escrita - revisão e edição (igual).</div>
+<div>2<sup>º</sup> autor: conceituação (suporte); curadoria de dados (suporte); análise formal (suporte); investigação (suporte); metodologia (suporte); administração de projeto (suporte); supervisão (suporte); validação (igual); escrita - rascunho original (suporte); escrita - revisão e edição (igual).</div>
+<div>3<sup>º</sup> autor: conceituação (suporte); análise formal (suporte); investigação (suporte); metodologia (suporte); validação (suporte); escrita - rascunho original (igual); escrita - revisão e edição (suporte).</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Figuras | Tabelas</h4>
+</div>
+<div class="modal-body">
+<ul class="nav nav-tabs md-tabs" role="tablist">
+<li role="presentation" class="col-md-4 col-sm-4 active"><a href="#figures" aria-controls="figures" role="tab" data-toggle="tab">Figuras
+                    (2)
+                </a></li>
+<li role="presentation" class="col-md-4 col-sm-4 "><a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">Tabelas
+                    (3)
+                </a></li>
+</ul>
+<div class="clearfix"></div>
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="figures">
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf1s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figura 1</strong><br>Fluxo do processo de seleção, segundo modelo de <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).</div>
+</div>
+<div class="row fig">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalFigf2s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Figura 2</strong><br>Sugestões de etapas futuras nos estudos sobre virtudes morais.</div>
+</div>
+</div>
+<div role="tabpanel" class="tab-pane " id="tables">
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet1s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 1</strong><br>Número de referências por base de dados, <i>query</i> e formato de busca.</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet2s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 2</strong><br>Escalas relacionadas a virtudes morais em nível individual - múltiplas e específicas.</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet3s"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 3</strong><br>Itens, amostra e medidas em escalas relacionadas a virtudes morais em nível individual.</div>
+</div>
+</div>
+</div>
+</div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf1s" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Abrir em nova janela" href="1982-7849-rac-26-06-e190379-gf1-pt.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figura 1   Fluxo do processo de seleção, segundo modelo de <span class="ref"><strong class="xref xrefblue">Moher et al. (2009</strong><span class="refCtt closed"><span>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. https://doi.org/10.1371/journal.pmed.1000097
+				</span><br><a href="https://doi.org/10.1371/journal.pmed.1000097" target="_blank">https://doi.org/10.1371/journal.pmed.100...
+            </a></span></span>).<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1982-7849-rac-26-06-e190379-gf1-pt.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalFigs" id="ModalFigf2s" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Abrir em nova janela" href="1982-7849-rac-26-06-e190379-gf2-pt.jpg"><span class="sci-ico-newWindow"></span></a><h4 class="modal-title">
+<span class="sci-ico-fileFigure"></span>Figura 2   Sugestões de etapas futuras nos estudos sobre virtudes morais.<br>
+</h4>
+</div>
+<div class="modal-body"><img style="max-width:100%" src="1982-7849-rac-26-06-e190379-gf2-pt.jpg"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet1s" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 1</strong>    Número de referências por base de dados, <i>query</i> e formato de busca.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Forma</th>
+<th align="center"><b>
+ <i>Query</i> de busca</b></th>
+<th align="center"><i>Ebsco</i></th>
+<th align="center"><i>Science Direct</i></th>
+<th align="center"><i>Scopus</i></th>
+<th align="center"><i>Web of Science</i></th>
+<th align="center"><i>Wiley</i></th>
+<th align="center">Total</th>
+</tr></thead>
+<tbody>
+<tr>
+<td align="center" rowspan="5">Todo o conteúdo</td>
+<td align="left">1 <i>“Scale development” AND “virtue* ethic*”</i>
+</td>
+<td align="center">3</td>
+<td align="center">0</td>
+<td align="center">2</td>
+<td align="center">2</td>
+<td align="center">100</td>
+<td align="center">107</td>
+</tr>
+<tr>
+<td align="left">2<i>. “scale*” AND “virtue* ethic*”</i>
+</td>
+<td align="center">11</td>
+<td align="center">1</td>
+<td align="center">16</td>
+<td align="center">14</td>
+<td align="center">-</td>
+<td align="center">42</td>
+</tr>
+<tr>
+<td align="left"><i>3. “scale*” AND “moral virtues”</i></td>
+<td align="center">-</td>
+<td align="center">116</td>
+<td align="center">5</td>
+<td align="center">34</td>
+<td align="center">-</td>
+<td align="center">155</td>
+</tr>
+<tr>
+<td align="left">4<i>. “scale development” AND “moral virtues”</i>
+</td>
+<td align="center">12</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center">8</td>
+<td align="center">65</td>
+<td align="center">86</td>
+</tr>
+<tr>
+<td align="left">5. <i>“measur*” AND “moral virtues”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">22</td>
+<td align="center">7</td>
+<td align="center">-</td>
+<td align="center">29</td>
+</tr>
+<tr>
+<td align="center" rowspan="5">Abstract</td>
+<td align="left">1. <i>“Scale development” AND “virtue* ethic*”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">4</td>
+<td align="center">1</td>
+<td align="center">1</td>
+<td align="center">6</td>
+</tr>
+<tr>
+<td align="left">2. <i>“scale*” AND “virtue* ethic*”</i>
+</td>
+<td align="center">2</td>
+<td align="center">3</td>
+<td align="center">66</td>
+<td align="center">14</td>
+<td align="center">17ª</td>
+<td align="center">102</td>
+</tr>
+<tr>
+<td align="left">3<i>. “scale*” AND “moral virtues”</i>
+</td>
+<td align="center">16ª</td>
+<td align="center">1</td>
+<td align="center">42</td>
+<td align="center">8</td>
+<td align="center">25ª </td>
+<td align="center">92</td>
+</tr>
+<tr>
+<td align="left">4<i>. “scale development” AND “moral virtues”</i>
+</td>
+<td align="center">-</td>
+<td align="center">-</td>
+<td align="center">4</td>
+<td align="center">2</td>
+<td align="center">1</td>
+<td align="center">7</td>
+</tr>
+<tr>
+<td align="left">5. <i>“measur*” AND “moral virtues”</i>
+</td>
+<td align="center">21ª </td>
+<td align="center">16ª </td>
+<td align="center">79</td>
+<td align="center">8</td>
+<td align="center">15</td>
+<td align="center">139</td>
+</tr>
+<tr>
+<td align="left"> </td>
+<td align="center">Total</td>
+<td align="center">65</td>
+<td align="center">138</td>
+<td align="center">240</td>
+<td align="center">98</td>
+<td align="center">224</td>
+<td align="center">765</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN5"><div>Nota. <sup>a</sup> Buscas com primeiro termo do <i>query</i> de busca no <i>abstract</i> e o segundo em todo o conteúdo do artigo.</div></li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet2s" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 2</strong>    Escalas relacionadas a virtudes morais em nível individual - múltiplas e específicas.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Escala</th>
+<th align="center">Autores</th>
+<th align="center"><i>Journal</i></th>
+<th align="right">Citações<sup>a</sup>
+</th>
+</tr></thead>
+<tbody>
+<tr><td align="center" colspan="4">Virtudes morais múltiplas </td></tr>
+<tr>
+<td align="left">
+<i>Virtue Scale</i> (VS)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Cawley, Martin e Johnson (2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Stoeber e Yang (2016</strong><span class="refCtt closed"><span>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				</span><br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">https://doi.org/10.1016/j.paid.2015.08.0...
+            </a></span></span>)</td>
+<td align="center">PID<br>
+									 PID</td>
+<td align="right">245<br>
+									 27</td>
+</tr>
+<tr>
+<td align="left">
+<i>Virtue Ethics Scale</i> (VES)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Shanahan e Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Racelis (2013</strong><span class="refCtt closed"><span>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				</span><br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">https://ajba.um.edu.my/article/view/2664...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Racelis (2014</strong><span class="refCtt closed"><span>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				</span><br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">https://www.academia.edu/10525406/Examin...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Donada, Mothe, Nogatchewsky e Ribeiro (2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>)<br>
+									 Shanahan e Hopkins (2019)</td>
+<td align="center">JBE<br>
+									 AJBA<br>
+									 APSSR<br>
+									 JBE<br>
+									 JBE<br>
+									 JBE</td>
+<td align="right">152<br>
+									 18<br>
+									 3<br>
+									 8<br>
+									 15<br>
+									 7</td>
+</tr>
+<tr>
+<td align="left"><i>VIA-Classification</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Park e Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Song e Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Arthur, Earl, Thompson e Ward (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>)</td>
+<td align="center">JA<br>
+									 JBE<br>
+									 JBE</td>
+<td align="right">775<br>
+									 27<br>
+									 3</td>
+</tr>
+<tr>
+<td align="left">
+<i>Virtuous Leadership Scale</i> (VLS)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Sarros, Cooper e Hartican (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Wang e Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">L&amp;ODJ<br>
+									 JBE</td>
+<td align="right">96<br>
+									 70</td>
+</tr>
+<tr>
+<td align="left"><i>Measure of Auditor’s Virtue</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Libby e Thorne (2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">65</td>
+</tr>
+<tr>
+<td align="left">
+<i>Leadership Virtues Questionnaire</i> (LVQ)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Riggio, Zhu, Reina e Maroosis (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>)</td>
+<td align="center">CPJPR</td>
+<td align="right">256</td>
+</tr>
+<tr>
+<td align="left"><i>Character Strengths Leadership Survey</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Thun e Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>)</td>
+<td align="center">CJAS</td>
+<td align="right">63</td>
+</tr>
+<tr>
+<td align="left">
+<i>Virtue Adjective Rating Scale</i> (VARS)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Yang, Stoeber e Wang (2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>)</td>
+<td align="center">PID</td>
+<td align="right">32</td>
+</tr>
+<tr>
+<td align="left">
+<i>Leadership Character Insight Assessment</i> (LCIA)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Seijts, Gandz, Crossan e Reno (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>)</td>
+<td align="center">OD</td>
+<td align="right">54</td>
+</tr>
+<tr>
+<td align="left"><i>Ethical Tendencies Scale</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Koçyiğit e Karadağ (2016</strong><span class="refCtt closed"><span>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				</span><br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">https://doi.org/10.12711/TJBE.2016.9.001...
+            </a></span></span>)</td>
+<td align="center">TJBE</td>
+<td align="right">9</td>
+</tr>
+<tr>
+<td align="left">
+<i>Virtuous Leadership Questionnaire</i> (VLQ)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Wang e Hackett (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">70</td>
+</tr>
+<tr>
+<td align="left">
+<i>Individual Business Virtues</i> (IBE) </td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">8</td>
+</tr>
+<tr><td align="center" colspan="4">Virtudes morais específicas </td></tr>
+<tr>
+<td align="left">
+<i>Multidimensional Ethics Scale</i> (MES)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Beekun, Westerman e Barghouti (2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Manly, Leonard e Riemenschneider (2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>)</td>
+<td align="center">JBE<br>
+									 JBE</td>
+<td align="right">56<br>
+									 36</td>
+</tr>
+<tr>
+<td align="left"><i>Deontic Justice Scale</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Beugré (2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>)</td>
+<td align="center">JASP</td>
+<td align="right">38</td>
+</tr>
+<tr>
+<td align="left">Escalas específicas correlacionadas com <i>Engagement Beauty Scale</i> (EBS)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Diessner, Iyer, Smith e Haidt (2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>)</td>
+<td align="center">JME</td>
+<td align="right">104</td>
+</tr>
+<tr>
+<td align="left"><i>Self-regarding and other regarding virtues</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Grappi, Romani e Bagozzi (2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>)</td>
+<td align="center">JBR</td>
+<td align="right">287</td>
+</tr>
+<tr>
+<td align="left">
+<i>Multicomponent Gratitude Measure</i> (MCGM)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Morgan et al. (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Gulliford, Morgan, Hemming e Abbott (2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>)<br>
+									 <span class="ref"><strong class="xref xrefblue">Hudecek, Blabst, Morgan e Lermer (2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>)</td>
+<td align="center">PID<br>
+									 CP<br>
+									 FP</td>
+<td align="right">55<br>
+									 6<br>
+									 1</td>
+</tr>
+<tr>
+<td align="left">
+<i>Moral Virtue Theory of Status Attainment</i> (MVT<i>)</i>
+</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Bai, Ho e Yan (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>)</td>
+<td align="center">JPSP</td>
+<td align="right">10</td>
+</tr>
+<tr>
+<td align="left"><i>Consumer moral virtue of Integrity</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Castro-González, Bande, Fernández-Ferrín e Kimura (2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>)</td>
+<td align="center">JCP</td>
+<td align="right">29</td>
+</tr>
+<tr>
+<td align="left"><i>Self-report Humility Scale</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Qin, Liu, Brown, Zheng e Owens (2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>)</td>
+<td align="center">JBE</td>
+<td align="right">6</td>
+</tr>
+<tr>
+<td align="left">
+<i>Gratitude Questionnaire</i> (G-20)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Bernabe-Valero, Blasco-Magraner e García-March (2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>)</td>
+<td align="center">FP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left"><i>Intellectually Humble Scale</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Colombo, Strangmann, Houkes, Kostadinova e Brandt (2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>)</td>
+<td align="center">RPP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">
+<i>Good and Evil Character Traits</i> (GECT) <i>Scale</i>
+</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Jiao, Yang, Guo, Xu, Zhang e Jiang (2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>)</td>
+<td align="center">SJP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">
+<i>Resilient Measurement Scale</i> (SPP-25)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Lasota, Tomaszek e Bosacki (2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>)</td>
+<td align="center">CP</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">
+<i>Professional Moral Courage scale</i> (PMC<i>; Sekerka 2009, 2 items)</i>
+</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Mansur, Sobral e Islam (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>)</td>
+<td align="center">BEER</td>
+<td align="right">1</td>
+</tr>
+<tr>
+<td align="left"><i>Temperance Scale</i></td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Shahab e Adil (2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>)</td>
+<td align="center">PJ</td>
+<td align="right">-</td>
+</tr>
+<tr>
+<td align="left">
+<i>Enright Self-Forgiveness Inventory</i> (ESFI)</td>
+<td align="left">
+										<span class="ref"><strong class="xref xrefblue">Kim, Volk e Enright (2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>)</td>
+<td align="center">CP</td>
+<td align="right">-</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote">
+<li id="TFN6"><div>Nota. <i>Personality and Individual Differences</i> (PID)<i>; Journal of Business Ethics</i> (JBE); <i>Asian Journal of Business &amp; Accounting</i> (AJBA); <i>Asia-Pacific Social Science Review</i> (APSSR); <i>Journal of Adolescence</i> (JA); <i>Leadership &amp; Organization Development Journal</i> (L&amp;ODJ); <i>Consulting Psychology Journal: Practice and Research</i> (CPJPR); <i>Canadian Journal of Administrative Science</i> (CJAS); <i>Organizational Dynamics; Turkish Journal of Business Ethics</i> (TJBE); <i>Journal of Applied Social Psychology</i> (JASP); <i>Journal of Moral Education</i> (JME); <i>Journal of Business Research</i> (JBR); <i>Journal of Personality &amp; Social Psychology</i> (JPSP); <i>Journal of Cleaner Production</i> (JCP); <i>Current Psychology</i> (CP); <i>Frontiers in Psychology</i> (FP); <i>Review of Philosophy and Psychology</i> (RPP)<i>; Scandinavian Journal of Psychology</i> (SJP); <i>Business Ethics: A European Review</i> (BEER)<i>; PsyCh Journal</i> (PJ).</div></li>
+<li id="TFN7">
+<sup class="xref big">a</sup><div> Consulta Google Scholar realizada em 2 de março de 2021.</div>
+</li>
+</ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet3s" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 3</strong>    Itens, amostra e medidas em escalas relacionadas a virtudes morais em nível individual.<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<colgroup>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+<col>
+</colgroup>
+<thead><tr>
+<th align="center">Artigos</th>
+<th align="center">Itens iniciais (A)</th>
+<th align="center">Amostra (B)</th>
+<th align="center">Proporção (B/A)</th>
+<th align="center">Itens finais</th>
+<th align="center">Análises estatísticas</th>
+<th align="center">País</th>
+<th align="center">Respondentes</th>
+</tr></thead>
+<tbody>
+<tr><td align="center" colspan="8">Virtudes morais múltiplas </td></tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Cawley et al. (2000</strong><span class="refCtt closed"><span>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. https://doi.org/10.1016/s0191-8869(99)00207-x
+				</span><br><a href="https://doi.org/10.1016/s0191-8869(99)00207-x" target="_blank">https://doi.org/10.1016/s0191-8869(99)00...
+            </a></span></span>)</td>
+<td align="center">140</td>
+<td align="center">390(1), 181(2), 143(3)</td>
+<td align="center">2,8</td>
+<td align="center">48</td>
+<td align="center">AFE</td>
+<td align="center">USA</td>
+<td align="center">Estudantes de psicologia</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Shanahan e Hyman (2003</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. https://doi.org/10.1023/A:1021914218659
+				</span><br><a href="https://doi.org/10.1023/A:1021914218659" target="_blank">https://doi.org/10.1023/A:1021914218659...
+            </a></span></span>)</td>
+<td align="center">45</td>
+<td align="center">445</td>
+<td align="center">9,9</td>
+<td align="center">33</td>
+<td align="center">AFE</td>
+<td align="center">USA</td>
+<td align="center">Estudantes de marketing</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Park e Peterson (2006</strong><span class="refCtt closed"><span>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. https://doi.org/10.1016/j.adolescence.2006.04.011
+				</span><br><a href="https://doi.org/10.1016/j.adolescence.2006.04.011" target="_blank">https://doi.org/10.1016/j.adolescence.20...
+            </a></span></span>)</td>
+<td align="center">198</td>
+<td align="center">250</td>
+<td align="center">1,3</td>
+<td align="center">24</td>
+<td align="center">AFE</td>
+<td align="center">USA</td>
+<td align="center">Estudantes (10-17 anos)</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Sarros et al. (2006</strong><span class="refCtt closed"><span>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. https://doi.org/10.1108/01437730610709291
+				</span><br><a href="https://doi.org/10.1108/01437730610709291" target="_blank">https://doi.org/10.1108/0143773061070929...
+            </a></span></span>)</td>
+<td align="center">7</td>
+<td align="center">238</td>
+<td align="center">34,0</td>
+<td align="center">7</td>
+<td align="center">ANOVA</td>
+<td align="center">Austrália</td>
+<td align="center">Membros de instituto de administração</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Libby e Thorne (2007</strong><span class="refCtt closed"><span>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. https://doi.org/10.1007/s10551-006-9127-0
+				</span><br><a href="https://doi.org/10.1007/s10551-006-9127-0" target="_blank">https://doi.org/10.1007/s10551-006-9127-...
+            </a></span></span>)</td>
+<td align="center">55</td>
+<td align="center">376</td>
+<td align="center">6,8</td>
+<td align="center">29</td>
+<td align="center">AFE</td>
+<td align="center">Canadá</td>
+<td align="center">Membros CICA</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Riggio et al. (2010</strong><span class="refCtt closed"><span>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. https://doi.org/10.1037/a0022286
+				</span><br><a href="https://doi.org/10.1037/a0022286" target="_blank">https://doi.org/10.1037/a0022286...
+            </a></span></span>)</td>
+<td align="center">36</td>
+<td align="center">200</td>
+<td align="center">5,6</td>
+<td align="center">19</td>
+<td align="center">AFE, AFC</td>
+<td align="center">USA</td>
+<td align="center">Administradores</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Thun e Kelloway (2011</strong><span class="refCtt closed"><span>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. https://doi.org/10.1002/cjas.216
+				</span><br><a href="https://doi.org/10.1002/cjas.216" target="_blank">https://doi.org/10.1002/cjas.216...
+            </a></span></span>)</td>
+<td align="center">27</td>
+<td align="center">327</td>
+<td align="center">12,1</td>
+<td align="center">14</td>
+<td align="center">AFE</td>
+<td align="center">Canadá</td>
+<td align="center">Empregados de universidade</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Racelis (2013</strong><span class="refCtt closed"><span>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from https://ajba.um.edu.my/article/view/2664
+				</span><br><a href="https://ajba.um.edu.my/article/view/2664" target="_blank">https://ajba.um.edu.my/article/view/2664...
+            </a></span></span>)</td>
+<td align="center">34</td>
+<td align="center">140</td>
+<td align="center">4,1</td>
+<td align="center">22</td>
+<td align="center">AFE</td>
+<td align="center">Filipinas</td>
+<td align="center">Universitários</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Racelis (2014</strong><span class="refCtt closed"><span>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens
+				</span><br><a href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens" target="_blank">https://www.academia.edu/10525406/Examin...
+            </a></span></span>)</td>
+<td align="center">34</td>
+<td align="center">141</td>
+<td align="center">4,1</td>
+<td align="center">22</td>
+<td align="center">AFE</td>
+<td align="center">Filipinas</td>
+<td align="center">Estudantes gestores</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Yang et al. (2015</strong><span class="refCtt closed"><span>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. https://doi.org/10.1016/j.paid.2014.11.040
+				</span><br><a href="https://doi.org/10.1016/j.paid.2014.11.040" target="_blank">https://doi.org/10.1016/j.paid.2014.11.0...
+            </a></span></span>)</td>
+<td align="center">90</td>
+<td align="center">348</td>
+<td align="center">3,9</td>
+<td align="center">90</td>
+<td align="center">AFE</td>
+<td align="center">China</td>
+<td align="center">Estudantes</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Seijts et al. (2015</strong><span class="refCtt closed"><span>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. https://doi.org/10.1016/j.orgdyn.2014.11.008
+				</span><br><a href="https://doi.org/10.1016/j.orgdyn.2014.11.008" target="_blank">https://doi.org/10.1016/j.orgdyn.2014.11...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">364</td>
+<td align="center">36,4</td>
+<td align="center">10</td>
+<td align="center">-</td>
+<td align="center">Canadá; USA</td>
+<td align="center">Líderes de organizações</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Koçyiğit e Karadağ (2016</strong><span class="refCtt closed"><span>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. https://doi.org/10.12711/TJBE.2016.9.0016
+				</span><br><a href="https://doi.org/10.12711/TJBE.2016.9.0016" target="_blank">https://doi.org/10.12711/TJBE.2016.9.001...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">312</td>
+<td align="center">31,2</td>
+<td align="center">26</td>
+<td align="center">AFE, AFC</td>
+<td align="center">Turquia</td>
+<td align="center">Estudantes de graduação</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Stoeber e Yang (2016</strong><span class="refCtt closed"><span>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. https://doi.org/10.1016/j.paid.2015.08.031
+				</span><br><a href="https://doi.org/10.1016/j.paid.2015.08.031" target="_blank">https://doi.org/10.1016/j.paid.2015.08.0...
+            </a></span></span>)</td>
+<td align="center">48</td>
+<td align="center">243</td>
+<td align="center">5,1</td>
+<td align="center">48</td>
+<td align="left"> </td>
+<td align="center">China</td>
+<td align="center">Estudantes universitários</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Wang e Hacket (2016</strong><span class="refCtt closed"><span>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. https://doi.org/10.1007/s10551-015-2560-1
+				</span><br><a href="https://doi.org/10.1007/s10551-015-2560-1" target="_blank">https://doi.org/10.1007/s10551-015-2560-...
+            </a></span></span>)</td>
+<td align="center">89</td>
+<td align="center">348</td>
+<td align="center">3,9</td>
+<td align="center">18</td>
+<td align="center">AFE, AFC</td>
+<td align="center">América do Norte</td>
+<td align="center">Estudantes de MBA</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Dawson (2018</strong><span class="refCtt closed"><span>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. https://doi.org/10.1007/s10551-017-3505-7
+				</span><br><a href="https://doi.org/10.1007/s10551-017-3505-7" target="_blank">https://doi.org/10.1007/s10551-017-3505-...
+            </a></span></span>)</td>
+<td align="center">45</td>
+<td align="center">137</td>
+<td align="center">3,0</td>
+<td align="center">13</td>
+<td align="center">AFE, AFC</td>
+<td align="center">UK</td>
+<td align="center">Profissionais RH</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Song e Kim (2018</strong><span class="refCtt closed"><span>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. https://doi.org/10.1007/s10551-016-3331-3
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3331-3" target="_blank">https://doi.org/10.1007/s10551-016-3331-...
+            </a></span></span>)</td>
+<td align="center">50</td>
+<td align="center">400</td>
+<td align="center">8</td>
+<td align="center">50</td>
+<td align="center">AFC</td>
+<td align="center">USA</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Arthur et al. (2021</strong><span class="refCtt closed"><span>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. https://doi.org/10.1007/s10551-019-04269-7
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04269-7" target="_blank">https://doi.org/10.1007/s10551-019-04269...
+            </a></span></span>)</td>
+<td align="center">24</td>
+<td align="center">2.340</td>
+<td align="center">97,5</td>
+<td align="center">24</td>
+<td align="center">ANOVA, AFC</td>
+<td align="center">USA</td>
+<td align="center">Profissionais de cinco áreas</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Donada et al. (2019</strong><span class="refCtt closed"><span>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. https://doi.org/10.1007/s10551-016-3418-x
+				</span><br><a href="https://doi.org/10.1007/s10551-016-3418-x" target="_blank">https://doi.org/10.1007/s10551-016-3418-...
+            </a></span></span>)</td>
+<td align="center">14</td>
+<td align="center">201</td>
+<td align="center">14,4</td>
+<td align="center">14</td>
+<td align="center">-</td>
+<td align="center">França</td>
+<td align="center">CEOs</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Shanahan e Hopkins (2019</strong><span class="refCtt closed"><span>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. https://doi.org/10.1007/s10551-018-3813-6
+				</span><br><a href="https://doi.org/10.1007/s10551-018-3813-6" target="_blank">https://doi.org/10.1007/s10551-018-3813-...
+            </a></span></span>)</td>
+<td align="center">3</td>
+<td align="center">129</td>
+<td align="center">43</td>
+<td align="center">3</td>
+<td align="center">AFC</td>
+<td align="center">USA</td>
+<td align="center">Gestores e vendedores</td>
+</tr>
+<tr><td align="center" colspan="8">Virtudes morais específicas </td></tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Beekun et al. (2005</strong><span class="refCtt closed"><span>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. https://doi.org/10.1007/s10551-005-4772-2
+				</span><br><a href="https://doi.org/10.1007/s10551-005-4772-2" target="_blank">https://doi.org/10.1007/s10551-005-4772-...
+            </a></span></span>)</td>
+<td align="center">14</td>
+<td align="center">165</td>
+<td align="center">11,8</td>
+<td align="center">14</td>
+<td align="center">AFE</td>
+<td align="center">USA; Rússia</td>
+<td align="center">Estudantes de MBA</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Beugré (2012</strong><span class="refCtt closed"><span>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. https://doi.org/10.1111/j.1559-1816.2012.00935.x
+				</span><br><a href="https://doi.org/10.1111/j.1559-1816.2012.00935.x" target="_blank">https://doi.org/10.1111/j.1559-1816.2012...
+            </a></span></span>)</td>
+<td align="center">36</td>
+<td align="center">124(1) 101(2)</td>
+<td align="center">3,4 2,8</td>
+<td align="center">18</td>
+<td align="center">-</td>
+<td align="center">USA</td>
+<td align="center">Trabalhadores de eletrônica</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Diessner et al. (2013</strong><span class="refCtt closed"><span>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. http://dx.doi.org/10.1080/03057240.2013.785941
+				</span><br><a href="http://dx.doi.org/10.1080/03057240.2013.785941" target="_blank">http://dx.doi.org/10.1080/03057240.2013....
+            </a></span></span>)</td>
+<td align="center">18</td>
+<td align="center">5.380 (1) 542(2)</td>
+<td align="center">298,9</td>
+<td align="center">18</td>
+<td align="center">SEM</td>
+<td align="center">USA (Idaho)</td>
+<td align="center">Universitários</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Grappi et al. (2013</strong><span class="refCtt closed"><span>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. https://doi.org/10.1016/j.jbusres.2013.02.002
+				</span><br><a href="https://doi.org/10.1016/j.jbusres.2013.02.002" target="_blank">https://doi.org/10.1016/j.jbusres.2013.0...
+            </a></span></span>)</td>
+<td align="center">5</td>
+<td align="center">280</td>
+<td align="center">56,0</td>
+<td align="center">5</td>
+<td align="center">AFC</td>
+<td align="center">Itália</td>
+<td align="center">Consumidores</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Manly et al. (2015</strong><span class="refCtt closed"><span>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. https://doi.org/10.1007/s10551-014-2060-8
+				</span><br><a href="https://doi.org/10.1007/s10551-014-2060-8" target="_blank">https://doi.org/10.1007/s10551-014-2060-...
+            </a></span></span>)</td>
+<td align="center">12</td>
+<td align="center">86</td>
+<td align="center">7,2</td>
+<td align="center">12</td>
+<td align="center">-</td>
+<td align="center">USA</td>
+<td align="center">Estudantes de negócios de TI</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Morgan et al. (2017</strong><span class="refCtt closed"><span>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. https://doi.org/10.1016/j.paid.2016.11.044
+				</span><br><a href="https://doi.org/10.1016/j.paid.2016.11.044" target="_blank">https://doi.org/10.1016/j.paid.2016.11.0...
+            </a></span></span>)</td>
+<td align="center">119</td>
+<td align="center">477(1) 1.599(2)</td>
+<td align="center">4,0 55,1</td>
+<td align="center">29</td>
+<td align="center">AFE, AFC, ANOVA, MANOVA</td>
+<td align="center">UK</td>
+<td align="center">Respondente on-line</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Castro-González et al. (2019</strong><span class="refCtt closed"><span>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. https://doi.org/10.1016/j.jclepro.2019.05.238
+				</span><br><a href="https://doi.org/10.1016/j.jclepro.2019.05.238" target="_blank">https://doi.org/10.1016/j.jclepro.2019.0...
+            </a></span></span>)</td>
+<td align="center">2</td>
+<td align="center">252</td>
+<td align="center">126</td>
+<td align="center">2</td>
+<td align="center">AFC</td>
+<td align="center">Espanha</td>
+<td align="center">Consumidores</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Gulliford et al. (2019</strong><span class="refCtt closed"><span>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. https://doi.org/10.1007/s12144-019-00330-w
+				</span><br><a href="https://doi.org/10.1007/s12144-019-00330-w" target="_blank">https://doi.org/10.1007/s12144-019-00330...
+            </a></span></span>)</td>
+<td align="center">6+29</td>
+<td align="center">311</td>
+<td align="center">8,9</td>
+<td align="center">6+29</td>
+<td align="center">ANOVA</td>
+<td align="center">UK</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Qin et al. (2019</strong><span class="refCtt closed"><span>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. https://doi.org/10.1007/s10551-019-04250-4
+				</span><br><a href="https://doi.org/10.1007/s10551-019-04250-4" target="_blank">https://doi.org/10.1007/s10551-019-04250...
+            </a></span></span>)</td>
+<td align="center">9</td>
+<td align="center">487</td>
+<td align="center">54,1</td>
+<td align="center">9</td>
+<td align="center">AFE, AFC</td>
+<td align="center">China</td>
+<td align="center">Supervisores e empregados</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Bai et al. (2020</strong><span class="refCtt closed"><span>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. http://doi.org/10.0.4.13/pspi0000192
+				</span><br><a href="http://doi.org/10.0.4.13/pspi0000192" target="_blank">http://doi.org/10.0.4.13/pspi0000192...
+            </a></span></span>)</td>
+<td align="center">60</td>
+<td align="center">292(1), 167(2) 155(3)</td>
+<td align="center">4,9</td>
+<td align="center">15</td>
+<td align="center">AFE, AFC</td>
+<td align="center">USA; China</td>
+<td align="center">Estudantes e gestores</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Bernabe-Valero et al. (2020</strong><span class="refCtt closed"><span>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. https://doi.org/10.3389/fpsyg.2020.626330
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.626330" target="_blank">https://doi.org/10.3389/fpsyg.2020.62633...
+            </a></span></span>)</td>
+<td align="center">20</td>
+<td align="center">302</td>
+<td align="center">15,1</td>
+<td align="center">20</td>
+<td align="center">AFC</td>
+<td align="center">USA</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Colombo et al. (2021</strong><span class="refCtt closed"><span>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. https://doi.org/10.1007/s13164-020-00496-4
+				</span><br><a href="https://doi.org/10.1007/s13164-020-00496-4" target="_blank">https://doi.org/10.1007/s13164-020-00496...
+            </a></span></span>)</td>
+<td align="center">20</td>
+<td align="center">60(1), 301(2), 347(3), 431(4)</td>
+<td align="center">3</td>
+<td align="center">20</td>
+<td align="center">-</td>
+<td align="center">Holanda</td>
+<td align="center">Universitários</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Hudecek et al. (2020</strong><span class="refCtt closed"><span>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. https://doi.org/10.3389/fpsyg.2020.590108
+				</span><br><a href="https://doi.org/10.3389/fpsyg.2020.590108" target="_blank">https://doi.org/10.3389/fpsyg.2020.59010...
+            </a></span></span>)</td>
+<td align="center">6</td>
+<td align="center">508(1) 1.599(2)</td>
+<td align="center">84,7</td>
+<td align="center">6</td>
+<td align="center">AFC</td>
+<td align="center">Alemanha; UK</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Jiao et al. (2020</strong><span class="refCtt closed"><span>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. https://doi.org/10.1111/sjop.12696
+				</span><br><a href="https://doi.org/10.1111/sjop.12696" target="_blank">https://doi.org/10.1111/sjop.12696...
+            </a></span></span>)</td>
+<td align="center">55</td>
+<td align="center">350</td>
+<td align="center">6,4</td>
+<td align="center">53</td>
+<td align="center">AFE, AFC</td>
+<td align="center">China</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Lasota et al. (2020</strong><span class="refCtt closed"><span>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. https://doi.org/10.1007/s12144-020-01178-1
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01178-1" target="_blank">https://doi.org/10.1007/s12144-020-01178...
+            </a></span></span>)</td>
+<td align="center">25</td>
+<td align="center">214</td>
+<td align="center">8,6</td>
+<td align="center">25</td>
+<td align="center">SEM</td>
+<td align="center">Polônia</td>
+<td align="center">Estudantes e empregados</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Mansur et al. (2020</strong><span class="refCtt closed"><span>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. https://doi.org/10.1111/beer.12270
+				</span><br><a href="https://doi.org/10.1111/beer.12270" target="_blank">https://doi.org/10.1111/beer.12270...
+            </a></span></span>)</td>
+<td align="center">10</td>
+<td align="center">202</td>
+<td align="center">20,2</td>
+<td align="center">9</td>
+<td align="center">AFE, AFC</td>
+<td align="center">Não contém</td>
+<td align="center">Adultos</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Shahab e Adil (2020</strong><span class="refCtt closed"><span>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. https://doi.org/10.1002/pchj.394
+				</span><br><a href="https://doi.org/10.1002/pchj.394" target="_blank">https://doi.org/10.1002/pchj.394...
+            </a></span></span>)</td>
+<td align="center">24</td>
+<td align="center">250(1) 268(2)</td>
+<td align="center">10,4</td>
+<td align="center">24</td>
+<td align="center">AFE, AFC</td>
+<td align="center">Paquistão</td>
+<td align="center">Universitários</td>
+</tr>
+<tr>
+<td align="left">
+											<span class="ref"><strong class="xref xrefblue">Kim et al. (2021</strong><span class="refCtt closed"><span>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. https://doi.org/10.1007/s12144-020-01248-4
+				</span><br><a href="https://doi.org/10.1007/s12144-020-01248-4" target="_blank">https://doi.org/10.1007/s12144-020-01248...
+            </a></span></span>)</td>
+<td align="center">60</td>
+<td align="center">252(1), 204(2), 343(3), 567(4) </td>
+<td align="center">4,2</td>
+<td align="center">30</td>
+<td align="center">AFE, AFC</td>
+<td align="center">USA</td>
+<td align="center">Estudantes-pais; adultos</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN8"><div>Nota. Análise fatorial exploratória (AFE), análise fatorial confirmatória (AFC), modelagem de equações estruturais (SEM), análise univariada da covariância (ANOVA), análise multivariada da covariância (MANOVA). </div></li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Como citar</h4>
+</div>
+<div class="modal-body">
+<p id="citation"></p>
+<input id="citationCut" type="text" value=""><a class="copyLink" data-clipboard-target="#citationCut"><span class="glyphBtn copyIcon"></span>copiar</a>
+</div>
+</div></div></div>
+<script type="text/javascript">
+            function currentDate() {
+            var today = new Date();
+            var months = ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
+            today.setTime(today.getTime());
+            return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+            }
+            var citation = 'Ames, Maria Clara F. Dalla Costa, Serafim, Mauricio C. e Martins, Felipe FlôresAnalysis of Scales and Measures of Moral Virtues: A Systematic Review. Revista de Administração Contemporânea [online]. 2022, v. 26, n. 06 [Acessado CURRENTDATE] , e190379. Disponível em: &lt;https://doi.org/10.1590/1982-7849rac2022190379.en https://doi.org/10.1590/1982-7849rac2022190379.por&gt;. Epub 18 Jul 2022. ISSN 1982-7849. https://doi.org/10.1590/1982-7849rac2022190379.en.'.replace('CURRENTDATE', currentDate());
+            document.getElementById('citation').innerHTML = citation;
+            document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+        </script>
+</div>
+<ul class="floatingMenu fm-slidein" data-fm-toogle="hover"><li class="fm-wrap">
+<a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a><ul class="fm-list">
+<li><a class="fm-button-child" data-fm-label="Figuras | Tabelas" data-toggle="modal" data-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+<li><a class="fm-button-child" data-toggle="modal" data-target="#ModalArticles" data-fm-label="How to
+                                          cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+</ul>
+</li></ul>
+<script src="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js"></script>
+</body>
+</html>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
@@ -744,32 +744,32 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote">
-<li>
-<h3><span class="xref big">Classificação JEL:</span></h3>
+<li class="articleSection" data-anchor="Classificação JEL:">
+<h3>Classificação JEL:</h3>
 <div>M1, M10.</div>
 </li>
-<li>
-<h3><span class="xref big">Relatório de Revisão por Pares:</span></h3>
+<li class="articleSection" data-anchor="Relatório de Revisão por Pares:">
+<h3>Relatório de Revisão por Pares:</h3>
 <div>O Relatório de Revisão por Pares está disponível neste <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">link externo</a>.</div>
 </li>
-<li>
-<h3><span class="xref big">Financiamento</span></h3>
+<li class="articleSection" data-anchor="Financiamento">
+<h3>Financiamento</h3>
 <div> Os autores agradecem o Ministério da Ciência, Tecnologia e Inovação, Conselho Nacional de Desenvolvimento Científico e Tecnológico (CHSSA, Processo nr. 445434/2015-5) pelo suporte financeiro ao projeto de pesquisa, a partir do qual o presente estudo foi desenvolvido.</div>
 </li>
-<li>
-<h3><span class="xref big">Verificação de Plágio</span></h3>
+<li class="articleSection" data-anchor="Verificação de Plágio">
+<h3>Verificação de Plágio</h3>
 <div> A RAC mantém a prática de submeter todos os documentos aprovados para publicação à verificação de plágio, mediante o emprego de ferramentas específicas, e.g.: iThenticate.</div>
 </li>
-<li>
-<h3><span class="xref big">Direitos Autorais</span></h3>
+<li class="articleSection" data-anchor="Direitos Autorais">
+<h3>Direitos Autorais</h3>
 <div> A RAC detém os direitos autorais deste conteúdo.</div>
 </li>
-<li>
-<h3><span class="xref big">Método de Revisão por Pares</span></h3>
+<li class="articleSection" data-anchor="Método de Revisão por Pares">
+<h3>Método de Revisão por Pares</h3>
 <div> Este conteúdo foi avaliado utilizando o processo de revisão por pares duplo-cego (<i>double-blind peer-review</i>). A divulgação das informações dos pareceristas constantes na primeira página e do Relatório de Revisão por Pares (Peer Review Report) é feita somente após a conclusão do processo avaliativo, e com o consentimento voluntário dos respectivos pareceristas e autores.</div>
 </li>
-<li>
-<h3><span class="xref big">Disponibilidade dos Dados</span></h3>
+<li class="articleSection" data-anchor="Disponibilidade dos Dados">
+<h3>Disponibilidade dos Dados</h3>
 <div>Os autores afirmam que todos os dados utilizados na pesquisa foram disponibilizados publicamente, e podem ser acessados por meio da plataforma Harvard Dataverse:</div>
 <div>
 <img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr-pt.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.xml
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.xml
@@ -1,0 +1,4457 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE article
+  PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<front>
+		<journal-meta>
+			<journal-id journal-id-type="publisher-id">rac</journal-id>
+			<journal-title-group>
+				<journal-title>Revista de Administração Contemporânea</journal-title>
+				<abbrev-journal-title abbrev-type="publisher">Rev. adm. contemp.</abbrev-journal-title>
+			</journal-title-group>
+			<issn pub-type="ppub">1415-6555</issn>
+			<issn pub-type="epub">1982-7849</issn>
+			<publisher>
+				<publisher-name>Associação Nacional de Pós-Graduação e Pesquisa em Administração</publisher-name>
+			</publisher>
+		</journal-meta>
+		<article-meta>
+			<article-id pub-id-type="doi">10.1590/1982-7849rac2022190379.en</article-id>
+			<article-id pub-id-type="other">01100</article-id>
+			<article-categories>
+				<subj-group subj-group-type="heading">
+					<subject>Theoretical-empirical Article</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>Analysis of Scales and Measures of Moral Virtues: A Systematic Review</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-0444-8764</contrib-id>
+					<name>
+						<surname>Ames</surname>
+						<given-names>Maria Clara F. Dalla Costa</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+					<xref ref-type="corresp" rid="c1">*</xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-4852-5119</contrib-id>
+					<name>
+						<surname>Serafim</surname>
+						<given-names>Mauricio C.</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0003-2987-5479</contrib-id>
+					<name>
+						<surname>Martins</surname>
+						<given-names>Felipe Flôres</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1"><sup>1</sup></xref>
+				</contrib>
+				<aff id="aff1">
+					<label>1</label>
+					<institution content-type="original">Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brazil.</institution>
+					<institution content-type="normalized">Universidade do Estado de Santa Catarina</institution>
+					<institution content-type="orgname">Universidade do Estado de Santa Catarina</institution>
+					<institution content-type="orgdiv1">Centro de Ciências da Administração e Socioeconômicas</institution>
+					<addr-line>
+						<city>Florianópolis</city>
+						<state>SC</state>
+					</addr-line>
+					<country country="BR">Brazil</country>
+				</aff>
+			</contrib-group>
+			<author-notes>
+				<corresp id="c1">
+					<label>*</label> Corresponding Author</corresp>
+				<fn fn-type="edited-by" id="fn2">
+					<label>Editors-in-chief:</label>
+							<p>Wesley Mendes-da-Silva (Fundação Getulio Vargas, EAESP, Brazil)</p>
+							<p>Marcelo de Souza Bispo (Universidade Federal da Paraíba, PPGA, Brazil)</p>
+				</fn>
+				<fn fn-type="other" id="fn3">
+					<label>Reviewers:</label>
+							<p>Janaína Cássia Grossi (Fundação Getulio Vargas, EAESP, Brazil)</p>
+							<p>Claudio Zancan (Universidade Federal do Paraná, Brazil)</p>
+				</fn>
+				<fn fn-type="current-aff" id="fn5">
+					<label>Authorship</label>
+							<p>Maria Clara Figueiredo Dalla Costa Ames*</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</p>
+							<p>E-mail: mariaclaraames@gmail.com</p>
+							<p> https://orcid.org/0000-0002-0444-8764</p>
+							<p>Mauricio C. Serafim</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</p>
+							<p>E-mail: serafim.esag@gmail.com</p>
+							<p> https://orcid.org/0000-0002-4852-5119</p>
+							<p>Felipe Flôres Martins</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brazil</p>
+							<p>E-mail: martins.felipef@gmail.com</p>
+							<p> https://orcid.org/0000-0003-2987-5479</p>
+				</fn>
+				<fn fn-type="conflict" id="fn7">
+					<label>Conflict of Interests</label>
+					<p> The authors have stated that there is no conflict of interest.</p>
+				</fn>
+				<fn fn-type="con" id="fn9">
+					<label>Authors' Contributions</label>
+							<p>1<sup>st</sup> author: conceptualization (lead); data curation (lead); formal analysis (lead); investigation (equal); methodology (lead); resources (equal); software (equal); supervision (equal); validation (equal); writing-original draft (equal); writing-review &amp; editing (equal).</p>
+							<p>2<sup>nd</sup> author: conceptualization (supporting); data curation (supporting); formal analysis (supporting); investigation (supporting); methodology (supporting); project administration (supporting); supervision (supporting); validation (equal); writing-original draft (supporting); writing-review &amp; editing (equal).</p>
+							<p>3<sup>rd</sup> author: conceptualization (supporting); formal analysis (supporting); investigation (supporting); methodology (supporting); validation (supporting); writing-original draft (equal); writing-review &amp; editing (supporting).</p>
+				</fn>
+			</author-notes>
+			<pub-date date-type="pub" publication-format="electronic">
+				<day>18</day>
+				<month>07</month>
+				<year>2022</year>
+			</pub-date>
+			<pub-date date-type="collection" publication-format="electronic">
+				<year>2022</year>
+			</pub-date>
+			<volume>26</volume>
+			<issue>06</issue>
+			<elocation-id>e190379</elocation-id>
+			<history>
+				<date date-type="received">
+					<day>17</day>
+					<month>11</month>
+					<year>2019</year>
+				</date>
+				<date date-type="rev-recd">
+					<day>15</day>
+					<month>06</month>
+					<year>2021</year>
+				</date>
+				<date date-type="accepted">
+					<day>16</day>
+					<month>06</month>
+					<year>2021</year>
+				</date>
+			</history>
+			<permissions>
+				<license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/" xml:lang="en">
+					<license-p>This is an open-access article distributed under the terms of the Creative Commons Attribution License</license-p>
+				</license>
+			</permissions>
+			<abstract>
+				<title>ABSTRACT</title>
+				<sec>
+					<title>Objective:</title>
+					<p> to investigate how scales for the concept of moral virtues are constructed and measured, in studies associated with business ethics and the tradition of virtue ethics. </p>
+				</sec>
+				<sec>
+					<title>Methods:</title>
+					<p> a systematic literature review was conducted to select empirical articles on moral virtues that design or apply scales. Based on search, selection, and analysis criteria, five databases were consulted, and 37 papers were selected, with subsequent analysis of the scales development and measurement procedure (items, sample, factor analysis) and emerging factors. </p>
+				</sec>
+				<sec>
+					<title>Results:</title>
+					<p> the study gathers scales of multiple moral virtues (19) and of specific virtues (18), showing limitations in the generation of items, and in the item-sample proportion in some scales, as well as theoretical contributions in leadership and relationship strengthening, making a theoretical and methodological discussion in the light of the assumptions of virtue ethics in the Aristotelian-Thomistic tradition. </p>
+				</sec>
+				<sec>
+					<title>Conclusions:</title>
+					<p> the article intends to contribute to a better understanding of moral virtues in management, by discussing the scales from the unity of virtues and the phronesis-moral virtues connection, with implications for human behavior and business ethics. Procedures are recommended for future qualitative and quantitative studies in new research contexts.</p>
+				</sec>
+			</abstract>
+			<kwd-group xml:lang="en">
+				<title>Keywords:</title>
+				<kwd>moral virtues</kwd>
+				<kwd>scale analysis</kwd>
+				<kwd>virtue ethics</kwd>
+				<kwd>business ethics</kwd>
+			</kwd-group>
+			<funding-group>
+				<award-group award-type="contract">
+					<funding-source>Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development </funding-source>
+					<award-id>445434/2015-5</award-id>
+				</award-group>
+				<funding-statement>The authors thank the Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development (CNPq) (CHSSA, Process nr. 445434/2015-5) for the financial support to the research project, from which this study was developed.</funding-statement>
+			</funding-group>
+			<counts>
+				<fig-count count="4"/>
+				<table-count count="6"/>
+				<equation-count count="0"/>
+				<ref-count count="82"/>
+			</counts>
+		</article-meta>
+	</front>
+	<body>
+		<sec sec-type="intro">
+			<title>INTRODUCTION</title>
+			<p>Virtue ethics has proved to be an influential tradition in business ethics studies in recent years (<xref ref-type="bibr" rid="B4">Alzola, Hennig, &amp; Romar, 2020</xref>). The interest in the topic has intensified since authors of moral philosophy such as <xref ref-type="bibr" rid="B7">Anscombe (1958</xref>) and MacIntyre (2007) reinterpreted <xref ref-type="bibr" rid="B8">Aristotle (2009</xref>). The ethical problems of organizational reality have been discussed based on different perspectives and traditions related to virtues (<xref ref-type="bibr" rid="B71">Sison, Ferrero, &amp; Guitián, 2018</xref>). Such perspectives and traditions are alternatives to consequentialists and deontological ethics, and empirical and quantitative studies have been a prominent theme in the field since the turn of the millennium (Sison &amp; Ferrero, 2015).</p>
+			<p>Empirical and quantitative studies have elaborated scales and measures based on the lists of moral virtues by <xref ref-type="bibr" rid="B75">Solomon (1992</xref>; 1999) and <xref ref-type="bibr" rid="B53">Murphy (1999</xref>). Such studies aim to identify and measure moral virtues in administration and business. However, the use of certain scientific methods from social sciences to address moral virtues - a philosophical concept valued in many cultures - has been criticized (<xref ref-type="bibr" rid="B69">Beadle, Sison, &amp; Fontrodona, 2015</xref>). These methods may reduce the elements and assumptions to mere observable behaviors, hindering a better understanding of virtues (Sison &amp; Ferrero, 2015; <xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). This process has reinforced the need for a solid theoretical basis on the moral virtues construct, considering its multidimensionality (<xref ref-type="bibr" rid="B1">Aguirre-Y-Luker, Hyman, &amp; Shanahan, 2017</xref>).</p>
+			<p>Another concept that has been developed in addition to individual moral virtues refers to organizational moral virtues, or virtuousness (<xref ref-type="bibr" rid="B35">Huhtala, Kangas, Kaptein, &amp; Feldt, 2018</xref>; <xref ref-type="bibr" rid="B28">Gomide, Vieira, &amp; Oliveira, 2016</xref>; <xref ref-type="bibr" rid="B60">Rego &amp; Cunha, 2015</xref>). Despite their strict relationship, the concepts of moral virtue and virtuousness are not identical: the first refers to the individual, while the second to the organization, to what can be externally verified (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>; <xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Thus, there are moral virtues scales at the individual level, and virtuousness scales at the group and organizational levels, such as those revisited by <xref ref-type="bibr" rid="B20">Dawson (2018</xref>) and <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker, Hyman e Shanahan (2017</xref>). This article is limited to investigating moral virtues scales at an individual level - characteristics of a single individual - leaving the virtuousness scales for future research.</p>
+			<p>The topic has different theoretical traditions (<xref ref-type="bibr" rid="B71">Sison et al., 2018</xref>) and extensive lists of virtues. Although the conception of virtues encompasses components or dimensions (<xref ref-type="bibr" rid="B54">Newstead, Macklin, Dawkins, &amp; Martin, 2018</xref>), empirical research has been restricted to observable traits or behaviors, revealing a methodological impasse in the relationship between the virtue ethics, originating in moral philosophy, and the experimental sciences, with certain ramifications in psychology. Given the development of new scales on virtues, this research seeks to answer the following question: ‘How are the scales for the moral virtues construct elaborated and measured in studies related to virtue ethics?’ This article seeks to analyze the scales and measures of the individual (personal) moral virtues construct, based on a systematic literature review (<xref ref-type="bibr" rid="B72">Snyder, 2019</xref>).</p>
+			<p>This study builds on two previous research works. One of them is the study by <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al. (2017</xref>) who address challenges, possibilities, and best practices for the development of scales, describing scales, items, and psychometric aspects. The other is <xref ref-type="bibr" rid="B20">Dawson (2018</xref>), who lists individual, group, and organizational moral virtues scales.</p>
+			<p>The intention is to continue these works offering a systematic review of articles that develop or apply scales based on the Preferred Reporting Items for Systematic Reviews and Meta-Analyses (PRISMA) by <xref ref-type="bibr" rid="B49">Moher, Liberati, Tetslaff and Altman (2009</xref>). Also, we conduct a statistical analysis following the recommendations by <xref ref-type="bibr" rid="B24">Fávero, Belfiore, Silva and Chan (2009</xref>), <xref ref-type="bibr" rid="B31">Hair, Babin, Money and Samouel (2005</xref>) and Hair, Black, Babin, Anderson and Tathan (2009).</p>
+			<p>Finally, this study seeks to contribute to the analysis of methods used to elaborate and apply moral virtues scales, given the methodological impasse for empirical research on virtue ethics. The analysis is conducted through a methodological and theoretical discussion, considering Aristotelian-Thomistic assumptions of virtue ethics (<xref ref-type="bibr" rid="B70">Sison, Beabout, &amp; Ferrero, 2017</xref>).</p>
+			<p>After this introduction, the second section below presents the concept of moral virtues, considering assumptions of virtue ethics and perspectives seeking to measure virtues. The subsequent section describes the methodological procedures and the analysis criteria adopted in this systematic review, followed by the fourth section presenting the results and discussions about measures and scales found in the literature, analyzing methods and theoretical assumptions. Lastly, we offer suggestions for future studies and present the final considerations, including the research limitations and conclusions.</p>
+		</sec>
+		<sec>
+			<title>MORAL VIRTUES ACCORDING TO THE TRADITION OF VIRTUES ETHICS IN BUSINESS ETHICS</title>
+			<p>The work of authors such as Elizabeth <xref ref-type="bibr" rid="B7">Anscombe (1958</xref>), Philippa <xref ref-type="bibr" rid="B27">Foot (1967</xref>), and Alasdair MacIntyre (2007), who return to Aristotelian and Thomistic concepts, were responsible for the resumption or reinterpretation of moral virtues in philosophy, psychology, education, and business ethics. Virtue ethics has been developed through both Western and Eastern perspectives (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>), that unfolded from moral traditions related to organizations’ ethical issues and different functions of Administration (<xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). </p>
+			<p>The interest in virtue ethics has been observed in conferences, thematic symposia and special calls for paper (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>; <xref ref-type="bibr" rid="B12">Beadle et al., 2015</xref>; Hühn, Habisch, <xref ref-type="bibr" rid="B36">Hartmann, &amp; Sison, 2020</xref>), handbooks on virtue ethics in administration (Sison et al., 2017), book publishing (Hartmann, 2020; <xref ref-type="bibr" rid="B50">Moore, 2017</xref>; Sison et al., 2018) and by the emergence of new research groups, such as Virtue Ethics in Business (VEiB), from University of Navarre. Also, scientific journals such as the Journal of Business Ethics, the Business Ethics Quarterly, and Business Ethics: Environment and Responsibility bring together many issues that address virtue ethics.</p>
+			<p>Studies on virtues can be linked to two distinct perspectives: virtue theory and virtue ethics (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Virtue theory refers to studies on virtues within the deontological and consequentialist models. In contrast, virtue ethics is adopted as a third perspective in moral philosophy to represent studies focused on character and anchored in the three elements <italic>arête</italic> (virtue or excellence), <italic>phronesis</italic> (prudence or practical wisdom), and <italic>eudaimonia</italic> (human flourishing). While the deontological and consequentialist perspectives refer to the action, virtue ethics focuses on the agent, considering particularities of the context regarding community life (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>).</p>
+			<p>
+				<xref ref-type="bibr" rid="B75">Solomon (1992</xref>) and <xref ref-type="bibr" rid="B48">Moberg (1999</xref>) were pioneers in considering virtue ethics in business ethics. Solomon (1992) attempted to address the gap between ethics and business practices through an Aristotle-based perspective (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>), with the idea that people and corporations are part of the community. Moberg (1999) explored the connection between virtue ethics and personality psychology, paving the way for empirical research on virtue ethics in business ethics.</p>
+			<p>Moral virtues are usually described as character dispositions that indicate the correct ends of actions, while prudence or practical wisdom (phronesis) is the virtue responsible for indicating the means to achieve such ends (<xref ref-type="bibr" rid="B5">Ames &amp; Serafim, 2019</xref>; <xref ref-type="bibr" rid="B8">Aristotle, 2009</xref>; <xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). The moment virtuous actions, such as courage and humility, are repeated, they turn into habits, and, in the long run, these habits determine their character. The virtuous agent expresses virtues in their actions, and therefore their actions and personal traits can serve as a reference for others (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). Such actions result from a will or intention with an end (or <italic>telos</italic>), seeking to achieve <italic>eudaimonia</italic>. The human being improves themselves and their future practices by performing virtuous actions. Thus, “the core of virtue ethics is the causal relationship it establishes between what the agent does and what the agent becomes through the acquisition of virtues and the development of character” (Ferrero, 2020, p. 11).</p>
+			<p>Among the main traditions of virtue ethics, the neo-Aristotelian tradition, the Thomist school, and the contributions of MacIntyre (2007), who delve into the ethics of Aristotle and Thomas Aquinas (<xref ref-type="bibr" rid="B82">Zyl, 2019</xref>), stand out. Recent studies share the notion of cardinal virtues - hinges of virtues - inherited from these traditions (<xref ref-type="bibr" rid="B51">Morales-Sánchez &amp; Cabello-Medina, 2013</xref>). There are four cardinal virtues: (1) temperance, also known as self-control or moderation (<xref ref-type="bibr" rid="B63">Sanz &amp; Fontrodona, 2019</xref>); (2) fortitude; (3) justice (Morales-Sánchez &amp; Cabello-Medina, 2013); and (4) prudence or practical wisdom; originally from the Greek term <italic>phronesis</italic> (<xref ref-type="bibr" rid="B6">Ames, Serafim, &amp; Zappellini, 2020</xref>; <xref ref-type="bibr" rid="B10">Bachmann, Habisch, &amp; Dierksmeier, 2017</xref>). Such traditions consider that virtues can be learned, especially through lived experience (Aristotle, 2009).</p>
+			<p>Assuming that other agents can perceive someone’s virtuous action, studies that use scales seek to measure the perception of moral virtues about the action of colleagues, leaders, and managers in general. <xref ref-type="bibr" rid="B75">Solomon's (1992</xref>; 1999) list of virtues contributed in this regard. Its framework considers six dimensions: community, excellence, role identity, integrity, judgment, and holism. The author suggests a list of virtues related to business - such as honesty, loyalty, courage, trustworthiness, benevolence, cooperation, civility - which underpin <xref ref-type="bibr" rid="B67">Shanahan and Hyman's (2003</xref>). moral virtues scale. However, the extent to which a set of virtues can be associated with administration and business is discussed without considering the context and the administrators’ own perception about the virtues to be cultivated (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>).</p>
+			<p>In addition to this empirical problem, positive psychology and positive organizational scholarship (POS) limit the definition of virtues in terms of behavior and based on aspects external to the individual (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>; <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al., 2017</xref>). According to <xref ref-type="bibr" rid="B69">Sison and Ferrero (2015</xref>) virtues cannot be reduced to the cognitive and emotional aspects of character, as they encompass other fundamental elements and assumptions, such as the interrelationship between actions, habits, character, and life trajectory. This context suggests that human nature has an end (<italic>telos</italic>), which is happiness (<italic>eudaimonia</italic>) or human flourishing.</p>
+			<p>There is no unanimous concept of virtue, given the contributions of different traditions and fields of knowledge. Notwithstanding, it tends to be considered “the human inclination to feel, think, and act in ways that express moral excellence and contribute to the common good.” (<xref ref-type="bibr" rid="B54">Newstead et al., 2018</xref>, p. 446). According to <xref ref-type="bibr" rid="B2">Alzola (2015</xref>), the “virtues are traits of character” whose intellectual, emotional, motivational and behavioral components “cannot be reduced to any of the others,” (Alzola, 2015, p. 306), which is something similar to the multi-components perceived by <xref ref-type="bibr" rid="B52">Morgan, Gulliford and Kristjánsson (2017</xref>). In virtue ethics, they are understood as personal inclinations or dispositions expressed by a range of other dispositions such as actions, habits, character, and lifestyle (way of living), with a view to the common good (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Therefore, it has been admitted that the behavioral manifestation of action is not enough to infer the presence of virtue (Alzola, 2015; <xref ref-type="bibr" rid="B62">Robson, 2015</xref>).</p>
+			<p>
+				<xref ref-type="bibr" rid="B54">Newstead, Macklin, Dawkins and Martin (2018</xref>) develop the concept of virtue (inclination toward good). The authors present the notion of virtues and virtuous, which represent the perception of a virtuous event, understood as a subjective experience, an interpretation an agent does about a virtue someone expresses (virtues) in an event/moment.</p>
+			<p>As observed in this section, the framework of virtue ethics brings together theoretical elements and fundamental assumptions. Among its elements are: the human agent and its nature, reiterated moral actions and habits that shape its character, the practice of moral virtues, coordinated by practical wisdom or prudence, an ultimate end aimed at human flourishing or eudaimonia, in a community context in which one contributes to the common good. As for the assumptions, two of them are worth highlighting, related to (1) the connection or interdependence between the virtue of phronesis and the moral virtues - for example, prudence in decision-making implies that temperance will manage the impulses that would affect such a decision, like anger or impatience; and, (2) the unity of the virtues: in the agent, the virtues are linked to each other - that is, there is no isolated virtue - which means that if a person has one virtue, this same person also has the others (<xref ref-type="bibr" rid="B82">Zyl, 2019</xref>).</p>
+			<sec>
+				<title>Perspectives that seek to measure moral virtues</title>
+				<p>In administration, studies of virtue ethics have formed a line of research that adopts quantitative and statistical methods to measure virtues and their positive impacts on organizations (<xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). Such a line of research is inserted in positive psychology and is called Positive Organizational Scholarship (POS) (<xref ref-type="bibr" rid="B47">Meyer, 2018</xref>; Sison &amp; Ferrero, 2015). It is divided into two perspectives that seek to measure virtues: (1) one linked to the positive psychology of <xref ref-type="bibr" rid="B56">Peterson and Seligman (2004</xref>) adopting an individual-level approach and corresponding to a positive movement in social sciences (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>); and (2) studies that assume the concept of virtuousness to access virtues at an organizational level (Meyer, 2018; <xref ref-type="bibr" rid="B35">Huhtala et al., 2018</xref>).</p>
+				<p>These two lines of research aim to measure virtues, adopting methods and assumptions that are different from those shared by the Aristotelian-Thomist tradition of virtue ethics (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B47">Meyer, 2018</xref>).</p>
+				<p>The first is linked to positive psychology and considers character strengths as individuals’ positive traits. <xref ref-type="bibr" rid="B56">Peterson and Seligman (2004</xref>) model was developed from reading classic texts from different cultures. The documents were reviewed by a research group that inductively brought together the human characteristics that lead to flourishing. There are differences between the concept of virtues and strengths of character (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). The VIA model - virtues in action - is composed of six main characteristics (virtues) and 24 strengths. However, this model has been methodologically and philosophically questioned. It does not assume the unity of virtues (<xref ref-type="bibr" rid="B62">Robson, 2015</xref>). <xref ref-type="bibr" rid="B39">Kinghorn (2017</xref>) explained how the model was built and argued that the cultural context is crucial to indicate if the model is valid or universal. It embraces the values of a modern democratic society that privileges the individuals’ self-determination, rights, and liberties (Kinghorn, 2017). For the author, there is no way for a set of virtues to transcend the particular political community in which they were conceived, which implies that the particular context matters and future instruments should consider the culture of the analyzed context and community.</p>
+				<p>The second line of research is positive organizational studies (POS), which adopts the concept of virtuousness that is not identical to the notion of virtue (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Virtuousness is manifested in structures, processes, attributes, and cultures and in individual and collective action and is expressed in and through organizations (<xref ref-type="bibr" rid="B16">Cameron, Bright, &amp; Caza, 2004</xref>; Sison &amp; Ferrero, 2015). It is understood as an aspect that contributes to organizational performance, which can be used instrumentally to achieve good indicators of commitment, satisfaction, and social capital (Sison &amp; Ferrero, 2015). In this approach, the concept of virtuousness is examined predominantly by quantitative methods and at an organizational level (<xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). Furthermore, this line of research does not address the role of phronesis in its framework for understanding organizations’ virtuousness (Sison &amp; Ferrero, 2015). </p>
+				<p>
+					<xref ref-type="bibr" rid="B69">Sison and Ferrero (2015</xref>) also refer to conceptual differences. The authors claim that the assumptions about human nature, the ultimate end, <italic>phronesis</italic> and <italic>eudaimonia</italic> underlying virtuousness are very different from virtue ethics and the locus of achievement. Virtues are found in people and only by analogy are associated with concepts such as corporate character. On the other hand, virtuousness refers to organizations primarily and only secondarily to individuals (<xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). </p>
+				<p>Among critics of virtue ethics, <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al. (2017</xref>) state that situationist criticism does not recognize the need to know internal factors inherent to behavior. In contrast, <xref ref-type="bibr" rid="B3">Alzola (2017</xref>) argues that moral virtues can help understand individuals’ actions. Despite the diversity and empirical challenges, adaptations for different contexts and cultures are still needed (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). Moreover, after all, can virtues be measured? There is no consensus on this issue. <xref ref-type="bibr" rid="B62">Robson (2015</xref>) argues that positive psychology is able to measure personality traits and behavior tendencies, but it is not able to coordinate virtues because it cannot propose a substantive architecture to support a virtues approach based on a tradition, like virtue ethics.</p>
+			</sec>
+		</sec>
+		<sec sec-type="methods">
+			<title>METHODOLOGICAL PROCEDURES</title>
+			<p>This section presents the systematic review and the procedures used to synthesize and compare evidence (Mendes-da-Silva, 2019; <xref ref-type="bibr" rid="B72">Snyder, 2019</xref>). The steps carried out and the criteria and method adopted to search and select studies are described below, together with the procedures adopted in the methodological-theoretical analysis and the presentation of results. The study was conducted after formulating a central research question (Mendes-da-Silva, 2019), and the main elements and eligibility criteria adopted sought replicable and transparent procedures (<xref ref-type="bibr" rid="B49">Moher, Liberati, Tetslaff, &amp; Altman, 2009</xref>). The eligibility criteria are:</p>
+			<p>
+				<list list-type="order">
+					<list-item>
+						<p>Type of study: empirical research that develops or applies moral virtues scales and measures at an individual level - this being the selection criterion;</p>
+					</list-item>
+					<list-item>
+						<p>Exclusion criteria: (a) research from other areas, such as medical and legal; (b) works that do not directly address virtues; (c) theoretical or empirical studies that do not address the construct through scales; (d) empirical research that develops or applies virtues scales at an organizational level (virtuousness);</p>
+					</list-item>
+					<list-item>
+						<p>Topic: the process of identifying and selecting the articles is conducted by reading the titles, abstracts, keywords, and the name of the journal;</p>
+					</list-item>
+					<list-item>
+						<p>Research design: empirical studies that report the development, application, and results obtained using virtues scales at the individual level;</p>
+					</list-item>
+					<list-item>
+						<p>Period researched: The study did not define a specific period;</p>
+					</list-item>
+					<list-item>
+						<p>Language: the review considered articles in Portuguese, English, and Spanish;</p>
+					</list-item>
+					<list-item>
+						<p>Publication status: peer-reviewed scientific articles;</p>
+					</list-item>
+					<list-item>
+						<p>Search criteria: consulting electronic databases and including studies cited in the selected articles (if they were not already part of the sample). The first stage took place in June 2017, and updates were carried out in 2018 and February 2021. The search was carried out in five databases: <italic>EBSCOhost, Science Direct, Scopus, Web of Science</italic> and <italic>Wiley</italic>.</p>
+					</list-item>
+				</list>
+			</p>
+			<p>Five different queries consisting of two terms were used to expand the scope of the searches. The first term referred to scales and measurement, and the second to virtues, as detailed in <xref ref-type="table" rid="t1">Table 1</xref>.</p>
+			<p>
+				<table-wrap id="t1">
+					<label>Table 1</label>
+					<caption>
+						<title>Number of references per database, query, and search format.</title>
+					</caption>
+					<table>
+						<colgroup>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+						</colgroup>
+						<thead>
+							<tr>
+								<th align="center">Form</th>
+								<th align="center">Search query</th>
+								<th align="center"><italic>Ebsco</italic></th>
+								<th align="center"><italic>Science Direct</italic></th>
+								<th align="center"><italic>Scopus</italic></th>
+								<th align="center"><italic>Web of Science</italic></th>
+								<th align="center"><italic>Wiley</italic></th>
+								<th align="center">Total</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="center" rowspan="5">All content</td>
+								<td align="left">1 <italic>“Scale development” AND “virtue* ethic*”</italic></td>
+								<td align="center">3</td>
+								<td align="center">0</td>
+								<td align="center">2</td>
+								<td align="center">2</td>
+								<td align="center">100</td>
+								<td align="center">107</td>
+							</tr>
+							<tr>
+								<td align="left">2<italic>. “scale*” AND “virtue* ethic*”</italic></td>
+								<td align="center">11</td>
+								<td align="center">1</td>
+								<td align="center">16</td>
+								<td align="center">14</td>
+								<td align="center">-</td>
+								<td align="center">42</td>
+							</tr>
+							<tr>
+								<td align="left"><italic>3. “scale*” AND “moral virtues”</italic></td>
+								<td align="center">-</td>
+								<td align="center">116</td>
+								<td align="center">5</td>
+								<td align="center">34</td>
+								<td align="center">-</td>
+								<td align="center">155</td>
+							</tr>
+							<tr>
+								<td align="left">4<italic>. “scale development” AND “moral virtues”</italic></td>
+								<td align="center">12</td>
+								<td align="center">1</td>
+								<td align="center">-</td>
+								<td align="center">8</td>
+								<td align="center">65</td>
+								<td align="center">86</td>
+							</tr>
+							<tr>
+								<td align="left">5. <italic>“measur*” AND “moral virtues”</italic></td>
+								<td align="center">-</td>
+								<td align="center">-</td>
+								<td align="center">22</td>
+								<td align="center">7</td>
+								<td align="center">-</td>
+								<td align="center">29</td>
+							</tr>
+							<tr>
+								<td align="center" rowspan="5">Abstract</td>
+								<td align="left">1. <italic>“Scale development” AND “virtue* ethic*”</italic></td>
+								<td align="center">-</td>
+								<td align="center">-</td>
+								<td align="center">4</td>
+								<td align="center">1</td>
+								<td align="center">1</td>
+								<td align="center">6</td>
+							</tr>
+							<tr>
+								<td align="left">2. <italic>“scale*” AND “virtue* ethic*”</italic></td>
+								<td align="center">2</td>
+								<td align="center">3</td>
+								<td align="center">66</td>
+								<td align="center">14</td>
+								<td align="center">17ª</td>
+								<td align="center">102</td>
+							</tr>
+							<tr>
+								<td align="left">3<italic>. “scale*” AND “moral virtues”</italic></td>
+								<td align="center">16ª</td>
+								<td align="center">1</td>
+								<td align="center">42</td>
+								<td align="center">8</td>
+								<td align="center">25ª </td>
+								<td align="center">92</td>
+							</tr>
+							<tr>
+								<td align="left">4<italic>. “scale development” AND “moral virtues”</italic></td>
+								<td align="center">-</td>
+								<td align="center">-</td>
+								<td align="center">4</td>
+								<td align="center">2</td>
+								<td align="center">1</td>
+								<td align="center">7</td>
+							</tr>
+							<tr>
+								<td align="left">5. <italic>“measur*” AND “moral virtues”</italic></td>
+								<td align="center">21ª </td>
+								<td align="center">16ª </td>
+								<td align="center">79</td>
+								<td align="center">8</td>
+								<td align="center">15</td>
+								<td align="center">139</td>
+							</tr>
+							<tr>
+								<td align="left"> </td>
+								<td align="center">Total</td>
+								<td align="center">65</td>
+								<td align="center">138</td>
+								<td align="center">240</td>
+								<td align="center">98</td>
+								<td align="center">224</td>
+								<td align="center">765</td>
+							</tr>
+						</tbody>
+					</table>
+					<table-wrap-foot>
+						<fn id="TFN1">
+							<p>Note. <sup>a</sup> Searches with the first term of the search query applied to the abstract and the second to the article’s entire content.</p>
+						</fn>
+					</table-wrap-foot>
+				</table-wrap>
+			</p>
+			<p>Until 2018, 517 articles were selected. In February 2021, 248 articles were added, completing a sample of 765 references. The experience gained with the selection carried out in 2018 offered elements to improve the process. Thus, the update in references in 2021 was conducted based only on the abstracts. Also, some articles were manually added to the sample of references (n=3), found during the search and reading work indicated in Step 2 of the selection process (<xref ref-type="fig" rid="f1">Figure 1</xref>). The following journals were carefully searched to ensure the selection of articles in the area: <italic>Journal of Business Ethics</italic>, <italic>Business Ethics: Environment and Responsibilty</italic> and <italic>Business Ethics Quarterly</italic>.</p>
+			<p>
+				<fig id="f1">
+					<label>Figure 1</label>
+					<caption>
+						<title>Selection process, according to the model by <xref ref-type="bibr" rid="B49">Moher et al. (2009</xref>).</title>
+					</caption>
+					<graphic xlink:href="1982-7849-rac-26-06-e190379-gf1.tif"/>
+				</fig>
+			</p>
+			<p>The references were exported to the Endnote 8 reference organizer in the first step and Mendeley in the last selection. The selection process during the stages was the same: first, the removal of duplicated articles; second, the reading of titles, abstracts, keywords, and name of the journal, applying the eligibility criteria. <xref ref-type="fig" rid="f1">Figure 1</xref> shows the flow of the selection process until reaching the number of 37 articles that develop or apply moral virtues at an individual level, forming the sample.</p>
+			<p>As shown in <xref ref-type="fig" rid="f1">Figure 1</xref>, sixteen references were excluded after being submitted to the eligibility analysis. Eight articles addressed other constructs, while another eight worked with virtuousness scales or virtue at an organizational level. The articles adopting the virtuousness scale were excluded since, based on virtue ethics, there are different assumptions between virtuousness and moral virtues (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). Studies referring to the organizational level - focusing on objectively verifiable elements expressed in or through organizations (such as structural and cultural elements) (Meyer, 2018) - were excluded since this research focuses on the individual level.</p>
+			<p>For a theoretical-methodological discussion on the development of virtues scales and measures, the articles were first thoroughly read and their primary data organized in Excel spreadsheets, containing information on (a) how the scale is constructed or applied, item generation, pre-tests, sample and respondents, item treatment; (b) statistical analysis adopted, statistical techniques, adjustment factors, analysis techniques, emerging factors; (c) eliminations of items, types of validations and related topics and; (d) country of application, to analyze possible limitations and the rigor used in creation and validation. For the analysis of the use of Exploratory Factor Analysis (EFA), Confirmatory Factor Analysis (CFA), and other techniques, we considered the guidelines by <xref ref-type="bibr" rid="B24">Fávero et al. (2009</xref>) and <xref ref-type="bibr" rid="B31">Hair et al. (2005</xref>). </p>
+			<p>After analyzing the scales, the contributions of the articles to the knowledge on moral virtues were examined. In this case, the analysis observed the articles listing a set of virtues and those exploring a single virtue in-depth. Methodological challenges to accessing moral virtues are discussed, especially for researchers who are part of a tradition of virtue ethics. The discussion examines how virtues are defined, operationalized, and accessed in order to discuss theoretical implications and methodological issues in a broader scope, as the debate on measuring virtues is an open question for which researchers in business ethics and psychology may have different positions on possibilities and relevance.</p>
+		</sec>
+		<sec sec-type="results|discussion">
+			<title>PRESENTATION AND DISCUSSION OF RESULTS</title>
+			<p>The 37 empirical articles selected show the contributions of two areas interested in virtues or virtue ethics: business ethics and psychology. The articles were published in 21 different journals. In the area of administration and business, the <italic>Journal of Business Ethics</italic> (JBE) published 11 articles on scales and measuring moral virtues at an individual level, followed by other journals in the area that published only one article each: <italic>Asian Journal of Business &amp; Accounting, Business Ethics: A European Review, Canadian Journal of Administrative Sciences, Journal of Business Research, Leadership &amp; Organization Development Journal</italic> and <italic>Organizational Dynamics.</italic> In the area of psychology, the journals <italic>Personality and Individual Differences</italic> (four articles), <italic>Current Psychology</italic> (three articles) and <italic>Frontiers in Psychology</italic> (two articles) stood out.</p>
+			<p>Studies that develop or apply virtues scales follow two predominant formats, focusing on (1) multiple virtues analyzed together or (2) a single moral virtue. In administration journals, the research works are mostly based on lists proposed by <xref ref-type="bibr" rid="B76">Solomon (1999</xref>) and <xref ref-type="bibr" rid="B53">Murphy (1999</xref>). As for psychology journals, the articles are based on the positive psychology developed by <xref ref-type="bibr" rid="B56">Peterson and Seligman (2004</xref>) or attempts to link psychology and moral philosophy (e.g., <xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>). Of the 37 articles, 19 refer to the use and development of scales on multiple virtues, which we chose to call multiple moral virtues, and 18 address scales and measures of specific moral virtues (<xref ref-type="table" rid="t2">Table 2</xref>).</p>
+			<p>
+				<table-wrap id="t2">
+					<label>Table 2</label>
+					<caption>
+						<title>Moral virtue scales at the individual level - multiple and specific moral virtues.</title>
+					</caption>
+					<table>
+						<colgroup>
+							<col/>
+							<col/>
+							<col/>
+							<col/>
+						</colgroup>
+						<thead>
+							<tr>
+								<th align="center">Scale</th>
+								<th align="center">Authors</th>
+								<th align="center">Journal</th>
+								<th align="right">Citations<sup>a</sup></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td align="center" colspan="4">Multiple moral virtues </td>
+							</tr>
+							<tr>
+								<td align="left">Virtue Scale (VS)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B18">Cawley, Martin and Johnson (2000</xref>)<break/>
+									 <xref ref-type="bibr" rid="B78">Stoeber and Yang (2016</xref>)</td>
+								<td align="center">PID<break/>
+									 PID</td>
+								<td align="right">245<break/>
+									 27</td>
+							</tr>
+							<tr>
+								<td align="left">Virtue Ethics Scale (VES)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B67">Shanahan and Hyman (2003</xref>)<break/>
+									 <xref ref-type="bibr" rid="B58">Racelis (2013</xref>)<break/>
+									 <xref ref-type="bibr" rid="B59">Racelis (2014</xref>)<break/>
+									 <xref ref-type="bibr" rid="B20">Dawson (2018</xref>)<break/>
+									 <xref ref-type="bibr" rid="B23">Donada, Mothe, Nogatchewsky and Ribeiro (2019</xref>)<break/>
+									 Shanahan and Hopkins (2019)</td>
+								<td align="center">JBE<break/>
+									 AJBA<break/>
+									 APSSR<break/>
+									 JBE<break/>
+									 JBE<break/>
+									 JBE</td>
+								<td align="right">152<break/>
+									 18<break/>
+									 3<break/>
+									 8<break/>
+									 15<break/>
+									 7</td>
+							</tr>
+							<tr>
+								<td align="left">VIA-Classification</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B55">Park and Peterson (2006</xref>)<break/>
+									 <xref ref-type="bibr" rid="B77">Song and Kim (2018</xref>)<break/>
+									 <xref ref-type="bibr" rid="B9">Arthur, Earl, Thompson and Ward (2021</xref>)</td>
+								<td align="center">JA<break/>
+									 JBE<break/>
+									 JBE</td>
+								<td align="right">775<break/>
+									 27<break/>
+									 3</td>
+							</tr>
+							<tr>
+								<td align="left">Virtuous Leadership Scale (VLS)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B64">Sarros, Cooper e Hartican (2006</xref>)<break/>
+									 <xref ref-type="bibr" rid="B80">Wang and Hackett (2016</xref>)</td>
+								<td align="center">L&amp;ODJ<break/>
+									 JBE</td>
+								<td align="right">96<break/>
+									 70</td>
+							</tr>
+							<tr>
+								<td align="left">Measure of Auditor’s Virtue</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B42">Libby and Thorne (2007</xref>)</td>
+								<td align="center">JBE</td>
+								<td align="right">65</td>
+							</tr>
+							<tr>
+								<td align="left">Leadership Virtues Questionnaire (LVQ)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B61">Riggio, Zhu, Reina and Maroosis (2010</xref>)</td>
+								<td align="center">CPJPR</td>
+								<td align="right">256</td>
+							</tr>
+							<tr>
+								<td align="left">Character Strengths Leadership Survey</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B79">Thun and Kelloway (2011</xref>)</td>
+								<td align="center">CJAS</td>
+								<td align="right">63</td>
+							</tr>
+							<tr>
+								<td align="left">Virtue Adjective Rating Scale (VARS)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B81">Yang, Stoeber and Wang (2015</xref>)</td>
+								<td align="center">PID</td>
+								<td align="right">32</td>
+							</tr>
+							<tr>
+								<td align="left">Leadership Character Insight Assessment (LCIA)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B65">Seijts, Gandz, Crossan and Reno (2015</xref>)</td>
+								<td align="center">OD</td>
+								<td align="right">54</td>
+							</tr>
+							<tr>
+								<td align="left">Ethical Tendencies Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B40">Koçyiğit and Karadağ (2016</xref>)</td>
+								<td align="center">TJBE</td>
+								<td align="right">9</td>
+							</tr>
+							<tr>
+								<td align="left">Virtuous Leadership Questionnaire (VLQ)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B80">Wang and Hackett (2016</xref>)</td>
+								<td align="center">JBE</td>
+								<td align="right">70</td>
+							</tr>
+							<tr>
+								<td align="left">Individual Business Virtues (IBE) </td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B20">Dawson (2018</xref>)</td>
+								<td align="center">JBE</td>
+								<td align="right">8</td>
+							</tr>
+							<tr>
+								<td align="center" colspan="4">Specific moral virtues </td>
+							</tr>
+							<tr>
+								<td align="left">Multidimensional Ethics Scale (MES)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B13">Beekun, Westerman and Barghouti (2005</xref>)<break/>
+									 <xref ref-type="bibr" rid="B44">Manly, Leonard and Riemenschneider (2015</xref>)</td>
+								<td align="center">JBE<break/>
+									 JBE</td>
+								<td align="right">56<break/>
+									 36</td>
+							</tr>
+							<tr>
+								<td align="left">Deontic Justice Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B15">Beugré (2012</xref>)</td>
+								<td align="center">JASP</td>
+								<td align="right">38</td>
+							</tr>
+							<tr>
+								<td align="left">Specific scales correlated with Engagement Beauty Scale (EBS)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B22">Diessner, Iyer, Smith and Haidt (2013</xref>)</td>
+								<td align="center">JME</td>
+								<td align="right">104</td>
+							</tr>
+							<tr>
+								<td align="left">Self-regarding and other regarding virtues</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B30">Grappi, Romani and Bagozzi (2013</xref>)</td>
+								<td align="center">JBR</td>
+								<td align="right">287</td>
+							</tr>
+							<tr>
+								<td align="left">Multicomponent Gratitude Measure (MCGM)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B52">Morgan et al. (2017</xref>)<break/>
+									 <xref ref-type="bibr" rid="B29">Gulliford, Morgan, Hemming and Abbott (2019</xref>)<break/>
+									 <xref ref-type="bibr" rid="B34">Hudecek, Blabst, Morgan and Lermer (2020</xref>)</td>
+								<td align="center">PID<break/>
+									 CP<break/>
+									 FP</td>
+								<td align="right">55<break/>
+									 6<break/>
+									 1</td>
+							</tr>
+							<tr>
+								<td align="left">Moral Virtue Theory of Status Attainment (MVT)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B11">Bai, Ho and Yan (2020</xref>)</td>
+								<td align="center">JPSP</td>
+								<td align="right">10</td>
+							</tr>
+							<tr>
+								<td align="left">Consumer moral virtue of Integrity</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B17">Castro-González, Bande, Fernández-Ferrín and Kimura (2019</xref>)</td>
+								<td align="center">JCP</td>
+								<td align="right">29</td>
+							</tr>
+							<tr>
+								<td align="left">Self-report Humility Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B57">Qin, Liu, Brown, Zheng and Owens (2019</xref>)</td>
+								<td align="center">JBE</td>
+								<td align="right">6</td>
+							</tr>
+							<tr>
+								<td align="left">Gratitude Questionnaire (G-20)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B14">Bernabe-Valero, Blasco-Magraner and García-March (2020</xref>)</td>
+								<td align="center">FP</td>
+								<td align="right">-</td>
+							</tr>
+							<tr>
+								<td align="left">Intellectually Humble Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B19">Colombo, Strangmann, Houkes, Kostadinova and Brandt (2021</xref>)</td>
+								<td align="center">RPP</td>
+								<td align="right">-</td>
+							</tr>
+							<tr>
+								<td align="left">Good and Evil Character Traits (GECT) Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B37">Jiao, Yang, Guo, Xu, Zhang and Jiang (2020</xref>)</td>
+								<td align="center">SJP</td>
+								<td align="right">-</td>
+							</tr>
+							<tr>
+								<td align="left">Resilient Measurement Scale (SPP-25)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B41">Lasota, Tomaszek and Bosacki (2020</xref>)</td>
+								<td align="center">CP</td>
+								<td align="right">-</td>
+							</tr>
+							<tr>
+								<td align="left">Professional Moral Courage scale (PMC; Sekerka 2009, 2 items)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B45">Mansur, Sobral and Islam (2020</xref>)</td>
+								<td align="center">BEER</td>
+								<td align="right">1</td>
+							</tr>
+							<tr>
+								<td align="left">Temperance Scale</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B66">Shahab and Adil (2020</xref>)</td>
+								<td align="center">PJ</td>
+								<td align="right">-</td>
+							</tr>
+							<tr>
+								<td align="left">Enright Self-Forgiveness Inventory (ESFI)</td>
+								<td align="left">
+									<xref ref-type="bibr" rid="B38">Kim, Volk and Enright (2021</xref>)</td>
+								<td align="center">CP</td>
+								<td align="right">-</td>
+							</tr>
+						</tbody>
+					</table>
+					<table-wrap-foot>
+						<fn id="TFN2">
+							<p>Note. <italic>Personality and Individual Differences</italic> (PID)<italic>; Journal of Business Ethics</italic> (JBE); <italic>Asian Journal of Business &amp; Accounting</italic> (AJBA); <italic>Asia-Pacific Social Science Review</italic> (APSSR); <italic>Journal of Adolescence</italic> (JA); <italic>Leadership &amp; Organization Development Journal</italic> (L&amp;ODJ); <italic>Consulting Psychology Journal: Practice and Research</italic> (CPJPR); <italic>Canadian Journal of Administrative Science</italic> (CJAS); <italic>Organizational Dynamics; Turkish Journal of Business Ethics</italic> (TJBE); <italic>Journal of Applied Social Psychology</italic> (JASP); <italic>Journal of Moral Education</italic> (JME); <italic>Journal of Business Research</italic> (JBR); <italic>Journal of Personality &amp; Social Psychology</italic> (JPSP); <italic>Journal of Cleaner Production</italic> (JCP); <italic>Current Psychology</italic> (CP); <italic>Frontiers in Psychology</italic> (FP); <italic>Review of Philosophy and Psychology</italic> (RPP)<italic>; Scandinavian Journal of Psychology</italic> (SJP); <italic>Business Ethics: A European Review</italic> (BEER)<italic>; PsyCh Journal</italic> (PJ).</p>
+						</fn>
+						<fn id="TFN3">
+							<label>a</label>
+							<p> Search conducted on Google Scholar on March 2, 2021.</p>
+						</fn>
+					</table-wrap-foot>
+				</table-wrap>
+			</p>
+			<p>The articles published in the first decade of the current millennium adopted multiple virtue scales, covering a list of character traits. In the following decade, there was a methodological discussion about changing the concept to address the organizational level, with discussions about organizational virtuousness and assumptions and positive psychology methods. Over the past three years, empirical studies have predominantly focused on measuring a specific virtue, seeking to address components such as thinking, feelings, and behaviors expressing virtues. However, it is noteworthy that these questions remain open, and there are different positions on the feasibility or not of coordinating moral philosophy and psychology to broaden the understanding of moral virtues (<xref ref-type="bibr" rid="B12">Beadle et al., 2015</xref>). Authors such as <xref ref-type="bibr" rid="B54">Newstead et al. (2018</xref>) and <xref ref-type="bibr" rid="B73">Snow, Whright and Warren (2020</xref>) consider that such coordination is possible.</p>
+			<p>It is crucial to emphasize that moral virtues scales, multiple or specific, access the perception of virtues, whether the respondent’s self-perception or the 'perception' in relation to other people (manager, employee, leadership, for instance), something similar to what <xref ref-type="bibr" rid="B54">Newstead et al. (2018</xref>) called virtues. However, such studies do not consider these perceptions as originated from an event. They are limited to an abstract opinion on a list of attributes, disconnected from an action context. This is verified in most of the measurement instruments in the list of items.</p>
+			<p>Articles that addressed specific moral virtues empirically observed one or two virtues: appreciation of virtues and their links with status (<xref ref-type="bibr" rid="B11">Bai, Ho, &amp; Yan, 2020</xref>), self-consideration and consideration for others (<xref ref-type="bibr" rid="B30">Grappi, Romani, &amp; Bagozzi, 2013</xref>), moral courage (<xref ref-type="bibr" rid="B45">Mansur, Sobral, &amp; Islam, 2020</xref>), gratitude (<xref ref-type="bibr" rid="B14">Bernabe-Valero, Blasco-Magraner, &amp; García-March, 2020</xref>; <xref ref-type="bibr" rid="B29">Gulliford, Morgan, Hemming, &amp; Abbott, 2019</xref>; <xref ref-type="bibr" rid="B34">Hudecek, Blabst, Morgan, &amp; Lermer, 2020</xref>; Morgan, Gulliford, &amp; Kristjánsson, 2017), gratitude and love (<xref ref-type="bibr" rid="B22">Diessner, Iyer, Smith, &amp; Haidt, 2013</xref>), humility (<xref ref-type="bibr" rid="B19">Colombo, Strangmann, Houkes, Kostadinova, &amp; Brandt, 2021</xref>; <xref ref-type="bibr" rid="B57">Qin, Liu, Brown, Zheng, &amp; Owens, 2019</xref>), integrity (<xref ref-type="bibr" rid="B17">Castro-González, Bande, Fernández-Ferrín, &amp; Kimura, 2019</xref>), justice (<xref ref-type="bibr" rid="B13">Beekun, Westerman, &amp; Barghouti, 2005</xref>; <xref ref-type="bibr" rid="B15">Beugré, 2012</xref>), self-forgiveness (Kim, Volk, &amp; Enright, 2021), respect and responsibility (<xref ref-type="bibr" rid="B44">Manly, Leonard, &amp; Riemenschneider, 2015</xref>), good and bad character traits (<xref ref-type="bibr" rid="B37">Jiao, Yang, Guo, Xu, Zhang, &amp; Jiang, 2020</xref>), resilience (<xref ref-type="bibr" rid="B41">Lasota, Tomaszek, &amp; Bosacki, 2020</xref>) and temperance (<xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>).</p>
+			<p>In addition to scales for specific virtues, several scales associated with leadership were developed (<xref ref-type="bibr" rid="B45">Mansur et al., 2020</xref>; <xref ref-type="bibr" rid="B57">Qin et al., 2019</xref>; <xref ref-type="bibr" rid="B61">Riggio, Zhu, Reina, &amp; Maroosis, 2010</xref>; <xref ref-type="bibr" rid="B79">Thun &amp; Kelloway, 2011</xref>; <xref ref-type="bibr" rid="B64">Sarros, Cooper, &amp; Hartican, 2006</xref>; <xref ref-type="bibr" rid="B65">Seijts, Gands, Crossan, &amp; Reno, 2015</xref>; <xref ref-type="bibr" rid="B80">Wang &amp; Hackett, 2016</xref>).</p>
+			<sec>
+				<title>Development and application of scales on moral virtues</title>
+				<p>
+					<xref ref-type="table" rid="t3">Table 3</xref> summarizes the information about the scales used in the articles analyzed. It is possible to observe the number of initial and final items, the item-sample ratio, the country, and the profile of respondents in the studies (mostly university students and practitioners). The scales found in the systematic review use items with a Likert response grid (strongly disagree - strongly agree) or adjective rating scales, ranging from four to ten-point scales.</p>
+				<p>
+					<table-wrap id="t3">
+						<label>Table 3</label>
+						<caption>
+							<title>Items, samples, and measures on moral virtues scales at the individual level.</title>
+						</caption>
+						<table>
+							<colgroup>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+							</colgroup>
+							<thead>
+								<tr>
+									<th align="center">Articles</th>
+									<th align="center">Initial Items (A)</th>
+									<th align="center">Sample (B)</th>
+									<th align="center">Proportion (B/A)</th>
+									<th align="center">Final Items</th>
+									<th align="center">Statistical analyses</th>
+									<th align="center">Country</th>
+									<th align="center">Respondents’ profile</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td align="center" colspan="8">Multiple moral virtues </td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B18">Cawley et al. (2000</xref>)</td>
+									<td align="center">140</td>
+									<td align="center">390(1), 181(2), 143(3)</td>
+									<td align="center">2.8</td>
+									<td align="center">48</td>
+									<td align="center">EFA</td>
+									<td align="center">US</td>
+									<td align="center">Psychology students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B67">Shanahan and Hyman (2003</xref>)</td>
+									<td align="center">45</td>
+									<td align="center">445</td>
+									<td align="center">9.9</td>
+									<td align="center">33</td>
+									<td align="center">EFA</td>
+									<td align="center">US</td>
+									<td align="center">Marketing students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B55">Park and Peterson (2006</xref>)</td>
+									<td align="center">198</td>
+									<td align="center">250</td>
+									<td align="center">1.3</td>
+									<td align="center">24</td>
+									<td align="center">EFA</td>
+									<td align="center">US</td>
+									<td align="center">Students (10-17 years old)</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>)</td>
+									<td align="center">7</td>
+									<td align="center">238</td>
+									<td align="center">34.0</td>
+									<td align="center">7</td>
+									<td align="center">ANOVA</td>
+									<td align="center">Australia</td>
+									<td align="center">Members of the Australian Institute of Management</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B42">Libby and Thorne (2007</xref>)</td>
+									<td align="center">55</td>
+									<td align="center">376</td>
+									<td align="center">6.8</td>
+									<td align="center">29</td>
+									<td align="center">EFA</td>
+									<td align="center">Canada</td>
+									<td align="center">CICA members</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>)</td>
+									<td align="center">36</td>
+									<td align="center">200</td>
+									<td align="center">5.6</td>
+									<td align="center">19</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">US</td>
+									<td align="center">Administrators</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B79">Thun and Kelloway (2011</xref>)</td>
+									<td align="center">27</td>
+									<td align="center">327</td>
+									<td align="center">12.1</td>
+									<td align="center">14</td>
+									<td align="center">EFA</td>
+									<td align="center"> Canada</td>
+									<td align="center">University employees</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B58">Racelis (2013</xref>)</td>
+									<td align="center">34</td>
+									<td align="center">140</td>
+									<td align="center">4.1</td>
+									<td align="center">22</td>
+									<td align="center">EFA</td>
+									<td align="center">Philippines</td>
+									<td align="center">University students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B59">Racelis (2014</xref>)</td>
+									<td align="center">34</td>
+									<td align="center">141</td>
+									<td align="center">4.1</td>
+									<td align="center">22</td>
+									<td align="center">EFA</td>
+									<td align="center">Philippines</td>
+									<td align="center">Students who are managers</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B81">Yang et al. (2015</xref>)</td>
+									<td align="center">90</td>
+									<td align="center">348</td>
+									<td align="center">3.9</td>
+									<td align="center">90</td>
+									<td align="center">EFA</td>
+									<td align="center"> China</td>
+									<td align="center">Students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B65">Seijts et al. (2015</xref>)</td>
+									<td align="center">10</td>
+									<td align="center">364</td>
+									<td align="center">36.4</td>
+									<td align="center">10</td>
+									<td align="center">-</td>
+									<td align="center">Canada and the US</td>
+									<td align="center">Organizations’ leaders</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B40">Koçyiğit and Karadağ (2016</xref>)</td>
+									<td align="center">10</td>
+									<td align="center">312</td>
+									<td align="center">31.2</td>
+									<td align="center">26</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">Turkey</td>
+									<td align="center">Undergraduate students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B78">Stoeber and Yang (2016</xref>)</td>
+									<td align="center">48</td>
+									<td align="center">243</td>
+									<td align="center">5.1</td>
+									<td align="center">48</td>
+									<td align="left"> </td>
+									<td align="center">China</td>
+									<td align="center">University students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B80">Wang and Hacket (2016</xref>)</td>
+									<td align="center">89</td>
+									<td align="center">348</td>
+									<td align="center">3.9</td>
+									<td align="center">18</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">North America</td>
+									<td align="center">MBA students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B20">Dawson (2018</xref>)</td>
+									<td align="center">45</td>
+									<td align="center">137</td>
+									<td align="center">3.0</td>
+									<td align="center">13</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">UK</td>
+									<td align="center">HR professionals</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B77">Song and Kim (2018</xref>)</td>
+									<td align="center">50</td>
+									<td align="center">400</td>
+									<td align="center">8</td>
+									<td align="center">50</td>
+									<td align="center">CFA</td>
+									<td align="center">US</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B9">Arthur et al. (2021</xref>)</td>
+									<td align="center">24</td>
+									<td align="center">2.340</td>
+									<td align="center">97.5</td>
+									<td align="center">24</td>
+									<td align="center">ANOVA, CFA</td>
+									<td align="center">US</td>
+									<td align="center">Professionals in five different areas</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B23">Donada et al. (2019</xref>)</td>
+									<td align="center">14</td>
+									<td align="center">201</td>
+									<td align="center">14.4</td>
+									<td align="center">14</td>
+									<td align="center">-</td>
+									<td align="center">France</td>
+									<td align="center">CEOs</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B68">Shanahan and Hopkins (2019</xref>)</td>
+									<td align="center">3</td>
+									<td align="center">129</td>
+									<td align="center">43</td>
+									<td align="center">3</td>
+									<td align="center">CFA</td>
+									<td align="center">US</td>
+									<td align="center">Managers and salespeople</td>
+								</tr>
+								<tr>
+									<td align="center" colspan="8">Specific moral virtues </td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B13">Beekun et al. (2005</xref>)</td>
+									<td align="center">14</td>
+									<td align="center">165</td>
+									<td align="center">11.8</td>
+									<td align="center">14</td>
+									<td align="center">EFA</td>
+									<td align="center">US and Russia</td>
+									<td align="center">MBA students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B15">Beugré (2012</xref>)</td>
+									<td align="center">36</td>
+									<td align="center">124(1) 101(2)</td>
+									<td align="center">3.4 2.8</td>
+									<td align="center">18</td>
+									<td align="center">-</td>
+									<td align="center">US</td>
+									<td align="center">Employees of an electronics retail chain</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B22">Diessner et al. (2013</xref>)</td>
+									<td align="center">18</td>
+									<td align="center">5.380 (1) 542(2)</td>
+									<td align="center">298.9</td>
+									<td align="center">18</td>
+									<td align="center">SEM</td>
+									<td align="center">US (Idaho)</td>
+									<td align="center">University students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B30">Grappi et al. (2013</xref>)</td>
+									<td align="center">5</td>
+									<td align="center">280</td>
+									<td align="center">56.0</td>
+									<td align="center">5</td>
+									<td align="center">CFA</td>
+									<td align="center">Italy</td>
+									<td align="center">Consumers</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B44">Manly et al. (2015</xref>)</td>
+									<td align="center">12</td>
+									<td align="center">86</td>
+									<td align="center">7.2</td>
+									<td align="center">12</td>
+									<td align="center">-</td>
+									<td align="center">US</td>
+									<td align="center">IT business students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B52">Morgan et al. (2017</xref>)</td>
+									<td align="center">119</td>
+									<td align="center">477(1) 1.599(2)</td>
+									<td align="center">4.0 55.1</td>
+									<td align="center">29</td>
+									<td align="center">EFA, CFA, ANOVA, MANOVA</td>
+									<td align="center">UK</td>
+									<td align="center">Online respondent</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B17">Castro-González et al. (2019</xref>)</td>
+									<td align="center">2</td>
+									<td align="center">252</td>
+									<td align="center">126</td>
+									<td align="center">2</td>
+									<td align="center">CFA</td>
+									<td align="center">Spain</td>
+									<td align="center">Consumers</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B29">Gulliford et al. (2019</xref>)</td>
+									<td align="center">6+29</td>
+									<td align="center">311</td>
+									<td align="center">8.9</td>
+									<td align="center">6+29</td>
+									<td align="center">ANOVA</td>
+									<td align="center">UK</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B57">Qin et al. (2019</xref>)</td>
+									<td align="center">9</td>
+									<td align="center">487</td>
+									<td align="center">54.1</td>
+									<td align="center">9</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">China</td>
+									<td align="center">Supervisors and employees</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B11">Bai et al. (2020</xref>)</td>
+									<td align="center">60</td>
+									<td align="center">292(1), 167(2) 155(3)</td>
+									<td align="center">4.9</td>
+									<td align="center">15</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">US and China</td>
+									<td align="center">Students Managers</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B14">Bernabe-Valero et al. (2020</xref>)</td>
+									<td align="center">20</td>
+									<td align="center">302</td>
+									<td align="center">15.1</td>
+									<td align="center">20</td>
+									<td align="center">CFA</td>
+									<td align="center">US</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B19">Colombo et al. (2021</xref>)</td>
+									<td align="center">20</td>
+									<td align="center">60(1), 301(2), 347(3), 431(4)</td>
+									<td align="center">3</td>
+									<td align="center">20</td>
+									<td align="center">-</td>
+									<td align="center">Netherlands</td>
+									<td align="center">University students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B34">Hudecek et al. (2020</xref>)</td>
+									<td align="center">6</td>
+									<td align="center">508(1) 1.599(2)</td>
+									<td align="center">84.7</td>
+									<td align="center">6</td>
+									<td align="center">CFA</td>
+									<td align="center">Germany and UK</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B37">Jiao et al. (2020</xref>)</td>
+									<td align="center">55</td>
+									<td align="center">350</td>
+									<td align="center">6.4</td>
+									<td align="center">53</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">China</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B41">Lasota et al. (2020</xref>)</td>
+									<td align="center">25</td>
+									<td align="center">214</td>
+									<td align="center">8.6</td>
+									<td align="center">25</td>
+									<td align="center">SEM</td>
+									<td align="center">Poland</td>
+									<td align="center">Students and employees</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B45">Mansur et al. (2020</xref>)</td>
+									<td align="center">10</td>
+									<td align="center">202</td>
+									<td align="center">20.2</td>
+									<td align="center">9</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">Not informed</td>
+									<td align="center">Adults</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B66">Shahab and Adil (2020</xref>)</td>
+									<td align="center">24</td>
+									<td align="center">250(1) 268(2)</td>
+									<td align="center">10.4</td>
+									<td align="center">24</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">Pakistan</td>
+									<td align="center">University students</td>
+								</tr>
+								<tr>
+									<td align="left">
+										<xref ref-type="bibr" rid="B38">Kim et al. (2021</xref>)</td>
+									<td align="center">60</td>
+									<td align="center">252(1), 204(2), 343(3), 567(4) </td>
+									<td align="center">4.2</td>
+									<td align="center">30</td>
+									<td align="center">EFA, CFA</td>
+									<td align="center">USA</td>
+									<td align="center">Students-parents; adults</td>
+								</tr>
+							</tbody>
+						</table>
+						<table-wrap-foot>
+							<fn id="TFN4">
+								<p>Note. Exploratory factor analysis (EFA), confirmatory factor analysis (CFA), structural equation modeling (SEM), univariate analysis of covariance (ANOVA), multivariate analysis of covariance (MANOVA).</p>
+							</fn>
+						</table-wrap-foot>
+					</table-wrap>
+				</p>
+				<p>As for the context, the articles portray research works carried out in 15 different countries. The United States (11 studies), China (3 studies), and the United Kingdom (3 studies) stand out. Some articles discussed research results referring to two countries (<xref ref-type="bibr" rid="B11">Bai et al., 2020</xref>; <xref ref-type="bibr" rid="B13">Beekun et al., 2005</xref>; <xref ref-type="bibr" rid="B34">Hudecek et al., 2020</xref>; <xref ref-type="bibr" rid="B65">Seijts et al., 2015</xref>). Some studies recruited respondents via platforms, such as remote workers on Amazon Mturk (<xref ref-type="bibr" rid="B14">Bernabe-Valero et al., 2020</xref>; <xref ref-type="bibr" rid="B19">Colombo et al., 2021</xref>; <xref ref-type="bibr" rid="B38">Kim et al., 2021</xref>; <xref ref-type="bibr" rid="B45">Mansur et al., 2020</xref>). In the selected article by Mansur et al. (2020), the authors did not specify the research context when describing the sample, even though the authors are affiliated with a Brazilian university. The literature shows that virtues depend on the context of action and, therefore, exploratory analysis in a new context is essential (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>; <xref ref-type="bibr" rid="B54">Newstead et al., 2018</xref>). For example, the virtue of temperance may be harder to develop depending on the country, and different virtues can be cultivated in each context. Also, choice of scales or adapting and developing scales are tasks that require analysis of the context, observing other cultures (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). </p>
+				<p>In the item-sample size ratio, some studies (n=11) did not reach the 5:1 ratio as recommended by <xref ref-type="bibr" rid="B32">Hair et al. (2009</xref>, p. 108). In contrast, <xref ref-type="bibr" rid="B11">Bai et al. (2020</xref>) seek a ratio of 10:1, which is a practice followed by most recent articles. For Hair et al. (2009), researchers should interpret any finding with caution when dealing with smaller samples or small proportions. In addition, the generation of more items through theoretical deepening, lexical analysis (<xref ref-type="bibr" rid="B37">Jiao et al., 2020</xref>), consultation with experts (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>), and potential respondents (pre-tests) are measures that could reveal items more aligned with virtues from specific contexts (<xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al., 2017</xref>). In this sense, the work by <xref ref-type="bibr" rid="B67">Shanahan and Hyman (2003</xref>) is an example of a study that conducted focus groups for pre-test among the few articles that used pre-testing (<xref ref-type="bibr" rid="B42">Libby &amp; Thorne, 2007</xref>; Shanahan &amp; Hyman, 2003).</p>
+				<p>The concepts adopted in the articles and their findings - both referring to elements of virtue ethics - were considered to illustrate the analysis of the scales’ development. Studies on virtues in leadership suggest that the leader’s character is still an essential attribute for ethics in administration, which could broaden the discussion on leadership traits and leadership as a process and expand the debate between heroic and post-heroic perspectives (<xref ref-type="bibr" rid="B74">Sobral &amp; Furtado, 2019</xref>). </p>
+				<p>
+					<xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>) suggest that integrity is a key attribute for a leader’s character. The article by <xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>) explores the cardinal virtues of temperance, fortitude, justice, and prudence related to leadership, based on assumptions by Thomas Aquinas and Aristotle. It is one of the few studies that seek to address the assumption of the unity of virtues. The authors carried out two stages of exploratory factor analysis and obtained results that suggest a single explanatory factor for the model, which Riggio et al. (2010) consider evidence of the unity of virtues.</p>
+				<p>
+					<xref ref-type="bibr" rid="B80">Wang and Hackett (2016</xref>) found support on Aristotelian and Confucian concepts to develop the Virtuous Leadership Questionnaire. They started from six virtues - courage, prudence, justice, temperance, humanity, and truthfulness and, by factor analysis, reach five factors: courage (4), temperance (4), justice (3), prudence (4), and humanity (3).</p>
+				<p>In their Character Strengths in Leadership scale, <xref ref-type="bibr" rid="B79">Thun and Kelloway (2011</xref>) find the factors humanity (4 items), wisdom (5), and temperance (5), while <xref ref-type="bibr" rid="B65">Seijts et al. (2015</xref>) discuss character as an amalgamation of virtues, personality traits, and values, describing 11 elements of character and their importance to the leadership. Finally, <xref ref-type="bibr" rid="B45">Mansur et al. (2020</xref>) suggest that moral courage contributes to ethical leadership and group citizenship behavior.</p>
+				<p>Further evidence of the role of moral virtues was observed in topics such as the relationships between buyer-seller (<xref ref-type="bibr" rid="B23">Donada, Mothe, Nogatchewsky, &amp; Ribeiro, 2019</xref>); leader-led (<xref ref-type="bibr" rid="B57">Qin et al., 2019</xref>); managers-salespeople (<xref ref-type="bibr" rid="B68">Shanahan &amp; Hopkins, 2019</xref>); the professionals’ character (<xref ref-type="bibr" rid="B9">Arthur et al., 2021</xref>); and responsible consumption (<xref ref-type="bibr" rid="B77">Song &amp; Kim, 2018</xref>).</p>
+				<p>Although elaborated with statistical rigor, leadership scales are specific to this role, i.e., they are elaborated from specific cultural, moral, and political contexts. Thus, these scales need re-elaboration when applied to other organizational contexts or inserted in a community with its particular culture. Such adaptation accommodates particularities in terms of moral virtues and the notion of human flourishing.</p>
+				<p>When applying <xref ref-type="bibr" rid="B56">Peterson and Seligman (2004</xref>), character strengths model, some studies partially or fully employ the items of character strengths: (a) <xref ref-type="bibr" rid="B55">Park and Peterson (2006</xref>) address moral competence as good character, using 198 out of the model’s 240 items. However, the authors’ sample consists of 250 adolescent students, making the item-sample ratio lower than statistically recommended. Park and Peterson (2006) apply the exploratory factor analysis (EFA), obtaining four factors - temperance (4 items), intellectual (6), theological (10), and other strengths (4); (b) <xref ref-type="bibr" rid="B77">Song and Kim (2018</xref>) approach nine virtues of the model to verify how positive consumer traits explain their responsible consumption; and, (c) <xref ref-type="bibr" rid="B9">Arthur et al. (2021</xref>) address professionals’ self-perception regarding the most important virtues of the model. Although there are differences and similarities between moral virtues and character strengths (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>), the paths to understanding them within organizations go through theoretical deepening and research strategies that allow reaching more than a single “picture” of virtues, recognizing that they are cultivated throughout life.</p>
+			</sec>
+			<sec>
+				<title>Discussion</title>
+				<p>Virtue is a concept with a philosophical root and is considered in the virtue ethics tradition as the middle ground between two vices: the lack of virtue and the excess of virtue (<xref ref-type="bibr" rid="B8">Aristotle, 2009</xref>). In this sense, the virtuous agent constantly reflects on their conduct, mistakes, and successes, seeking a path toward good. In this sense, self-education or self-improvement is a key element. Therefore, the importance of context, of action within a broader perspective (in life’s trajectory), is highlighted. After making a few or several mistakes, one learns the virtues, such as self-forgiveness (<xref ref-type="bibr" rid="B38">Kim et al., 2021</xref>). Thus, a comprehensive ethical framework is desirable, a framework capable of considering negative and positive aspects of character, mistakes and successes, vices and virtues, as seems to be the case with virtue ethics.</p>
+				<p>A form of reaching a more detailed understanding of a virtue’s multi-components is choosing the strategy of examining only one virtue, as recent studies have done. For example, the emerging factors indicated from the EFAs represent a set of perceptions of virtues or character traits, even though they result from the operationalization from different areas and ethical assumptions. Some factors appear more than once, such as temperance (<xref ref-type="bibr" rid="B55">Park &amp; Peterson, 2006</xref>; <xref ref-type="bibr" rid="B61">Riggio et al., 2010</xref>; <xref ref-type="bibr" rid="B79">Thun &amp; Kelloway, 2011</xref>; <xref ref-type="bibr" rid="B80">Wang &amp; Hackett, 2016</xref>), justice (<xref ref-type="bibr" rid="B13">Beekun et al., 2005</xref>; Riggio et al., 2010; Wang &amp; Hackett, 2016) and resourcefulness (<xref ref-type="bibr" rid="B18">Cawley, Martin, &amp; Johnson, 2000</xref>; <xref ref-type="bibr" rid="B81">Yang, Stoeber &amp; Wang, 2015</xref>; <xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). The virtue of prudence is found in the studies by Riggio et al. (2010) and Wang and Hackett (2016), while <xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>) and Thun and Kelloway (2011) define the factor as wisdom.</p>
+				<p>On the other hand, it would be a limitation not to consider, for example, the role of <italic>phronesis</italic> linked to moral virtues (<xref ref-type="bibr" rid="B6">Ames et al., 2020</xref>; <xref ref-type="bibr" rid="B10">Bachmann et al., 2017</xref>). The unity of virtues recognizes the connection between them, i.e., to be virtuous, someone expresses more than one virtue. It is the case, for example, of honesty and justice to communicate in the best possible way; courage and prudence to make good decisions in the face of environmental risks.</p>
+				<p>As for the assumptions regarding the participation of prudence in each virtue and the unity of virtues (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>), most articles do not consider them in the development or use of scales. Among the few exceptions is the attempt by <xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>). Some works rely on authors of virtue ethics - such as <xref ref-type="bibr" rid="B8">Aristotle (2009</xref>), MacIntyre (2007) and Sison and Ferrero (2015) - while others connect virtue ethics to positive psychology (e.g., <xref ref-type="bibr" rid="B9">Arthur et al., 2021</xref>; <xref ref-type="bibr" rid="B23">Donada et al., 2019</xref>; <xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>). </p>
+				<p>What would the possible research strategies be, considering the need for further theoretical development on virtues in administration? Based on this question, we resume some theoretical-methodological aspects to gather suggestions for future studies.</p>
+			</sec>
+		</sec>
+		<sec>
+			<title>SUGGESTIONS FOR FUTURE STUDIES</title>
+			<p>From a theoretical-methodological perspective, four points are worth mentioning: learning of virtues, their presence in different social roles, subjective-objective duality, and judgment-action. The first is that the cultivation and learning of virtues take place throughout life, based on experience (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Methods that occasionally consult respondents at a specific time, without a contextualized analysis of their life trajectories, cannot access the context and circumstance of action, which is considered in the tradition of virtue ethics (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>). It is also worth bearing in mind the respondents’ age or experience, which can make a difference in moral maturity.</p>
+			<p>The second point is connected to the first as it refers to someone’s reflection on their life as a whole. Thus, research must include the professional dimension and the harmony among the individuals’ different social roles (<xref ref-type="bibr" rid="B71">Sison et al., 2018</xref>). The third point refers to the subjective-objective duality related to the concept of virtue, which needs to be addressed by approaches focused on observable behaviors or in the use of scales on the perception of virtues. Such duality is important because a moral virtue expresses harmony between subjective-objective, will and action, something complex to access through scales and measures. Finally, the fourth point raises the question of the judgment-action gap that separates the moment of answering a test/scale on a given hypothetical question from the experience of an ethical question. Accessing the virtues from someone’s life trajectory could find reliable evidence of the participant’s experience.</p>
+			<p>Therefore, some interpretative research strategies and qualitative approaches could achieve a deeper understanding of the virtues in a specific national and organizational context, considering the assumptions of the unity of virtues and the crucial role of <italic>phronesis</italic> (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B82">Zyl, 2019</xref>). Possible contributions from oral history, narrative approaches, case studies, ethnography, and phenomenology can be considered. Exploratory strategies usually precede quantitative approaches to subsidize future studies using scales, such as step 1, suggested in <xref ref-type="fig" rid="f2">Figure 2</xref>.</p>
+			<p>
+				<fig id="f2">
+					<label>Figure 2</label>
+					<caption>
+						<title>Suggestions of steps in future studies on moral virtues.</title>
+					</caption>
+					<graphic xlink:href="1982-7849-rac-26-06-e190379-gf2.tif"/>
+				</fig>
+			</p>
+			<p>The review of works that seek to measure virtues requires a methodological and theoretical discussion. As for the method, this article a) questions why the studies have been seeking to measure virtues, b) tries to understand the limitations and possibilities based on the articles reviewed, and c) seeks to engage in discussions about which methods can be considered for empirical studies of virtue ethics. Against this backdrop, possible procedures in future studies are suggested, as pointed out in <xref ref-type="fig" rid="f2">Figure 2</xref>.</p>
+			<p>Steps 1 and 2 are understood as a route to studies on moral virtues. Step 2 follows basic guidelines for the development of scales, as proposed by <xref ref-type="bibr" rid="B21">DeVellis (2016</xref>). </p>
+			<p>Future studies facing concerns about the instrumentation of the construct to improve performance or productivity may address its contribution to human flourishing and interpersonal relationships. The perception of virtues may allow us to understand how people associate these attributes with other organizational issues, such as leadership, decision-making, or organizational culture. From a theoretical perspective, there is still a debate about using scales to expand or deepen the understanding of moral virtues in the organizational and business environments while bearing in mind the assumptions and elements of the tradition of virtue ethics as a framework for the study of ethics in Administration.</p>
+			<p>Among the research limitations, this study focuses on analyzing moral virtue scales at the individual level. Therefore, the virtuousness scales (at the organizational level) can be approached in future studies. Also, the studies were selected for the systematic review based on a search limited to terms such as virtue ethics and moral virtues. Thus, further studies may look for a specific virtue. Finally, the research reports do not describe how convergent and discriminant validations were carried out in relation to other concepts. The article was organized to offer a general analysis in the light of virtue ethics, discussing only some of the assumptions.</p>
+		</sec>
+		<sec sec-type="conclusions">
+			<title>FINAL CONSIDERATIONS</title>
+			<p>This study carried out a systematic review and analyzed how scales on moral virtues are constructed and measured in studies associated with virtue ethics in administration. The 37 articles used in the analysis were retrieved from five databases. They were published in 21 journals, most of them in business ethics, and portray studies that developed or applied scales related to the perception of moral virtues at the individual level. Nineteen articles covered multiple moral virtues, and 18 articles sought a specific moral virtue.</p>
+			<p>The Aristotelian-Thomistic virtue ethics assumptions and statistical recommendations for the development and application of scales supported the analysis offered in this article. The research analyzed the construction of scales in the studies examined, presenting numbers on the generation of items before and after factor analysis, the proportion of respondents per item (sample-item), the respondents’ profile in each study, the research context (given by the 15 countries represented in the articles selected), and the types of statistical analyses adopted (such as exploratory and confirmatory factor analysis and emerging factors, structural equation modeling, Anova, Manova).</p>
+			<p>The selected studies illustrate areas in the field of administration related to the theme of virtues, such as leadership, manager-employee relationship, and responsible consumption. As a portion of respondents is university students, further studies are required to access practitioners working in the field. Virtues such as courage, gratitude, humility, integrity, forgiveness, respect, resilience, and temperance were discussed.</p>
+			<p>The results were discussed theoretically and methodologically, considering the use of scales in relation to the conceptual deepening of the area, and the assumptions regarding the particularities of the contexts, the unity of virtues, and their interconnection with phronesis (practical wisdom). Learning, presence in different roles, and judgment-action duality were also discussed to elucidate theoretical and practical implications of the limitations found in conceptual deepening and operationalization.</p>
+			<p>Therefore, it was possible to suggest procedures for future studies on moral virtues, organized in successive stages. The intention is to coordinate the first step with qualitative exploratory studies - which grants conceptual precision and data on the context and targeted participants - and the second step, with recommendations for the development of scales on the perception of virtues, obtaining larger sets of items, the better item-sample ratio in accessing the field, validation with experts and potential respondents, and pre-testing.</p>
+			<p>Conceptual deepening encompasses Western and Eastern traditions for virtue ethics, and it is necessary to reflect on the reasons for trying to measure virtues in the field of administration. An alternative path can be analyzing and identifying organizational aspects that help people cultivate virtues, such as practices and institutions, organizational culture, and administrative functions. </p>
+		</sec>
+	</body>
+	<back>
+		<ref-list>
+			<title>REFERENCES</title>
+			<ref id="B1">
+				<mixed-citation>Aguirre-Y-Luker, G; Hyman, M., &amp; Shanahan, K. (2017). Measuring systems of virtues development. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Aguirre-Y-Luker</surname>
+							<given-names>G</given-names>
+						</name>
+						<name>
+							<surname>Hyman</surname>
+							<given-names>M.,</given-names>
+						</name>
+						<name>
+							<surname>Shanahan</surname>
+							<given-names>K.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<chapter-title>Measuring systems of virtues development</chapter-title>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sison</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Beabout</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+					</person-group>
+					<source>Handbook of virtues ethics in business and management</source>
+					<publisher-loc>Netherlands</publisher-loc>
+					<publisher-name>Springer</publisher-name>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B2">
+				<mixed-citation>Alzola, M. (2015, July). Virtuous persons and virtuous actions in business ethics and organizational research. Business Ethics Quarterly, 25 (3), 287-318. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/beq.2015.24">https://doi.org/10.1017/beq.2015.24</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Alzola</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Virtuous persons and virtuous actions in business ethics and organizational research</article-title>
+					<source>Business Ethics Quarterly</source>
+					<volume>25</volume>
+					<issue>3</issue>
+					<fpage>287</fpage>
+					<lpage>318</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/beq.2015.24">https://doi.org/10.1017/beq.2015.24</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B3">
+				<mixed-citation>Alzola, M. (2017). Virtues and their explanatory and predictive power in the workplace. In A. Sison, G. Beabout, &amp; I. Ferrero (Eds.), Handbook of virtues ethics in business and management. Netherlands: Springer. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Alzola</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<chapter-title>Virtues and their explanatory and predictive power in the workplace</chapter-title>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sison</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Beabout</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+					</person-group>
+					<source>Handbook of virtues ethics in business and management</source>
+					<publisher-loc>Netherlands</publisher-loc>
+					<publisher-name>Springer</publisher-name>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B4">
+				<mixed-citation>Alzola, M., Hennig, A., &amp; Homar, E. (2020). Thematic symposium editorial: Virtue ethics between east and west. Journal of Business Ethics, 165, 177-189. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04317-2">https://doi.org/10.1007/s10551-019-04317-2</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Alzola</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Hennig</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Homar</surname>
+							<given-names>E.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Thematic symposium editorial: Virtue ethics between east and west</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>165</volume>
+					<fpage>177</fpage>
+					<lpage>189</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04317-2">https://doi.org/10.1007/s10551-019-04317-2</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B5">
+				<mixed-citation>Ames, M. C. F. D. C., &amp; Serafim, M. C. (2019). Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review. Revista de Administração Contemporânea, 23(4), 564-586. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-7849rac2019180301">https://doi.org/10.1590/1982-7849rac2019180301</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ames</surname>
+							<given-names>M. C. F. D. C.</given-names>
+						</name>
+						<name>
+							<surname>Serafim</surname>
+							<given-names>M. C.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Teaching-learning practical wisdom (phronesis) in Administration: A Systematic Review</article-title>
+					<source>Revista de Administração Contemporânea</source>
+					<volume>23</volume>
+					<issue>4</issue>
+					<fpage>564</fpage>
+					<lpage>586</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-7849rac2019180301">https://doi.org/10.1590/1982-7849rac2019180301</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B6">
+				<mixed-citation>Ames, M. C. F. D. C., Serafim, M. C., &amp; Zappellini, M. B. (2020). Phronesis in administration and organizations: a literature review and future research agenda. Business Ethics, the Environment &amp; Responsibility, 29(S1), 65-83. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12296">https://doi.org/10.1111/beer.12296</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ames</surname>
+							<given-names>M. C. F. D. C.</given-names>
+						</name>
+						<name>
+							<surname>Serafim</surname>
+							<given-names>M. C.</given-names>
+						</name>
+						<name>
+							<surname>Zappellini</surname>
+							<given-names>M. B.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Phronesis in administration and organizations: a literature review and future research agenda</article-title>
+					<source>Business Ethics, the Environment &amp; Responsibility</source>
+					<volume>29</volume>
+					<issue>S1</issue>
+					<fpage>65</fpage>
+					<lpage>83</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12296">https://doi.org/10.1111/beer.12296</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B7">
+				<mixed-citation>Anscombe, G. E. M. (1958). Modern moral Philosophy. Philosophy, 33(124), 1-19. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/S0031819100037943">https://doi.org/10.1017/S0031819100037943</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Anscombe</surname>
+							<given-names>G. E. M.</given-names>
+						</name>
+					</person-group>
+					<year>1958</year>
+					<article-title>Modern moral Philosophy</article-title>
+					<source>Philosophy</source>
+					<volume>33</volume>
+					<issue>124</issue>
+					<fpage>1</fpage>
+					<lpage>19</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1017/S0031819100037943">https://doi.org/10.1017/S0031819100037943</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B8">
+				<mixed-citation>Aristotle. (2009). Ética a Nicômaco. (A. C. Caieiro, Trad.). São Paulo, SP: Atlas.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Aristotle</surname>
+ 						</name>
+					</person-group>
+					<year>2009</year>
+					<source>Ética a Nicômaco</source>
+					<publisher-loc>São Paulo, SP</publisher-loc>
+					<publisher-name>Atlas</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B9">
+				<mixed-citation>Arthur, J., Earl, S. R., Thompson, A. P., &amp; Ward, J. W. (2021). The value of character-based judgement in the professional domain. Journal of Business Ethics, 169, 293-308. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04269-7">https://doi.org/10.1007/s10551-019-04269-7</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Arthur</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Earl</surname>
+							<given-names>S. R.</given-names>
+						</name>
+						<name>
+							<surname>Thompson</surname>
+							<given-names>A. P.</given-names>
+						</name>
+						<name>
+							<surname>Ward</surname>
+							<given-names>J. W.</given-names>
+						</name>
+					</person-group>
+					<year>2021</year>
+					<article-title>The value of character-based judgement in the professional domain</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>169</volume>
+					<fpage>293</fpage>
+					<lpage>308</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04269-7">https://doi.org/10.1007/s10551-019-04269-7</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B10">
+				<mixed-citation>Bachmann, C., Habisch, A., &amp; Dierksmeier, C. (2017). Practical wisdom: Management’s no longer forgotten virtue. Journal of Business Ethics, 153, 147-165. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3417-y">https://doi.org/10.1007/s10551-016-3417-y</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Bachmann</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name>
+							<surname>Habisch</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Dierksmeier</surname>
+							<given-names>C.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<article-title>Practical wisdom: Management’s no longer forgotten virtue</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>153</volume>
+					<fpage>147</fpage>
+					<lpage>165</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3417-y">https://doi.org/10.1007/s10551-016-3417-y</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B11">
+				<mixed-citation>Bai, F., Ho, G. C. C., &amp; Yan, J. (2020). Does Virtue lead to status? Testing the moral virtue theory of status attainment. Journal of Personality &amp; Social Psychology, 118(3), 501-531. <ext-link ext-link-type="uri" xlink:href="http://doi.org/10.0.4.13/pspi0000192">http://doi.org/10.0.4.13/pspi0000192</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Bai</surname>
+							<given-names>F</given-names>
+						</name>
+					</person-group>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ho</surname>
+							<given-names>G. C. C.</given-names>
+						</name>
+						<name>
+							<surname>Yan</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Does Virtue lead to status? Testing the moral virtue theory of status attainment</article-title>
+					<source>Journal of Personality &amp; Social Psychology</source>
+					<volume>118</volume>
+					<issue>3</issue>
+					<fpage>501</fpage>
+					<lpage>531</lpage>
+					<ext-link ext-link-type="uri" xlink:href="http://doi.org/10.0.4.13/pspi0000192">http://doi.org/10.0.4.13/pspi0000192</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B12">
+				<mixed-citation>Beadle, R., Sison, A. J. G., &amp; Fontrodona, J. (2015). Introduction-virtue and virtuousness: when will the twain ever meet? Business Ethics: A European Review, 24(S2), S67-S77. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12098">https://doi.org/10.1111/beer.12098</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Beadle</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Sison</surname>
+							<given-names>A. J. G.</given-names>
+						</name>
+						<name>
+							<surname>Fontrodona</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Introduction-virtue and virtuousness: when will the twain ever meet</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>24</volume>
+					<issue>S2</issue>
+					<fpage>S67</fpage>
+					<lpage>S77</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12098">https://doi.org/10.1111/beer.12098</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B13">
+				<mixed-citation>Beekun, R. I., Westerman, J., &amp; Barghouti, J. (2005). Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia. Journal of Business Ethics, 61(3), 235-247. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-005-4772-2">https://doi.org/10.1007/s10551-005-4772-2</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Beekun</surname>
+							<given-names>R. I.</given-names>
+						</name>
+						<name>
+							<surname>Westerman</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Barghouti</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2005</year>
+					<article-title>Utility of ethical frameworks in determining behavioral intention: A comparison of the US and Russia</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>61</volume>
+					<issue>3</issue>
+					<fpage>235</fpage>
+					<lpage>247</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-005-4772-2">https://doi.org/10.1007/s10551-005-4772-2</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B14">
+				<mixed-citation>Bernabe-Valero, G., Blasco-Magraner, J. S., &amp; García-March, M. R. (2020). Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis. Frontiers in Psychology, 11(December), 1-9. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/fpsyg.2020.626330">https://doi.org/10.3389/fpsyg.2020.626330</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Bernabe-Valero</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name>
+							<surname>Blasco-Magraner</surname>
+							<given-names>J. S.</given-names>
+						</name>
+						<name>
+							<surname>García-March</surname>
+							<given-names>M. R.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Gratitude questionnaire-20 Items (G20): A cross-cultural, psychometric and crowdsourcing analysis</article-title>
+					<source>Frontiers in Psychology</source>
+					<volume>11</volume>
+					<fpage>1</fpage>
+					<lpage>9</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/fpsyg.2020.626330">https://doi.org/10.3389/fpsyg.2020.626330</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B15">
+				<mixed-citation>Beugré, C. D. (2012). Development and validation of a deontic justice scale. Journal of Applied Social Psychology, 42(9), 2163-2190. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/j.1559-1816.2012.00935.x">https://doi.org/10.1111/j.1559-1816.2012.00935.x</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Beugré</surname>
+							<given-names>C. D.</given-names>
+						</name>
+					</person-group>
+					<year>2012</year>
+					<article-title>Development and validation of a deontic justice scale</article-title>
+					<source>Journal of Applied Social Psychology</source>
+					<volume>42</volume>
+					<issue>9</issue>
+					<fpage>2163</fpage>
+					<lpage>2190</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/j.1559-1816.2012.00935.x">https://doi.org/10.1111/j.1559-1816.2012.00935.x</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B16">
+				<mixed-citation>Cameron, K., Bright, D., &amp; Caza, A. (2004). Exploring the relationships between organizational virtuousness and performance. American Behavioral Scientist, 47(6), 1-14. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1177/0002764203260209">https://doi.org/10.1177/0002764203260209</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Cameron</surname>
+							<given-names>K.</given-names>
+						</name>
+						<name>
+							<surname>Bright</surname>
+							<given-names>D.</given-names>
+						</name>
+						<name>
+							<surname>Caza</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2004</year>
+					<article-title>Exploring the relationships between organizational virtuousness and performance</article-title>
+					<source>American Behavioral Scientist</source>
+					<volume>47</volume>
+					<issue>6</issue>
+					<fpage>1</fpage>
+					<lpage>14</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1177/0002764203260209">https://doi.org/10.1177/0002764203260209</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B17">
+				<mixed-citation>Castro-González, S., Bande, B., Fernández-Ferrín, P., &amp; Kimura, T. (2019). Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues. Journal of Cleaner Production, 231, 846-855. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jclepro.2019.05.238">https://doi.org/10.1016/j.jclepro.2019.05.238</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Castro-González</surname>
+							<given-names>S.</given-names>
+						</name>
+						<name>
+							<surname>Bande</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Fernández-Ferrín</surname>
+							<given-names>P.</given-names>
+						</name>
+						<name>
+							<surname>Kimura</surname>
+							<given-names>T.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Corporate social responsibility and consumer advocacy behaviors: The importance of emotions and moral virtues</article-title>
+					<source>Journal of Cleaner Production</source>
+					<volume>231</volume>
+					<fpage>846</fpage>
+					<lpage>855</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jclepro.2019.05.238">https://doi.org/10.1016/j.jclepro.2019.05.238</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B18">
+				<mixed-citation>Cawley, M. J., Martin, J. E., &amp; Johnson, J. A. (2000). A virtues approach to personality. Personality and Individual Differences, 28(5), 997-1013. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/s0191-8869(99)00207-x">https://doi.org/10.1016/s0191-8869(99)00207-x</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Cawley</surname>
+							<given-names>M. J.</given-names>
+						</name>
+						<name>
+							<surname>Martin</surname>
+							<given-names>J. E.</given-names>
+						</name>
+						<name>
+							<surname>Johnson</surname>
+							<given-names>J. A.</given-names>
+						</name>
+					</person-group>
+					<year>2000</year>
+					<article-title>A virtues approach to personality</article-title>
+					<source>Personality and Individual Differences</source>
+					<volume>28</volume>
+					<issue>5</issue>
+					<fpage>997</fpage>
+					<lpage>1013</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/s0191-8869(99)00207-x">https://doi.org/10.1016/s0191-8869(99)00207-x</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B19">
+				<mixed-citation>Colombo, M., Strangmann, K., Houkes, L., Kostadinova, Z., &amp; Brandt, M. J. (2021). Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue. Review of Philosophy and Psychology,12, 353-371. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s13164-020-00496-4">https://doi.org/10.1007/s13164-020-00496-4</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Colombo</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Strangmann</surname>
+							<given-names>K.</given-names>
+						</name>
+						<name>
+							<surname>Houkes</surname>
+							<given-names>L.</given-names>
+						</name>
+						<name>
+							<surname>Kostadinova</surname>
+							<given-names>Z.</given-names>
+						</name>
+						<name>
+							<surname>Brandt</surname>
+							<given-names>M. J.</given-names>
+						</name>
+					</person-group>
+					<year>2021</year>
+					<article-title>Intellectually Humble, but Prejudiced People. A Paradox of Intellectual Virtue</article-title>
+					<source>Review of Philosophy and Psychology</source>
+					<volume>12</volume>
+					<fpage>353</fpage>
+					<lpage>371</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s13164-020-00496-4">https://doi.org/10.1007/s13164-020-00496-4</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B20">
+				<mixed-citation>Dawson, D. (2018). Measuring Individuals’ Virtues in Business. Journal of Business Ethics, 147(4), 793-805. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-017-3505-7">https://doi.org/10.1007/s10551-017-3505-7</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Dawson</surname>
+							<given-names>D.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>Measuring Individuals’ Virtues in Business</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>147</volume>
+					<issue>4</issue>
+					<fpage>793</fpage>
+					<lpage>805</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-017-3505-7">https://doi.org/10.1007/s10551-017-3505-7</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B21">
+				<mixed-citation>DeVellis, R. F. (2016). Scale development: Theory and applications. (4th ed). Thousand Oaks, CA: Sage Publications.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>DeVellis</surname>
+							<given-names>R. F.</given-names>
+						</name>
+					</person-group>
+					<year>2016</year>
+					<source>Scale development: Theory and applications</source>
+					<edition>4th </edition>
+					<publisher-loc>Thousand Oaks, CA</publisher-loc>
+					<publisher-name>Sage Publications</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B22">
+				<mixed-citation>Diessner, R., Iyer, R., Smith, M. M., &amp; Haidt, J. (2013). Who engages with moral beauty? Journal of Moral Education, 42(2), 139-163. <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1080/03057240.2013.785941">http://dx.doi.org/10.1080/03057240.2013.785941</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Diessner</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Iyer</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Smith</surname>
+							<given-names>M. M.</given-names>
+						</name>
+						<name>
+							<surname>Haidt</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2013</year>
+					<article-title>Who engages with moral beauty</article-title>
+					<source>Journal of Moral Education</source>
+					<volume>42</volume>
+					<issue>2</issue>
+					<fpage>139</fpage>
+					<lpage>163</lpage>
+					<ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1080/03057240.2013.785941">http://dx.doi.org/10.1080/03057240.2013.785941</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B23">
+				<mixed-citation>Donada, C., Mothe, C., Nogatchewsky, G., &amp; Ribeiro, G. C. de. (2019). The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win. Journal of Business Ethics, 154(1), 211-228. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3418-x">https://doi.org/10.1007/s10551-016-3418-x</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Donada</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name>
+							<surname>Mothe</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name>
+							<surname>Nogatchewsky</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name>
+							<surname>Ribeiro</surname>
+							<given-names>G. C. de.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>The Respective effects of virtues and inter-organizational management control systems on relationship quality and performance: Virtues Win</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>154</volume>
+					<issue>1</issue>
+					<fpage>211</fpage>
+					<lpage>228</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3418-x">https://doi.org/10.1007/s10551-016-3418-x</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B24">
+				<mixed-citation>Fávero, L. P. L., Belfiore, P. P., Silva, F. L. &amp; Chan, B. L. (2009) Análise de dados: Modelagem multivariada para tomada de decisões. Rio de Janeiro, RJ: Elsevier.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Fávero</surname>
+							<given-names>L. P. L.</given-names>
+						</name>
+						<name>
+							<surname>Belfiore</surname>
+							<given-names>P. P.</given-names>
+						</name>
+						<name>
+							<surname>Silva</surname>
+							<given-names>F. L.</given-names>
+						</name>
+						<name>
+							<surname>Chan</surname>
+							<given-names>B. L.</given-names>
+						</name>
+					</person-group>
+					<year>2009</year>
+					<source>Análise de dados: Modelagem multivariada para tomada de decisões</source>
+					<publisher-loc>Rio de Janeiro, RJ</publisher-loc>
+					<publisher-name>Elsevier</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B25">
+				<mixed-citation>Ferrero, I., &amp; Sison, A. (2014). A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011). Business ethics: A European Review, 23(4), 375-400. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12057">https://doi.org/10.1111/beer.12057</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+						<name>
+							<surname>Sison</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2014</year>
+					<article-title>A quantitative analysis of authors, schools and themes in virtue ethics articles in business ethics and management journals (1980-2011)</article-title>
+					<source>Business ethics: A European Review</source>
+					<volume>23</volume>
+					<issue>4</issue>
+					<fpage>375</fpage>
+					<lpage>400</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12057">https://doi.org/10.1111/beer.12057</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B26">
+				<mixed-citation>Ferrero, I. Prefácio. In M. C. Serafim (Org.). (2020). Virtudes e dilemas morais na Administração. (pp. 9-14). Florianópolis: Admethics.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I</given-names>
+						</name>
+					</person-group>
+					<chapter-title>Prefácio</chapter-title>
+					<person-group person-group-type="author">
+						<name>
+							<surname>Serafim</surname>
+							<given-names>M. C.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<source>Virtudes e dilemas morais na Administração</source>
+					<fpage>9</fpage>
+					<lpage>14</lpage>
+					<publisher-loc>Florianópolis</publisher-loc>
+					<publisher-name>Admethics</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B27">
+				<mixed-citation>Foot, P. (1967). The problem of abortion and the doctrine of double effect. Oxford Reviews, 5, 5-15. Retrieved from <ext-link ext-link-type="uri" xlink:href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf">https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Foot</surname>
+							<given-names>P.</given-names>
+						</name>
+					</person-group>
+					<year>1967</year>
+					<article-title>The problem of abortion and the doctrine of double effect</article-title>
+					<source>Oxford Reviews</source>
+					<volume>5</volume>
+					<fpage>5</fpage>
+					<lpage>15</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf">https://spot.colorado.edu/~heathwoo/phil3100,SP09/foot.pdf</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B28">
+				<mixed-citation>Gomide, S. Jr., Vieira, L. E., &amp; Oliveira, A. F. (2016). Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro. Psicologia: Organizações e Trabalho, 16(3), 298-307. <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.17652/rpot/2016.3.10417">http://dx.doi.org/10.17652/rpot/2016.3.10417</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Gomide</surname>
+							<given-names>S. Jr.</given-names>
+						</name>
+						<name>
+							<surname>Vieira</surname>
+							<given-names>L. E.</given-names>
+						</name>
+						<name>
+							<surname>Oliveira</surname>
+							<given-names>A. F.</given-names>
+						</name>
+					</person-group>
+					<year>2016</year>
+					<article-title>Percepção de virtudes morais organizacionais: Evidências de validade de um instrumento de medida para o contexto brasileiro</article-title>
+					<source>Psicologia: Organizações e Trabalho</source>
+					<volume>16</volume>
+					<issue>3</issue>
+					<fpage>298</fpage>
+					<lpage>307</lpage>
+					<ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.17652/rpot/2016.3.10417">http://dx.doi.org/10.17652/rpot/2016.3.10417</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B29">
+				<mixed-citation>Gulliford, L., Morgan, B., Hemming, E., &amp; Abbott, J. (2019). Gratitude, self-monitoring and social intelligence: A prosocial relationship? Current Psychology, 38(4), 1021-1032. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-019-00330-w">https://doi.org/10.1007/s12144-019-00330-w</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Gulliford</surname>
+							<given-names>L.</given-names>
+						</name>
+						<name>
+							<surname>Morgan</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Hemming</surname>
+							<given-names>E.</given-names>
+						</name>
+						<name>
+							<surname>Abbott</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Gratitude, self-monitoring and social intelligence: A prosocial relationship</article-title>
+					<source>Current Psychology</source>
+					<volume>38</volume>
+					<issue>4</issue>
+					<fpage>1021</fpage>
+					<lpage>1032</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-019-00330-w">https://doi.org/10.1007/s12144-019-00330-w</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B30">
+				<mixed-citation>Grappi, S., Romani, S., &amp; Bagozzi, R. P. (2013). Consumer response to corporate irresponsible behavior: Moral emotions and virtues. Journal of Business Research, 66(10), 1814-1821. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jbusres.2013.02.002">https://doi.org/10.1016/j.jbusres.2013.02.002</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Grappi</surname>
+							<given-names>S.</given-names>
+						</name>
+						<name>
+							<surname>Romani</surname>
+							<given-names>S.</given-names>
+						</name>
+						<name>
+							<surname>Bagozzi</surname>
+							<given-names>R. P.</given-names>
+						</name>
+					</person-group>
+					<year>2013</year>
+					<article-title>Consumer response to corporate irresponsible behavior: Moral emotions and virtues</article-title>
+					<source>Journal of Business Research</source>
+					<volume>66</volume>
+					<issue>10</issue>
+					<fpage>1814</fpage>
+					<lpage>1821</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jbusres.2013.02.002">https://doi.org/10.1016/j.jbusres.2013.02.002</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B31">
+				<mixed-citation>Hair, J., Jr., Babin, B., Money, A., &amp; Samouel, P. (2005). Fundamentos de métodos de pesquisa em Administração. Porto Alegre: Bookman.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hair</surname>
+							<given-names>J., Jr.</given-names>
+						</name>
+						<name>
+							<surname>Babin</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Money</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Samouel</surname>
+							<given-names>P</given-names>
+						</name>
+					</person-group>
+					<year>2005</year>
+					<source>Fundamentos de métodos de pesquisa em Administração</source>
+					<publisher-loc>Porto Alegre</publisher-loc>
+					<publisher-name>Bookman</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B32">
+				<mixed-citation>Hair, J., Jr., Black, W., Babin, B., Anderson, R., &amp; Tathan, R. (2009) Análise multivariada de dados. (6th ed.). Porto Alegre, RS: Bookman.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hair</surname>
+							<given-names>J., Jr.</given-names>
+						</name>
+						<name>
+							<surname>Black</surname>
+							<given-names>W.</given-names>
+						</name>
+						<name>
+							<surname>Babin</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Anderson</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Tathan</surname>
+							<given-names>R</given-names>
+						</name>
+					</person-group>
+					<year>2009</year>
+					<source>Análise multivariada de dados</source>
+					<edition>6th </edition>
+					<publisher-loc>Porto Alegre, RS</publisher-loc>
+					<publisher-name>Bookman</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B33">
+				<mixed-citation>Hartmann, E. M. (2020). Arriving where we started: Aristotle and business ethics (E-book, Vol. 51). Cham: Switzerland: Springer. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-3-030-44089-3">https://doi.org/10.1007/978-3-030-44089-3</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hartmann</surname>
+							<given-names>E. M</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<source>Arriving where we started: Aristotle and business ethics (E-book, Vol. 51)</source>
+					<publisher-loc>Cham</publisher-loc>
+					<publisher-loc>Switzerland</publisher-loc>
+					<publisher-name>Springer</publisher-name>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-3-030-44089-3">https://doi.org/10.1007/978-3-030-44089-3</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B34">
+				<mixed-citation>Hudecek, M. F. C., Blabst, N., Morgan, B., &amp; Lermer, E. (2020). Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G). Frontiers in Psychology, 11. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/fpsyg.2020.590108">https://doi.org/10.3389/fpsyg.2020.590108</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hudecek</surname>
+							<given-names>M. F. C.</given-names>
+						</name>
+						<name>
+							<surname>Blabst</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name>
+							<surname>Morgan</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Lermer</surname>
+							<given-names>E.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Measuring gratitude in Germany: Validation study of the German version of the Gratitude Questionnaire-Six Item Form (GQ-6-G) and the Multi-Component Gratitude Measure (MCGM-G)</article-title>
+					<source>Frontiers in Psychology</source>
+					<volume>11</volume>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.3389/fpsyg.2020.590108">https://doi.org/10.3389/fpsyg.2020.590108</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B35">
+				<mixed-citation>Huhtala, M., Kangas, M., Kaptein, M., &amp; Feldt, T. (2018). The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups. Business Ethics: A European Review, 27(3), 238-247. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12184">https://doi.org/10.1111/beer.12184</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Huhtala</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Kangas</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Kaptein</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Feldt</surname>
+							<given-names>T.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>The shortened Corporate Ethical Virtues scale: Measurement invariance and mean differences across two occupational groups</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>27</volume>
+					<issue>3</issue>
+					<fpage>238</fpage>
+					<lpage>247</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12184">https://doi.org/10.1111/beer.12184</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B36">
+				<mixed-citation>Hühn, M. P., Habish, A., Hartmann, E. M., &amp; Sison, A. J. G. (2020). Practicing management wisely. Business Ethics: A European Review, 29(S1), 1-5. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12321">https://doi.org/10.1111/beer.12321</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Hühn</surname>
+							<given-names>M. P.</given-names>
+						</name>
+						<name>
+							<surname>Habish</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Hartmann</surname>
+							<given-names>E. M.</given-names>
+						</name>
+						<name>
+							<surname>Sison</surname>
+							<given-names>A. J. G.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Practicing management wisely</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>29</volume>
+					<issue>S1</issue>
+					<fpage>1</fpage>
+					<lpage>5</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12321">https://doi.org/10.1111/beer.12321</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B37">
+				<mixed-citation>Jiao, L., Yang, Y., Guo, Z., Xu, Y., Zhang, H., &amp; Jiang, J. (2020). Development and validation of the good and evil character traits (GECT) scale. Scandinavian Journal of Psychology, 62(2), 276-287. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/sjop.12696">https://doi.org/10.1111/sjop.12696</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Jiao</surname>
+							<given-names>L.</given-names>
+						</name>
+						<name>
+							<surname>Yang</surname>
+							<given-names>Y.</given-names>
+						</name>
+						<name>
+							<surname>Guo</surname>
+							<given-names>Z.</given-names>
+						</name>
+						<name>
+							<surname>Xu</surname>
+							<given-names>Y.</given-names>
+						</name>
+						<name>
+							<surname>Zhang</surname>
+							<given-names>H.</given-names>
+						</name>
+						<name>
+							<surname>Jiang</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Development and validation of the good and evil character traits (GECT) scale</article-title>
+					<source>Scandinavian Journal of Psychology</source>
+					<volume>62</volume>
+					<issue>2</issue>
+					<fpage>276</fpage>
+					<lpage>287</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/sjop.12696">https://doi.org/10.1111/sjop.12696</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B38">
+				<mixed-citation>Kim, J. J., Volk, F., &amp; Enright, R. D. (2021). Validating the Enright Self-Forgiveness Inventory (ESFI). Current Psychology. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-020-01248-4">https://doi.org/10.1007/s12144-020-01248-4</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Kim</surname>
+							<given-names>J. J.</given-names>
+						</name>
+						<name>
+							<surname>Volk</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name>
+							<surname>Enright</surname>
+							<given-names>R. D.</given-names>
+						</name>
+					</person-group>
+					<year>2021</year>
+					<article-title>Validating the Enright Self-Forgiveness Inventory (ESFI)</article-title>
+					<source>Current Psychology</source>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-020-01248-4">https://doi.org/10.1007/s12144-020-01248-4</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B39">
+				<mixed-citation>Kinghorn, W. (2017). The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths. The Journal of Positive Psychology, 12(5), 436-446. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1080/17439760.2016.1228009">https://doi.org/10.1080/17439760.2016.1228009</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Kinghorn</surname>
+							<given-names>W.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<article-title>The politics of virtue: An Aristotelian-Thomistic engagement with the VIA classification of character strengths</article-title>
+					<source>The Journal of Positive Psychology</source>
+					<volume>12</volume>
+					<issue>5</issue>
+					<fpage>436</fpage>
+					<lpage>446</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1080/17439760.2016.1228009">https://doi.org/10.1080/17439760.2016.1228009</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B40">
+				<mixed-citation>Koçyiğit, M., &amp; Karadağ, E. (2016). Developing an ethical tendencies scale based on the theories of ethics. Turkish Journal of Business Ethics, 9(2), 297-307. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.12711/TJBE.2016.9.0016">https://doi.org/10.12711/TJBE.2016.9.0016</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Koçyiğit</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Karadağ</surname>
+							<given-names>E.</given-names>
+						</name>
+					</person-group>
+					<year>2016</year>
+					<article-title>Developing an ethical tendencies scale based on the theories of ethics</article-title>
+					<source>Turkish Journal of Business Ethics</source>
+					<volume>9</volume>
+					<issue>2</issue>
+					<fpage>297</fpage>
+					<lpage>307</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.12711/TJBE.2016.9.0016">https://doi.org/10.12711/TJBE.2016.9.0016</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B41">
+				<mixed-citation>Lasota, A., Tomaszek, K., &amp; Bosacki, S. (2020). How to become more grateful? The mediating role of resilience between empathy and gratitude. Current Psychology. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-020-01178-1">https://doi.org/10.1007/s12144-020-01178-1</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Lasota</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Tomaszek</surname>
+							<given-names>K.</given-names>
+						</name>
+						<name>
+							<surname>Bosacki</surname>
+							<given-names>S.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>How to become more grateful? The mediating role of resilience between empathy and gratitude</article-title>
+					<source>Current Psychology</source>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s12144-020-01178-1">https://doi.org/10.1007/s12144-020-01178-1</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B42">
+				<mixed-citation>Libby, T., &amp; Thorne, L. (2007). The development of a measure of auditors’ virtue. Journal of Business Ethics, 71(1), 89-99. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-006-9127-0">https://doi.org/10.1007/s10551-006-9127-0</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Libby</surname>
+							<given-names>T.</given-names>
+						</name>
+						<name>
+							<surname>Thorne</surname>
+							<given-names>L.</given-names>
+						</name>
+					</person-group>
+					<year>2007</year>
+					<article-title>The development of a measure of auditors’ virtue</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>71</volume>
+					<issue>1</issue>
+					<fpage>89</fpage>
+					<lpage>99</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-006-9127-0">https://doi.org/10.1007/s10551-006-9127-0</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B43">
+				<mixed-citation>Macintyre, A. (2007). After virtue: A study in moral theory (3rd ed.). Notre Dame, IN: University of Notre Dame Press.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Macintyre</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2007</year>
+					<source>After virtue: A study in moral theory</source>
+					<edition>3rd </edition>
+					<publisher-loc>Notre Dame, IN</publisher-loc>
+					<publisher-name>University of Notre Dame Press</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B44">
+				<mixed-citation>Manly, T. S., Leonard, L. N. K., &amp; Riemenschneider, C. K. (2015). Academic integrity in the information age: Virtues of respect and responsibility. Journal of Business Ethics, 127(3), 579-590. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-014-2060-8">https://doi.org/10.1007/s10551-014-2060-8</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Manly</surname>
+							<given-names>T. S.</given-names>
+						</name>
+						<name>
+							<surname>Leonard</surname>
+							<given-names>L. N. K.</given-names>
+						</name>
+						<name>
+							<surname>Riemenschneider</surname>
+							<given-names>C. K.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Academic integrity in the information age: Virtues of respect and responsibility</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>127</volume>
+					<issue>3</issue>
+					<fpage>579</fpage>
+					<lpage>590</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-014-2060-8">https://doi.org/10.1007/s10551-014-2060-8</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B45">
+				<mixed-citation>Mansur, J., Sobral, F., &amp; Islam, G. (2020). Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors. Business Ethics: A European Review, 29(3), 587-601. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12270">https://doi.org/10.1111/beer.12270</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Mansur</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Sobral</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name>
+							<surname>Islam</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Leading with moral courage: The interplay of guilt and courage on perceived ethical leadership and group organizational citizenship behaviors</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>29</volume>
+					<issue>3</issue>
+					<fpage>587</fpage>
+					<lpage>601</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12270">https://doi.org/10.1111/beer.12270</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B46">
+				<mixed-citation>Mendes-Da-Silva, W. (2019). Contribuições e limitações de revisões narrativas e revisões sistemáticas na área de negócios. Revista de Administração Contemporânea, 23(2), <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-7849rac2019190094">https://doi.org/10.1590/1982-7849rac2019190094</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Mendes-Da-Silva</surname>
+							<given-names>W.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Contribuições e limitações de revisões narrativas e revisões sistemáticas na área de negócios</article-title>
+					<source>Revista de Administração Contemporânea</source>
+					<volume>23</volume>
+					<issue>2</issue>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-7849rac2019190094">https://doi.org/10.1590/1982-7849rac2019190094</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B47">
+				<mixed-citation>Meyer, M. (2018). The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship. Journal of Business Ethics, 153, 245-264. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3388-z">https://doi.org/10.1007/s10551-016-3388-z</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Meyer</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>The evolution and challenges of the concept of organizational virtuousness in positive organizational scholarship</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>153</volume>
+					<fpage>245</fpage>
+					<lpage>264</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3388-z">https://doi.org/10.1007/s10551-016-3388-z</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B48">
+				<mixed-citation>Moberg, D. J. (1999). The big five and organizational virtue. Business Ethics Quarterly, 9(2), 245-272. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/3857474">https://doi.org/10.2307/3857474</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Moberg</surname>
+							<given-names>D. J.</given-names>
+						</name>
+					</person-group>
+					<year>1999</year>
+					<article-title>The big five and organizational virtue</article-title>
+					<source>Business Ethics Quarterly</source>
+					<volume>9</volume>
+					<issue>2</issue>
+					<fpage>245</fpage>
+					<lpage>272</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/3857474">https://doi.org/10.2307/3857474</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B49">
+				<mixed-citation>Moher, D., Liberati, A., Tetslaff, J., &amp; Altman, D. G. (2009). Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement. Annals of Internal Medicine, 151(4), 264-269. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1371/journal.pmed.1000097">https://doi.org/10.1371/journal.pmed.1000097</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Moher</surname>
+							<given-names>D.</given-names>
+						</name>
+						<name>
+							<surname>Liberati</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Tetslaff</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Altman</surname>
+							<given-names>D. G.</given-names>
+						</name>
+					</person-group>
+					<year>2009</year>
+					<article-title>Preferred reporting items for systematic reviews and meta-analyses: The PRISMA Statement</article-title>
+					<source>Annals of Internal Medicine</source>
+					<volume>151</volume>
+					<issue>4</issue>
+					<fpage>264</fpage>
+					<lpage>269</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1371/journal.pmed.1000097">https://doi.org/10.1371/journal.pmed.1000097</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B50">
+				<mixed-citation>Moore, G. (2017). Virtue at work: Ethics for individuals, managers, and organizations. Oxford, UK: Oxford University Press.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Moore</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<source>Virtue at work: Ethics for individuals, managers, and organizations</source>
+					<publisher-loc>Oxford, UK</publisher-loc>
+					<publisher-name>Oxford University Press</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B51">
+				<mixed-citation>Morales-Sánchez, R., &amp; Cabello-Medina, C. (2013). The role of four moral competencies in Ethical Decision-making. Journal of Business Ethics, 116(4), 717-734. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-013-1817-9">https://doi.org/10.1007/s10551-013-1817-9</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Morales-Sánchez</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Cabello-Medina</surname>
+							<given-names>C.</given-names>
+						</name>
+					</person-group>
+					<year>2013</year>
+					<article-title>The role of four moral competencies in Ethical Decision-making</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>116</volume>
+					<issue>4</issue>
+					<fpage>717</fpage>
+					<lpage>734</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-013-1817-9">https://doi.org/10.1007/s10551-013-1817-9</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B52">
+				<mixed-citation>Morgan, B., Gulliford, L., &amp; Kristjánsson, K. (2017). A new approach to measuring moral virtues: The Multi-Component Gratitude Measure. Personality and Individual Differences, 107(1), 179-189. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2016.11.044">https://doi.org/10.1016/j.paid.2016.11.044</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Morgan</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Gulliford</surname>
+							<given-names>L.</given-names>
+						</name>
+						<name>
+							<surname>Kristjánsson</surname>
+							<given-names>K.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<article-title>A new approach to measuring moral virtues: The Multi-Component Gratitude Measure</article-title>
+					<source>Personality and Individual Differences</source>
+					<volume>107</volume>
+					<issue>1</issue>
+					<fpage>179</fpage>
+					<lpage>189</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2016.11.044">https://doi.org/10.1016/j.paid.2016.11.044</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B53">
+				<mixed-citation>Murphy, P. (1999). Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators. Journal of Business Ethics, 18(1), 107-124. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1023/A:1006072413165">https://doi.org/10.1023/A:1006072413165</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Murphy</surname>
+							<given-names>P.</given-names>
+						</name>
+					</person-group>
+					<year>1999</year>
+					<article-title>Character and Virtue Ethics in International Marketing: An agenda for managers, researchers and educators</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>18</volume>
+					<issue>1</issue>
+					<fpage>107</fpage>
+					<lpage>124</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1023/A:1006072413165">https://doi.org/10.1023/A:1006072413165</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B54">
+				<mixed-citation>Newstead, T., Macklin, R., Dawkins, S., &amp; Martin, A. (2018). What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry. Academy of Management Perspectives, 32(4), 443-457. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5465/amp.2016.0162">https://doi.org/10.5465/amp.2016.0162</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Newstead</surname>
+							<given-names>T.</given-names>
+						</name>
+						<name>
+							<surname>Macklin</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Dawkins</surname>
+							<given-names>S.</given-names>
+						</name>
+						<name>
+							<surname>Martin</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>What is virtue? Advancing the conceptualization of virtue to inform positive organizational inquiry</article-title>
+					<source>Academy of Management Perspectives</source>
+					<volume>32</volume>
+					<issue>4</issue>
+					<fpage>443</fpage>
+					<lpage>457</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5465/amp.2016.0162">https://doi.org/10.5465/amp.2016.0162</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B55">
+				<mixed-citation>Park, N., &amp; Peterson, C. (2006). Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth. Journal of Adolescence, 29(6), 891-909. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.adolescence.2006.04.011">https://doi.org/10.1016/j.adolescence.2006.04.011</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Park</surname>
+							<given-names>N.</given-names>
+						</name>
+						<name>
+							<surname>Peterson</surname>
+							<given-names>C.</given-names>
+						</name>
+					</person-group>
+					<year>2006</year>
+					<article-title>Moral competence and character strengths among adolescents: The development and validation of the values in action inventory of strengths for youth</article-title>
+					<source>Journal of Adolescence</source>
+					<volume>29</volume>
+					<issue>6</issue>
+					<fpage>891</fpage>
+					<lpage>909</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.adolescence.2006.04.011">https://doi.org/10.1016/j.adolescence.2006.04.011</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B56">
+				<mixed-citation>Peterson, C., &amp; Seligman, M. (2004). Character strengths and virtues: A handbook and classification. New York, NY: Oxford University Press.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Peterson</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name>
+							<surname>Seligman</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>2004</year>
+					<source>Character strengths and virtues: A handbook and classification</source>
+					<publisher-loc>New York, NY</publisher-loc>
+					<publisher-name>Oxford University Press</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B57">
+				<mixed-citation>Qin, X., Liu, X., Brown, J. A., Zheng, X., &amp; Owens, B. P. (2019). Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors. Journal of Business Ethics, 170, 147-165. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04250-4">https://doi.org/10.1007/s10551-019-04250-4</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Qin</surname>
+							<given-names>X.</given-names>
+						</name>
+						<name>
+							<surname>Liu</surname>
+							<given-names>X.</given-names>
+						</name>
+						<name>
+							<surname>Brown</surname>
+							<given-names>J. A.</given-names>
+						</name>
+						<name>
+							<surname>Zheng</surname>
+							<given-names>X.</given-names>
+						</name>
+						<name>
+							<surname>Owens</surname>
+							<given-names>B. P.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Humility harmonized? Exploring whether and how leader and employee humility (in)congruence influences employee citizenship and deviance behaviors</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>170</volume>
+					<fpage>147</fpage>
+					<lpage>165</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-019-04250-4">https://doi.org/10.1007/s10551-019-04250-4</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B58">
+				<mixed-citation>Racelis, A. D. (2013). Developing a virtue ethics scale: Exploratory survey of Philippine managers. Asian Journal of Business &amp; Accounting, 6(1), 15-37. Retrieved from <ext-link ext-link-type="uri" xlink:href="https://ajba.um.edu.my/article/view/2664">https://ajba.um.edu.my/article/view/2664</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Racelis</surname>
+							<given-names>A. D.</given-names>
+						</name>
+					</person-group>
+					<year>2013</year>
+					<article-title>Developing a virtue ethics scale: Exploratory survey of Philippine managers</article-title>
+					<source>Asian Journal of Business &amp; Accounting</source>
+					<volume>6</volume>
+					<issue>1</issue>
+					<fpage>15</fpage>
+					<lpage>37</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://ajba.um.edu.my/article/view/2664">https://ajba.um.edu.my/article/view/2664</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B59">
+				<mixed-citation>Racelis, A. D. (2014). Examining the global financial crisis from a virtue theory lens. Asia-Pacific Social Science Review, 14(2), 23-38. Retrieved from <ext-link ext-link-type="uri" xlink:href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens">https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Racelis</surname>
+							<given-names>A. D.</given-names>
+						</name>
+					</person-group>
+					<year>2014</year>
+					<article-title>Examining the global financial crisis from a virtue theory lens</article-title>
+					<source>Asia-Pacific Social Science Review</source>
+					<volume>14</volume>
+					<issue>2</issue>
+					<fpage>23</fpage>
+					<lpage>38</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens">https://www.academia.edu/10525406/Examining_the_Global_Financial_Crisis_from_a_Virtue_Theory_Lens</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B60">
+				<mixed-citation>Rego, A., &amp; Cunha, M. P. (2015). As virtudes nas organizações. Análise Psicológica, 4(33), 349-359. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.14417/ap.1022">https://doi.org/10.14417/ap.1022</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Rego</surname>
+							<given-names>A.</given-names>
+						</name>
+						<name>
+							<surname>Cunha</surname>
+							<given-names>M. P.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>As virtudes nas organizações</article-title>
+					<source>Análise Psicológica</source>
+					<volume>4</volume>
+					<issue>33</issue>
+					<fpage>349</fpage>
+					<lpage>359</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.14417/ap.1022">https://doi.org/10.14417/ap.1022</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B61">
+				<mixed-citation>Riggio, R., Zhu, W., Reina, C., &amp; Maroosis, J. (2010). Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire. Consulting Psychology Journal: Practice and Research, 62(4), 235-250. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1037/a0022286">https://doi.org/10.1037/a0022286</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Riggio</surname>
+							<given-names>R.</given-names>
+						</name>
+						<name>
+							<surname>Zhu</surname>
+							<given-names>W.</given-names>
+						</name>
+						<name>
+							<surname>Reina</surname>
+							<given-names>C.</given-names>
+						</name>
+						<name>
+							<surname>Maroosis</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2010</year>
+					<article-title>Virtue-Based Measurement of Ethical Leadership: The Leadership Virtues Questionnaire</article-title>
+					<source>Consulting Psychology Journal: Practice and Research</source>
+					<volume>62</volume>
+					<issue>4</issue>
+					<fpage>235</fpage>
+					<lpage>250</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1037/a0022286">https://doi.org/10.1037/a0022286</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B62">
+				<mixed-citation>Robson, A. (2015). Constancy and integrity: (un)measurable virtues? Business Ethics: A European Review, 24(S2), S115-S129. <ext-link ext-link-type="uri" xlink:href="https://doi.org/ 10.1111/beer.12103">https://doi.org/ 10.1111/beer.12103</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Robson</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Constancy and integrity: (un)measurable virtues</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>24</volume>
+					<issue>S2</issue>
+					<fpage>S115</fpage>
+					<lpage>S129</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/ 10.1111/beer.12103">https://doi.org/ 10.1111/beer.12103</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B63">
+				<mixed-citation>Sanz, P., &amp; Fontrodona, J. (2019). Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace. Journal of Business Ethics, 155, 981-994. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-018-3899-x">https://doi.org/10.1007/s10551-018-3899-x</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sanz</surname>
+							<given-names>P.</given-names>
+						</name>
+						<name>
+							<surname>Fontrodona</surname>
+							<given-names>J.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Moderation as a Moral Competence: Integrating Perspectives for a Better Understanding of Temperance in the Workplace</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>155</volume>
+					<fpage>981</fpage>
+					<lpage>994</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-018-3899-x">https://doi.org/10.1007/s10551-018-3899-x</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B64">
+				<mixed-citation>Sarros, J., Cooper, B. &amp; Hartican, A. (2006). Leadership and Character. Leadership &amp; Organization Development Journal, 27(8), 682-699. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1108/01437730610709291">https://doi.org/10.1108/01437730610709291</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sarros</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Cooper</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Hartican</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2006</year>
+					<article-title>Leadership and Character</article-title>
+					<source>Leadership &amp; Organization Development Journal</source>
+					<volume>27</volume>
+					<issue>8</issue>
+					<fpage>682</fpage>
+					<lpage>699</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1108/01437730610709291">https://doi.org/10.1108/01437730610709291</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B65">
+				<mixed-citation>Seijts, G., Gandz, J., Crossan, M., &amp; Reno, M. (2015). Character matters: character dimensions´ impact on leader performance and outcomes. Organizational Dynamics, 44(1), 65-74. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.orgdyn.2014.11.008">https://doi.org/10.1016/j.orgdyn.2014.11.008</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Seijts</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name>
+							<surname>Gandz</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Crossan</surname>
+							<given-names>M.</given-names>
+						</name>
+						<name>
+							<surname>Reno</surname>
+							<given-names>M.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Character matters: character dimensions´ impact on leader performance and outcomes</article-title>
+					<source>Organizational Dynamics</source>
+					<volume>44</volume>
+					<issue>1</issue>
+					<fpage>65</fpage>
+					<lpage>74</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.orgdyn.2014.11.008">https://doi.org/10.1016/j.orgdyn.2014.11.008</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B66">
+				<mixed-citation>Shahab, S. O., &amp; Adil, A. (2020). Development and validation of Temperance Scale in Pakistan. PsyCh Journal, 9(6), 911-923. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1002/pchj.394">https://doi.org/10.1002/pchj.394</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Shahab</surname>
+							<given-names>S. O.</given-names>
+						</name>
+						<name>
+							<surname>Adil</surname>
+							<given-names>A.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Development and validation of Temperance Scale in Pakistan</article-title>
+					<source>PsyCh Journal</source>
+					<volume>9</volume>
+					<issue>6</issue>
+					<fpage>911</fpage>
+					<lpage>923</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1002/pchj.394">https://doi.org/10.1002/pchj.394</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B67">
+				<mixed-citation>Shanahan, K. J., &amp; Hyman, M. R. (2003). The Development of a Virtue Ethics Scale. Journal of Business Ethics, 42(2), 197-208. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1023/A:1021914218659">https://doi.org/10.1023/A:1021914218659</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Shanahan</surname>
+							<given-names>K. J.</given-names>
+						</name>
+						<name>
+							<surname>Hyman</surname>
+							<given-names>M. R.</given-names>
+						</name>
+					</person-group>
+					<year>2003</year>
+					<article-title>The Development of a Virtue Ethics Scale</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>42</volume>
+					<issue>2</issue>
+					<fpage>197</fpage>
+					<lpage>208</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1023/A:1021914218659">https://doi.org/10.1023/A:1021914218659</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B68">
+				<mixed-citation>Shanahan, K. J., &amp; Hopkins, C. D. (2019). Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent. Journal of Business Ethics, 159(3), 837-848. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-018-3813-6">https://doi.org/10.1007/s10551-018-3813-6</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Shanahan</surname>
+							<given-names>K. J.</given-names>
+						</name>
+						<name>
+							<surname>Hopkins</surname>
+							<given-names>C. D.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Level of Agreement Between Sales Managers and Salespeople on the Need for Internal Virtue Ethics and a Direct Path from Satisfaction with Manager to Turnover Intent</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>159</volume>
+					<issue>3</issue>
+					<fpage>837</fpage>
+					<lpage>848</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-018-3813-6">https://doi.org/10.1007/s10551-018-3813-6</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B69">
+				<mixed-citation>Sison, A. J. G., &amp; Ferrero, I. (2015). How different is neo-Aristotelian virtue from positive organizational virtuousness? Business Ethics: A European Review, 24(S2), S78-S98. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12099">https://doi.org/10.1111/beer.12099</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sison</surname>
+							<given-names>A. J. G.</given-names>
+						</name>
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>How different is neo-Aristotelian virtue from positive organizational virtuousness</article-title>
+					<source>Business Ethics: A European Review</source>
+					<volume>24</volume>
+					<issue>S2</issue>
+					<fpage>S78</fpage>
+					<lpage>S98</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1111/beer.12099">https://doi.org/10.1111/beer.12099</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B70">
+				<mixed-citation>Sison, A. J. G., Beabout, G. R., &amp; Ferrero, I. (Eds.). (2017). Handbook of virtue ethics in business and management. Dordrecht, the Netherlands: Springer. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sison</surname>
+							<given-names>A. J. G.</given-names>
+						</name>
+						<name>
+							<surname>Beabout</surname>
+							<given-names>G. R.</given-names>
+						</name>
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+					</person-group>
+					<year>2017</year>
+					<source>Handbook of virtue ethics in business and management</source>
+					<publisher-loc>Dordrecht, the Netherlands</publisher-loc>
+					<publisher-name>Springer</publisher-name>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/978-94-007-6510-8">https://doi.org/10.1007/978-94-007-6510-8</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B71">
+				<mixed-citation>Sison, A. J. G., Ferrero, I., &amp; Guitián, G. (Eds.). (2018). Business ethics: A virtue ethics and common good approach. New York, NY: Routledge.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sison</surname>
+							<given-names>A. J. G.</given-names>
+						</name>
+						<name>
+							<surname>Ferrero</surname>
+							<given-names>I.</given-names>
+						</name>
+						<name>
+							<surname>Guitián</surname>
+							<given-names>G.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<source>Business ethics: A virtue ethics and common good approach</source>
+					<publisher-loc>New York, NY</publisher-loc>
+					<publisher-name>Routledge</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B72">
+				<mixed-citation>Snyder, H. (2019). Literature review as a research methodology: An overview and guidelines. Journal of Business Research, 104, 333-339. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jbusres.2019.07.039">https://doi.org/10.1016/j.jbusres.2019.07.039</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Snyder</surname>
+							<given-names>H.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>Literature review as a research methodology: An overview and guidelines</article-title>
+					<source>Journal of Business Research</source>
+					<volume>104</volume>
+					<fpage>333</fpage>
+					<lpage>339</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.jbusres.2019.07.039">https://doi.org/10.1016/j.jbusres.2019.07.039</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B73">
+				<mixed-citation>Snow, N. E., Wright, J. C., &amp; Warren, M. T. (2020). Virtue Measurement: Theory and Applications. Ethical Theory and Moral Practice, 23, 277-293. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10677-019-10050-6">https://doi.org/10.1007/s10677-019-10050-6</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Snow</surname>
+							<given-names>N. E.</given-names>
+						</name>
+						<name>
+							<surname>Wright</surname>
+							<given-names>J. C.</given-names>
+						</name>
+						<name>
+							<surname>Warren</surname>
+							<given-names>M. T.</given-names>
+						</name>
+					</person-group>
+					<year>2020</year>
+					<article-title>Virtue Measurement: Theory and Applications</article-title>
+					<source>Ethical Theory and Moral Practice</source>
+					<volume>23</volume>
+					<fpage>277</fpage>
+					<lpage>293</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10677-019-10050-6">https://doi.org/10.1007/s10677-019-10050-6</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B74">
+				<mixed-citation>Sobral, F., &amp; Furtado, L. (2019). A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança. Revista de Administração de Empresas, 59(3), 209-214. <ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1590/S0034-759020190306">http://dx.doi.org/10.1590/S0034-759020190306</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Sobral</surname>
+							<given-names>F.</given-names>
+						</name>
+						<name>
+							<surname>Furtado</surname>
+							<given-names>L.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<article-title>A liderança pós-heroica: Tendências atuais e desafios para o ensino de liderança</article-title>
+					<source>Revista de Administração de Empresas</source>
+					<volume>59</volume>
+					<issue>3</issue>
+					<fpage>209</fpage>
+					<lpage>214</lpage>
+					<ext-link ext-link-type="uri" xlink:href="http://dx.doi.org/10.1590/S0034-759020190306">http://dx.doi.org/10.1590/S0034-759020190306</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B75">
+				<mixed-citation>Solomon, R. (1992). Corporate roles, personal virtues: An Aristotelean approach to business ethics. Business Ethics Quarterly, 2(3), 317-339. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/3857536">https://doi.org/10.2307/3857536</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Solomon</surname>
+							<given-names>R.</given-names>
+						</name>
+					</person-group>
+					<year>1992</year>
+					<article-title>Corporate roles, personal virtues: An Aristotelean approach to business ethics</article-title>
+					<source>Business Ethics Quarterly</source>
+					<volume>2</volume>
+					<issue>3</issue>
+					<fpage>317</fpage>
+					<lpage>339</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.2307/3857536">https://doi.org/10.2307/3857536</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B76">
+				<mixed-citation>Solomon, R. (1999). A better way to think about business: how personal integrity leads to corporate success. New York, NY: Oxford University Press.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Solomon</surname>
+							<given-names>R.</given-names>
+						</name>
+					</person-group>
+					<year>1999</year>
+					<source>A better way to think about business: how personal integrity leads to corporate success</source>
+					<publisher-loc>New York, NY</publisher-loc>
+					<publisher-name>Oxford University Press</publisher-name>
+				</element-citation>
+			</ref>
+			<ref id="B77">
+				<mixed-citation>Song, S. Y., &amp; Kim, Y. K. (2018). Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption? Journal of Business Ethics, 152(4), 1159-1175. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3331-3">https://doi.org/10.1007/s10551-016-3331-3</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Song</surname>
+							<given-names>S. Y.</given-names>
+						</name>
+						<name>
+							<surname>Kim</surname>
+							<given-names>Y. K.</given-names>
+						</name>
+					</person-group>
+					<year>2018</year>
+					<article-title>Theory of Virtue ethics: Do consumers’ good traits predict their socially responsible consumption</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>152</volume>
+					<issue>4</issue>
+					<fpage>1159</fpage>
+					<lpage>1175</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-016-3331-3">https://doi.org/10.1007/s10551-016-3331-3</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B78">
+				<mixed-citation>Stoeber, J., &amp; Yang, H. F. (2016). Moral perfectionism and moral values, virtues, and judgments: Further investigations. Personality and Individual Differences, 88(1), 6-11. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2015.08.031">https://doi.org/10.1016/j.paid.2015.08.031</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Stoeber</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Yang</surname>
+							<given-names>H. F.</given-names>
+						</name>
+					</person-group>
+					<year>2016</year>
+					<article-title>Moral perfectionism and moral values, virtues, and judgments: Further investigations</article-title>
+					<source>Personality and Individual Differences</source>
+					<volume>88</volume>
+					<issue>1</issue>
+					<fpage>6</fpage>
+					<lpage>11</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2015.08.031">https://doi.org/10.1016/j.paid.2015.08.031</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B79">
+				<mixed-citation>Thun, B., &amp; Kelloway, E. K. (2011). Virtuous leaders: Assessing character strengths in the workplace. Canadian Journal of Administrative Sciences, 28(3), 270-283. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1002/cjas.216">https://doi.org/10.1002/cjas.216</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Thun</surname>
+							<given-names>B.</given-names>
+						</name>
+						<name>
+							<surname>Kelloway</surname>
+							<given-names>E. K.</given-names>
+						</name>
+					</person-group>
+					<year>2011</year>
+					<article-title>Virtuous leaders: Assessing character strengths in the workplace</article-title>
+					<source>Canadian Journal of Administrative Sciences</source>
+					<volume>28</volume>
+					<issue>3</issue>
+					<fpage>270</fpage>
+					<lpage>283</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1002/cjas.216">https://doi.org/10.1002/cjas.216</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B80">
+				<mixed-citation>Wang, G., &amp; Hackett, R. D. (2016). Conceptualization and measurement of virtuous leadership: Doing well by doing good. Journal of Business Ethics, 137(2), 321-345. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-015-2560-1">https://doi.org/10.1007/s10551-015-2560-1</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Wang</surname>
+							<given-names>G.</given-names>
+						</name>
+						<name>
+							<surname>Hackett</surname>
+							<given-names>R. D.</given-names>
+						</name>
+					</person-group>
+					<year>2016</year>
+					<article-title>Conceptualization and measurement of virtuous leadership: Doing well by doing good</article-title>
+					<source>Journal of Business Ethics</source>
+					<volume>137</volume>
+					<issue>2</issue>
+					<fpage>321</fpage>
+					<lpage>345</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1007/s10551-015-2560-1">https://doi.org/10.1007/s10551-015-2560-1</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B81">
+				<mixed-citation>Yang, H., Stoeber, J., Wang, Y. (2015). Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation. Personality and Individual Differences, 75, 229-233. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2014.11.040">https://doi.org/10.1016/j.paid.2014.11.040</ext-link>
+				</mixed-citation>
+				<element-citation publication-type="journal">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Yang</surname>
+							<given-names>H.</given-names>
+						</name>
+						<name>
+							<surname>Stoeber</surname>
+							<given-names>J.</given-names>
+						</name>
+						<name>
+							<surname>Wang</surname>
+							<given-names>Y.</given-names>
+						</name>
+					</person-group>
+					<year>2015</year>
+					<article-title>Moral perfectionism and moral values, virtues, and judgments: a preliminary investigation</article-title>
+					<source>Personality and Individual Differences</source>
+					<volume>75</volume>
+					<fpage>229</fpage>
+					<lpage>233</lpage>
+					<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.paid.2014.11.040">https://doi.org/10.1016/j.paid.2014.11.040</ext-link>
+				</element-citation>
+			</ref>
+			<ref id="B82">
+				<mixed-citation>Zyl, L. van. (2019). Virtue ethics: A contemporary Introduction. New York, NY: Routledge.</mixed-citation>
+				<element-citation publication-type="book">
+					<person-group person-group-type="author">
+						<name>
+							<surname>Zyl</surname>
+							<given-names>L. van.</given-names>
+						</name>
+					</person-group>
+					<year>2019</year>
+					<source>Virtue ethics: A contemporary Introduction</source>
+					<publisher-loc>New York, NY</publisher-loc>
+					<publisher-name>Routledge</publisher-name>
+				</element-citation>
+			</ref>
+		</ref-list>
+		<fn-group>
+			<fn fn-type="other" id="fn1">
+				<label>JEL Code:</label>
+				<p>M1, M10.</p>
+			</fn>
+			<fn fn-type="other" id="fn4">
+				<label>Peer Review Report:</label>
+				<p>The Peer Review Report is available at this <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5281/zenodo.6608808">external URL</ext-link>.</p>
+			</fn>
+			<fn fn-type="financial-disclosure" id="fn6">
+				<label>Funding</label>
+				<p> The authors thank the Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development (CNPq) (CHSSA, Process nr. 445434/2015-5) for the financial support to the research project, from which this study was developed.</p>
+			</fn>
+			<fn fn-type="other" id="fn8">
+				<label>Plagiarism Check</label>
+				<p> The RAC maintains the practice of submitting all documents approved for publication to the plagiarism check, using specific tools, e.g.: iThenticate.</p>
+			</fn>
+			<fn fn-type="other" id="fn10">
+				<label>Copyrights</label>
+				<p> RAC owns the copyright to this content.</p>
+			</fn>
+			<fn fn-type="other" id="fn11">
+				<label>Peer Review Method</label>
+				<p> This content was evaluated using the double-blind peer review process. The disclosure of the reviewers' information on the first page, as well as the Peer Review Report, is made only after concluding the evaluation process, and with the voluntary consent of the respective reviewers and authors.</p>
+			</fn>
+			<fn fn-type="other" id="fn12">
+				<label>Data Availability</label>
+						<p>The authors claim that all data used in the research have been made publicly available through the Harvard Dataverse platform and can be accessed at:</p>
+						<p><inline-graphic xlink:href="1982-7849-rac-26-06-e190379-i001qr.tif"/>Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, &quot;Replication Data for &quot;Analysis of scales and measures of moral virtues: A systematic review&quot; published by RAC - Revista de Administração Contemporânea&quot;, Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</p>
+						<p>RAC encourages data sharing but, in compliance with ethical principles, it does not demand the disclosure of any means of identifying research subjects, preserving the privacy of research subjects. The practice of open data is to enable the reproducibility of results, and to ensure the unrestricted transparency of the results of the published research, without requiring the identity of research subjects. </p>
+			</fn>
+		</fn-group>
+	</back>
+	<sub-article article-type="translation" id="s1" xml:lang="pt">
+		<front-stub>
+			<article-id pub-id-type="doi">10.1590/1982-7849rac2022190379.por</article-id>
+			<article-categories>
+				<subj-group subj-group-type="heading">
+					<subject>Artigo Teórico-empírico</subject>
+				</subj-group>
+			</article-categories>
+			<title-group>
+				<article-title>Análise de Escalas e Medidas de Virtudes Morais: Uma Revisão Sistemática</article-title>
+			</title-group>
+			<contrib-group>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-0444-8764</contrib-id>
+					<name>
+						<surname>Ames</surname>
+						<given-names>Maria Clara F. Dalla Costa</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1s"><sup>1</sup></xref>
+					<xref ref-type="corresp" rid="c1s">*</xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0002-4852-5119</contrib-id>
+					<name>
+						<surname>Serafim</surname>
+						<given-names>Mauricio C.</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1s"><sup>1</sup></xref>
+				</contrib>
+				<contrib contrib-type="author">
+					<contrib-id contrib-id-type="orcid">0000-0003-2987-5479</contrib-id>
+					<name>
+						<surname>Martins</surname>
+						<given-names>Felipe Flôres</given-names>
+					</name>
+					<xref ref-type="aff" rid="aff1s"><sup>1</sup></xref>
+				</contrib>
+				<aff id="aff1s">
+					<label>1</label>
+					<institution content-type="original">Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas, Florianópolis, SC, Brasil.</institution>
+				</aff>
+			</contrib-group>
+			<author-notes>
+				<corresp id="c1s">
+					<label>*</label> Autora Correspondente</corresp>
+				<fn fn-type="edited-by" id="fn2s">
+					<label>Editores-chefes:</label>
+							<p>Wesley Mendes-da-Silva (Fundação Getulio Vargas, EAESP, Brasil)</p>
+							<p>Marcelo de Souza Bispo (Universidade Federal da Paraíba, PPGA, Brasil)</p>
+				</fn>
+				<fn fn-type="other" id="fn3s">
+					<label>Pareceristas:</label>
+							<p>Janaína Cássia Grossi (Fundação Getulio Vargas, EAESP, Brasil)</p>
+							<p>Claudio Zancan (Universidade Federal do Paraná, Brasil)</p>
+				</fn>
+				<fn fn-type="current-aff" id="fn5s">
+					<label>Autoria</label>
+							<p>Maria Clara Figueiredo Dalla Costa Ames*</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</p>
+							<p>E-mail: mariaclaraames@gmail.com</p>
+							<p>https://orcid.org/0000-0002-0444-8764</p>
+							<p>Mauricio C. Serafim</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</p>
+							<p>E-mail: serafim.esag@gmail.com</p>
+							<p>https://orcid.org/0000-0002-4852-5119</p>
+							<p>Felipe Flôres Martins</p>
+							<p>Universidade do Estado de Santa Catarina, Centro de Ciências da Administração e Socioeconômicas</p>
+							<p>Avenida Madre Benvenuta, n. 2037, Itacorubi, 88035-001, Florianópolis, SC, Brasil</p>
+							<p>E-mail: martins.felipef@gmail.com</p>
+							<p>https://orcid.org/0000-0003-2987-5479</p>
+				</fn>
+				<fn fn-type="conflict" id="fn7s">
+					<label>Conflito de Interesses</label>
+					<p> Os autores informaram que não há conflito de interesses.</p>
+				</fn>
+				<fn fn-type="con" id="fn10s">
+					<label>Contribuições dos Autores</label>
+							<p>1<sup>ª</sup> autora: conceituação (liderança); curadoria de dados (liderança); análise formal (liderança); investigação (igual); metodologia (liderança); recursos (igual); software (igual); supervisão (igual); validação (igual); escrita - rascunho original (igual); escrita - revisão e edição (igual).</p>
+							<p>2<sup>º</sup> autor: conceituação (suporte); curadoria de dados (suporte); análise formal (suporte); investigação (suporte); metodologia (suporte); administração de projeto (suporte); supervisão (suporte); validação (igual); escrita - rascunho original (suporte); escrita - revisão e edição (igual).</p>
+							<p>3<sup>º</sup> autor: conceituação (suporte); análise formal (suporte); investigação (suporte); metodologia (suporte); validação (suporte); escrita - rascunho original (igual); escrita - revisão e edição (suporte).</p>
+				</fn>
+			</author-notes>
+			<abstract>
+				<title>RESUMO</title>
+				<sec>
+					<title>Objetivo:</title>
+					<p> investigar como as escalas para o conceito de virtudes morais são construídas e mensuradas, em estudos associados à ética empresarial e à tradição da ética das virtudes. </p>
+				</sec>
+				<sec>
+					<title>Métodos:</title>
+					<p> realizou-se uma revisão sistemática da literatura para selecionar artigos empíricos sobre virtudes morais que elaboram ou aplicam escalas. Com base em critérios de busca, seleção e análise, foram consultadas cinco bases de dados e selecionados 37 trabalhos, analisando-se o procedimento de desenvolvimento e mensuração de escalas (itens, amostra, análise fatorial) e fatores emergentes. </p>
+				</sec>
+				<sec>
+					<title>Resultados:</title>
+					<p> o estudo reúne escalas de múltiplas virtudes morais (19) e de virtudes específicas (18), evidenciando limitações na geração de itens e na proporção item-amostra em algumas escalas, como também contribuições teóricas em liderança e fortalecimento de relações, fazendo uma discussão teórico-metodológica, à luz dos pressupostos da ética das virtudes na tradição aristotélico-tomista. </p>
+				</sec>
+				<sec>
+					<title>Conclusões:</title>
+					<p> o artigo intenciona contribuir para uma melhor compreensão sobre as virtudes morais em administração, ao discutir as escalas a partir da unidade das virtudes e da conexão <italic>phronesis</italic>-virtudes morais, com implicações no comportamento humano e na ética empresarial. Recomendam-se procedimentos para estudos futuros qualitativos e quantitativos em novos contextos de pesquisa.</p>
+				</sec>
+			</abstract>
+			<kwd-group xml:lang="pt">
+				<title>Palavras-chave:</title>
+				<kwd>virtudes morais</kwd>
+				<kwd>análise de escalas</kwd>
+				<kwd>ética das virtudes</kwd>
+				<kwd>ética empresarial</kwd>
+			</kwd-group>
+		</front-stub>
+		<body>
+			<sec sec-type="intro">
+				<title>INTRODUÇÃO</title>
+				<p>A ética das virtudes tem se revelado nos últimos anos uma influente tradição nos estudos sobre ética empresarial (<xref ref-type="bibr" rid="B4">Alzola, Hennig, &amp; Romar, 2020</xref>). O interesse pelo tema tem se intensificado desde a reinterpretação de Aristóteles (2009) por autores da filosofia moral, como <xref ref-type="bibr" rid="B7">Anscombe (1958</xref>) e MacIntyre (2007). Os problemas éticos da realidade organizacional têm sido discutidos por diferentes perspectivas e tradições relacionadas às virtudes (<xref ref-type="bibr" rid="B71">Sison, Ferrero, &amp; Guitián, 2018</xref>), como alternativa às éticas consequencialistas e deontológicas, sendo a corrente de estudos empíricos e quantitativos um tema proeminente da área desde a virada do milênio (Sison &amp; Ferrero, 2015).</p>
+				<p>Essa corrente tem elaborado escalas e medidas, tendo por base as listas de virtudes morais propostas por <xref ref-type="bibr" rid="B75">Solomon (1992</xref>; 1999) e <xref ref-type="bibr" rid="B53">Murphy (1999</xref>). Tais estudos visam a identificar e mensurar virtudes morais no contexto da administração e negócios. No entanto, tem-se criticado o uso de certos métodos científicos das ciências sociais (<xref ref-type="bibr" rid="B69">Beadle, Sison, &amp; Fontrodona, 2015</xref>), empregados para abordar virtudes morais, um conceito de raiz filosófica e valorado por muitas culturas. Nesse processo, elementos e pressupostos podem ser reduzidos a meros comportamentos observáveis, o que pode prejudicar uma melhor compreensão das virtudes (Sison &amp; Ferrero, 2015; <xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). Isso vem reforçando a necessidade de uma sólida base teórica sobre o construto virtudes morais em sua multidimensionalidade (<xref ref-type="bibr" rid="B1">Aguirre-Y-Luker, Hyman, &amp; Shanahan, 2017</xref>).</p>
+				<p>Além de virtudes morais individuais, outro construto desenvolvido se refere às virtudes morais organizacionais, ou virtuosidade (<xref ref-type="bibr" rid="B35">Huhtala, Kangas, Kaptein, &amp; Feldt, 2018</xref>; <xref ref-type="bibr" rid="B28">Gomide, Vieira, &amp; Oliveira, 2016</xref>; <xref ref-type="bibr" rid="B60">Rego &amp; Cunha, 2015</xref>). Apesar de sua estrita relação, os conceitos de virtude moral e virtuosidade não são idênticos: o primeiro se refere ao indivíduo, enquanto o segundo à organização, ao que pode ser externamente verificado (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>; <xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Dessa maneira, há escalas de virtudes morais em âmbito individual e outras em âmbito de grupo e organizacional (<italic>virtuousness</italic>), como as revisitadas por <xref ref-type="bibr" rid="B20">Dawson (2018</xref>) e <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker, Hyman e Shanahan (2017</xref>). Este artigo limita-se a investigar escalas de virtudes morais em âmbito individual, isto é, relacionadas às características de um único indivíduo, deixando as escalas de virtuosidade para uma futura pesquisa.</p>
+				<p>O tema dispõe de diferentes tradições teóricas (<xref ref-type="bibr" rid="B71">Sison et al., 2018</xref>) e amplas listas de virtudes. Embora a concepção de virtudes contemple seus componentes ou dimensões (<xref ref-type="bibr" rid="B54">Newstead, Macklin, Dawkins, &amp; Martin, 2018</xref>), a pesquisa empírica tem se restringido a traços ou comportamentos observáveis, revelando um impasse metodológico na relação entre a ética das virtudes - com origem na filosofia moral - e as ciências experimentais, como certas ramificações na psicologia. Diante do desenvolvimento de novas escalas sobre virtudes, este trabalho se propõe a responder à seguinte pergunta: ‘Como as escalas para o construto virtudes morais são construídas e mensuradas em estudos associados à ética das virtudes?’ O presente artigo visa a analisar as escalas e medidas do construto virtudes morais individuais (pessoais), partindo de uma revisão sistemática da literatura (<xref ref-type="bibr" rid="B72">Snyder, 2019</xref>).</p>
+				<p>Dois trabalhos antecedentes contribuem nesse sentido. <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al. (2017</xref>) abordam desafios, possibilidades e cuidados para o desenvolvimento de escalas, descrevendo escalas, itens e aspectos psicométricos, enquanto <xref ref-type="bibr" rid="B20">Dawson (2018</xref>) lista escalas de virtudes morais individuais, de grupo e organizacionais.</p>
+				<p>O artigo em curso pretende dar continuidade a esses trabalhos ao fazer uma revisão sistemática de artigos que desenvolvem ou aplicam escalas a partir dos Principais Itens para Relatar Revisões Sistemáticas e Meta-Análises, de <xref ref-type="bibr" rid="B49">Moher, Liberati, Tetslaff e Altman (2009</xref>), seguida de uma análise estatística segundo recomendações de <xref ref-type="bibr" rid="B24">Fávero, Belfiore, Silva e Chan (2009</xref>), <xref ref-type="bibr" rid="B31">Hair, Babin, Money e Samouel (2005</xref>) e Hair, Black, Babin, Anderson e Tathan (2009).</p>
+				<p>O trabalho procura contribuir com a análise de métodos empregados para elaboração e aplicação de escalas de virtudes morais, diante do impasse metodológico para pesquisas empíricas sobre a ética das virtudes. Isso é realizado e discutido metodológica e teoricamente, considerando pressupostos da ética das virtudes na tradição aristotélico-tomista (<xref ref-type="bibr" rid="B70">Sison, Beabout, &amp; Ferrero, 2017</xref>).</p>
+				<p>As próximas seções deste artigo estão assim organizadas. Primeiro, discute-se o conceito de virtudes morais, considerando pressupostos da ética das virtudes e perspectivas que buscam mensurar virtudes. Na sequência, descrevem-se os procedimentos para a revisão sistemática de artigos, bem como critérios de análise. Na seção seguinte são apresentados os resultados e análises das medidas e escalas encontradas, seguidos de uma discussão sobre métodos e pressupostos teóricos e de sugestões de estudos futuros. Ao final, consideram-se as limitações e conclusões de pesquisa. </p>
+			</sec>
+			<sec>
+				<title><bold>VIRTUDES MORAIS SEGUNDO A TRADIÇÃO DA ÉTICA DAS VIRTUDES EM <italic>BUSINESS ETHICS</italic>
+</bold></title>
+				<p>A retomada ou reinterpretação das virtudes morais na filosofia, psicologia, educação e ética empresarial é tributária ao trabalho de autores como Elizabeth <xref ref-type="bibr" rid="B7">Anscombe (1958</xref>), Philippa <xref ref-type="bibr" rid="B27">Foot (1967</xref>) e Alasdair MacIntyre (2007), os quais retomam conceitos aristotélicos e tomistas. A ética das virtudes tem sido desenvolvida por meio de várias perspectivas, tanto ocidentais como orientais (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>), que se desenvolveram a partir de tradições morais, relacionadas a questões éticas de organizações e de diferentes funções da administração (<xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). </p>
+				<p>O interesse pela ética das virtudes tem se evidenciado em conferências, simpósios temáticos e chamadas especiais de trabalho (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>; <xref ref-type="bibr" rid="B12">Beadle et al., 2015</xref>; Hühn, Habisch, <xref ref-type="bibr" rid="B36">Hartmann, &amp; Sison, 2020</xref>), <italic>handbooks</italic> de ética das virtudes na Administração (Sison et al., 2017), publicação de livros (Hartmann, 2020; <xref ref-type="bibr" rid="B50">Moore, 2017</xref>; Sison et al., 2018) e na formação de grupos de pesquisa, como o <italic>Virtue Ethics in Business</italic> (VEiB), da Universidade de Navarra. Adicionalmente, revistas como o <italic>Journal of Business Ethics</italic>, o <italic>Business Ethics Quarterly</italic> e o <italic>Business Ethics: Environment and Responsibility</italic> reúnem muitas questões que abordam a ética das virtudes. </p>
+				<p>Os estudos sobre as virtudes podem ser vinculados a duas distintas perspectivas: teoria da virtude e ética das virtudes (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). São chamados de teoria da virtude os estudos sobre virtudes internas aos modelos deontológicos e consequencialistas. Diferentemente, a ética das virtudes é adotada como uma terceira perspectiva na filosofia moral, para representar estudos centrados no caráter, ancorados no tripé <italic>arête</italic> (virtude ou excelência), <italic>phronesis</italic> (prudência ou sabedoria prática) e <italic>eudaimonia</italic> (florescimento humano). Enquanto as perspectivas dentológicas e consequencialistas têm como referência a ação, a ética das virtudes enfoca no agente, considerando as particularidades contextuais que vivencia em comunidade (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>).</p>
+				<p>
+					<xref ref-type="bibr" rid="B75">Solomon (1992</xref>) e <xref ref-type="bibr" rid="B48">Moberg (1999</xref>) foram precursores na consideração da ética das virtudes na ética empresarial. Solomon (1992) tentou abordar a lacuna entre ética e prática nos negócios por meio de uma perspectiva baseada em Aristóteles (<xref ref-type="bibr" rid="B4">Alzola et al., 2020</xref>), com a ideia de que as pessoas e as corporações fazem parte da comunidade. Moberg (1999) explorou a conexão entre ética das virtudes e psicologia da personalidade, abrindo caminho para as pesquisas empíricas sobre ética das virtudes na ética empresarial.</p>
+				<p>As virtudes morais são geralmente descritas como disposições do caráter responsáveis por indicar os corretos fins das ações, enquanto a prudência ou <italic>practical wisdom</italic> (<italic>phronesis</italic>) é a virtude responsável por indicar os meios para a consecução de tais fins (<xref ref-type="bibr" rid="B5">Ames &amp; Serafim, 2019</xref>; Aristóteles, 2009; <xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). No momento em que ações virtuosas, como coragem e humildade, começam a ser repetidas, tornam-se hábitos de alguém, e no longo prazo isso determina o seu caráter. O agente virtuoso é aquele que expressa virtudes em suas ações, e por isso suas ações e seus traços pessoais podem servir como referência para os demais (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). Tais ações são fruto de uma vontade ou intenção, a qual tem um fim, ou <italic>telos</italic>, voltado para o alcance da <italic>eudaimonia</italic>. Ao realizar ações virtuosas, o ser humano se aprimora, assim como as suas ações. Dessa forma, “o núcleo central da ética das virtudes reside na relação causal que se estabelece entre o que o agente faz e o que o agente se torna, por meio da aquisição de virtudes e do desenvolvimento do caráter” (Ferrero, 2020, p. 11).</p>
+				<p>Entre suas principais tradições, pode-se destacar a tradição neoaristotélica, a escola tomista e as contribuições de MacIntyre (2007), o qual se aprofunda na ética de Aristóteles e Tomás de Aquino (<xref ref-type="bibr" rid="B82">Zyl, 2019</xref>). Estudos recentes compartilham da noção de virtudes cardeais - um “eixo principal” de virtudes - herdadas dessas tradições (<xref ref-type="bibr" rid="B51">Morales-Sánchez &amp; Cabello-Medina, 2013</xref>). As virtudes cardeais são um grupo de quatro virtudes: (1) temperança, também conhecida como autodomínio ou moderação (<xref ref-type="bibr" rid="B63">Sanz &amp; Fontrodona, 2019</xref>); (2) fortaleza ou coragem; (3) justiça (Morales-Sánchez &amp; Cabello-Medina, 2013); e (4) prudência ou sabedoria prática, originalmente do grego <italic>phronesis</italic> (<xref ref-type="bibr" rid="B6">Ames, Serafim, &amp; Zappellini, 2020</xref>; <xref ref-type="bibr" rid="B10">Bachmann, Habisch, &amp; Dierksmeier, 2017</xref>). Tais tradições consideram que as virtudes podem ser aprendidas, especialmente pela experiência vivida (Aristóteles, 2009).</p>
+				<p>Pressupondo que a ação virtuosa de alguém pode ser percebida pelos demais agentes, estudos que utilizam escalas buscam mensurar a percepção das virtudes morais sobre a ação de colegas, líderes e administradores de uma forma geral. A lista de virtudes de <xref ref-type="bibr" rid="B75">Solomon (1992</xref>; 1999) contribuiu nesse sentido. Seu arcabouço considera seis dimensões: comunidade, excelência, identidade do papel ou cargo, integridade, julgamento e holismo. Ele sugere uma lista de virtudes relacionadas à esfera dos negócios - honestidade, lealdade, sinceridade, coragem, confiabilidade, benevolência, cooperação, civilidade, para citar algumas - as quais servem de base para a escala de virtudes morais de <xref ref-type="bibr" rid="B67">Shanahan e Hyman (2003</xref>). Contudo, discute-se em que medida um grupo de virtudes pode ser associado à administração e negócios, sem que se considere adicionalmente o contexto e a percepção dos próprios administradores sobre virtudes a cultivar (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>).</p>
+				<p>Além desse problema empírico, a psicologia positiva e a <italic>positive organizational scholarship</italic> (POS) limitam a definição de virtudes em termos de comportamento e por aspectos externos ao indivíduo (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>; <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al., 2017</xref>). <xref ref-type="bibr" rid="B69">Sison e Ferrero (2015</xref>) argumentam que não se pode reduzi-las aos aspectos cognitivos e emocionais do caráter, pois envolvem outros elementos e pressupostos fundamentais, como a inter-relação entre ações, hábitos, caráter e trajetória de vida. Isso pressupõe uma natureza humana que tem por fim (<italic>telos</italic>) a felicidade (<italic>eudaimonia</italic>) ou florescimento humano.</p>
+				<p>Não há um conceito unânime para a virtude, haja vista as contribuições de diferentes tradições e campos do saber. Ainda assim, ela tende a ser vista como “uma inclinação [ou disposição] humana para sentir, pensar e agir de forma a expressar a excelência moral e contribuir para o bem comum” (<xref ref-type="bibr" rid="B54">Newstead et al., 2018</xref>, p. 446, tradução nossa). Considera-se que seus componentes intelectual, emocional, motivacional e comportamental “não são redutíveis um ao outro” (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>, p. 306, tradução nossa), algo similar aos multicomponentes percebidos por <xref ref-type="bibr" rid="B52">Morgan, Gulliford e Kristjánsson (2017</xref>). Na ética das virtudes, são entendidas como inclinações ou disposições pessoais expressas por uma gama de disposições: ações, hábitos, caráter e estilo de vida (forma de viver), com vistas ao bem comum (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Por isso, tem-se admitido que a manifestação comportamental de uma ação não é suficiente para inferir a presença de virtude (Alzola, 2015; <xref ref-type="bibr" rid="B62">Robson, 2015</xref>).</p>
+				<p>
+					<xref ref-type="bibr" rid="B54">Newstead, Macklin, Dawkins e Martin (2018</xref>) desdobram o conceito em <italic>virtue</italic> (a inclinação virtuosa em si), <italic>virtues</italic> e <italic>virtuous</italic>, este último correspondendo à percepção frente a um evento virtuoso, descrito como uma experiência subjetiva experienciada, uma interpretação que um agente faz sobre a virtude expressada por alguém (<italic>virtues</italic>) em um evento/momento.</p>
+				<p>Como exposto, o arcabouço da ética das virtudes reúne elementos teóricos e pressupostos fundamentais. Entre seus elementos estão: o agente humano e sua natureza, ações e hábitos morais reiterados que formam o seu caráter, a prática de virtudes morais, coordenadas pela sabedoria prática ou prudência, um fim último voltado para o florescimento humano ou <italic>eudaimonia</italic>, em um contexto comunitário em que se contribui para o bem comum. Entre seus pressupostos, dois deles merecem destaque e estão relacionados: (1) a conexão ou interdependência entre a virtude da <italic>phronesis</italic> e as virtudes morais - por exemplo, para ser prudente em decisões é preciso que a temperança contenha os impulsos que afetariam tal decisão, como a raiva ou a impaciência; e (2) a unidade das virtudes: no agente as virtudes estão vinculadas umas às outras - isto é, não há virtude isolada -, o que significa que se uma pessoa tem uma virtude, ela também tem as outras (<xref ref-type="bibr" rid="B82">Zyl, 2019</xref>).</p>
+				<sec>
+					<title>Perspectivas que buscam mensurar virtudes morais</title>
+					<p>Em administração, os estudos da ética das virtudes se ramificaram para uma corrente que emprega métodos quantitativos e estatísticos no intuito de mensurar virtudes e seus impactos positivos nas organizações (<xref ref-type="bibr" rid="B25">Ferrero &amp; Sison, 2014</xref>). Tal corrente está inserida no campo da psicologia positiva e é chamada de <italic>positive organizational scholarship</italic> (POS) (Sison &amp; Ferrero, 2015; <xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). Essa corrente se ramifica em duas perspectivas que buscam mensurar virtudes: (1) uma atrelada à psicologia positiva de <xref ref-type="bibr" rid="B56">Peterson e Seligman (2004</xref>) e de abordagem em nível individual, correspondente a um movimento positivo nas ciências sociais (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>); e (2) os estudos que assumem o conceito de <italic>virtuousness</italic> ou virtuosidade, para acessar virtudes em âmbito organizacional (Meyer, 2018; <xref ref-type="bibr" rid="B35">Huhtala et al., 2018</xref>). </p>
+					<p>Essas duas correntes buscam mensurar virtudes, adotando métodos e assumindo pressupostos distintos daqueles compartilhados pela tradição aristotélico-tomista da ética das virtudes (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B47">Meyer, 2018</xref>).</p>
+					<p>A primeira é atrelada à psicologia positiva e considera as forças do caráter como traços positivos dos indivíduos. O modelo de <xref ref-type="bibr" rid="B56">Peterson e Seligman (2004</xref>) foi desenvolvido a partir da leitura de textos clássicos de diferentes culturas, revisados pelo grupo de pesquisa dedicado a tais estudos, reunindo indutivamente as características humanas que levam ao florescimento. Há diferenças entre o conceito de virtudes e de forças do caráter (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>). O modelo VIA - virtudes em ação - é composto por seis principais características (virtudes) e 24 forças. Contudo, esse modelo tem sido metodológica e filosoficamente questionado. Ele não assume o pressuposto da unidade das virtudes (<xref ref-type="bibr" rid="B62">Robson, 2015</xref>). <xref ref-type="bibr" rid="B39">Kinghorn (2017</xref>) elucida como o modelo foi construído e argumenta que não oferece condições para se dizer universal ou válido independentemente do contexto cultural. Tal modelo acolhe valores da sociedade democrática moderna, na qual se privilegia a autodeterminação dos indivíduos, seus direitos e liberdades (Kinghorn, 2017). O autor conclui que não há como um grupo de virtudes transcender a comunidade política particular na qual foi pensado, o que implica que o contexto particular importa e futuros instrumentos deveriam considerar a cultura do contexto e comunidade em análise. </p>
+					<p>A segunda é a corrente de estudos organizacionais positivos (EOP) e utiliza o conceito de virtuosidade, o qual não é idêntico à noção de virtude (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). A virtuosidade é manifesta em estruturas, processos, atributos e culturas, bem como na ação individual e coletiva, e é expresso na e por meio das organizações (<xref ref-type="bibr" rid="B16">Cameron, Bright, &amp; Caza, 2004</xref>; Sison &amp; Ferrero, 2015). Ela é entendida como um aspecto que contribui para a performance organizacional, o que pode vir a ser usado instrumentalmente para alcançar bons indicadores de comprometimento, satisfação e capital social (Sison &amp; Ferrero, 2015). Nessa abordagem, o conceito de virtuosidade é investigado predominantemente por métodos quantitativos e em âmbito organizacional (<xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). Além disso, essa corrente não trata do papel da <italic>phronesis</italic> em seu arcabouço para compreender a virtuosidade em organizações (Sison &amp; Ferrero, 2015). </p>
+					<p>
+						<xref ref-type="bibr" rid="B69">Sison e Ferrero (2015</xref>) ainda remetem às diferenças conceituais. Afirmam que os pressupostos sobre a natureza humana, fim último, <italic>phronesis</italic> e <italic>eudaimonia</italic> subjacentes à virtuosidade são muito diferentes da ética das virtudes, bem como o <italic>locus</italic> de realização: as virtudes são encontradas nas pessoas e apenas por analogia se associam a conceitos como os de caráter corporativo. Por outro lado, a virtuosidade se refere a organizações primeiramente e apenas secundariamente a indivíduos (<xref ref-type="bibr" rid="B47">Meyer, 2018</xref>). </p>
+					<p>Entre os críticos da ética das virtudes, <xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al. (2017</xref>) expõem que a crítica situacionista não reconhece a necessidade de se conhecer fatores internos inerentes ao comportamento. Diferentemente, <xref ref-type="bibr" rid="B3">Alzola (2017</xref>) argumenta que as virtudes morais podem ajudar na compreensão das ações dos indivíduos. Apesar da diversidade e desafios empíricos, ainda são necessárias adaptações para diferentes contextos e culturas (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). E afinal, virtudes podem ser mensuradas? Não há consenso sobre essa questão. <xref ref-type="bibr" rid="B62">Robson (2015</xref>) argumenta que a psicologia positiva é capaz de mensurar traços de personalidade e tendências de comportamento, mas não é capaz de articular virtudes, porque não pode propor um tipo de arquitetura substantiva, para dar suporte a uma abordagem de virtudes a partir de uma tradição, como a ética das virtudes.</p>
+				</sec>
+			</sec>
+			<sec sec-type="methods">
+				<title>PROCEDIMENTOS METODOLÓGICOS</title>
+				<p>Esta seção apresenta os procedimentos de busca e análise desta revisão sistemática, empregados para sintetizar e comparar evidências (Mendes-da-Silva, 2019; <xref ref-type="bibr" rid="B72">Snyder, 2019</xref>). São descritos etapas, procedimentos e critérios de busca e seleção de estudos, de análise metodológico-teórica e de apresentação dos resultados. Partiu-se da formulação da pergunta central sobre o fenômeno de interesse (Mendes-da-Silva, 2019). Os principais itens e os critérios de elegibilidade adotados para esta revisão sistemática visam a empregar um procedimento replicável e transparente (<xref ref-type="bibr" rid="B49">Moher, Liberati, Tetslaff, &amp; Altman, 2009</xref>). Os critérios de elegibilidade são: </p>
+				<p>
+					<list list-type="order">
+						<list-item>
+							<p>Tipo de estudo: pesquisas empíricas que desenvolvem ou aplicam escalas e medidas de virtudes morais em âmbito individual, sendo esse o critério de seleção. </p>
+						</list-item>
+						<list-item>
+							<p>Critérios de exclusão: (a) pesquisas de outras áreas, como a médica e jurídica; (b) trabalhos que não abordam virtudes diretamente; (c) estudos teóricos ou empíricos que não abordam o construto por meio de escalas; (d) pesquisas empíricas que desenvolvam ou apliquem escalas de virtudes em âmbito organizacional (virtuosidade).</p>
+						</list-item>
+						<list-item>
+							<p>Tópico: a identificação e seleção dos trabalhos é feita por uma leitura nos títulos e resumos, palavras-chave e revistas. </p>
+						</list-item>
+						<list-item>
+							<p>Design de pesquisa: estudos empíricos que relatam o desenvolvimento, aplicação e resultados obtidos com o uso de escalas de virtudes em nível individual. </p>
+						</list-item>
+						<list-item>
+							<p>Recorte temporal: sem recortes temporais. </p>
+						</list-item>
+						<list-item>
+							<p>Idioma: acolhem-se trabalhos em português, inglês e espanhol. </p>
+						</list-item>
+						<list-item>
+							<p>Status da publicação: artigos científicos revisados por pares.</p>
+						</list-item>
+						<list-item>
+							<p>Critérios de busca: consultas às bases de dados eletrônicas e, complementarmente, inclusão de estudos citados pelos estudos selecionados, ainda não integrantes da amostra. A primeira etapa ocorreu no mês de junho de 2017 e atualizações foram realizadas em 2018 e fevereiro de 2021. A busca foi realizada em cinco bases de dados: <italic>EBSCOhost, Science Direct, Scopus, Web of Science</italic> e <italic>Wiley</italic>.</p>
+						</list-item>
+					</list>
+				</p>
+				<p>Com o intuito de ampliar o alcance das buscas, empregaram-se cinco <italic>queries</italic> diferentes, compostos por dois termos: o primeiro referente a escalas e mensuração e o segundo às virtudes, conforme detalhado na <xref ref-type="table" rid="t1s">Tabela 1</xref>.</p>
+				<p>
+					<table-wrap id="t1s">
+						<label>Tabela 1</label>
+						<caption>
+							<title>Número de referências por base de dados, <italic>query</italic> e formato de busca.</title>
+						</caption>
+						<table>
+							<colgroup>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+							</colgroup>
+							<thead>
+								<tr>
+									<th align="center">Forma</th>
+									<th align="center"><bold>
+ <italic>Query</italic> de busca</bold></th>
+									<th align="center"><italic>Ebsco</italic></th>
+									<th align="center"><italic>Science Direct</italic></th>
+									<th align="center"><italic>Scopus</italic></th>
+									<th align="center"><italic>Web of Science</italic></th>
+									<th align="center"><italic>Wiley</italic></th>
+									<th align="center">Total</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td align="center" rowspan="5">Todo o conteúdo</td>
+									<td align="left">1 <italic>“Scale development” AND “virtue* ethic*”</italic></td>
+									<td align="center">3</td>
+									<td align="center">0</td>
+									<td align="center">2</td>
+									<td align="center">2</td>
+									<td align="center">100</td>
+									<td align="center">107</td>
+								</tr>
+								<tr>
+									<td align="left">2<italic>. “scale*” AND “virtue* ethic*”</italic></td>
+									<td align="center">11</td>
+									<td align="center">1</td>
+									<td align="center">16</td>
+									<td align="center">14</td>
+									<td align="center">-</td>
+									<td align="center">42</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>3. “scale*” AND “moral virtues”</italic></td>
+									<td align="center">-</td>
+									<td align="center">116</td>
+									<td align="center">5</td>
+									<td align="center">34</td>
+									<td align="center">-</td>
+									<td align="center">155</td>
+								</tr>
+								<tr>
+									<td align="left">4<italic>. “scale development” AND “moral virtues”</italic></td>
+									<td align="center">12</td>
+									<td align="center">1</td>
+									<td align="center">-</td>
+									<td align="center">8</td>
+									<td align="center">65</td>
+									<td align="center">86</td>
+								</tr>
+								<tr>
+									<td align="left">5. <italic>“measur*” AND “moral virtues”</italic></td>
+									<td align="center">-</td>
+									<td align="center">-</td>
+									<td align="center">22</td>
+									<td align="center">7</td>
+									<td align="center">-</td>
+									<td align="center">29</td>
+								</tr>
+								<tr>
+									<td align="center" rowspan="5">Abstract</td>
+									<td align="left">1. <italic>“Scale development” AND “virtue* ethic*”</italic></td>
+									<td align="center">-</td>
+									<td align="center">-</td>
+									<td align="center">4</td>
+									<td align="center">1</td>
+									<td align="center">1</td>
+									<td align="center">6</td>
+								</tr>
+								<tr>
+									<td align="left">2. <italic>“scale*” AND “virtue* ethic*”</italic></td>
+									<td align="center">2</td>
+									<td align="center">3</td>
+									<td align="center">66</td>
+									<td align="center">14</td>
+									<td align="center">17ª</td>
+									<td align="center">102</td>
+								</tr>
+								<tr>
+									<td align="left">3<italic>. “scale*” AND “moral virtues”</italic></td>
+									<td align="center">16ª</td>
+									<td align="center">1</td>
+									<td align="center">42</td>
+									<td align="center">8</td>
+									<td align="center">25ª </td>
+									<td align="center">92</td>
+								</tr>
+								<tr>
+									<td align="left">4<italic>. “scale development” AND “moral virtues”</italic></td>
+									<td align="center">-</td>
+									<td align="center">-</td>
+									<td align="center">4</td>
+									<td align="center">2</td>
+									<td align="center">1</td>
+									<td align="center">7</td>
+								</tr>
+								<tr>
+									<td align="left">5. <italic>“measur*” AND “moral virtues”</italic></td>
+									<td align="center">21ª </td>
+									<td align="center">16ª </td>
+									<td align="center">79</td>
+									<td align="center">8</td>
+									<td align="center">15</td>
+									<td align="center">139</td>
+								</tr>
+								<tr>
+									<td align="left"> </td>
+									<td align="center">Total</td>
+									<td align="center">65</td>
+									<td align="center">138</td>
+									<td align="center">240</td>
+									<td align="center">98</td>
+									<td align="center">224</td>
+									<td align="center">765</td>
+								</tr>
+							</tbody>
+						</table>
+						<table-wrap-foot>
+							<fn id="TFN5">
+								<p>Nota. <sup>a</sup> Buscas com primeiro termo do <italic>query</italic> de busca no <italic>abstract</italic> e o segundo em todo o conteúdo do artigo.</p>
+							</fn>
+						</table-wrap-foot>
+					</table-wrap>
+				</p>
+				<p>Até 2018 foram selecionadas 517 referências e, com a adição de 248 referências em fevereiro de 2021, foram totalizadas 765. Com a experiência das primeiras etapas, optou-se por fazer a atualização de 2021 restringindo-se a buscas no <italic>abstract</italic>. Além delas, alguns artigos foram adicionados à amostra manualmente (n=3), encontrados a partir do trabalho de buscas e leitura, indicado na Etapa 2 no fluxo do processo de seleção, na <xref ref-type="fig" rid="f1s">Figura 1</xref>. Atentou-se para as publicações das revistas <italic>Journal of Business Ethics</italic>, <italic>Business Ethics: Environment and Responsibilty</italic> e <italic>Business Ethics Quarterly,</italic> para assegurar a seleção de artigos da área.</p>
+				<p>
+					<fig id="f1s">
+						<label>Figura 1</label>
+						<caption>
+							<title>Fluxo do processo de seleção, segundo modelo de <xref ref-type="bibr" rid="B49">Moher et al. (2009</xref>).</title>
+						</caption>
+						<graphic xlink:href="1982-7849-rac-26-06-e190379-gf1-pt.tif"/>
+					</fig>
+				</p>
+				<p>As referências foram exportadas para o organizador de referências EndNote 8, na primeira etapa, e Mendeley na última seleção. O processo de seleção durante as etapas foi o mesmo: primeiro, a retirada dos registros repetidos; segundo, a leitura de títulos, resumos, palavras-chave e nome da revista, aplicando os critérios de elegibilidade. A <xref ref-type="fig" rid="f1s">Figura 1</xref> apresenta o fluxo do processo de seleção até chegar-se ao número de artigos incluídos na amostra, ou seja, 37 artigos que desenvolvem ou aplicam escalas de virtudes morais em nível individual.</p>
+				<p>Conforme a <xref ref-type="fig" rid="f1s">Figura 1</xref>, oito artigos entre os disponíveis tratavam de outros construtos e outros oito abordavam escalas de virtuosidade, ou virtude em âmbito organizacional, que não é o foco desta revisão. As razões dessa opção remetem aos pressupostos distintos entre o conceito de virtuosidade e virtudes morais a partir do arcabouço da ética das virtudes (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B47">Meyer, 2018</xref>) e, além disso, seu foco de análise é em âmbito organizacional, ou seja, focam no que é objetivamente verificável, naquilo expresso na e por meio da organização, como nos elementos de estrutura e cultura (Meyer, 2018). </p>
+				<p>Para uma discussão teórico-metodológica sobre o desenvolvimento de escalas e medidas de virtudes, primeiramente os artigos foram inteiramente lidos e seus dados principais organizados em planilhas do Excel, contendo informações sobre: (a) como a escala é construída ou aplicada, geração de itens, pré-testes, amostra e respondentes, tratamento dos itens; (b) análise estatística utilizada, técnicas estatísticas, fatores de ajuste, técnicas de análise, fatores emergentes; (c) eliminações de itens, tipos de validações e temas relacionados; e (d) país de aplicação, para analisar possíveis limitações e o rigor empregado na criação e validação. Para a análise do uso de análise fatorial exploratória (AFE), de análise fatorial confirmatória (AFC) e de outras técnicas, seguiram-se as orientações de <xref ref-type="bibr" rid="B24">Fávero et al. (2009</xref>) e <xref ref-type="bibr" rid="B31">Hair et al. (2005</xref>). </p>
+				<p>Após a análise das escalas, buscou-se analisar as contribuições dos trabalhos para o conhecimento sobre virtudes morais, considerando os artigos que listam um conjunto de virtudes e aqueles que se aprofundam em uma única. Discutem-se desafios metodológicos para acessar virtudes morais, especialmente para pesquisadores que se inserem em uma tradição da ética das virtudes. Discute-se como são definidas, operacionalizadas e acessadas, de modo a discutir implicações teóricas e questões metodológicas em um escopo maior, pois o debate sobre mensuração de virtudes é uma questão em aberto, para a qual pesquisadores de ética empresarial e de psicologia podem ter posições diferentes sobre sua possibilidade, relevância e pertinência. </p>
+			</sec>
+			<sec sec-type="results|discussion">
+				<title>APRESENTAÇÃO E DISCUSSÃO DOS RESULTADOS</title>
+				<p>Os 37 artigos empíricos selecionados refletem as contribuições de duas áreas com interesse em virtudes ou ética das virtudes: a ética empresarial e a psicologia. Os trabalhos foram publicados por 21 diferentes <italic>journals</italic>. Da área de administração e negócios, o <italic>Journal of Business Ethics</italic> (JBE) publicou 11 artigos sobre escalas e mensuração de virtudes morais em âmbito individual, seguido de outras revistas da área com um artigo: <italic>Asian Journal of Business &amp; Accounting, Business Ethics: A European Review, Canadian Journal of Administrative Sciences, Journal of Business Research, Leadership &amp; Organization Development Journal</italic> e <italic>Organizational Dynamics.</italic> Da área da psicologia destacam-se as revistas <italic>Personality and Individual Differences</italic> (4 artigos), <italic>Current Psychology</italic> (3) e <italic>Frontiers in Psychology</italic> (2).</p>
+				<p>As investigações que desenvolvem ou aplicam escalas de virtudes seguem dois formatos predominantes: focam em múltiplas virtudes analisadas conjuntamente, ou em uma única virtude moral. Em revistas do campo da administração, os trabalhos partem, na sua maioria, de listas desenvolvidas a partir de <xref ref-type="bibr" rid="B76">Solomon (1999</xref>) e <xref ref-type="bibr" rid="B53">Murphy (1999</xref>). No campo da psicologia, os trabalhos se apoiam na psicologia positiva de <xref ref-type="bibr" rid="B56">Peterson e Seligman (2004</xref>) ou em tentativas de articulação entre psicologia e filosofia moral (ex.: <xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>). Dos 37 artigos, 19 se referem ao uso e desenvolvimento de escalas sobre múltiplas virtudes, que optamos por chamar de 'virtudes morais múltiplas'; e 18 abordam escalas e medidas de 'virtudes morais específicas', como exposto na <xref ref-type="table" rid="t2s">Tabela 2</xref>.</p>
+				<p>
+					<table-wrap id="t2s">
+						<label>Tabela 2</label>
+						<caption>
+							<title>Escalas relacionadas a virtudes morais em nível individual - múltiplas e específicas.</title>
+						</caption>
+						<table>
+							<colgroup>
+								<col/>
+								<col/>
+								<col/>
+								<col/>
+							</colgroup>
+							<thead>
+								<tr>
+									<th align="center">Escala</th>
+									<th align="center">Autores</th>
+									<th align="center"><italic>Journal</italic></th>
+									<th align="right">Citações<sup>a</sup></th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td align="center" colspan="4">Virtudes morais múltiplas </td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Virtue Scale</italic> (VS)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B18">Cawley, Martin e Johnson (2000</xref>)<break/>
+									 <xref ref-type="bibr" rid="B78">Stoeber e Yang (2016</xref>)</td>
+									<td align="center">PID<break/>
+									 PID</td>
+									<td align="right">245<break/>
+									 27</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Virtue Ethics Scale</italic> (VES)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B67">Shanahan e Hyman (2003</xref>)<break/>
+									 <xref ref-type="bibr" rid="B58">Racelis (2013</xref>)<break/>
+									 <xref ref-type="bibr" rid="B59">Racelis (2014</xref>)<break/>
+									 <xref ref-type="bibr" rid="B20">Dawson (2018</xref>)<break/>
+									 <xref ref-type="bibr" rid="B23">Donada, Mothe, Nogatchewsky e Ribeiro (2019</xref>)<break/>
+									 Shanahan e Hopkins (2019)</td>
+									<td align="center">JBE<break/>
+									 AJBA<break/>
+									 APSSR<break/>
+									 JBE<break/>
+									 JBE<break/>
+									 JBE</td>
+									<td align="right">152<break/>
+									 18<break/>
+									 3<break/>
+									 8<break/>
+									 15<break/>
+									 7</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>VIA-Classification</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B55">Park e Peterson (2006</xref>)<break/>
+									 <xref ref-type="bibr" rid="B77">Song e Kim (2018</xref>)<break/>
+									 <xref ref-type="bibr" rid="B9">Arthur, Earl, Thompson e Ward (2021</xref>)</td>
+									<td align="center">JA<break/>
+									 JBE<break/>
+									 JBE</td>
+									<td align="right">775<break/>
+									 27<break/>
+									 3</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Virtuous Leadership Scale</italic> (VLS)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B64">Sarros, Cooper e Hartican (2006</xref>)<break/>
+									 <xref ref-type="bibr" rid="B80">Wang e Hackett (2016</xref>)</td>
+									<td align="center">L&amp;ODJ<break/>
+									 JBE</td>
+									<td align="right">96<break/>
+									 70</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Measure of Auditor’s Virtue</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B42">Libby e Thorne (2007</xref>)</td>
+									<td align="center">JBE</td>
+									<td align="right">65</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Leadership Virtues Questionnaire</italic> (LVQ)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B61">Riggio, Zhu, Reina e Maroosis (2010</xref>)</td>
+									<td align="center">CPJPR</td>
+									<td align="right">256</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Character Strengths Leadership Survey</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B79">Thun e Kelloway (2011</xref>)</td>
+									<td align="center">CJAS</td>
+									<td align="right">63</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Virtue Adjective Rating Scale</italic> (VARS)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B81">Yang, Stoeber e Wang (2015</xref>)</td>
+									<td align="center">PID</td>
+									<td align="right">32</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Leadership Character Insight Assessment</italic> (LCIA)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B65">Seijts, Gandz, Crossan e Reno (2015</xref>)</td>
+									<td align="center">OD</td>
+									<td align="right">54</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Ethical Tendencies Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B40">Koçyiğit e Karadağ (2016</xref>)</td>
+									<td align="center">TJBE</td>
+									<td align="right">9</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Virtuous Leadership Questionnaire</italic> (VLQ)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B80">Wang e Hackett (2016</xref>)</td>
+									<td align="center">JBE</td>
+									<td align="right">70</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Individual Business Virtues</italic> (IBE) </td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B20">Dawson (2018</xref>)</td>
+									<td align="center">JBE</td>
+									<td align="right">8</td>
+								</tr>
+								<tr>
+									<td align="center" colspan="4">Virtudes morais específicas </td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Multidimensional Ethics Scale</italic> (MES)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B13">Beekun, Westerman e Barghouti (2005</xref>)<break/>
+									 <xref ref-type="bibr" rid="B44">Manly, Leonard e Riemenschneider (2015</xref>)</td>
+									<td align="center">JBE<break/>
+									 JBE</td>
+									<td align="right">56<break/>
+									 36</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Deontic Justice Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B15">Beugré (2012</xref>)</td>
+									<td align="center">JASP</td>
+									<td align="right">38</td>
+								</tr>
+								<tr>
+									<td align="left">Escalas específicas correlacionadas com <italic>Engagement Beauty Scale</italic> (EBS)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B22">Diessner, Iyer, Smith e Haidt (2013</xref>)</td>
+									<td align="center">JME</td>
+									<td align="right">104</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Self-regarding and other regarding virtues</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B30">Grappi, Romani e Bagozzi (2013</xref>)</td>
+									<td align="center">JBR</td>
+									<td align="right">287</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Multicomponent Gratitude Measure</italic> (MCGM)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B52">Morgan et al. (2017</xref>)<break/>
+									 <xref ref-type="bibr" rid="B29">Gulliford, Morgan, Hemming e Abbott (2019</xref>)<break/>
+									 <xref ref-type="bibr" rid="B34">Hudecek, Blabst, Morgan e Lermer (2020</xref>)</td>
+									<td align="center">PID<break/>
+									 CP<break/>
+									 FP</td>
+									<td align="right">55<break/>
+									 6<break/>
+									 1</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Moral Virtue Theory of Status Attainment</italic> (MVT<italic>)</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B11">Bai, Ho e Yan (2020</xref>)</td>
+									<td align="center">JPSP</td>
+									<td align="right">10</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Consumer moral virtue of Integrity</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B17">Castro-González, Bande, Fernández-Ferrín e Kimura (2019</xref>)</td>
+									<td align="center">JCP</td>
+									<td align="right">29</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Self-report Humility Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B57">Qin, Liu, Brown, Zheng e Owens (2019</xref>)</td>
+									<td align="center">JBE</td>
+									<td align="right">6</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Gratitude Questionnaire</italic> (G-20)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B14">Bernabe-Valero, Blasco-Magraner e García-March (2020</xref>)</td>
+									<td align="center">FP</td>
+									<td align="right">-</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Intellectually Humble Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B19">Colombo, Strangmann, Houkes, Kostadinova e Brandt (2021</xref>)</td>
+									<td align="center">RPP</td>
+									<td align="right">-</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Good and Evil Character Traits</italic> (GECT) <italic>Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B37">Jiao, Yang, Guo, Xu, Zhang e Jiang (2020</xref>)</td>
+									<td align="center">SJP</td>
+									<td align="right">-</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Resilient Measurement Scale</italic> (SPP-25)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B41">Lasota, Tomaszek e Bosacki (2020</xref>)</td>
+									<td align="center">CP</td>
+									<td align="right">-</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Professional Moral Courage scale</italic> (PMC<italic>; Sekerka 2009, 2 items)</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B45">Mansur, Sobral e Islam (2020</xref>)</td>
+									<td align="center">BEER</td>
+									<td align="right">1</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Temperance Scale</italic></td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B66">Shahab e Adil (2020</xref>)</td>
+									<td align="center">PJ</td>
+									<td align="right">-</td>
+								</tr>
+								<tr>
+									<td align="left"><italic>Enright Self-Forgiveness Inventory</italic> (ESFI)</td>
+									<td align="left">
+										<xref ref-type="bibr" rid="B38">Kim, Volk e Enright (2021</xref>)</td>
+									<td align="center">CP</td>
+									<td align="right">-</td>
+								</tr>
+							</tbody>
+						</table>
+						<table-wrap-foot>
+							<fn id="TFN6">
+								<p>Nota. <italic>Personality and Individual Differences</italic> (PID)<italic>; Journal of Business Ethics</italic> (JBE); <italic>Asian Journal of Business &amp; Accounting</italic> (AJBA); <italic>Asia-Pacific Social Science Review</italic> (APSSR); <italic>Journal of Adolescence</italic> (JA); <italic>Leadership &amp; Organization Development Journal</italic> (L&amp;ODJ); <italic>Consulting Psychology Journal: Practice and Research</italic> (CPJPR); <italic>Canadian Journal of Administrative Science</italic> (CJAS); <italic>Organizational Dynamics; Turkish Journal of Business Ethics</italic> (TJBE); <italic>Journal of Applied Social Psychology</italic> (JASP); <italic>Journal of Moral Education</italic> (JME); <italic>Journal of Business Research</italic> (JBR); <italic>Journal of Personality &amp; Social Psychology</italic> (JPSP); <italic>Journal of Cleaner Production</italic> (JCP); <italic>Current Psychology</italic> (CP); <italic>Frontiers in Psychology</italic> (FP); <italic>Review of Philosophy and Psychology</italic> (RPP)<italic>; Scandinavian Journal of Psychology</italic> (SJP); <italic>Business Ethics: A European Review</italic> (BEER)<italic>; PsyCh Journal</italic> (PJ).</p>
+							</fn>
+							<fn id="TFN7">
+								<label>a</label>
+								<p> Consulta Google Scholar realizada em 2 de março de 2021.</p>
+							</fn>
+						</table-wrap-foot>
+					</table-wrap>
+				</p>
+				<p>Os trabalhos da primeira década do atual milênio optaram por escalas de múltiplas virtudes, abordando uma lista de traços do caráter. Na década seguinte, ocorre uma discussão metodológica sobre a mudança do conceito para o âmbito organizacional, com discussões sobre a virtuosidade organizacional, bem como sobre os pressupostos e métodos da psicologia positiva. Nos últimos três anos, os estudos empíricos focam predominantemente na mensuração de uma virtude específica, buscando abordar componentes como pensamento, sentimentos e comportamentos que expressam virtudes. Mas cabe ressaltar que essas questões permanecem em aberto e há posicionamentos distintos sobre a viabilidade ou não de articular a filosofia moral e a psicologia para ampliar o entendimento sobre virtudes morais (<xref ref-type="bibr" rid="B12">Beadle et al., 2015</xref>). Possibilidades de articulação são consideradas por <xref ref-type="bibr" rid="B54">Newstead et al. (2018</xref>) e <xref ref-type="bibr" rid="B73">Snow, Whright e Warren (2020</xref>).</p>
+				<p>É importante ressaltar que as escalas de virtudes morais, múltiplas ou específicas, acessam a ‘percepção’ de virtudes, seja a autopercepção do respondente, seja a percepção em relação às outras pessoas (gestor, colaborador, liderança, etc.), algo próximo ao que <xref ref-type="bibr" rid="B54">Newstead et al. (2018</xref>) chamaram de <italic>virtues</italic>. Mas tais estudos não as consideram a partir de um evento, limitando-se ao julgamento abstrato sobre lista de atributos, desconectado de um contexto de ação. Isso se verifica em boa parte dos instrumentos de medida no estilo de lista de itens. </p>
+				<p>Os artigos que abordam virtudes morais específicas se dedicam a observar empiricamente uma ou duas virtudes: admiração às virtudes e sua relação com status (<xref ref-type="bibr" rid="B11">Bai, Ho, &amp; Yan, 2020</xref>), autoconsideração e consideração pelos outros (<xref ref-type="bibr" rid="B30">Grappi, Romani, &amp; Bagozzi, 2013</xref>), coragem moral (<xref ref-type="bibr" rid="B45">Mansur, Sobral, &amp; Islam, 2020</xref>), gratidão (<xref ref-type="bibr" rid="B14">Bernabe-Valero, Blasco-Magraner, &amp; García-March, 2020</xref>; <xref ref-type="bibr" rid="B29">Gulliford, Morgan, Hemming, &amp; Abbott, 2019</xref>; <xref ref-type="bibr" rid="B34">Hudecek, Blabst, Morgan, &amp; Lermer, 2020</xref>; Morgan, Gulliford, &amp; Kristjánsson, 2017), gratidão e amor (<xref ref-type="bibr" rid="B22">Diessner, Iyer, Smith, &amp; Haidt, 2013</xref>), humildade (<xref ref-type="bibr" rid="B19">Colombo, Strangmann, Houkes, Kostadinova, &amp; Brandt, 2021</xref>; <xref ref-type="bibr" rid="B57">Qin, Liu, Brown, Zheng, &amp; Owens, 2019</xref>), integridade (<xref ref-type="bibr" rid="B17">Castro-González, Bande, Fernández-Ferrín, &amp; Kimura, 2019</xref>), justiça (<xref ref-type="bibr" rid="B13">Beekun, Westerman, &amp; Barghouti, 2005</xref>; <xref ref-type="bibr" rid="B15">Beugré, 2012</xref>), perdão de si mesmo (Kim, Volk, &amp; Enright, 2021), respeito e responsabilidade (<xref ref-type="bibr" rid="B44">Manly, Leonard, &amp; Riemenschneider, 2015</xref>), traços bons e maus do caráter (<xref ref-type="bibr" rid="B37">Jiao, Yang, Guo, Xu, Zhang, &amp; Jiang, 2020</xref>), resiliência (<xref ref-type="bibr" rid="B41">Lasota, Tomaszek, &amp; Bosacki, 2020</xref>) e temperança (<xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>).</p>
+				<p>Além de virtudes específicas, virtudes associadas à liderança foram uma temática para a qual se desenvolveram várias escalas (<xref ref-type="bibr" rid="B45">Mansur et al., 2020</xref>; <xref ref-type="bibr" rid="B57">Qin et al., 2019</xref>; <xref ref-type="bibr" rid="B61">Riggio, Zhu, Reina, &amp; Maroosis, 2010</xref>; <xref ref-type="bibr" rid="B79">Thun &amp; Kelloway, 2011</xref>; <xref ref-type="bibr" rid="B64">Sarros, Cooper, &amp; Hartican, 2006</xref>; <xref ref-type="bibr" rid="B65">Seijts, Gands, Crossan, &amp; Reno, 2015</xref>; <xref ref-type="bibr" rid="B80">Wang &amp; Hackett, 2016</xref>).</p>
+				<sec>
+					<title>Desenvolvimento e aplicação de escalas sobre virtudes morais</title>
+					<p>A <xref ref-type="table" rid="t3s">Tabela 3</xref> resume as informações da construção de escalas. Nela é possível observar o número de itens iniciais e finais, a proporção item-amostra, o país e o perfil dos respondentes, em sua maioria universitários e profissionais da área. As escalas empregam itens com grade de respostas no formato Likert (‘discordo totalmente - concordo totalmente’) ou escalas adjetivais, variando entre escalas de quatro a dez pontos. </p>
+					<p>
+						<table-wrap id="t3s">
+							<label>Tabela 3</label>
+							<caption>
+								<title>Itens, amostra e medidas em escalas relacionadas a virtudes morais em nível individual.</title>
+							</caption>
+							<table>
+								<colgroup>
+									<col/>
+									<col/>
+									<col/>
+									<col/>
+									<col/>
+									<col/>
+									<col/>
+									<col/>
+								</colgroup>
+								<thead>
+									<tr>
+										<th align="center">Artigos</th>
+										<th align="center">Itens iniciais (A)</th>
+										<th align="center">Amostra (B)</th>
+										<th align="center">Proporção (B/A)</th>
+										<th align="center">Itens finais</th>
+										<th align="center">Análises estatísticas</th>
+										<th align="center">País</th>
+										<th align="center">Respondentes</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td align="center" colspan="8">Virtudes morais múltiplas </td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B18">Cawley et al. (2000</xref>)</td>
+										<td align="center">140</td>
+										<td align="center">390(1), 181(2), 143(3)</td>
+										<td align="center">2,8</td>
+										<td align="center">48</td>
+										<td align="center">AFE</td>
+										<td align="center">USA</td>
+										<td align="center">Estudantes de psicologia</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B67">Shanahan e Hyman (2003</xref>)</td>
+										<td align="center">45</td>
+										<td align="center">445</td>
+										<td align="center">9,9</td>
+										<td align="center">33</td>
+										<td align="center">AFE</td>
+										<td align="center">USA</td>
+										<td align="center">Estudantes de marketing</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B55">Park e Peterson (2006</xref>)</td>
+										<td align="center">198</td>
+										<td align="center">250</td>
+										<td align="center">1,3</td>
+										<td align="center">24</td>
+										<td align="center">AFE</td>
+										<td align="center">USA</td>
+										<td align="center">Estudantes (10-17 anos)</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>)</td>
+										<td align="center">7</td>
+										<td align="center">238</td>
+										<td align="center">34,0</td>
+										<td align="center">7</td>
+										<td align="center">ANOVA</td>
+										<td align="center">Austrália</td>
+										<td align="center">Membros de instituto de administração</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B42">Libby e Thorne (2007</xref>)</td>
+										<td align="center">55</td>
+										<td align="center">376</td>
+										<td align="center">6,8</td>
+										<td align="center">29</td>
+										<td align="center">AFE</td>
+										<td align="center">Canadá</td>
+										<td align="center">Membros CICA</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>)</td>
+										<td align="center">36</td>
+										<td align="center">200</td>
+										<td align="center">5,6</td>
+										<td align="center">19</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Administradores</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B79">Thun e Kelloway (2011</xref>)</td>
+										<td align="center">27</td>
+										<td align="center">327</td>
+										<td align="center">12,1</td>
+										<td align="center">14</td>
+										<td align="center">AFE</td>
+										<td align="center">Canadá</td>
+										<td align="center">Empregados de universidade</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B58">Racelis (2013</xref>)</td>
+										<td align="center">34</td>
+										<td align="center">140</td>
+										<td align="center">4,1</td>
+										<td align="center">22</td>
+										<td align="center">AFE</td>
+										<td align="center">Filipinas</td>
+										<td align="center">Universitários</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B59">Racelis (2014</xref>)</td>
+										<td align="center">34</td>
+										<td align="center">141</td>
+										<td align="center">4,1</td>
+										<td align="center">22</td>
+										<td align="center">AFE</td>
+										<td align="center">Filipinas</td>
+										<td align="center">Estudantes gestores</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B81">Yang et al. (2015</xref>)</td>
+										<td align="center">90</td>
+										<td align="center">348</td>
+										<td align="center">3,9</td>
+										<td align="center">90</td>
+										<td align="center">AFE</td>
+										<td align="center">China</td>
+										<td align="center">Estudantes</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B65">Seijts et al. (2015</xref>)</td>
+										<td align="center">10</td>
+										<td align="center">364</td>
+										<td align="center">36,4</td>
+										<td align="center">10</td>
+										<td align="center">-</td>
+										<td align="center">Canadá; USA</td>
+										<td align="center">Líderes de organizações</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B40">Koçyiğit e Karadağ (2016</xref>)</td>
+										<td align="center">10</td>
+										<td align="center">312</td>
+										<td align="center">31,2</td>
+										<td align="center">26</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">Turquia</td>
+										<td align="center">Estudantes de graduação</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B78">Stoeber e Yang (2016</xref>)</td>
+										<td align="center">48</td>
+										<td align="center">243</td>
+										<td align="center">5,1</td>
+										<td align="center">48</td>
+										<td align="left"> </td>
+										<td align="center">China</td>
+										<td align="center">Estudantes universitários</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B80">Wang e Hacket (2016</xref>)</td>
+										<td align="center">89</td>
+										<td align="center">348</td>
+										<td align="center">3,9</td>
+										<td align="center">18</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">América do Norte</td>
+										<td align="center">Estudantes de MBA</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B20">Dawson (2018</xref>)</td>
+										<td align="center">45</td>
+										<td align="center">137</td>
+										<td align="center">3,0</td>
+										<td align="center">13</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">UK</td>
+										<td align="center">Profissionais RH</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B77">Song e Kim (2018</xref>)</td>
+										<td align="center">50</td>
+										<td align="center">400</td>
+										<td align="center">8</td>
+										<td align="center">50</td>
+										<td align="center">AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B9">Arthur et al. (2021</xref>)</td>
+										<td align="center">24</td>
+										<td align="center">2.340</td>
+										<td align="center">97,5</td>
+										<td align="center">24</td>
+										<td align="center">ANOVA, AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Profissionais de cinco áreas</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B23">Donada et al. (2019</xref>)</td>
+										<td align="center">14</td>
+										<td align="center">201</td>
+										<td align="center">14,4</td>
+										<td align="center">14</td>
+										<td align="center">-</td>
+										<td align="center">França</td>
+										<td align="center">CEOs</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B68">Shanahan e Hopkins (2019</xref>)</td>
+										<td align="center">3</td>
+										<td align="center">129</td>
+										<td align="center">43</td>
+										<td align="center">3</td>
+										<td align="center">AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Gestores e vendedores</td>
+									</tr>
+									<tr>
+										<td align="center" colspan="8">Virtudes morais específicas </td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B13">Beekun et al. (2005</xref>)</td>
+										<td align="center">14</td>
+										<td align="center">165</td>
+										<td align="center">11,8</td>
+										<td align="center">14</td>
+										<td align="center">AFE</td>
+										<td align="center">USA; Rússia</td>
+										<td align="center">Estudantes de MBA</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B15">Beugré (2012</xref>)</td>
+										<td align="center">36</td>
+										<td align="center">124(1) 101(2)</td>
+										<td align="center">3,4 2,8</td>
+										<td align="center">18</td>
+										<td align="center">-</td>
+										<td align="center">USA</td>
+										<td align="center">Trabalhadores de eletrônica</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B22">Diessner et al. (2013</xref>)</td>
+										<td align="center">18</td>
+										<td align="center">5.380 (1) 542(2)</td>
+										<td align="center">298,9</td>
+										<td align="center">18</td>
+										<td align="center">SEM</td>
+										<td align="center">USA (Idaho)</td>
+										<td align="center">Universitários</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B30">Grappi et al. (2013</xref>)</td>
+										<td align="center">5</td>
+										<td align="center">280</td>
+										<td align="center">56,0</td>
+										<td align="center">5</td>
+										<td align="center">AFC</td>
+										<td align="center">Itália</td>
+										<td align="center">Consumidores</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B44">Manly et al. (2015</xref>)</td>
+										<td align="center">12</td>
+										<td align="center">86</td>
+										<td align="center">7,2</td>
+										<td align="center">12</td>
+										<td align="center">-</td>
+										<td align="center">USA</td>
+										<td align="center">Estudantes de negócios de TI</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B52">Morgan et al. (2017</xref>)</td>
+										<td align="center">119</td>
+										<td align="center">477(1) 1.599(2)</td>
+										<td align="center">4,0 55,1</td>
+										<td align="center">29</td>
+										<td align="center">AFE, AFC, ANOVA, MANOVA</td>
+										<td align="center">UK</td>
+										<td align="center">Respondente on-line</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B17">Castro-González et al. (2019</xref>)</td>
+										<td align="center">2</td>
+										<td align="center">252</td>
+										<td align="center">126</td>
+										<td align="center">2</td>
+										<td align="center">AFC</td>
+										<td align="center">Espanha</td>
+										<td align="center">Consumidores</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B29">Gulliford et al. (2019</xref>)</td>
+										<td align="center">6+29</td>
+										<td align="center">311</td>
+										<td align="center">8,9</td>
+										<td align="center">6+29</td>
+										<td align="center">ANOVA</td>
+										<td align="center">UK</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B57">Qin et al. (2019</xref>)</td>
+										<td align="center">9</td>
+										<td align="center">487</td>
+										<td align="center">54,1</td>
+										<td align="center">9</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">China</td>
+										<td align="center">Supervisores e empregados</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B11">Bai et al. (2020</xref>)</td>
+										<td align="center">60</td>
+										<td align="center">292(1), 167(2) 155(3)</td>
+										<td align="center">4,9</td>
+										<td align="center">15</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">USA; China</td>
+										<td align="center">Estudantes e gestores</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B14">Bernabe-Valero et al. (2020</xref>)</td>
+										<td align="center">20</td>
+										<td align="center">302</td>
+										<td align="center">15,1</td>
+										<td align="center">20</td>
+										<td align="center">AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B19">Colombo et al. (2021</xref>)</td>
+										<td align="center">20</td>
+										<td align="center">60(1), 301(2), 347(3), 431(4)</td>
+										<td align="center">3</td>
+										<td align="center">20</td>
+										<td align="center">-</td>
+										<td align="center">Holanda</td>
+										<td align="center">Universitários</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B34">Hudecek et al. (2020</xref>)</td>
+										<td align="center">6</td>
+										<td align="center">508(1) 1.599(2)</td>
+										<td align="center">84,7</td>
+										<td align="center">6</td>
+										<td align="center">AFC</td>
+										<td align="center">Alemanha; UK</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B37">Jiao et al. (2020</xref>)</td>
+										<td align="center">55</td>
+										<td align="center">350</td>
+										<td align="center">6,4</td>
+										<td align="center">53</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">China</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B41">Lasota et al. (2020</xref>)</td>
+										<td align="center">25</td>
+										<td align="center">214</td>
+										<td align="center">8,6</td>
+										<td align="center">25</td>
+										<td align="center">SEM</td>
+										<td align="center">Polônia</td>
+										<td align="center">Estudantes e empregados</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B45">Mansur et al. (2020</xref>)</td>
+										<td align="center">10</td>
+										<td align="center">202</td>
+										<td align="center">20,2</td>
+										<td align="center">9</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">Não contém</td>
+										<td align="center">Adultos</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B66">Shahab e Adil (2020</xref>)</td>
+										<td align="center">24</td>
+										<td align="center">250(1) 268(2)</td>
+										<td align="center">10,4</td>
+										<td align="center">24</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">Paquistão</td>
+										<td align="center">Universitários</td>
+									</tr>
+									<tr>
+										<td align="left">
+											<xref ref-type="bibr" rid="B38">Kim et al. (2021</xref>)</td>
+										<td align="center">60</td>
+										<td align="center">252(1), 204(2), 343(3), 567(4) </td>
+										<td align="center">4,2</td>
+										<td align="center">30</td>
+										<td align="center">AFE, AFC</td>
+										<td align="center">USA</td>
+										<td align="center">Estudantes-pais; adultos</td>
+									</tr>
+								</tbody>
+							</table>
+							<table-wrap-foot>
+								<fn id="TFN8">
+									<p>Nota. Análise fatorial exploratória (AFE), análise fatorial confirmatória (AFC), modelagem de equações estruturais (SEM), análise univariada da covariância (ANOVA), análise multivariada da covariância (MANOVA). </p>
+								</fn>
+							</table-wrap-foot>
+						</table-wrap>
+					</p>
+					<p>Quanto ao contexto, as pesquisas foram realizadas em 15 diferentes países: Estados Unidos (11 estudos), China (3), Reino Unido (3), entre outros. Algumas analisam resultados de dois países (<xref ref-type="bibr" rid="B11">Bai et al., 2020</xref>; <xref ref-type="bibr" rid="B13">Beekun et al., 2005</xref>; <xref ref-type="bibr" rid="B34">Hudecek et al., 2020</xref>; <xref ref-type="bibr" rid="B65">Seijts et al., 2015</xref>). Outras recrutaram respondentes em plataformas, como na Amazon MTurk, de trabalhadores remotos (<xref ref-type="bibr" rid="B14">Bernabe-Valero et al., 2020</xref>; <xref ref-type="bibr" rid="B19">Colombo et al., 2021</xref>; <xref ref-type="bibr" rid="B38">Kim et al., 2021</xref>; <xref ref-type="bibr" rid="B45">Mansur et al., 2020</xref>). Embora Mansur et al. (2020) tenham vínculo com universidade brasileira, a descrição de sua amostra não especifica o contexto de pesquisa. Análises exploratórias em um novo contexto são importantes, pois as virtudes dependem do contexto de ação (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>; <xref ref-type="bibr" rid="B54">Newstead et al., 2018</xref>). Por exemplo, ser temperante em um dado país pode exigir mais do que ser em outro, e diferentes virtudes podem ser cultivadas em cada contexto. No uso de escalas, isso requer desenvolver algo a partir do contexto, adaptando as desenvolvidas em outras culturas (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). </p>
+					<p>Na proporção item-tamanho da amostra, alguns trabalhos (n=11) não alcançam a razão de 5:1 indicada por <xref ref-type="bibr" rid="B32">Hair et al. (2009</xref>, p. 108). Diferentemente, <xref ref-type="bibr" rid="B11">Bai et al. (2020</xref>) buscam uma proporção de 10:1, algo acompanhado pela maioria dos artigos recentes. Hair et al. (2009) recomendam que o pesquisador deve interpretar qualquer descoberta com precaução, quando se lida com amostras menores ou com uma proporção pequena. Além disso, a geração de itens em maior número, mediante aprofundamento teórico, análise léxica (<xref ref-type="bibr" rid="B37">Jiao et al., 2020</xref>), consulta com especialistas (<xref ref-type="bibr" rid="B20">Dawson, 2018</xref>) e potenciais respondentes (pré-testes), poderia reunir itens mais atrelados a virtudes de determinado contexto (<xref ref-type="bibr" rid="B1">Aguirre-Y-Luker et al., 2017</xref>). Por exemplo, <xref ref-type="bibr" rid="B67">Shanahan e Hyman (2003</xref>) fizeram grupos focais, mas poucos trabalhos descrevem a realização de pré-testes (<xref ref-type="bibr" rid="B42">Libby &amp; Thorne, 2007</xref>; Shanahan &amp; Hyman, 2003).</p>
+					<p>Para ilustrar a análise do desenvolvimento de escalas, consideram-se conceitos e resultados encontrados, os quais remetem a elementos da ética das virtudes. Os estudos sobre virtudes na liderança sugerem que o caráter do líder ainda é um atributo de suma importância para a ética em administração, o que poderia ampliar a discussão sobre traços de liderança e liderança como processo e entre as perspectivas heroicas e pós-heroicas (<xref ref-type="bibr" rid="B74">Sobral &amp; Furtado, 2019</xref>). </p>
+					<p>
+						<xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>) sugerem que a integridade é um atributo-chave para o caráter de líderes. <xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>) investigam as virtudes cardeais da temperança, fortaleza, justiça e prudência relacionadas à liderança, baseados em premissas de Tomás de Aquino e Aristóteles, sendo um dos poucos estudos que procura abordar o pressuposto da unidade das virtudes. Os resultados de duas etapas de análise fatorial exploratória sugerem um único fator explicativo do modelo, o que Riggio et al. (2010) consideram uma evidência da unidade das virtudes.</p>
+					<p>Apoiando-se em conceitos aristotélicos e confucianos para desenvolver o Questionário de Liderança Virtuosa, <xref ref-type="bibr" rid="B80">Wang e Hackett (2016</xref>) partem de seis virtudes - coragem, prudência, justiça, temperança, humanidade e confiabilidade e, pela análise fatorial, chegam a cinco fatores: coragem (4), temperança (4), justiça (3), prudência (4) e humanidade (3). </p>
+					<p>Na Escala de Forças do Caráter da Liderança, <xref ref-type="bibr" rid="B79">Thun e Kelloway (2011</xref>) encontram os fatores humanidade (4 itens), sabedoria (5) e temperança (5), enquanto <xref ref-type="bibr" rid="B65">Seijts et al. (2015</xref>) discutem o caráter como uma amálgama de virtudes, traços de personalidade e valores, descrevendo 11 elementos do caráter e sua importância para a liderança. Por fim, <xref ref-type="bibr" rid="B45">Mansur et al. (2020</xref>) sugerem que a coragem moral contribui para a liderança ética e o comportamento cidadão em grupo. </p>
+					<p>Outras evidências do papel das virtudes morais aparecem nos seguintes temas: relações entre comprador-vendedor (<xref ref-type="bibr" rid="B23">Donada, Mothe, Nogatchewsky, &amp; Ribeiro, 2019</xref>); líder-liderado (<xref ref-type="bibr" rid="B57">Qin et al., 2019</xref>); gerentes-vendedores (<xref ref-type="bibr" rid="B68">Shanahan &amp; Hopkins, 2019</xref>); caráter de profissionais (<xref ref-type="bibr" rid="B9">Arthur et al., 2021</xref>); e consumo responsável (<xref ref-type="bibr" rid="B77">Song &amp; Kim, 2018</xref>). </p>
+					<p>Embora elaboradas com rigor estatístico, escalas de liderança são específicas para esse papel. Além disso, são elaboradas a partir de contextos culturais, morais e políticos específicos, o que requer reelaboração para outros contextos organizacionais, inseridos na cultura de uma comunidade, de forma a acolher as particularidades em termos de virtudes morais e da noção de florescimento humano. </p>
+					<p>Considerando as aplicações do modelo de forças do caráter de <xref ref-type="bibr" rid="B56">Peterson e Seligman (2004</xref>), alguns estudos empregam parcial ou integralmente os itens das forças do caráter: (a) <xref ref-type="bibr" rid="B55">Park e Peterson (2006</xref>) abordam a competência moral como bom caráter, utilizando 198 itens dentre os 240 do modelo. Sua amostra, porém, é de 250 estudantes adolescentes, fazendo com que a proporção item-amostra seja inferior ao indicado estatisticamente. Aplicando a análise fatorial exploratória (AFE), chegam a quatro fatores: temperança (4), intelectual (6), teológico (10), e outras forças (4); (b) <xref ref-type="bibr" rid="B77">Song e Kim (2018</xref>) abordam nove virtudes do modelo para verificar como traços positivos dos consumidores explicam seu consumo responsável; e (c) <xref ref-type="bibr" rid="B9">Arthur et al. (2021</xref>) abordam a autopercepção de profissionais sobre as virtudes mais importantes do modelo. Embora haja diferenças e similaridades entre virtudes morais e forças do caráter (<xref ref-type="bibr" rid="B2">Alzola, 2015</xref>), os caminhos para o seu entendimento no âmbito das organizações passam por aprofundamento teórico e estratégias de pesquisa que permitam alcançar mais que um 'retrato' instantâneo sobre virtudes, pois elas são cultivadas ao longo da vida.</p>
+				</sec>
+				<sec>
+					<title>Discussão</title>
+					<p>A virtude é um conceito de raiz filosófica e é considerada na tradição da ética das virtudes como o meio termo entre dois vícios: a sua falta, de um lado, e o seu excesso, do outro (Aristóteles, 2009). Nesse sentido, o agente virtuoso está em constante reflexão sobre sua conduta, seus erros e acertos, buscando nortear-se em vistas a um bem, sendo sua autoeducação ou autoaperfeiçoamento um elemento-chave. Por isso, destaca-se a importância do contexto, da ação dentro de uma perspectiva maior, na trajetória de vida. Muitas vezes é depois de cometidos alguns ou vários erros que se aprendem as virtudes, a exemplo do perdão de si mesmo (<xref ref-type="bibr" rid="B38">Kim et al., 2021</xref>). Nesse sentido, caberia um arcabouço ético compreensivo, capaz de considerar aspectos negativos e positivos do caráter, erros e acertos, vícios e virtudes, como parece ser o caso da ética das virtudes. </p>
+					<p>Optar por abordar somente uma virtude, como estudos recentes têm feito, seria uma maneira de alcançar um entendimento mais detalhado de seus multicomponentes. Por exemplo, os fatores emergentes indicados a partir das AFEs representam uma coletânea de percepções de virtudes ou traços do caráter, muito embora resultem da operacionalização a partir de diferentes áreas e pressupostos éticos. Alguns fatores aparecem mais de uma vez. É o caso de temperança (<xref ref-type="bibr" rid="B55">Park &amp; Peterson, 2006</xref>; <xref ref-type="bibr" rid="B61">Riggio et al., 2010</xref>; <xref ref-type="bibr" rid="B79">Thun &amp; Kelloway, 2011</xref>; <xref ref-type="bibr" rid="B80">Wang &amp; Hackett, 2016</xref>), justiça (<xref ref-type="bibr" rid="B13">Beekun et al., 2005</xref>; Riggio et al., 2010; Wang &amp; Hackett, 2016) e desenvoltura (<xref ref-type="bibr" rid="B18">Cawley, Martin, &amp; Johnson, 2000</xref>; <xref ref-type="bibr" rid="B81">Yang, Stoeber &amp; Wang, 2015</xref>; <xref ref-type="bibr" rid="B20">Dawson, 2018</xref>). A virtude da prudência é encontrada nos trabalhos de Riggio et al. (2010) e Wang e Hackett (2016), enquanto <xref ref-type="bibr" rid="B64">Sarros et al. (2006</xref>) e Thun e Kelloway (2011) definem o fator como sabedoria. </p>
+					<p>Por outro lado, seria uma limitação não considerar, por exemplo, o papel da <italic>phronesis</italic> vinculada às virtudes morais (<xref ref-type="bibr" rid="B6">Ames et al., 2020</xref>; <xref ref-type="bibr" rid="B10">Bachmann et al., 2017</xref>). A unidade das virtudes reconhece a conexão entre elas, ou seja, que para ser virtuoso alguém expressa mais que uma virtude - por exemplo: honestidade e justiça, para comunicar da melhor forma possível; coragem e prudência, para tomar boas decisões frente aos riscos do ambiente. </p>
+					<p>Considerando os pressupostos da participação da prudência em cada virtude e da unidade das virtudes (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>), percebe-se que a maioria dos artigos não considera tais pressupostos no desenvolvimento ou uso de escalas. Entre as poucas exceções, há a tentativa de <xref ref-type="bibr" rid="B61">Riggio et al. (2010</xref>). Alguns trabalhos se apoiam em autores da ética das virtudes - como em Aristóteles (2009), MacIntyre (2007) e Sison e Ferrero (2015) - enquanto outros a articulam à psicologia positiva (ex.: <xref ref-type="bibr" rid="B9">Arthur et al., 2021</xref>; <xref ref-type="bibr" rid="B23">Donada et al., 2019</xref>; <xref ref-type="bibr" rid="B66">Shahab &amp; Adil, 2020</xref>). </p>
+					<p>Quais estratégias de pesquisa seriam possíveis, considerando a necessidade de maior desenvolvimento teórico sobre virtudes em administração? Baseando-se nessa pergunta, é possível retomar alguns aspectos teórico-metodológicos para reunir sugestões a estudos futuros.</p>
+				</sec>
+			</sec>
+			<sec>
+				<title>SUGESTÕES PARA ESTUDOS FUTUROS</title>
+				<p>Do ponto de vista teórico-metodológico, quatro pontos cabem ser mencionados: aprendizagem de virtudes, sua presença em diferentes papéis sociais, dualidade subjetivo-objetivo e julgamento-ação. O primeiro deles é que o cultivo e a aprendizagem das virtudes se dão ao longo da vida, com a experiência (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>). Métodos que pontualmente consultam respondentes em um momento específico, sem uma análise contextualizada em suas trajetórias de vida, não conseguem acessar o contexto e a circunstância de ação, algo considerado na tradição da ética das virtudes (<xref ref-type="bibr" rid="B39">Kinghorn, 2017</xref>). Cabe ainda levar em conta a idade ou tempo de experiência dos pesquisados, o que pode fazer a diferença na maturidade moral. </p>
+				<p>O segundo ponto está atrelado ao primeiro, pois remete à reflexão de alguém sobre a sua vida como um todo, o que envolve considerar em pesquisas não somente o trabalho no âmbito profissional, mas a harmonia entre os diferentes papéis sociais (<xref ref-type="bibr" rid="B71">Sison et al., 2018</xref>). O terceiro ponto se refere à dualidade subjetivo-objetivo relacionada ao conceito de virtude, algo que precisa ser considerado pelas abordagens focadas em comportamentos observáveis, ou no uso de escalas de percepção sobre virtudes. Tal dualidade é importante porque uma virtude moral expressa uma harmonia entre subjetivo-objetivo, isto é, entre vontade e ação, algo complexo de se acessar por escalas e medidas. Finalmente, o quarto ponto levanta a questão da lacuna julgamento-ação que separa o momento de responder a um teste/escala, sobre uma dada questão hipotética, da vivência real de uma questão ética. Acessar as virtudes a partir da trajetória de vida de alguém poderia encontrar evidências fidedignas à experiência do participante. </p>
+				<p>Diante disso, algumas estratégias de pesquisa interpretativas e de abordagens qualitativas poderiam alcançar um conhecimento mais aprofundado sobre as virtudes em um contexto nacional e organizacional específico, considerando os pressupostos da unidade das virtudes e do papel crucial da <italic>phronesis</italic> (<xref ref-type="bibr" rid="B69">Sison &amp; Ferrero, 2015</xref>; <xref ref-type="bibr" rid="B82">Zyl, 2019</xref>). Podem-se cogitar possíveis contribuições da história oral, de abordagens narrativas, estudo de caso, etnografia e fenomenologia. Estratégias exploratórias geralmente antecedem abordagens quantitativas, de modo a prover conhecimento para futuros estudos utilizando escalas, como a Etapa 1, sugerida na <xref ref-type="fig" rid="f2s">Figura 2</xref>. </p>
+				<p>
+					<fig id="f2s">
+						<label>Figura 2</label>
+						<caption>
+							<title>Sugestões de etapas futuras nos estudos sobre virtudes morais.</title>
+						</caption>
+						<graphic xlink:href="1982-7849-rac-26-06-e190379-gf2-pt.tif"/>
+					</fig>
+				</p>
+				<p>A revisão de trabalhos que buscam mensurar virtudes requer uma discussão metodológica e teórica. Quanto ao método, essa discussão questiona por que as pesquisas buscam mensurar virtudes, as limitações e possibilidades a partir dos artigos revisados, e busca se inserir nas discussões sobre quais métodos podem ser considerados para estudos empíricos de ética das virtudes. A partir disso, sugerem-se possíveis procedimentos em estudos futuros, como pontuado na <xref ref-type="fig" rid="f2s">Figura 2</xref>.</p>
+				<p>Entendem-se as Etapas 1 e 2 como um percurso para os estudos sobre virtudes morais. A Etapa 2 segue diretrizes básicas para o desenvolvimento de escalas, como propostas por <xref ref-type="bibr" rid="B21">DeVellis (2016</xref>). </p>
+				<p>Diante de preocupações sobre a instrumentalização do construto para a melhoria da performance ou produtividade, estudos futuros podem abordar a sua contribuição para o florescimento humano e o relacionamento interpessoal. A percepção de virtudes, por sua vez, pode permitir entender como as pessoas associam tais atributos a outras questões organizacionais, como liderança, tomada de decisão ou cultura organizacional. Do ponto de vista teórico, permanece a discussão sobre as contribuições do uso de escalas para a expansão ou aprofundamento do entendimento que se tem sobre as virtudes morais no ambiente organizacional e de negócios, tendo em mente os pressupostos e elementos da tradição da ética das virtudes como arcabouço para o estudo da ética em administração.</p>
+				<p>Dentre as limitações de pesquisa, optou-se por analisar escalas de virtude morais no âmbito individual. Portanto, as escalas de virtuosidade (âmbito organizacional) podem ser revisadas em estudos futuros. Na busca por artigos, o estudo limitou-se aos termos como ética das virtudes e virtudes morais. Assim, estudos posteriores podem buscar por uma virtude específica. No relato desta pesquisa não se descreveu como se fizeram validações convergentes e discriminantes em relação a outros conceitos, e procurou-se fazer uma análise geral à luz da ética das virtudes, restringindo-se a discutir alguns de seus pressupostos.</p>
+			</sec>
+			<sec sec-type="conclusions">
+				<title>CONSIDERAÇÕES FINAIS</title>
+				<p>Este artigo buscou analisar como as escalas sobre virtudes morais são construídas e mensuradas em estudos associados à ética das virtudes em administração, a partir de uma revisão sistemática de artigos. Buscando-se em cinco bases de dados, foram selecionados 37 artigos, publicados em 21 <italic>journals</italic> das áreas de ética empresarial em sua maioria, que desenvolvem ou aplicam escalas relacionadas à percepção de virtudes morais em âmbito individual, dos quais 19 abrangem virtudes morais múltiplas e 18 buscam por uma virtude moral específica. </p>
+				<p>Apoiando-se em pressupostos da ética das virtudes aristotélico-tomista e em recomendações estatísticas para o desenvolvimento e aplicação de escalas, este estudo analisou a sua construção, apresentando números sobre a geração de itens antes e depois de análises fatoriais, a proporção de respondentes por itens (amostra-item), o perfil dos respondentes, o contexto de pesquisa ilustrativo de 15 países, bem como os tipos de análises estatísticas empregadas (análises fatoriais exploratórias e confirmatórias e fatores emergentes, modelagem de equações estruturais, Manova, entre outras). </p>
+				<p>Os estudos selecionados ilustram áreas do campo de administração relacionadas ao tema das virtudes, como liderança, relação gerentes-colaboradores, consumo responsável, entre outros campos. Uma parcela dos respondentes é público universitário, o que demanda novos estudos para acesso aos profissionais atuantes na área. Abordaram-se virtudes como coragem, gratidão, humildade, integridade, perdão, respeito, resiliência e temperança. </p>
+				<p>Os resultados foram discutidos teórica e metodologicamente, considerando o uso de escalas em relação ao aprofundamento conceitual da área e levando-se em conta os pressupostos da particularidade contextual, da unidade das virtudes e de sua interconexão com a <italic>phronesis</italic> (sabedoria prática). Aprendizagem, presença em diversos papéis e dualidade julgamento-ação também foram discutidos para elucidar implicações teóricas e práticas de algumas limitações encontradas no aprofundamento e na operacionalização conceitual.</p>
+				<p>Isso permitiu sugerir procedimentos para estudos futuros sobre virtudes morais, organizados em etapas sucessivas, de modo a articular estudos exploratórios qualitativos, inicialmente, para alcançar-se clareza conceitual, dados do contexto e dos participantes em foco, bem como recomendações para o desenvolvimento de escalas de percepção de virtudes como um passo subsequente: maiores conjuntos de itens, melhor proporção item-amostra no acesso ao campo, validação com especialistas e potenciais respondentes e realização de pré-testes. </p>
+				<p>Os aprofundamentos conceituais dispõem de tradições ocidentais e orientais para a ética das virtudes, mas é necessário refletir sobre as razões de se tentar mensurar virtudes no campo da administração. Um caminho alternativo pode ser a análise e a identificação de aspectos organizacionais que contribuam para que as pessoas cultivem virtudes, como as práticas e instituições, a cultura organizacional e funções administrativas. </p>
+			</sec>
+		</body>
+		<back>
+			<fn-group>
+				<fn fn-type="other" id="fn1s">
+					<label>Classificação JEL:</label>
+				<p>M1, M10.</p>
+				</fn>
+				<fn fn-type="other" id="fn4s">
+					<label>Relatório de Revisão por Pares:</label>
+				<p>O Relatório de Revisão por Pares está disponível neste <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5281/zenodo.6608808">link externo</ext-link>.</p>
+				</fn>
+				<fn fn-type="financial-disclosure" id="fn6s">
+					<label>Financiamento</label>
+					<p> Os autores agradecem o Ministério da Ciência, Tecnologia e Inovação, Conselho Nacional de Desenvolvimento Científico e Tecnológico (CHSSA, Processo nr. 445434/2015-5) pelo suporte financeiro ao projeto de pesquisa, a partir do qual o presente estudo foi desenvolvido.</p>
+				</fn>
+				<fn fn-type="other" id="fn8s">
+					<label>Verificação de Plágio</label>
+					<p> A RAC mantém a prática de submeter todos os documentos aprovados para publicação à verificação de plágio, mediante o emprego de ferramentas específicas, e.g.: iThenticate.</p>
+				</fn>
+				<fn fn-type="other" id="fn9s">
+					<label>Direitos Autorais</label>
+					<p> A RAC detém os direitos autorais deste conteúdo.</p>
+				</fn>
+				<fn fn-type="other" id="fn11s">
+					<label>Método de Revisão por Pares</label>
+					<p> Este conteúdo foi avaliado utilizando o processo de revisão por pares duplo-cego (<italic>double-blind peer-review</italic>). A divulgação das informações dos pareceristas constantes na primeira página e do Relatório de Revisão por Pares (Peer Review Report) é feita somente após a conclusão do processo avaliativo, e com o consentimento voluntário dos respectivos pareceristas e autores.</p>
+				</fn>
+				<fn fn-type="other" id="fn12s">
+					<label>Disponibilidade dos Dados</label>
+							<p>Os autores afirmam que todos os dados utilizados na pesquisa foram disponibilizados publicamente, e podem ser acessados por meio da plataforma Harvard Dataverse:</p>
+							<p><inline-graphic xlink:href="1982-7849-rac-26-06-e190379-i001qr-pt.tif"/>Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, &quot;Replication Data for &quot;Analysis of scales and measures of moral virtues: A systematic review&quot; published by RAC - Revista de Administração Contemporânea&quot;, Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</p>
+							<p>A RAC incentiva o compartilhamento de dados mas, por observância a ditames éticos, não demanda a divulgação de qualquer meio de identificação de sujeitos de pesquisa, preservando a privacidade dos sujeitos de pesquisa. A prática de <italic>open data</italic> é viabilizar a reproducibilidade de resultados, e assegurar a irrestrita transparência dos resultados da pesquisa publicada, sem que seja demandada a identidade de sujeitos de pesquisa. </p>
+				</fn>
+			</fn-group>
+		</back>
+	</sub-article>
+</article>


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona ao menu lateral esquerdo da página do artigo, as notas de rodapé.
O objetivo é destacar editor de seção, disponibilidade de dados de pesquisa, entre outros, a fim de explicitar práticas de Ciência Aberta.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando htmlgenerator

```console
htmlgenerator --nonetwork --nochecks tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="272" alt="Captura de Tela 2022-11-18 às 08 35 04" src="https://user-images.githubusercontent.com/505143/202696567-060e3cf1-1857-42d4-a5ea-0dd7b89dce2c.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2451
https://github.com/scieloorg/opac/issues/2426

### Referências
https://wp.scielo.org/wp-content/uploads/dados.pdf
