### PR TITLE
Cria na página do artigo a seção "Dados de Pesquisa"

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    version="1.0">
+
+    <xsl:template match="article" mode="data-availability">
+        <xsl:if test="article-meta/supplementary-material or .//element-citation[@publication-type='data' or @publication-type='database']">
+            <xsl:variable name="title">
+                <xsl:apply-templates select="." mode="text-labels">
+                    <xsl:with-param name="text">Data availability</xsl:with-param>
+                </xsl:apply-templates>
+            </xsl:variable>
+            <div class="articleSection">
+                <xsl:attribute name="data-anchor"><xsl:value-of select="$title"/></xsl:attribute>
+                <h1 class="articleSectionTitle"><xsl:value-of select="$title"/></h1>
+                <xsl:apply-templates select=".//article-meta" mode="data-availability"/>
+                <xsl:apply-templates select=".//ref-list" mode="data-availability"/>
+             </div>
+       </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="article-meta" mode="data-availability">
+        <xsl:apply-templates select="element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability"/>
+    </xsl:template>
+
+    <xsl:template match="ref-list" mode="data-availability">
+        <xsl:if test=".//element-citation[@publication-type='data' or @publication-type='database']">
+            <xsl:apply-templates select=".//element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability"/>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="article-meta/supplementary-material" mode="data-availability">
+        <div class="row">
+            <div class="col-md-12 col-sm-12">
+                <p>
+                    <xsl:apply-templates select="."/>
+                </p>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability">
+        <div class="row">
+            <div class="col-md-12 col-sm-12">
+                <p>
+                    <xsl:apply-templates select="../mixed-citation"/>
+                </p>
+            </div>
+        </div>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -36,6 +36,7 @@
     <xsl:include href="article-text-boxed-text.xsl"/>
     <xsl:include href="article-text-list.xsl"/>
     <xsl:include href="article-text-supplementary-material.xsl"/>
+    <xsl:include href="article-text-section-data-availability.xsl"/>
 
     <xsl:include href="article-text-graphic.xsl"/>
     <xsl:include href="article-text-table.xsl"/>
@@ -254,6 +255,7 @@
 
             <xsl:apply-templates select="front/article-meta" mode="generic-pub-date"/>
             <xsl:apply-templates select="front/article-meta" mode="generic-history"/>
+            <xsl:apply-templates select="." mode="data-availability"/>
 
             <section class="documentLicense">
                 <div class="container-license">

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <labels>
     <term>
+        <name>Data availability</name>
+        <name lang="pt">Dados de pesquisa</name>
+        <name lang="es">Datos de investigación</name>
+    </term>
+    <term>
         <name>Text</name>
         <name lang="pt">Texto</name>
         <name lang="es">Texto</name>

--- a/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.en.html
+++ b/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.en.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css">
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css" media="print">
+<link rel="alternate" type="application/rss+xml" title="SciELO" href="">
+</head>
+<body class="journal article">
+<a name="top"></a><div id="standalonearticle">
+<section class="articleCtt"><div class="container"><div class="articleTxt">
+<div class="articleBadge-editionMeta-doi-copyLink">
+<span class="_articleBadge">ORIGINAL ARTICLE</span><span class="_separator"> • </span><span class="_editionMeta">Rev. Bras. Enferm. 75 
+                (06)
+            <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.1590/0034-7167-2021-0534" class="_doi" target="_blank">https://doi.org/10.1590/0034-7167-2021-0534</a>
+         
+        <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/0034-7167-2021-0534"><span class="sci-ico-link"></span>copy</a></span>
+</div>
+<h1 class="article-title">
+<span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Breastfeeding and diseases prevalent in the first two years of a child’s life: a cross-sectional study<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+</h1>
+<h2 class="article-title">Lactancia materna y enfermedades prevalentes en los dos primeros años de vida del niño: un estudio transversal</h2>
+<div class="articleMeta"></div>
+<div class="contribGroup">
+<span class="dropdown"><a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Evelin Matilde Arcain Nass </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<div class="corresp">
+<b>Corresponding author:</b> Evelin Matilde Arcain Nass <a href="mailto:evelinmarcain@gmail.com">evelinmarcain@gmail.com</a> </div>
+<a href="http://orcid.org/0000-0002-5140-3104" class="btnContribLinks orcid">http://orcid.org/0000-0002-5140-3104</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Sonia Silva Marcon </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<a href="http://orcid.org/0000-0002-6607-362X" class="btnContribLinks orcid">http://orcid.org/0000-0002-6607-362X</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Elen Ferraz Teston </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+<strong></strong>Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brazil.<a href="http://orcid.org/0000-0001-6835-0574" class="btnContribLinks orcid">http://orcid.org/0000-0001-6835-0574</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor4" class="dropdown-toggle" data-toggle="dropdown"><span> Luciana Pedrosa Leal </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor4">
+<strong></strong>Universidade Federal de Pernambuco. Recife, Pernambuco. Brazil.<a href="http://orcid.org/0000-0003-3776-0997" class="btnContribLinks orcid">http://orcid.org/0000-0003-3776-0997</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor5" class="dropdown-toggle" data-toggle="dropdown"><span> Sueli Mutsumi Tsukuda Ichisato </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor5">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<a href="http://orcid.org/0000-0002-6008-2795" class="btnContribLinks orcid">http://orcid.org/0000-0002-6008-2795</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor6" class="dropdown-toggle" data-toggle="dropdown"><span> Beatriz Rosana Gonçalves de Oliveira Toso </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor6">
+<strong></strong>Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brazil.<a href="http://orcid.org/0000-0001-7366-077X" class="btnContribLinks orcid">http://orcid.org/0000-0001-7366-077X</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor7" class="dropdown-toggle" data-toggle="dropdown"><span> Mariana Angela Rossaneis Moreira </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor7">
+<strong></strong>Universidade Estadual de Londrina. Londrina, Paraná. Brazil.<a href="http://orcid.org/0000-0002-8607-0020" class="btnContribLinks orcid">http://orcid.org/0000-0002-8607-0020</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor8" class="dropdown-toggle" data-toggle="dropdown"><span> Fabiane Blanco Silva Bernardino </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor8">
+<strong></strong>Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brazil.<a href="http://orcid.org/0000-0003-0339-9451" class="btnContribLinks orcid">http://orcid.org/0000-0003-0339-9451</a>
+</ul></span><a href="" class="outlineFadeLink" data-toggle="modal" data-target="#ModalTutors">About the authors</a>
+</div>
+<div class="row">
+<ul class="col-md-2 hidden-sm articleMenu"></ul>
+<article id="articleText" class="col-md-10 col-md-offset-2 col-sm-12 col-sm-offset-0"><div class="articleSection" data-anchor="ABSTRACT">
+<h1 class="articleSectionTitle">ABSTRACT</h1>
+<h2>Objectives:</h2>
+<p>to assess the association between breastfeeding and diseases prevalent in the first two years of a child’s life.</p>
+<h2>Methods:</h2>
+<p>a retrospective cross-sectional study that analyzed electronic medical records of 401 children. Data on birth, growth, breastfeeding and medical care in the first two years of life were collected. In the analysis, Poisson regression with robust variance was used.</p>
+<h2>Results:</h2>
+<p>27.9% of children were exclusively breastfed until six months, and, at 24 months, 93.3% had already had some prevalent childhood disease. In the crude analysis, 5-minute Apgar association, length, weight at 12 months, exclusive and non-exclusive breastfeeding time had association. In the adjusted analysis, only the variable breastfeeding at six months maintained the association with prevalent childhood diseases.</p>
+<h2>Conclusions:</h2>
+<p>children who were not breastfed, exclusively or not, up to six months of age, had a higher prevalence of diseases compared to breastfed children.</p>
+<p><strong>Descriptors:</strong><br>Breast Feeding; Integrated Management of Childhood Illness; Comprehensive Health Care; Education; Nursing; Child Health Services</p>
+</div>
+<div class="articleSection" data-anchor="RESUMEN">
+<h1 class="articleSectionTitle">RESUMEN</h1>
+<h2>Objetivos:</h2>
+<p>evaluar la asociación entre lactancia materna y enfermedades prevalentes en los dos primeros años de vida del niño.</p>
+<h2>Métodos:</h2>
+<p>estudio transversal retrospectivo que analizó las historias clínicas electrónicas de 401 niños. Se recogieron datos sobre nacimiento, crecimiento, lactancia y atención médica en los dos primeros años de vida. En el análisis se utilizó la regresión de Poisson con varianza robusta.</p>
+<h2>Resultados:</h2>
+<p>el 27,9% de los niños fueron amamantados exclusivamente hasta los seis meses de edad y, a los 24 meses, el 93,3% ya había tenido alguna enfermedad infantil prevalente. En el análisis crudo presentaron asociación de Apgar al minuto 5, longitud, peso a los 12 meses, tiempo de lactancia materna exclusiva y no exclusiva. En el análisis ajustado, sólo la variable lactancia materna a los seis meses mantuvo la asociación con las enfermedades prevalentes de la infancia.</p>
+<h2>Conclusiones:</h2>
+<p>los niños que no fueron amamantados, exclusivamente o no, hasta los seis meses de edad, presentaron mayor prevalencia de enfermedades en comparación con los niños amamantados.</p>
+<p><strong>Descriptores:</strong><br>Lactancia Materna; Atención Integrada a las Enfermedades Prevalentes de la Infancia; Atención Integral de Salud; Enfermería Perioperatoria; Servicios de Salud Infantil</p>
+</div>
+<div class="articleSection" data-anchor="RESUMO">
+<h1 class="articleSectionTitle">RESUMO</h1>
+<h2>Objetivos:</h2>
+<p>avaliar a associação do aleitamento materno e as doenças prevalentes nos primeiros dois anos de vida da criança.</p>
+<h2>Métodos:</h2>
+<p>estudo transversal retrospectivo, que analisou prontuários eletrônicos de 401 crianças. Foram coletados dados sobre nascimento, crescimento, aleitamento materno e atendimentos médicos nos dois primeiros anos de vida. Na análise, utilizou-se Regressão de Poisson com variância robusta.</p>
+<h2>Resultados:</h2>
+<p>receberam aleitamento exclusivo até os seis meses 27,9% das crianças, e, aos 24 meses de vida, 93,3% já haviam tido alguma doença prevalente da infância. Na análise bruta, apresentaram associação Apgar no 5º minuto, comprimento, peso aos 12 meses, tempo de aleitamento exclusivo e não exclusivo. Na análise ajustada, apenas a variável aleitamento materno aos seis meses manteve a associação com as doenças prevalentes da infância.</p>
+<h2>Conclusões:</h2>
+<p>as crianças que não foram amamentadas, exclusivamente ou não, até os seis meses, apresentaram maior prevalência de doenças em relação às amamentadas.</p>
+<p><strong>Descritores:</strong><br>Aleitamento Materno; Atenção Integrada às Doenças Prevalentes na Infância; Assistência Integral à Saúde da Criança; Enfermagem Pediátrica; Serviços de Saúde Infantil</p>
+</div>
+<div class="articleSection" data-anchor="Text">
+<h1 class="articleSectionTitle">SUPPLEMENTARY MATERIAL</h1>
+<p>The research database was deposited in SCIELO Data: Arcain, Evelin, 2021, “<i>Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal</i>”, <a href="https://doi.org/10.48331/scielodata.XPWWYD" target="_blank">https://doi.org/10.48331/scielodata.XPWWYD,</a> SciELO Data, DRAFT VERSION, UNF:6:rWHWyqc8p/Ef7BQh3BLfwQ== [fileUNF].</p>
+</div>
+<div>
+<h1></h1>
+<div class="ref-list"><ul class="refList footnote"><li>
+<div>
+          <b>FUNDING</b>
+        </div>
+<div>The present study was carried out with support from the Higher Education Personnel Improvement Coordination - Brazil (CAPES - <i>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior</i>) - Financing Code 001.</div>
+</li></ul></div>
+</div>
+<div class="articleSection" data-anchor="REFERENCES">
+<h1 class="articleSectionTitle">REFERENCES</h1>
+<div class="ref-list"><ul class="refList">
+<li>
+<sup class="xref big">1</sup><div> Ministério da Saúde (BR). Manual AIDPI Criança: 2 meses a 5 anos[Internet]. Brasília, DF: SVS; 2017[cited 2020 Mar 23]. Available from: portalarquivos.saude.gov.br/imagens/pdf/2017/julho/12/17-0056-Online.pdf</div>
+</li>
+<li>
+<sup class="xref big">2</sup><div> Ministério da Saúde (BR). Portaria nº 2.436, de 21 de setembro de 2017. Aprova a Política Nacional de Atenção Básica, estabelecendo a revisão de diretrizes para a organização da Atenção Básica, no âmbito do Sistema Único de Saúde[Internet]. Brasília, DF: 2017[cited 2020 Mar 20]. Available from: https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html <br><a href="https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436%C2%AC-_22_09_2017.html" target="_blank">» https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html</a>
+</div>
+</li>
+<li>
+<sup class="xref big">3</sup><div> World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 <br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">» https://apps.who.int/iris/handle/10665/259386</a>
+</div>
+</li>
+<li>
+<sup class="xref big">4</sup><div> Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. https://doi.org/10.1590/1413-81232018236.03942018 <br><a href="https://doi.org/10.1590/1413-81232018236.03942018" target="_blank">» https://doi.org/10.1590/1413-81232018236.03942018</a>
+</div>
+</li>
+<li>
+<sup class="xref big">5</sup><div> Videholm S, Wallby T, Silfverdal SA. Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden. BMJ Open. 2021;11:e046583. https://doi.org/10.1136/bmjopen-2020-046583 <br><a href="https://doi.org/10.1136/bmjopen-2020-046583" target="_blank">» https://doi.org/10.1136/bmjopen-2020-046583</a>
+</div>
+</li>
+<li>
+<sup class="xref big">6</sup><div> Baye A, Adane M, Sisay T, Hailemeskel HS. Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study. BMC Pediatrics. 2021;21:155. https://doi.org/10.1186/s12887-021-02592-5 <br><a href="https://doi.org/10.1186/s12887-021-02592-5" target="_blank">» https://doi.org/10.1186/s12887-021-02592-5</a>
+</div>
+</li>
+<li>
+<sup class="xref big">7</sup><div> Vijay J, Patel KK. Risk factors of infant mortality in Bangladesh. Clin Epidemiol Global Health. 2020;8(1):211-4. https://doi.org/10.1016/j.cegh.2019.07.003 <br><a href="https://doi.org/10.1016/j.cegh.2019.07.003" target="_blank">» https://doi.org/10.1016/j.cegh.2019.07.003</a>
+</div>
+</li>
+<li>
+<sup class="xref big">8</sup><div> Costa BR, Cevallos M, Altman DG, Rutjes AWS, Egger M. Uses and misuses of the STROBE statement: bibliographic study. BMJ Open. 2011;1:e 000048. https://doi.org/10.1136/bmjopen-2010-000048 <br><a href="https://doi.org/10.1136/bmjopen-2010-000048" target="_blank">» https://doi.org/10.1136/bmjopen-2010-000048</a>
+</div>
+</li>
+<li>
+<sup class="xref big">9</sup><div> Lopes WC, Marques FKS, Oliveira CF, Rodrigues JÁ, Silveira MF, Caldeira AP, et al. Infant feeding in the first two years of life. Rev Paul Pediatr. 2018;36(2):164-70. https://doi.org/10.1590/1984-0462/;2018;36;2;00004 <br><a href="https://doi.org/10.1590/1984-0462/;2018;36;2;00004" target="_blank">» https://doi.org/10.1590/1984-0462/;2018;36;2;00004</a>
+</div>
+</li>
+<li>
+<sup class="xref big">10</sup><div> Ministério da Saúde (BR), Secretaria de Vigilância em Saúde. Sistema de informações sobre nascidos vivos (SINASC) [Internet]. Brasília, DF: SVS; 2017 [cited 2020 Feb 10]. Available from: www2.datasus.gov.br/DATASUS/index.php?area=060702 <br><a href="http://www2.datasus.gov.br/DATASUS/index.php?area=060702" target="_blank">» www2.datasus.gov.br/DATASUS/index.php?area=060702</a>
+</div>
+</li>
+<li>
+<sup class="xref big">11</sup><div> Ministério da Saúde (BR). Caderneta de Saúde da Criança[Internet]. Brasília, DF: 2018[cited 2021 Jan 22]. Available from: https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf <br><a href="https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf" target="_blank">» https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf</a>
+</div>
+</li>
+<li>
+<sup class="xref big">12</sup><div> Brahma P, Valdés V. Benefits of breastfeeding and risks associated with not breastfeeding. Rev Child Pediatr. 2017;88(1):15-21. https://doi.org/10.4067/S0370-4106201700010000001 <br><a href="https://doi.org/10.4067/S0370-4106201700010000001" target="_blank">» https://doi.org/10.4067/S0370-4106201700010000001</a>
+</div>
+</li>
+<li>
+<sup class="xref big">13</sup><div> Prezotto KH, Lentsck MH, Aidar T, Fertonani HP, Mathias TAF. Hospitalizations of children for preventable conditions in the state of Parana: causes and trends. Acta Paul Enferm. 2017;30(3):254-61. https://doi.org/10.1590/1982-0194201700039 <br><a href="https://doi.org/10.1590/1982-0194201700039" target="_blank">» https://doi.org/10.1590/1982-0194201700039</a>
+</div>
+</li>
+<li>
+<sup class="xref big">14</sup><div> Flores TR, Nunes BP, Neves RG, Wendt AT, Costa CS, Wehrmeister FC, et al. Maternal breastfeeding and associated factors in children under two years: the Brazilian National Health Survey, 2013. Cad Saúde Pública. 2017;33(11):e00068816. https://doi.org/10.1590/0102-311x00068816 <br><a href="https://doi.org/10.1590/0102-311x00068816" target="_blank">» https://doi.org/10.1590/0102-311x00068816</a>
+</div>
+</li>
+<li>
+<sup class="xref big">15</sup><div> Boccolini CS, Boccolini PMM, Monteiro FR, Venâncio SI, Giugliani ERJ. Breastfeeding indicators trends in Brazil for three decades. Rev Saude Publica. 2017;51:108. https://doi.org/10.11606/S1518-8787.2017051000029 <br><a href="https://doi.org/10.11606/S1518-8787.2017051000029" target="_blank">» https://doi.org/10.11606/S1518-8787.2017051000029</a>
+</div>
+</li>
+<li>
+<sup class="xref big">16</sup><div> Garcez JCD, Oliveira Jr EN, Nunes MDS, Pinto LS, Soares TB, Silva MM, et al. Clinical and epidemiological profile in the first year of life. Rev Enferm UFPE. 2019;13:e241564. https://doi.org/10.5205/1981-8963.2019.241564 <br><a href="https://doi.org/10.5205/1981-8963.2019.241564" target="_blank">» https://doi.org/10.5205/1981-8963.2019.241564</a>
+</div>
+</li>
+<li>
+<sup class="xref big">17</sup><div> Peres JF, Carvalho ARS, Viera CS, Christoffel MM, Toso BRGO. Percepções dos profissionais de saúde acerca dos fatores biopsicossocioculturais relacionados com o aleitamento materno. Saúde Debate. 2021;45(128):141051. https://doi.org/10.1590/0103-1104202112811 <br><a href="https://doi.org/10.1590/0103-1104202112811" target="_blank">» https://doi.org/10.1590/0103-1104202112811</a>
+</div>
+</li>
+<li>
+<sup class="xref big">18</sup><div> Tronco CS, Bonilha ALL, Teles JM. Rede de apoio para o aleitamento materno na prematuridade tardia. Cienc Cuid Saude. 2020;19:e46479. https://doi.org/10.4025/cienccuidsaude.v19i0.46479 <br><a href="https://doi.org/10.4025/cienccuidsaude.v19i0.46479" target="_blank">» https://doi.org/10.4025/cienccuidsaude.v19i0.46479</a>
+</div>
+</li>
+<li>
+<sup class="xref big">19</sup><div> Contarato AAPF, Rocha EDM, Czarnobay SA, Mastroeni SSBS, Veugelers PJ, Mastroeni MF. Independent effect of type of breastfeeding on overweight and obesity in children aged 12-24 months. Cad Saúde Pública. 2016;32(12):e00119015. https://doi.org/10.1590/0102-311X00119015 <br><a href="https://doi.org/10.1590/0102-311X00119015" target="_blank">» https://doi.org/10.1590/0102-311X00119015</a>
+</div>
+</li>
+<li>
+<sup class="xref big">20</sup><div> Frank NM, Lynch KF, Uusitalo U, Yang J, Lonnrot M, Virtanen SM, et al. The relationship between breastfeeding and reported respiratory and gastrointestinal infection rates in young children. BMC Pediatrics. 2019;19:339. https://doi.org/10.1186/s12887-019-1693-2 <br><a href="https://doi.org/10.1186/s12887-019-1693-2" target="_blank">» https://doi.org/10.1186/s12887-019-1693-2</a>
+</div>
+</li>
+<li>
+<sup class="xref big">21</sup><div> Oliveira RKL, Oliveira BSB, Bezerra JC, Silva MJN, Melo FMS, Joventino ES. Influence of socio-economic conditions and maternal knowledge in self-effectiveness for prevention of childhood diarrhea. Esc Anna Nery. 2017;21(4):e20160361. https://doi.org/10.1590/2177-9465-ean-2016-0361 <br><a href="https://doi.org/10.1590/2177-9465-ean-2016-0361" target="_blank">» https://doi.org/10.1590/2177-9465-ean-2016-0361</a>
+</div>
+</li>
+<li>
+<sup class="xref big">22</sup><div> Monteiro ATA, Ferrari RAP, Tacla MTGM, Souza ALDM. Pediatric nursing consultation after maternity discharge: follow-up in primary care. Rev Soc Bras Enferm Ped. 2017;17(1):7-13. https://doi.org/10.31508/1676-3793201700002 <br><a href="https://doi.org/10.31508/1676-3793201700002" target="_blank">» https://doi.org/10.31508/1676-3793201700002</a>
+</div>
+</li>
+<li>
+<sup class="xref big">23</sup><div> Pinheiro JGA, Rodrigues NS, Silveira AO, Martins G. Mother and nursing academic: experience with intestinal constipation. Rev Enferm UFPE [Internet]. 2019[cited 2020 Feb 10];13(5):1520-1519. Available from: https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782 <br><a href="https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782" target="_blank">» https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782</a>
+</div>
+</li>
+<li>
+<sup class="xref big">24</sup><div> Melo KM, Cruz ACP, Brito MFSF, Pinho L. Influence of parents' behavior during the meal and on overweight in childhood. Esc Anna Nery. 2017;21(4):e20170102. https://doi.org/10.1590/2177-9465-EAN-2017-0102 <br><a href="https://doi.org/10.1590/2177-9465-EAN-2017-0102" target="_blank">» https://doi.org/10.1590/2177-9465-EAN-2017-0102</a>
+</div>
+</li>
+<li>
+<sup class="xref big">25</sup><div> Nadal LF, Rodrigues AH, Costa CC, Godoi VC, Klossowski DG, Fujinaga CI. Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media. Rev CEFAC. 2017;19(3):387-94. https://doi.org/10.1590/1982-0216201719314916 <br><a href="https://doi.org/10.1590/1982-0216201719314916" target="_blank">» https://doi.org/10.1590/1982-0216201719314916</a>
+</div>
+</li>
+<li>
+<sup class="xref big">26</sup><div> Silva VLS, França GVA, Santos IS, Barros FC, Matijasevich A. Characteristics and factors associated with hospitalization in early childhood: 2004 Pelotas (Brazil) birth cohort. Cad Saúde Pública. 2017;33(10):e00035716. https://doi.org/10.1590/0102-311X00035716 <br><a href="https://doi.org/10.1590/0102-311X00035716" target="_blank">» https://doi.org/10.1590/0102-311X00035716</a>
+</div>
+</li>
+<li>
+<sup class="xref big">27</sup><div> Alive &amp; Thrive. The economic costs of not breastfeeding in Brazil [Internet]. 2020[cited 2020 Oct 20]. Available from: https://aliveandthrive.org/country-stat/brazil/#ec__children <br><a href="https://aliveandthrive.org/country-stat/brazil/#ec__children" target="_blank">» https://aliveandthrive.org/country-stat/brazil/#ec__children</a>
+</div>
+</li>
+</ul></div>
+</div>
+<div class="articleSection" data-anchor="Publication Dates">
+<h1 class="articleSectionTitle">Publication Dates</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Publication in this collection</strong><br>06 June 2022</li>
+<li>
+<strong>Date of issue</strong><br>2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="History">
+<h1 class="articleSectionTitle">History</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Received</strong><br>23 Aug 2021</li>
+<li>
+<strong>Accepted</strong><br>11 Feb 2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="Data availability">
+<h1 class="articleSectionTitle">Data availability</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><p> World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </p></div></div>
+<div class="row"><div class="col-md-12 col-sm-12"><p> Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. https://doi.org/10.1590/1413-81232018236.03942018 </p></div></div>
+</div>
+<section class="documentLicense"><div class="container-license"><div class="row">
+<div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+<div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">This is an Open Access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</a></div>
+</div></div></section></article>
+</div>
+</div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">About the authors</h4>
+</div>
+<div class="modal-body">
+<div class="info">
+<div class="tutors">
+<strong> Evelin Matilde Arcain Nass </strong><strong></strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-5140-3104" class="btnContribLinks orcid">http://orcid.org/0000-0002-5140-3104</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Sonia Silva Marcon </strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-6607-362X" class="btnContribLinks orcid">http://orcid.org/0000-0002-6607-362X</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Elen Ferraz Teston </strong><br><div>Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0001-6835-0574" class="btnContribLinks orcid">http://orcid.org/0000-0001-6835-0574</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Luciana Pedrosa Leal </strong><br><div>Universidade Federal de Pernambuco. Recife, Pernambuco. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-3776-0997" class="btnContribLinks orcid">http://orcid.org/0000-0003-3776-0997</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Sueli Mutsumi Tsukuda Ichisato </strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-6008-2795" class="btnContribLinks orcid">http://orcid.org/0000-0002-6008-2795</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Beatriz Rosana Gonçalves de Oliveira Toso </strong><br><div>Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0001-7366-077X" class="btnContribLinks orcid">http://orcid.org/0000-0001-7366-077X</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Mariana Angela Rossaneis Moreira </strong><br><div>Universidade Estadual de Londrina. Londrina, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-8607-0020" class="btnContribLinks orcid">http://orcid.org/0000-0002-8607-0020</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Fabiane Blanco Silva Bernardino </strong><br><div>Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-0339-9451" class="btnContribLinks orcid">http://orcid.org/0000-0003-0339-9451</a></li></ul>
+<div class="clearfix"></div>
+</div>
+</div>
+<div class="info">
+<b>Corresponding author:</b> Evelin Matilde Arcain Nass <a href="mailto:evelinmarcain@gmail.com">evelinmarcain@gmail.com</a> </div>
+<div class="info"><div>EDITOR IN CHIEF: Antonio José de Almeida Filho</div></div>
+<div class="info"><div>ASSOCIATE EDITOR: Alexandre Balsanelli</div></div>
+</div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">How to cite</h4>
+</div>
+<div class="modal-body">
+<p id="citation"></p>
+<input id="citationCut" type="text" value=""><a class="copyLink" data-clipboard-target="#citationCut"><span class="glyphBtn copyIcon"></span>copy</a>
+</div>
+</div></div></div>
+<script type="text/javascript">
+            function currentDate() {
+            var today = new Date();
+            var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+            today.setTime(today.getTime());
+            return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+            }
+            var citation = 'Nass, Evelin Matilde Arcain et al. ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Breastfeeding and diseases prevalent in the first two years of a child’s life: a cross-sectional study. Revista Brasileira de Enfermagem [online]. 2022, v. 75, n. 06 [Accessed CURRENTDATE] , e20210534. Available from: &lt;https://doi.org/10.1590/0034-7167-2021-0534 https://doi.org/10.1590/0034-7167-2021-0534pt&gt;. Epub 06 June 2022. ISSN 1984-0446. https://doi.org/10.1590/0034-7167-2021-0534.'.replace('CURRENTDATE', currentDate());
+            document.getElementById('citation').innerHTML = citation;
+            document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+        </script>
+</div>
+<ul class="floatingMenu fm-slidein" data-fm-toogle="hover"><li class="fm-wrap">
+<a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a><ul class="fm-list">
+<li><a class="fm-button-child" data-fm-label="Tables" data-toggle="modal" data-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+<li><a class="fm-button-child" data-toggle="modal" data-target="#ModalArticles" data-fm-label="How to
+                                          cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+</ul>
+</li></ul>
+<script src="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js"></script>
+</body>
+</html>

--- a/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.pt.html
+++ b/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.pt.html
@@ -1,0 +1,1393 @@
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title></title>
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css">
+<link rel="stylesheet" href="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css" media="print">
+<link rel="alternate" type="application/rss+xml" title="SciELO" href="">
+</head>
+<body class="journal article">
+<a name="top"></a><div id="standalonearticle">
+<section class="articleCtt"><div class="container"><div class="articleTxt">
+<div class="articleBadge-editionMeta-doi-copyLink">
+<span class="_articleBadge">ARTIGO ORIGINAL</span><span class="_separator"> • </span><span class="_editionMeta">Rev. Bras. Enferm. 75 
+                (06)
+            <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.1590/0034-7167-2021-0534pt" class="_doi" target="_blank">https://doi.org/10.1590/0034-7167-2021-0534pt</a>
+         
+        <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/0034-7167-2021-0534pt"><span class="sci-ico-link"></span>copiar</a></span>
+</div>
+<h1 class="article-title">
+<span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+</h1>
+<div class="articleMeta"></div>
+<div class="contribGroup">
+<span class="dropdown"><a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Evelin Matilde Arcain Nass </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<div class="corresp">
+<b>Autor Correspondente:</b> Evelin Matilde Arcain Nass <a href="mailto:evelinmarcain@gmail.com">evelinmarcain@gmail.com</a> </div>
+<a href="http://orcid.org/0000-0002-5140-3104" class="btnContribLinks orcid">http://orcid.org/0000-0002-5140-3104</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Sonia Silva Marcon </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<a href="http://orcid.org/0000-0002-6607-362X" class="btnContribLinks orcid">http://orcid.org/0000-0002-6607-362X</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Elen Ferraz Teston </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+<strong></strong>Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brazil.<a href="http://orcid.org/0000-0001-6835-0574" class="btnContribLinks orcid">http://orcid.org/0000-0001-6835-0574</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor4" class="dropdown-toggle" data-toggle="dropdown"><span> Luciana Pedrosa Leal </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor4">
+<strong></strong>Universidade Federal de Pernambuco. Recife, Pernambuco. Brazil.<a href="http://orcid.org/0000-0003-3776-0997" class="btnContribLinks orcid">http://orcid.org/0000-0003-3776-0997</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor5" class="dropdown-toggle" data-toggle="dropdown"><span> Sueli Mutsumi Tsukuda Ichisato </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor5">
+<strong></strong>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.<a href="http://orcid.org/0000-0002-6008-2795" class="btnContribLinks orcid">http://orcid.org/0000-0002-6008-2795</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor6" class="dropdown-toggle" data-toggle="dropdown"><span> Beatriz Rosana Gonçalves de Oliveira Toso </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor6">
+<strong></strong>Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brazil.<a href="http://orcid.org/0000-0001-7366-077X" class="btnContribLinks orcid">http://orcid.org/0000-0001-7366-077X</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor7" class="dropdown-toggle" data-toggle="dropdown"><span> Mariana Angela Rossaneis Moreira </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor7">
+<strong></strong>Universidade Estadual de Londrina. Londrina, Paraná. Brazil.<a href="http://orcid.org/0000-0002-8607-0020" class="btnContribLinks orcid">http://orcid.org/0000-0002-8607-0020</a>
+</ul></span><span class="dropdown"><a id="contribGroupTutor8" class="dropdown-toggle" data-toggle="dropdown"><span> Fabiane Blanco Silva Bernardino </span></a><ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor8">
+<strong></strong>Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brazil.<a href="http://orcid.org/0000-0003-0339-9451" class="btnContribLinks orcid">http://orcid.org/0000-0003-0339-9451</a>
+</ul></span><a href="" class="outlineFadeLink" data-toggle="modal" data-target="#ModalTutors">Sobre os autores</a>
+</div>
+<div class="row">
+<ul class="col-md-2 hidden-sm articleMenu"></ul>
+<article id="articleText" class="col-md-10 col-md-offset-2 col-sm-12 col-sm-offset-0"><div class="articleSection" data-anchor="ABSTRACT">
+<h1 class="articleSectionTitle">ABSTRACT</h1>
+<h2>Objectives:</h2>
+<p>to assess the association between breastfeeding and diseases prevalent in the first two years of a child’s life.</p>
+<h2>Methods:</h2>
+<p>a retrospective cross-sectional study that analyzed electronic medical records of 401 children. Data on birth, growth, breastfeeding and medical care in the first two years of life were collected. In the analysis, Poisson regression with robust variance was used.</p>
+<h2>Results:</h2>
+<p>27.9% of children were exclusively breastfed until six months, and, at 24 months, 93.3% had already had some prevalent childhood disease. In the crude analysis, 5-minute Apgar association, length, weight at 12 months, exclusive and non-exclusive breastfeeding time had association. In the adjusted analysis, only the variable breastfeeding at six months maintained the association with prevalent childhood diseases.</p>
+<h2>Conclusions:</h2>
+<p>children who were not breastfed, exclusively or not, up to six months of age, had a higher prevalence of diseases compared to breastfed children.</p>
+<p><strong>Descriptors:</strong><br>Breast Feeding; Integrated Management of Childhood Illness; Comprehensive Health Care; Education; Nursing; Child Health Services</p>
+</div>
+<div class="articleSection" data-anchor="RESUMEN">
+<h1 class="articleSectionTitle">RESUMEN</h1>
+<h2>Objetivos:</h2>
+<p>evaluar la asociación entre lactancia materna y enfermedades prevalentes en los dos primeros años de vida del niño.</p>
+<h2>Métodos:</h2>
+<p>estudio transversal retrospectivo que analizó las historias clínicas electrónicas de 401 niños. Se recogieron datos sobre nacimiento, crecimiento, lactancia y atención médica en los dos primeros años de vida. En el análisis se utilizó la regresión de Poisson con varianza robusta.</p>
+<h2>Resultados:</h2>
+<p>el 27,9% de los niños fueron amamantados exclusivamente hasta los seis meses de edad y, a los 24 meses, el 93,3% ya había tenido alguna enfermedad infantil prevalente. En el análisis crudo presentaron asociación de Apgar al minuto 5, longitud, peso a los 12 meses, tiempo de lactancia materna exclusiva y no exclusiva. En el análisis ajustado, sólo la variable lactancia materna a los seis meses mantuvo la asociación con las enfermedades prevalentes de la infancia.</p>
+<h2>Conclusiones:</h2>
+<p>los niños que no fueron amamantados, exclusivamente o no, hasta los seis meses de edad, presentaron mayor prevalencia de enfermedades en comparación con los niños amamantados.</p>
+<p><strong>Descriptores:</strong><br>Lactancia Materna; Atención Integrada a las Enfermedades Prevalentes de la Infancia; Atención Integral de Salud; Enfermería Perioperatoria; Servicios de Salud Infantil</p>
+</div>
+<div class="articleSection" data-anchor="RESUMO">
+<h1 class="articleSectionTitle">RESUMO</h1>
+<h2>Objetivos:</h2>
+<p>avaliar a associação do aleitamento materno e as doenças prevalentes nos primeiros dois anos de vida da criança.</p>
+<h2>Métodos:</h2>
+<p>estudo transversal retrospectivo, que analisou prontuários eletrônicos de 401 crianças. Foram coletados dados sobre nascimento, crescimento, aleitamento materno e atendimentos médicos nos dois primeiros anos de vida. Na análise, utilizou-se Regressão de Poisson com variância robusta.</p>
+<h2>Resultados:</h2>
+<p>receberam aleitamento exclusivo até os seis meses 27,9% das crianças, e, aos 24 meses de vida, 93,3% já haviam tido alguma doença prevalente da infância. Na análise bruta, apresentaram associação Apgar no 5º minuto, comprimento, peso aos 12 meses, tempo de aleitamento exclusivo e não exclusivo. Na análise ajustada, apenas a variável aleitamento materno aos seis meses manteve a associação com as doenças prevalentes da infância.</p>
+<h2>Conclusões:</h2>
+<p>as crianças que não foram amamentadas, exclusivamente ou não, até os seis meses, apresentaram maior prevalência de doenças em relação às amamentadas.</p>
+<p><strong>Descritores:</strong><br>Aleitamento Materno; Atenção Integrada às Doenças Prevalentes na Infância; Assistência Integral à Saúde da Criança; Enfermagem Pediátrica; Serviços de Saúde Infantil</p>
+</div>
+<div>
+<h1 class="articleSectionTitle">INTRODUÇÃO</h1>
+<p>A estratégia de Atenção Integrada às Doenças Prevalentes na Infância (AIDPI), desenvolvida pela Organização Mundial da Saúde (OMS), Organização Panamericana da Saúde e Fundo das Nações Unidas para a Infância, visa diminuir a morbimortalidade em crianças entre dois meses e cinco anos de idade(<span class="ref"><sup class="xref xrefblue">1</sup><span class="refCtt closed"><span>1 Ministério da Saúde (BR). Manual AIDPI Criança: 2 meses a 5 anos[Internet]. Brasília, DF: SVS; 2017[cited 2020 Mar 23]. Available from: portalarquivos.saude.gov.br/imagens/pdf/2017/julho/12/17-0056-Online.pdf</span></span></span>), mediante a melhoria da qualidade da assistência ofertada pela Atenção Básica(<span class="ref"><sup class="xref xrefblue">2</sup><span class="refCtt closed"><span>2 Ministério da Saúde (BR). Portaria nº 2.436, de 21 de setembro de 2017. Aprova a Política Nacional de Atenção Básica, estabelecendo a revisão de diretrizes para a organização da Atenção Básica, no âmbito do Sistema Único de Saúde[Internet]. Brasília, DF: 2017[cited 2020 Mar 20]. Available from: https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html </span><br><a href="https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436%C2%AC-_22_09_2017.html" target="_blank">https://bvsms.saude.gov.br/bvs/saudelegi...
+            </a></span></span>).</p>
+<p>Uma das principais ações preconizadas pela AIDPI relativas à promoção da saúde é a recomendação do aleitamento materno exclusivo (AME) nos primeiros seis meses de vida e complementado até os dois anos ou mais, uma vez que o leite materno (LM) constitui importante fator de proteção para a saúde da criança, estando relacionado à prevenção de anemias, fortalecimento do sistema imunológico, redução dos casos de infecção, diarreias e desnutrição(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>) e inclusive mortalidade infantil(<span class="ref"><sup class="xref xrefblue">4</sup><span class="refCtt closed"><span>4 Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. https://doi.org/10.1590/1413-81232018236.03942018 </span><br><a href="https://doi.org/10.1590/1413-81232018236.03942018" target="_blank">https://doi.org/10.1590/1413-81232018236...
+            </a></span></span>).</p>
+<p>No que se refere às doenças prevalentes, um estudo de coorte realizado na Suécia, com o objetivo de avaliar a associação entre a prática de amamentação e as hospitalizações por doenças infecciosas em crianças de até quatro anos, revelou que o risco de internações por doenças infecciosas diminuiu com a duração do AME. Na primeira infância, o aleitamento materno foi associado a uma diminuição do risco de infecções entéricas e respiratórias e, nas crianças de dois a quatro anos, a um menor risco de infecções respiratórias(<span class="ref"><sup class="xref xrefblue">5</sup><span class="refCtt closed"><span>5 Videholm S, Wallby T, Silfverdal SA. Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden. BMJ Open. 2021;11:e046583. https://doi.org/10.1136/bmjopen-2020-046583 </span><br><a href="https://doi.org/10.1136/bmjopen-2020-046583" target="_blank">https://doi.org/10.1136/bmjopen-2020-046...
+            </a></span></span>).</p>
+<p>Pesquisa, cujo objetivo foi avaliar os determinantes da diarreia em crianças de 0 a 23 meses na cidade de Dessie, nordeste da Etiópia, evidenciou que a redução da doença diarreica aguda entre crianças menores de dois anos se concentra na melhoria das práticas exclusivas de amamentação(<span class="ref"><sup class="xref xrefblue">6</sup><span class="refCtt closed"><span>6 Baye A, Adane M, Sisay T, Hailemeskel HS. Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study. BMC Pediatrics. 2021;21:155. https://doi.org/10.1186/s12887-021-02592-5 </span><br><a href="https://doi.org/10.1186/s12887-021-02592-5" target="_blank">https://doi.org/10.1186/s12887-021-02592...
+            </a></span></span>).</p>
+<p>Apesar da notoriedade em relação aos benefícios do AME e seus desfechos, fortalecer as evidências atuais acerca da ocorrência de doenças prevalentes da infância nos dois primeiros anos de vida e sua associação com a proteção conferida pelo aleitamento materno poderá reiterar a hipótese de que aqueles bebês que foram amamentados terão maior proteção em relação àqueles que não receberam AME. Dessa forma, os resultados deste estudo podem conferir a possibilidade para o enfermeiro discutir e apoiar as mulheres que desejam amamentar, uma vez que os subsídios teóricos e práticos produzidos trarão exemplos da relação direta entre o aleitamento e a proteção contra algumas doenças, além de implementar intervenções seguras que permitirão o aperfeiçoamento de medidas de promoção e proteção à amamentação.</p>
+<p>A atenção à saúde da criança no Brasil, enquanto uma das prioridades no âmbito das políticas públicas, passou por um extenso processo de construção ao longo da história, partindo de um modelo centrado na doença e em ações curativas para outro baseado em uma visão ampliada da saúde, com foco em ações preventivas e de promoção e proteção da saúde, em que a prática do enfermeiro está ancorada(<span class="ref"><sup class="xref xrefblue">5</sup><span class="refCtt closed"><span>5 Videholm S, Wallby T, Silfverdal SA. Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden. BMJ Open. 2021;11:e046583. https://doi.org/10.1136/bmjopen-2020-046583 </span><br><a href="https://doi.org/10.1136/bmjopen-2020-046583" target="_blank">https://doi.org/10.1136/bmjopen-2020-046...
+            </a></span></span>). Além disso, o segundo e o quarto eixo da Política Nacional de Atenção Integral à Saúde da Criança (PNAISC) orientam o aleitamento materno (AM) e alimentação complementar saudável, e a atenção integral a crianças com agravos prevalentes na infância e com doenças crônicas, respectivamente(<span class="ref"><sup class="xref xrefblue">6</sup><span class="refCtt closed"><span>6 Baye A, Adane M, Sisay T, Hailemeskel HS. Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study. BMC Pediatrics. 2021;21:155. https://doi.org/10.1186/s12887-021-02592-5 </span><br><a href="https://doi.org/10.1186/s12887-021-02592-5" target="_blank">https://doi.org/10.1186/s12887-021-02592...
+            </a></span></span>).</p>
+<p>Contudo, salienta-se que, mesmo com o progresso em relação à sobrevivência e à saúde infantil em países em desenvolvimento, como o Brasil, a desigualdade socioeconômica ainda é presente e tem se acentuado nos últimos anos, o que constitui um fator determinante no processo saúde-doença infantil e influência nas ações de prevenção do adoecimento e das mortes por causas evitáveis na infância(<span class="ref"><sup class="xref xrefblue">7</sup><span class="refCtt closed"><span>7 Vijay J, Patel KK. Risk factors of infant mortality in Bangladesh. Clin Epidemiol Global Health. 2020;8(1):211-4. https://doi.org/10.1016/j.cegh.2019.07.003 </span><br><a href="https://doi.org/10.1016/j.cegh.2019.07.003" target="_blank">https://doi.org/10.1016/j.cegh.2019.07.0...
+            </a></span></span>). Nesse contexto, pesquisas que reiteradamente avaliam a influência do AM na promoção da saúde das crianças colaboram para direcionar políticas públicas e as próprias práticas profissionais, a partir de evidências recentes e confiáveis.</p>
+<h1 class="articleSectionTitle">OBJETIVOS</h1>
+<p>Avaliar a associação do AM e as doenças prevalentes nos primeiros dois anos de vida da criança.</p>
+<h1 class="articleSectionTitle">MÉTODOS</h1>
+<h2>Aspectos éticos</h2>
+<p>O estudo ocorreu em conformidade com o preconizado pela Resolução 466/2012 da Comissão Nacional de Ética em Pesquisa (CONEP). Seu projeto foi autorizado pela Secretaria Municipal de Saúde e aprovado pelo Comitê de Ética da instituição signatária, que autorizou a dispensa de assinatura do Termo de consentimento Livre e Esclarecido, por utilizar dados secundários.</p>
+<h2>Desenho, período e local do estudo</h2>
+<p>Estudo transversal, recorte de pesquisa matricial, realizada em dois hospitais que realizam o parto pelo Sistema Único de Saúde (SUS) no munícipio de Maringá, PR, sul do Brasil, sendo somente um deles Hospital Amigo da Criança. O estudo matricial objetivou avaliar o ganho de peso gestacional e a retenção de peso pós-parto e possível relação com as condições de vida e saúde da criança. Para elaboração e descrição do estudo, consideraram-se as orientações do <i>Strengthening the Reporting of Observational studies in Epidemiology</i> (STROBE)(<span class="ref"><sup class="xref xrefblue">8</sup><span class="refCtt closed"><span>8 Costa BR, Cevallos M, Altman DG, Rutjes AWS, Egger M. Uses and misuses of the STROBE statement: bibliographic study. BMJ Open. 2011;1:e 000048. https://doi.org/10.1136/bmjopen-2010-000048 </span><br><a href="https://doi.org/10.1136/bmjopen-2010-000048" target="_blank">https://doi.org/10.1136/bmjopen-2010-000...
+            </a></span></span>).</p>
+<h2>População ou amostra; critérios de inclusão e exclusão</h2>
+<p>A população do estudo foi composta pelos filhos de mães que participaram da pesquisa matricial. Na delimitação do tamanho amostral, ponderaram-se a prevalência de 30,2% de desmame antes dos 180 dias de vida(<span class="ref"><sup class="xref xrefblue">9</sup><span class="refCtt closed"><span>9 Lopes WC, Marques FKS, Oliveira CF, Rodrigues JÁ, Silveira MF, Caldeira AP, et al. Infant feeding in the first two years of life. Rev Paul Pediatr. 2018;36(2):164-70. https://doi.org/10.1590/1984-0462/;2018;36;2;00004 </span><br><a href="https://doi.org/10.1590/1984-0462/;2018;36;2;00004" target="_blank">https://doi.org/10.1590/1984-0462/;2018;...
+            </a></span></span>), o número de 5157 crianças nascidas em 2017 no municípiosegundo o Sistema de Informações sobre Nascidos Vivos (SINASC-DATASUS)(<span class="ref"><sup class="xref xrefblue">10</sup><span class="refCtt closed"><span>10 Ministério da Saúde (BR), Secretaria de Vigilância em Saúde. Sistema de informações sobre nascidos vivos (SINASC) [Internet]. Brasília, DF: SVS; 2017 [cited 2020 Feb 10]. Available from: www2.datasus.gov.br/DATASUS/index.php?area=060702 </span><br><a href="www2.datasus.gov.br/DATASUS/index.php?area=060702" target="_blank">www2.datasus.gov.br/DATASUS/index.php?ar...
+            </a></span></span>), o nível de significância de 5%, o intervalo de confiança de 95% e o erro de 5%, o que resultou em uma amostra de 334 crianças que, acrescida de 20% para possíveis perdas e descontinuidade, totalizando 401 crianças.</p>
+<p>Foram incluídos no estudo prontuários de crianças que residiam em Maringá, PR, que nasceram com idade gestacional ≥ 37 semanas e que, no puerpério imediato, estavam em AME. Por sua vez, não foram incluídos os gemelares, os neonatos que interromperam o AME antes da alta hospitalar e as crianças que, à época da coleta de dados, ainda não haviam completado 24 meses de vida.</p>
+<h2>Protocolo do estudo</h2>
+<p>Os dados foram coletados no período de março a outubro de 2020, mediante consulta ao prontuário eletrônico das crianças no sistema Gestor da Secretaria Municipal de Saúde. Esse sistema é utilizado, de forma integrada, por todas as Unidades Básicas de Saúde do município, o que possibilitou que os participantes fossem localizados a partir das informações obtidas na pesquisa matricial.</p>
+<p>A consulta e coleta de dados no sistema gestor foi realizada por uma única pessoa (pesquisadora principal) que, mediante agendamento prévio, compareceu durante oito meses, duas vezes na semana, na sala do CECAPS - Assessoria de Formação e Capacitação dos Trabalhadores da Saúde - da Secretaria de Saúde e acessava o sistema mediante autorização do setor.</p>
+<p>Os dados de interesse foram os referentes à alimentação, crescimento e atendimentos médicos prestados à criança nos serviços de saúde do município.</p>
+<p>Foram consideradas como variáveis de exposição:</p>
+<ol type="a">
+<li><p>características sociodemográficas: sexo (feminino, masculino); raça/cor (branco, amarelo, pardo, preto).</p></li>
+<li><p>dados do nascimento: Apgar 1° minuto e 5° minuto (pontuação); peso e comprimento ao nascer (utilizadas as curvas de crescimento de zero a dois anos segundo o sexo (meninos/meninas), e considerado peso adequado para a idade o padrão de escore-z ≥-2 e ≤ +2 e peso inadequado quando elevado para a idade (&gt; + 2), baixo para a idade (≥-3 e &lt;-2) e muito baixo para idade (&lt;-3); comprimento adequado para idade o padrão de escore-z ≥-2 e ≤ +2 e comprimento inadequado quando elevado para a idade (&gt; + 2), baixo para a idade (≥-3 e &lt;-2) e muito baixo para idade (&lt;-3), conforme recomendado pela OMS)(<span class="ref"><sup class="xref xrefblue">11</sup><span class="refCtt closed"><span>11 Ministério da Saúde (BR). Caderneta de Saúde da Criança[Internet]. Brasília, DF: 2018[cited 2021 Jan 22]. Available from: https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf </span><br><a href="https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf" target="_blank">https://bvsms.saude.gov.br/bvs/publicaco...
+            </a></span></span>).</p></li>
+<li><p>dados de crescimento: peso corporal aos 12 e 24 meses (parâmetros adotados nas curvas de crescimento(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>).</p></li>
+<li><p>condições de vida e saúde - alimentação: AME até os seis meses (somente LM, direto da mama ou ordenhado, ou leite humano de outra fonte, sem outros líquidos ou sólidos, com exceção de gotas ou xaropes contendo vitaminas, sais de reidratação oral, suplementos minerais ou medicamentos)(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>); AM aos 12 e 24 meses (LM direto da mama ou ordenhado, independentemente de receber outros alimentos)(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>); atualização do calendário vacinal aos 24 meses de idade; histórico de hospitalização (sim/não); frequência a centro de educação infantil (sim/não).</p></li>
+</ol>
+<p>A variável de desfecho primário sob investigação foi a presença (registro em prontuário) de doenças prevalentes da infância nos primeiros dois anos de vida e sua associação com o AME, identificada a partir do diagnóstico registrado pelo médico no prontuário. Este registro é acompanhado do número identificado na Classificação Internacional de Doenças (CID-10). Consideraram-se, para análise, os diagnósticos com frequência ≥ 10,0%, quais sejam: CID J06 - infecção aguda de vias áreas; CID 05 - tosse; CID H66 - otite; CID R50 - febre; CID A09 - diarreia e gastroenterite; CID R10 - dor abdominal e pélvica; CID K59 - transtorno funcionais do intestino; CID K21 - refluxo gastroesofágico; CID N39 - transtorno trato urinário; e CID L22 - dermatite das fraldas. Para categorização, considerou-se “presença” quando as crianças apresentaram ao menos um episódio das doenças acima mencionadas. Os desfechos secundários foram a associação da alimentação e do crescimento e as referidas doenças, ambos vinculados às recomendações da OMS(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>).</p>
+<h2>Análise dos resultados e estatística</h2>
+<p>As análises estatísticas foram realizadas no programa <i>Statistical Package for the Social Sciences</i> (SPSS), 21.0. Primeiramente, realizou-se a análise bivariada entre as variáveis independentes com a variável de desfecho doenças prevalentes nos dois primeiros anos de vida. A normalidade dos dados foi testada por meio do Teste de Shapiro Wilk e de Kolmogorov-Smirnov. Variáveis com valor de p &lt; 0,20 na análise bivariada foram selecionadas para compor o modelo ajustado por regressão de Poisson, pelo método <i>stepwise</i>, com variância robusta. Possíveis variáveis confundidoras foram testadas no modelo estatístico para poder explicar a associação de interesse. A medida de associação empregada foi à razão de prevalência (RP) tanto para a análise bivariada quanto para a regressão de Poisson. Para ambas as análises, adotou-se o nível de significância de 5% no Teste do Qui-Quadrado de Wald, e foram apresentados o valor de p e o intervalo de confiança de 95% (IC95%).</p>
+<h1 class="articleSectionTitle">RESULTADOS</h1>
+<p>Das 401 crianças cujos prontuários integraram o estudo, a maioria era do sexo masculino (57,6%) e nasceu com peso adequado (83,5%), mas este percentual foi decaindo ao longo do tempo, de modo que, aos 12 meses, 66,3% tinham o peso adequado, e, aos 24 meses, este percentual caiu para 44,6%. Aos dois anos, 92,8% das crianças estavam com o esquema vacinal atualizado, e 84,8% frequentavam centro de educação infantil.</p>
+<p>Em relação à alimentação, 27,9% receberam AME até os seis meses, 83,8% mantiveram AM até os 12 meses, e, 44,1%, até os 24 meses. Referente à saúde, 81,5% já tinha apresentado algum problema de saúde aos 12 meses, e, aos 24, este percentual aumentou para 93,3%. Por fim, aos 24 meses, 99 (24,7%) crianças já haviam passado por pelo menos um episódio de hospitalização.</p>
+<p>Na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet6"><span class="sci-ico-fileTable"></span>Tabela 1</a>, observa-se que ocorreu maior frequência de adoecimento nas crianças sem AME aos seis meses e naquelas sem AM e com peso inadequado aos 24 meses.</p>
+<div class="row table" id="t6">
+<a name="t6"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet6"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 1</strong><br>Condições de nascimento, crescimento e saúde segundo a presença de doenças nos dois primeiros anos de vida de crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</div>
+</div>
+<p>Na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet7"><span class="sci-ico-fileTable"></span>Tabela 2</a>, consta-se o número de atendimentos médicos nos dois primeiros anos de vida, para puericultura ou problemas de saúde segundo AME. Observa-se que ausência ou apenas um episódio de doença prevalente está estatisticamente associado à maior frequência de AME (valor de p 0,0098), enquanto presença de seis a 15 episódios está significativamente associado à ausência de AME até o sexto mês de vida (valor de p= 0,0350).</p>
+<div class="row table" id="t7">
+<a name="t7"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet7"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 2</strong><br>Atendimentos médicos nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020<br>
+</div>
+</div>
+<p>Na <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet8"><span class="sci-ico-fileTable"></span>Tabela 3</a>, são apresentadas as doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento nos primeiros seis meses de vida, na qual se observa que a proporção de crianças com AME acometidas por alguma doença prevalente da infância foi significativamente menor, com exceção dos casos de otite média supurativa e outros transtornos do trato urinário, cujo valor de p não foi estatisticamente significante em relação à AME.</p>
+<div class="row table" id="t8">
+<a name="t8"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet8"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 3</strong><br>Doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020<br>
+</div>
+</div>
+<p>Destaca-se que, no prontuário de 27 (6,7%) crianças, os registros médicos eram relacionados apenas com puericultura. Ou seja, essas crianças não procuraram os serviços públicos de saúde do município por queixas relacionadas à intercorrência na saúde.</p>
+<p>As <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet4"><span class="sci-ico-fileTable"></span>Tabelas 4</a> to <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet5"><span class="sci-ico-fileTable"></span>5</a> apresentam a Regressão de Poisson. Observa-se que, na análise bruta (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet9"><span class="sci-ico-fileTable"></span>Tabela 4</a>), sete variáveis evidenciaram associação com as doenças prevalentes, sendo duas delas relacionadas às características do nascimento (Apgar no 5º minuto e comprimento ao nascer alterados), ao tipo de alimentação (AME aos seis meses e AM aos 12 e 24 meses), peso aos 12 meses de vida e estado vacinal.</p>
+<div class="row table" id="t9">
+<a name="t9"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet9"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 4</strong><br>Razão de prevalência bruta da presença de doenças nos 24 meses de vida segundo variáveis sociodemográficas, do nascimento, estado nutricional, aleitamento materno e imunização de crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</div>
+</div>
+<p>Na análise de RP ajustada (<a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalTablet10"><span class="sci-ico-fileTable"></span>Tabela 5</a>), observa-se que, independentemente de qualquer outra variável analisada, as crianças que não foram amamentadas exclusivamente até os seis meses ou não receberam LM até 12 meses apresentaram maior prevalência de doenças prevalentes em relação às amamentadas (RP&gt;1; valor de p &lt;0,05).</p>
+<div class="row table" id="t10">
+<a name="t10"></a><div class="col-md-4 col-sm-4"><a data-toggle="modal" data-target="#ModalTablet10"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8 col-sm-8">
+<strong>Tabela 5</strong><br>Razão de prevalência ajustada da presença de doenças aos seis, 12 e 24 meses segundo variáveis tipo de amamentação aos seis, 12 e 24 meses, Apgar 5<sup>0</sup> minuto, peso aos 12 meses e comprimento ao nascer alterado das crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</div>
+</div>
+<h1 class="articleSectionTitle">DISCUSSÃO</h1>
+<p>Os resultados do modelo de análise múltipla reiteram a associação entre a duração do AME menor que seis meses e sua manutenção até os 12 meses e a presença de doenças prevalentes na infância nos dois primeiros anos de vida. Esse fato corrobora a indicação de manter o AME nos primeiros seis meses, como recomendado, reforçando as evidências que ancoram as orientações dos enfermeiros na atenção primária à família para a promoção da saúde da criança.</p>
+<p>Os enfermeiros na atenção primária, a partir desses dados, podem demonstrar que a maior prevalência de doenças está associada com ausência de AME aos seis meses e sua manutenção até os 12 meses de vida, e, desse modo, durante a consulta de enfermagem e as ações coletivas, de posse da compreensão das complicações preveníveis, encorajarem a prática e a manutenção do aleitamento.</p>
+<p>A baixa prevalência de AME aos seis meses no estudo (27,9%) indica a necessidade de, apesar de todos os investimentos e pesquisas em AM, buscar-se estratégias de apoio à família e à nutriz que possam aumentar a adesão e a manutenção dessa prática.</p>
+<p>Para aumentar a prevalência de AME, o apoio à família e à nutriz deve estar presente durante o período gestacional, no puerpério e nos primeiros anos de vida da criança. Neste sentido, é preciso considerar que as crianças em estudo nasceram em um dos dois hospitais do município que realizam partos (normais e cesáreas) financiados pelo SUS e que apenas um deles é certificado como Hospital Amigo da Criança. O hospital responsável por mais de 70% dos partos pelo SUS no município não tinha esta certificação por ocasião da coleta de dados do estudo matricial.</p>
+<p>Ressalta-se que os benefícios do AM envolvem os fatores de diminuição dos gastos com a saúde, redução de 36% do risco de morte súbita e 13% da mortalidade infantil mundial, resultando no aumento da expectativa e qualidade de vida(<span class="ref"><sup class="xref xrefblue">12</sup><span class="refCtt closed"><span>12 Brahma P, Valdés V. Benefits of breastfeeding and risks associated with not breastfeeding. Rev Child Pediatr. 2017;88(1):15-21. https://doi.org/10.4067/S0370-4106201700010000001 </span><br><a href="https://doi.org/10.4067/S0370-4106201700010000001" target="_blank">https://doi.org/10.4067/S0370-4106201700...
+            </a></span></span>). Frente a isso, na prática de enfermagem, discutir com a mulher os desafios da amamentação, os mitos e as possibilidades de manejo mediante as dificuldades vivenciadas podem favorecer maior adesão e permanência das mulheres nesse processo.</p>
+<p>Cabe destacar que as causas das doenças prevalentes na infância podem ser identificadas precocemente, o que reforça a importância da puericultura para o adequado acompanhamento do crescimento e desenvolvimento da criança. Por meio dela, os profissionais de saúde, mediante a realização sistemática de exames físico/clínico, orientações à família sobre os cuidados específicos para cada idade e identificação precoce de sinais dos principais agravos na infância(<span class="ref"><sup class="xref xrefblue">13</sup><span class="refCtt closed"><span>13 Prezotto KH, Lentsck MH, Aidar T, Fertonani HP, Mathias TAF. Hospitalizations of children for preventable conditions in the state of Parana: causes and trends. Acta Paul Enferm. 2017;30(3):254-61. https://doi.org/10.1590/1982-0194201700039 </span><br><a href="https://doi.org/10.1590/1982-0194201700039" target="_blank">https://doi.org/10.1590/1982-01942017000...
+            </a></span></span>), podem recomendar à família as ações mais efetivas, como enfatizar a importância de manter o AME. Salienta-se que, devido à capacidade em construir vínculo com os pacientes, o enfermeiro tem uma oportunidade singular de educar, apoiar e motivar.</p>
+<p>Na análise bruta deste estudo, associaram-se significativamente com doenças prevalentes da infância as variáveis Apgar 5º minuto entre sete e oito, comprimento inadequado ao nascer, ausência de AME até seis meses, AM aos seis, 12 e 24 meses e peso inadequado aos 12 meses, mas, na análise ajustada, a maior prevalência de doenças se associou significativamente com ausência de AME aos seis meses e de sua manutenção até os 12 meses de vida.</p>
+<p>A pesquisa evidenciou que a prevalência do AME até seis meses identificada foi inferior ao preconizado pela OMS(<span class="ref"><sup class="xref xrefblue">3</sup><span class="refCtt closed"><span>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </span><br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">https://apps.who.int/iris/handle/10665/2...
+            </a></span></span>). Este resultado corrobora os dados de estudo realizado na Região Sul do Brasil, com crianças menores de dois anos, o qual constatou prevalência de AME de 20,6%(<span class="ref"><sup class="xref xrefblue">14</sup><span class="refCtt closed"><span>14 Flores TR, Nunes BP, Neves RG, Wendt AT, Costa CS, Wehrmeister FC, et al. Maternal breastfeeding and associated factors in children under two years: the Brazilian National Health Survey, 2013. Cad Saúde Pública. 2017;33(11):e00068816. https://doi.org/10.1590/0102-311x00068816 </span><br><a href="https://doi.org/10.1590/0102-311x00068816" target="_blank">https://doi.org/10.1590/0102-311x0006881...
+            </a></span></span>). No entanto, os índices de AM aos 12 e 24 meses se encontraram acima dos valores identificados em inquéritos nacionais anteriores (1986, 1996, 2006 e 2013), em que a prevalência de AM no primeiro ano de vida subiu de 22,7% em 1986 para 45,4% em 2013, e, aos dois anos de idade, em torno de 25% entre 1986 e 2006, chegando a 31,8% em 2013(<span class="ref"><sup class="xref xrefblue">15</sup><span class="refCtt closed"><span>15 Boccolini CS, Boccolini PMM, Monteiro FR, Venâncio SI, Giugliani ERJ. Breastfeeding indicators trends in Brazil for three decades. Rev Saude Publica. 2017;51:108. https://doi.org/10.11606/S1518-8787.2017051000029 </span><br><a href="https://doi.org/10.11606/S1518-8787.2017051000029" target="_blank">https://doi.org/10.11606/S1518-8787.2017...
+            </a></span></span>).</p>
+<p>A introdução alimentar tem importância ímpar no crescimento da criança e no surgimento de doenças, dependendo da época em que é iniciada e dos tipos de alimentos introduzidos. O fornecimento de alimentos inadequados de forma precoce poderá acarretar na manifestação de doenças na infância e também na fase adulta(<span class="ref"><sup class="xref xrefblue">16</sup><span class="refCtt closed"><span>16 Garcez JCD, Oliveira Jr EN, Nunes MDS, Pinto LS, Soares TB, Silva MM, et al. Clinical and epidemiological profile in the first year of life. Rev Enferm UFPE. 2019;13:e241564. https://doi.org/10.5205/1981-8963.2019.241564 </span><br><a href="https://doi.org/10.5205/1981-8963.2019.241564" target="_blank">https://doi.org/10.5205/1981-8963.2019.2...
+            </a></span></span>).</p>
+<p>A manutenção do AME até os seis meses e do AM por tempo prolongado não deve ser compreendido como uma responsabilidade única da mãe. A atuação dos membros da rede social da mulher e as orientações dos profissionais de saúde sobre a importância do AM desde o pré-natal são fundamentais(<span class="ref"><sup class="xref xrefblue">17</sup><span class="refCtt closed"><span>17 Peres JF, Carvalho ARS, Viera CS, Christoffel MM, Toso BRGO. Percepções dos profissionais de saúde acerca dos fatores biopsicossocioculturais relacionados com o aleitamento materno. Saúde Debate. 2021;45(128):141051. https://doi.org/10.1590/0103-1104202112811 </span><br><a href="https://doi.org/10.1590/0103-1104202112811" target="_blank">https://doi.org/10.1590/0103-11042021128...
+            </a></span></span>). Na prática assistencial, nas maternidades e Unidades Básicas de Saúde, a simples incorporação da conduta de orientar e realizar a ordenha mamária e de oferecer o leite ordenhado poderá contribuir significativamente para a promoção e manutenção do AM(<span class="ref"><sup class="xref xrefblue">18</sup><span class="refCtt closed"><span>18 Tronco CS, Bonilha ALL, Teles JM. Rede de apoio para o aleitamento materno na prematuridade tardia. Cienc Cuid Saude. 2020;19:e46479. https://doi.org/10.4025/cienccuidsaude.v19i0.46479 </span><br><a href="https://doi.org/10.4025/cienccuidsaude.v19i0.46479" target="_blank">https://doi.org/10.4025/cienccuidsaude.v...
+            </a></span></span>). Do mesmo modo, durante o processo de formação do enfermeiro, torna-se necessária a utilização de diferentes estratégias que, de fato, aproximem o futuro profissional da realidade prática na realização de ações de incentivo e manutenção do aleitamento que vão além do conhecimento teórico. Assim, atividades direcionadas, por exemplo, pela simulação, podem desenvolver a capacidade de lidar com situações de amamentação mais complexas.</p>
+<p>O peso adequado estava presente em mais da metade das crianças que receberam AME, semelhante a estudo realizado em Santa Catarina com 303 crianças, avaliadas dois anos após o parto, o qual identificou que as crianças não amamentas de maneira exclusiva apresentaram maior risco de desenvolver excesso de peso corporal(<span class="ref"><sup class="xref xrefblue">19</sup><span class="refCtt closed"><span>19 Contarato AAPF, Rocha EDM, Czarnobay SA, Mastroeni SSBS, Veugelers PJ, Mastroeni MF. Independent effect of type of breastfeeding on overweight and obesity in children aged 12-24 months. Cad Saúde Pública. 2016;32(12):e00119015. https://doi.org/10.1590/0102-311X00119015 </span><br><a href="https://doi.org/10.1590/0102-311X00119015" target="_blank">https://doi.org/10.1590/0102-311X0011901...
+            </a></span></span>).</p>
+<p>No que concerne aos problemas de saúde, os mais frequentes foram os relacionados aos sistemas digestivo e respiratório, caracterizando-se com uma frequência significativamente menor nas crianças que receberam AME. Esse resultado corrobora a coorte realizada com 6.861 crianças pertencentes a seis centros de pesquisa clínica nos Estados Unidos e na Europa, que identificou episódio infeccioso gastrointestinal e respiratório significativamente reduzidos entre as crianças em AME(<span class="ref"><sup class="xref xrefblue">20</sup><span class="refCtt closed"><span>20 Frank NM, Lynch KF, Uusitalo U, Yang J, Lonnrot M, Virtanen SM, et al. The relationship between breastfeeding and reported respiratory and gastrointestinal infection rates in young children. BMC Pediatrics. 2019;19:339. https://doi.org/10.1186/s12887-019-1693-2 </span><br><a href="https://doi.org/10.1186/s12887-019-1693-2" target="_blank">https://doi.org/10.1186/s12887-019-1693-...
+            </a></span></span>).</p>
+<p>Referente às doenças do sistema digestivo nas crianças que não receberam AME, a diarreia e a gastroenterite podem estar relacionadas à ausência de higienização adequada de mamadeiras e demais utensílios de cozinha, além da possibilidade de intolerância alimentar relacionada ao tipo de leite oferecido(<span class="ref"><sup class="xref xrefblue">21</sup><span class="refCtt closed"><span>21 Oliveira RKL, Oliveira BSB, Bezerra JC, Silva MJN, Melo FMS, Joventino ES. Influence of socio-economic conditions and maternal knowledge in self-effectiveness for prevention of childhood diarrhea. Esc Anna Nery. 2017;21(4):e20160361. https://doi.org/10.1590/2177-9465-ean-2016-0361 </span><br><a href="https://doi.org/10.1590/2177-9465-ean-2016-0361" target="_blank">https://doi.org/10.1590/2177-9465-ean-20...
+            </a></span></span>), as quais poderiam ser consideradas variáveis confundidoras, entretanto não foram avaliadas neste estudo. A dor abdominal e pélvica, por sua vez, sofre influência dos mitos e tabus que acompanham a amamentação, uma vez que as mães são culturalmente persuadidas pela família e conhecidos a introduzirem líquidos, como água e chás, acreditando que a criança está com sede e que sua atuação diminuirá a dor, e, desta forma, irá acalmá-la e fará com que durma mais(<span class="ref"><sup class="xref xrefblue">22</sup><span class="refCtt closed"><span>22 Monteiro ATA, Ferrari RAP, Tacla MTGM, Souza ALDM. Pediatric nursing consultation after maternity discharge: follow-up in primary care. Rev Soc Bras Enferm Ped. 2017;17(1):7-13. https://doi.org/10.31508/1676-3793201700002 </span><br><a href="https://doi.org/10.31508/1676-3793201700002" target="_blank">https://doi.org/10.31508/1676-3793201700...
+            </a></span></span>).</p>
+<p>Os transtornos funcionais do intestino se apresentam como uma doença característica da introdução alimentar precoce, e isso ocorre devido ao fornecimento de alimentos sólidos, associados a uma baixa ingestão de líquidos. Destaca-se que o desenvolvimento da alimentação pode ser reflexo dos hábitos alimentares dos pais e cuidadores(<span class="ref"><sup class="xref xrefblue">23</sup><span class="refCtt closed"><span>23 Pinheiro JGA, Rodrigues NS, Silveira AO, Martins G. Mother and nursing academic: experience with intestinal constipation. Rev Enferm UFPE [Internet]. 2019[cited 2020 Feb 10];13(5):1520-1519. Available from: https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782 </span><br><a href="https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782" target="_blank">https://pesquisa.bvsalud.org/portal/reso...
+            </a></span></span>-<span class="ref"><sup class="xref xrefblue">24</sup><span class="refCtt closed"><span>24 Melo KM, Cruz ACP, Brito MFSF, Pinho L. Influence of parents' behavior during the meal and on overweight in childhood. Esc Anna Nery. 2017;21(4):e20170102. https://doi.org/10.1590/2177-9465-EAN-2017-0102 </span><br><a href="https://doi.org/10.1590/2177-9465-EAN-2017-0102" target="_blank">https://doi.org/10.1590/2177-9465-EAN-20...
+            </a></span></span>).</p>
+<p>Em relação às doenças do sistema respiratório, as infecções agudas das vias aéreas superiores, na maioria dos casos, encontram-se associadas às práticas das mães durante o aleitamento e ao posicionamento do bebê. Estudo realizado na Região Centro-Oeste do Paraná, com 60 mães de crianças com idades entre quatro e 180 dias (média de 40 dias), identificou que, entre os 49 bebês com AME, nove (18,4%) tiveram infecções de vias aéreas superiores ou otites, proporção muito menor do que a encontrada entre as 11 sem AME, visto que sete delas (63,6%) manifestaram estes episódios(<span class="ref"><sup class="xref xrefblue">25</sup><span class="refCtt closed"><span>25 Nadal LF, Rodrigues AH, Costa CC, Godoi VC, Klossowski DG, Fujinaga CI. Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media. Rev CEFAC. 2017;19(3):387-94. https://doi.org/10.1590/1982-0216201719314916 </span><br><a href="https://doi.org/10.1590/1982-0216201719314916" target="_blank">https://doi.org/10.1590/1982-02162017193...
+            </a></span></span>).</p>
+<p>A otite média em crianças pode estar relacionada ao posicionamento anatômico, uma vez que a tuba auditiva nos lactentes se encontra em uma posição mais horizontalizada. Dessa forma, a fisiologia da sucção durante o AM difere da que ocorre durante o fornecimento de bebidas lácteas por meio da mamadeira, em que a contração muscular é reduzida, com consequente flacidez da musculatura do palato mole, e, assim, o leite entra pela orofaringe e atinge a tuba auditiva. Uma vez que o leite artificial não possui anticorpos, como o LM, é favorecida a rápida proliferação de bactérias(<span class="ref"><sup class="xref xrefblue">25</sup><span class="refCtt closed"><span>25 Nadal LF, Rodrigues AH, Costa CC, Godoi VC, Klossowski DG, Fujinaga CI. Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media. Rev CEFAC. 2017;19(3):387-94. https://doi.org/10.1590/1982-0216201719314916 </span><br><a href="https://doi.org/10.1590/1982-0216201719314916" target="_blank">https://doi.org/10.1590/1982-02162017193...
+            </a></span></span>).</p>
+<p>A frequência de hospitalização neste estudo (24,7%) se assemelha à taxa encontrada no estudo de coorte realizado no Rio Grande do Sul, com 4.231 crianças acompanhadas com um, dois, quatro e seis anos de vida. Durante o primeiro ano de vida, a frequência de hospitalização foi de 19,1%, observando-se que os grupos “influenza e pneumonia” e “doenças crônicas das vias aéreas inferiores” estiveram presentes entre as três principais causas de hospitalização, e o grupo das “doenças infecciosas intestinais” esteve classificado entre a terceira e a quinta posições(<span class="ref"><sup class="xref xrefblue">26</sup><span class="refCtt closed"><span>26 Silva VLS, França GVA, Santos IS, Barros FC, Matijasevich A. Characteristics and factors associated with hospitalization in early childhood: 2004 Pelotas (Brazil) birth cohort. Cad Saúde Pública. 2017;33(10):e00035716. https://doi.org/10.1590/0102-311X00035716 </span><br><a href="https://doi.org/10.1590/0102-311X00035716" target="_blank">https://doi.org/10.1590/0102-311X0003571...
+            </a></span></span>).</p>
+<p>No Brasil, mais de 3.000 mortes anuais de crianças poderiam ser evitadas se as mesmas fossem amamentadas exclusivamente ao seio materno até os seis meses de vida. Em termos financeiros, poderiam ser economizados quase um bilhão e meio de dólares por amamentação inadequada e mortes evitáveis, mais de 42 milhões de dólares, no tratamento de diarreia e infecção respiratória aguda/pneumonia em crianças, e mais de 12 bilhões dólares poderiam ser otimizados por perdas cognitivas decorrentes da falta de amamentação. Ou seja, para além da vida, que não tem preço, a economia decorrente da combinação de gastos com saúde, mortalidade e perdas cognitivas totalizaria mais de 14 bilhões de dólares, o que reforça a importância do AM para economia e qualidade de vida de toda a sociedade(<span class="ref"><sup class="xref xrefblue">27</sup><span class="refCtt closed"><span>27 Alive &amp; Thrive. The economic costs of not breastfeeding in Brazil [Internet]. 2020[cited 2020 Oct 20]. Available from: https://aliveandthrive.org/country-stat/brazil/#ec__children </span><br><a href="https://aliveandthrive.org/country-stat/brazil/#ec__children" target="_blank">https://aliveandthrive.org/country-stat/...
+            </a></span></span>).</p>
+<h2>Limitações do estudo</h2>
+<p>Destaca-se como limitação do estudo a utilização de dados secundários, uma vez que são circunscritos à fidedignidade das informações obtidas, pois a digitação no sistema é realizada de forma descentralizada e pelo profissional responsável pelo atendimento. Contudo, seus resultados reiteram a importância em enfatizar o AM como fator de proteção paras as doenças mais frequentes na infância, subsidiando reflexões quanto à necessidade de os profissionais de saúde fazerem uso de estratégias práticas de incentivo ao mesmo.</p>
+<p>Outra limitação diz respeito aos dados serem provenientes de registro dos atendimentos médicos, o que se justifica pelo fato do diagnóstico de doença ser uma atribuição médica. Ressalta-se que as consultas de puericultura realizadas pelas enfermeiras não foram avaliadas no estudo, pois, nestas, o foco está nos diagnósticos de enfermagem e nas intervenções/orientações realizadas. Contudo, é importante considerar que o prontuário na unidade de saúde engloba dados de atendimento multiprofissional, e o enfermeiro, pelo menos nos prontuários analisados, não efetuou registro de atividades desenvolvidas referente às ações de cuidado e/ou orientação. Destarte, muitas vezes, as intercorrências são inicialmente identificadas ou relatadas à equipe de enfermagem, mas isto não é registrado em prontuário, o que contribui para pouca visibilidade da atuação do enfermeiro na atenção primária.</p>
+<h2>Contribuições para a área de enfermagem e saúde</h2>
+<p>Os resultados do estudo indicam que na prática do enfermeiro, de acompanhamento do crescimento e desenvolvimento infantil no âmbito da atenção primária, por meio das consultas de puericultura, segue sendo fundamental para apoiar e promover o AM para a nutrição infantil, devido à sua relação com os resultados de saúde nos primeiros anos de vida. Esse conhecimento é primordial para desenvolver e direcionar intervenções que objetivam reduzir a morbimortalidade e melhorar a saúde infantil e a qualidade de vida das crianças.</p>
+<p>A baixa prevalência do AME aos seis meses e a prevalência de doenças infecciosas nos primeiros anos de vida, especialmente do trato respiratório e gastrointestinal, observadas neste estudo, são elementos que despertam a necessidade de se discutir a qualidade do atendimento às crianças e famílias na atenção primária. Doenças preveníveis por meio de cuidados de higiene pessoal, dos alimentos, do ambiente, reforço em orientações adequadas de alimentação, imunização, entre outros, deveriam ser cada vez menos frequentes na população. A capacitação de enfermeiros e a aplicação da estratégia AIDPI neonatal e criança na atenção básica poderiam contribuir para essa redução.</p>
+<h1 class="articleSectionTitle">CONCLUSÕES</h1>
+<p>Concluiu-se que, independentemente de qualquer outra variável analisada, as crianças que não foram amamentadas exclusivamente até os seis meses e não mantiveram o AM até os 12 meses apresentaram maior prevalência de doenças em relação às amamentadas.</p>
+<h1 class="articleSectionTitle">MATERIAL SUPLEMENTAR</h1>
+<p>O banco de dados da pesquisa foi depositado no SCIELO Data: Arcain, Evelin, 2021, “Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal”, <a href="https://doi.org/10.48331/scielodata.XPWWYD" target="_blank">https://doi.org/10.48331/scielodata.XPWWYD,</a> SciELO Data, DRAFT VERSION, UNF:6:rWHWyqc8p/Ef7BQh3BLfwQ== [fileUNF].</p>
+</div>
+<div>
+<h1></h1>
+<div class="ref-list"><ul class="refList footnote"><li>
+<div>
+            <b>FOMENTO</b>
+          </div>
+<div>O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES), Código de Financiamento 001.</div>
+</li></ul></div>
+</div>
+<div class="articleSection" data-anchor="Referências bibliográficas">
+<h1 class="articleSectionTitle">Referências bibliográficas</h1>
+<div class="ref-list"><ul class="refList">
+<li>
+<sup class="xref big">1</sup><div> Ministério da Saúde (BR). Manual AIDPI Criança: 2 meses a 5 anos[Internet]. Brasília, DF: SVS; 2017[cited 2020 Mar 23]. Available from: portalarquivos.saude.gov.br/imagens/pdf/2017/julho/12/17-0056-Online.pdf</div>
+</li>
+<li>
+<sup class="xref big">2</sup><div> Ministério da Saúde (BR). Portaria nº 2.436, de 21 de setembro de 2017. Aprova a Política Nacional de Atenção Básica, estabelecendo a revisão de diretrizes para a organização da Atenção Básica, no âmbito do Sistema Único de Saúde[Internet]. Brasília, DF: 2017[cited 2020 Mar 20]. Available from: https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html <br><a href="https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436%C2%AC-_22_09_2017.html" target="_blank">» https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html</a>
+</div>
+</li>
+<li>
+<sup class="xref big">3</sup><div> World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 <br><a href="https://apps.who.int/iris/handle/10665/259386" target="_blank">» https://apps.who.int/iris/handle/10665/259386</a>
+</div>
+</li>
+<li>
+<sup class="xref big">4</sup><div> Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. https://doi.org/10.1590/1413-81232018236.03942018 <br><a href="https://doi.org/10.1590/1413-81232018236.03942018" target="_blank">» https://doi.org/10.1590/1413-81232018236.03942018</a>
+</div>
+</li>
+<li>
+<sup class="xref big">5</sup><div> Videholm S, Wallby T, Silfverdal SA. Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden. BMJ Open. 2021;11:e046583. https://doi.org/10.1136/bmjopen-2020-046583 <br><a href="https://doi.org/10.1136/bmjopen-2020-046583" target="_blank">» https://doi.org/10.1136/bmjopen-2020-046583</a>
+</div>
+</li>
+<li>
+<sup class="xref big">6</sup><div> Baye A, Adane M, Sisay T, Hailemeskel HS. Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study. BMC Pediatrics. 2021;21:155. https://doi.org/10.1186/s12887-021-02592-5 <br><a href="https://doi.org/10.1186/s12887-021-02592-5" target="_blank">» https://doi.org/10.1186/s12887-021-02592-5</a>
+</div>
+</li>
+<li>
+<sup class="xref big">7</sup><div> Vijay J, Patel KK. Risk factors of infant mortality in Bangladesh. Clin Epidemiol Global Health. 2020;8(1):211-4. https://doi.org/10.1016/j.cegh.2019.07.003 <br><a href="https://doi.org/10.1016/j.cegh.2019.07.003" target="_blank">» https://doi.org/10.1016/j.cegh.2019.07.003</a>
+</div>
+</li>
+<li>
+<sup class="xref big">8</sup><div> Costa BR, Cevallos M, Altman DG, Rutjes AWS, Egger M. Uses and misuses of the STROBE statement: bibliographic study. BMJ Open. 2011;1:e 000048. https://doi.org/10.1136/bmjopen-2010-000048 <br><a href="https://doi.org/10.1136/bmjopen-2010-000048" target="_blank">» https://doi.org/10.1136/bmjopen-2010-000048</a>
+</div>
+</li>
+<li>
+<sup class="xref big">9</sup><div> Lopes WC, Marques FKS, Oliveira CF, Rodrigues JÁ, Silveira MF, Caldeira AP, et al. Infant feeding in the first two years of life. Rev Paul Pediatr. 2018;36(2):164-70. https://doi.org/10.1590/1984-0462/;2018;36;2;00004 <br><a href="https://doi.org/10.1590/1984-0462/;2018;36;2;00004" target="_blank">» https://doi.org/10.1590/1984-0462/;2018;36;2;00004</a>
+</div>
+</li>
+<li>
+<sup class="xref big">10</sup><div> Ministério da Saúde (BR), Secretaria de Vigilância em Saúde. Sistema de informações sobre nascidos vivos (SINASC) [Internet]. Brasília, DF: SVS; 2017 [cited 2020 Feb 10]. Available from: www2.datasus.gov.br/DATASUS/index.php?area=060702 <br><a href="http://www2.datasus.gov.br/DATASUS/index.php?area=060702" target="_blank">» www2.datasus.gov.br/DATASUS/index.php?area=060702</a>
+</div>
+</li>
+<li>
+<sup class="xref big">11</sup><div> Ministério da Saúde (BR). Caderneta de Saúde da Criança[Internet]. Brasília, DF: 2018[cited 2021 Jan 22]. Available from: https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf <br><a href="https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf" target="_blank">» https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf</a>
+</div>
+</li>
+<li>
+<sup class="xref big">12</sup><div> Brahma P, Valdés V. Benefits of breastfeeding and risks associated with not breastfeeding. Rev Child Pediatr. 2017;88(1):15-21. https://doi.org/10.4067/S0370-4106201700010000001 <br><a href="https://doi.org/10.4067/S0370-4106201700010000001" target="_blank">» https://doi.org/10.4067/S0370-4106201700010000001</a>
+</div>
+</li>
+<li>
+<sup class="xref big">13</sup><div> Prezotto KH, Lentsck MH, Aidar T, Fertonani HP, Mathias TAF. Hospitalizations of children for preventable conditions in the state of Parana: causes and trends. Acta Paul Enferm. 2017;30(3):254-61. https://doi.org/10.1590/1982-0194201700039 <br><a href="https://doi.org/10.1590/1982-0194201700039" target="_blank">» https://doi.org/10.1590/1982-0194201700039</a>
+</div>
+</li>
+<li>
+<sup class="xref big">14</sup><div> Flores TR, Nunes BP, Neves RG, Wendt AT, Costa CS, Wehrmeister FC, et al. Maternal breastfeeding and associated factors in children under two years: the Brazilian National Health Survey, 2013. Cad Saúde Pública. 2017;33(11):e00068816. https://doi.org/10.1590/0102-311x00068816 <br><a href="https://doi.org/10.1590/0102-311x00068816" target="_blank">» https://doi.org/10.1590/0102-311x00068816</a>
+</div>
+</li>
+<li>
+<sup class="xref big">15</sup><div> Boccolini CS, Boccolini PMM, Monteiro FR, Venâncio SI, Giugliani ERJ. Breastfeeding indicators trends in Brazil for three decades. Rev Saude Publica. 2017;51:108. https://doi.org/10.11606/S1518-8787.2017051000029 <br><a href="https://doi.org/10.11606/S1518-8787.2017051000029" target="_blank">» https://doi.org/10.11606/S1518-8787.2017051000029</a>
+</div>
+</li>
+<li>
+<sup class="xref big">16</sup><div> Garcez JCD, Oliveira Jr EN, Nunes MDS, Pinto LS, Soares TB, Silva MM, et al. Clinical and epidemiological profile in the first year of life. Rev Enferm UFPE. 2019;13:e241564. https://doi.org/10.5205/1981-8963.2019.241564 <br><a href="https://doi.org/10.5205/1981-8963.2019.241564" target="_blank">» https://doi.org/10.5205/1981-8963.2019.241564</a>
+</div>
+</li>
+<li>
+<sup class="xref big">17</sup><div> Peres JF, Carvalho ARS, Viera CS, Christoffel MM, Toso BRGO. Percepções dos profissionais de saúde acerca dos fatores biopsicossocioculturais relacionados com o aleitamento materno. Saúde Debate. 2021;45(128):141051. https://doi.org/10.1590/0103-1104202112811 <br><a href="https://doi.org/10.1590/0103-1104202112811" target="_blank">» https://doi.org/10.1590/0103-1104202112811</a>
+</div>
+</li>
+<li>
+<sup class="xref big">18</sup><div> Tronco CS, Bonilha ALL, Teles JM. Rede de apoio para o aleitamento materno na prematuridade tardia. Cienc Cuid Saude. 2020;19:e46479. https://doi.org/10.4025/cienccuidsaude.v19i0.46479 <br><a href="https://doi.org/10.4025/cienccuidsaude.v19i0.46479" target="_blank">» https://doi.org/10.4025/cienccuidsaude.v19i0.46479</a>
+</div>
+</li>
+<li>
+<sup class="xref big">19</sup><div> Contarato AAPF, Rocha EDM, Czarnobay SA, Mastroeni SSBS, Veugelers PJ, Mastroeni MF. Independent effect of type of breastfeeding on overweight and obesity in children aged 12-24 months. Cad Saúde Pública. 2016;32(12):e00119015. https://doi.org/10.1590/0102-311X00119015 <br><a href="https://doi.org/10.1590/0102-311X00119015" target="_blank">» https://doi.org/10.1590/0102-311X00119015</a>
+</div>
+</li>
+<li>
+<sup class="xref big">20</sup><div> Frank NM, Lynch KF, Uusitalo U, Yang J, Lonnrot M, Virtanen SM, et al. The relationship between breastfeeding and reported respiratory and gastrointestinal infection rates in young children. BMC Pediatrics. 2019;19:339. https://doi.org/10.1186/s12887-019-1693-2 <br><a href="https://doi.org/10.1186/s12887-019-1693-2" target="_blank">» https://doi.org/10.1186/s12887-019-1693-2</a>
+</div>
+</li>
+<li>
+<sup class="xref big">21</sup><div> Oliveira RKL, Oliveira BSB, Bezerra JC, Silva MJN, Melo FMS, Joventino ES. Influence of socio-economic conditions and maternal knowledge in self-effectiveness for prevention of childhood diarrhea. Esc Anna Nery. 2017;21(4):e20160361. https://doi.org/10.1590/2177-9465-ean-2016-0361 <br><a href="https://doi.org/10.1590/2177-9465-ean-2016-0361" target="_blank">» https://doi.org/10.1590/2177-9465-ean-2016-0361</a>
+</div>
+</li>
+<li>
+<sup class="xref big">22</sup><div> Monteiro ATA, Ferrari RAP, Tacla MTGM, Souza ALDM. Pediatric nursing consultation after maternity discharge: follow-up in primary care. Rev Soc Bras Enferm Ped. 2017;17(1):7-13. https://doi.org/10.31508/1676-3793201700002 <br><a href="https://doi.org/10.31508/1676-3793201700002" target="_blank">» https://doi.org/10.31508/1676-3793201700002</a>
+</div>
+</li>
+<li>
+<sup class="xref big">23</sup><div> Pinheiro JGA, Rodrigues NS, Silveira AO, Martins G. Mother and nursing academic: experience with intestinal constipation. Rev Enferm UFPE [Internet]. 2019[cited 2020 Feb 10];13(5):1520-1519. Available from: https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782 <br><a href="https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782" target="_blank">» https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782</a>
+</div>
+</li>
+<li>
+<sup class="xref big">24</sup><div> Melo KM, Cruz ACP, Brito MFSF, Pinho L. Influence of parents' behavior during the meal and on overweight in childhood. Esc Anna Nery. 2017;21(4):e20170102. https://doi.org/10.1590/2177-9465-EAN-2017-0102 <br><a href="https://doi.org/10.1590/2177-9465-EAN-2017-0102" target="_blank">» https://doi.org/10.1590/2177-9465-EAN-2017-0102</a>
+</div>
+</li>
+<li>
+<sup class="xref big">25</sup><div> Nadal LF, Rodrigues AH, Costa CC, Godoi VC, Klossowski DG, Fujinaga CI. Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media. Rev CEFAC. 2017;19(3):387-94. https://doi.org/10.1590/1982-0216201719314916 <br><a href="https://doi.org/10.1590/1982-0216201719314916" target="_blank">» https://doi.org/10.1590/1982-0216201719314916</a>
+</div>
+</li>
+<li>
+<sup class="xref big">26</sup><div> Silva VLS, França GVA, Santos IS, Barros FC, Matijasevich A. Characteristics and factors associated with hospitalization in early childhood: 2004 Pelotas (Brazil) birth cohort. Cad Saúde Pública. 2017;33(10):e00035716. https://doi.org/10.1590/0102-311X00035716 <br><a href="https://doi.org/10.1590/0102-311X00035716" target="_blank">» https://doi.org/10.1590/0102-311X00035716</a>
+</div>
+</li>
+<li>
+<sup class="xref big">27</sup><div> Alive &amp; Thrive. The economic costs of not breastfeeding in Brazil [Internet]. 2020[cited 2020 Oct 20]. Available from: https://aliveandthrive.org/country-stat/brazil/#ec__children <br><a href="https://aliveandthrive.org/country-stat/brazil/#ec__children" target="_blank">» https://aliveandthrive.org/country-stat/brazil/#ec__children</a>
+</div>
+</li>
+</ul></div>
+</div>
+<div class="articleSection" data-anchor="Datas de Publicação ">
+<h1 class="articleSectionTitle">Datas de Publicação </h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Publicação nesta coleção</strong><br>06 Jun 2022</li>
+<li>
+<strong>Data do Fascículo</strong><br>2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="Histórico">
+<h1 class="articleSectionTitle">Histórico</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><ul class="articleTimeline">
+<li>
+<strong>Recebido</strong><br>23 Ago 2021</li>
+<li>
+<strong>Aceito</strong><br>11 Fev 2022</li>
+</ul></div></div>
+</div>
+<div class="articleSection" data-anchor="Dados de pesquisa">
+<h1 class="articleSectionTitle">Dados de pesquisa</h1>
+<div class="row"><div class="col-md-12 col-sm-12"><p> World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: https://apps.who.int/iris/handle/10665/259386 </p></div></div>
+<div class="row"><div class="col-md-12 col-sm-12"><p> Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. https://doi.org/10.1590/1413-81232018236.03942018 </p></div></div>
+</div>
+<section class="documentLicense"><div class="container-license"><div class="row">
+<div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+<div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">This is an Open Access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</a></div>
+</div></div></section></article>
+</div>
+</div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Sobre os autores</h4>
+</div>
+<div class="modal-body">
+<div class="info">
+<div class="tutors">
+<strong> Evelin Matilde Arcain Nass </strong><strong></strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-5140-3104" class="btnContribLinks orcid">http://orcid.org/0000-0002-5140-3104</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Sonia Silva Marcon </strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-6607-362X" class="btnContribLinks orcid">http://orcid.org/0000-0002-6607-362X</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Elen Ferraz Teston </strong><br><div>Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0001-6835-0574" class="btnContribLinks orcid">http://orcid.org/0000-0001-6835-0574</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Luciana Pedrosa Leal </strong><br><div>Universidade Federal de Pernambuco. Recife, Pernambuco. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-3776-0997" class="btnContribLinks orcid">http://orcid.org/0000-0003-3776-0997</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Sueli Mutsumi Tsukuda Ichisato </strong><br><div>Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-6008-2795" class="btnContribLinks orcid">http://orcid.org/0000-0002-6008-2795</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Beatriz Rosana Gonçalves de Oliveira Toso </strong><br><div>Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0001-7366-077X" class="btnContribLinks orcid">http://orcid.org/0000-0001-7366-077X</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Mariana Angela Rossaneis Moreira </strong><br><div>Universidade Estadual de Londrina. Londrina, Paraná. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0002-8607-0020" class="btnContribLinks orcid">http://orcid.org/0000-0002-8607-0020</a></li></ul>
+<div class="clearfix"></div>
+</div>
+<div class="tutors">
+<strong> Fabiane Blanco Silva Bernardino </strong><br><div>Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brazil.</div>
+<ul class="md-list inline"><li><a href="http://orcid.org/0000-0003-0339-9451" class="btnContribLinks orcid">http://orcid.org/0000-0003-0339-9451</a></li></ul>
+<div class="clearfix"></div>
+</div>
+</div>
+<div class="info">
+<b>Autor Correspondente:</b> Evelin Matilde Arcain Nass <a href="mailto:evelinmarcain@gmail.com">evelinmarcain@gmail.com</a> </div>
+<div class="info"><div>EDITOR CHEFE: Antonio José de Almeida Filho</div></div>
+<div class="info"><div>EDITOR ASSOCIADO: Alexandre Balsanelli</div></div>
+</div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Tabelas</h4>
+</div>
+<div class="modal-body">
+<ul class="nav nav-tabs md-tabs" role="tablist"><li role="presentation" class="col-md-4 col-sm-4 active"><a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">Tabelas
+                    (5)
+                </a></li></ul>
+<div class="clearfix"></div>
+<div class="tab-content"><div role="tabpanel" class="tab-pane active" id="tables">
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet6"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 1</strong><br>Condições de nascimento, crescimento e saúde segundo a presença de doenças nos dois primeiros anos de vida de crianças nascidas em Maringá, Paraná, Brasil, 2020</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet7"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 2</strong><br>Atendimentos médicos nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet8"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 3</strong><br>Doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet9"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 4</strong><br>Razão de prevalência bruta da presença de doenças nos 24 meses de vida segundo variáveis sociodemográficas, do nascimento, estado nutricional, aleitamento materno e imunização de crianças nascidas em Maringá, Paraná, Brasil, 2020</div>
+</div>
+<div class="row table">
+<div class="col-md-4"><a data-toggle="modal" data-target="#ModalTablet10"><div class="thumbOff">
+                        Thumbnail
+                        <div class="zoom"><span class="sci-ico-zoom"></span></div>
+</div></a></div>
+<div class="col-md-8">
+<strong>Tabela 5</strong><br>Razão de prevalência ajustada da presença de doenças aos seis, 12 e 24 meses segundo variáveis tipo de amamentação aos seis, 12 e 24 meses, Apgar 5<sup>0</sup> minuto, peso aos 12 meses e comprimento ao nascer alterado das crianças nascidas em Maringá, Paraná, Brasil, 2020</div>
+</div>
+</div></div>
+</div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet6" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 1</strong>    Condições de nascimento, crescimento e saúde segundo a presença de doenças nos dois primeiros anos de vida de crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<thead>
+<tr>
+<th align="left" rowspan="2">Variáveis</th>
+<th align="center">Total <br>(401)</th>
+<th align="center">Doenças em menores de <br>6 meses (96)</th>
+<th align="center">Doenças <br>de 7 a 11 <br>meses (231)</th>
+<th align="center">Doenças <br>de 12 a 24 <br>meses (374)</th>
+<th align="center" rowspan="2">Valor de <i>p</i>
+</th>
+</tr>
+<tr>
+<th align="center">n %</th>
+<th align="center">n %</th>
+<th align="center">n %</th>
+<th align="center">n %</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">Sexo</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Feminino</td>
+<td align="center">170 42,4</td>
+<td align="center">41 24,1</td>
+<td align="center">93 54,7</td>
+<td align="center">159 93,5</td>
+<td align="center">0,6811</td>
+</tr>
+<tr>
+<td align="left">Masculino</td>
+<td align="center">231 57,6</td>
+<td align="center">55 23,8</td>
+<td align="center">138 59,7</td>
+<td align="center">215 93,1</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Raça/cor</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Branca/amarela</td>
+<td align="center">202 50,4</td>
+<td align="center">51 25,5</td>
+<td align="center">116 57,4</td>
+<td align="center">189 93,6</td>
+<td align="center">0,8875</td>
+</tr>
+<tr>
+<td align="left">Parda/preta</td>
+<td align="center">199 49,6</td>
+<td align="center">45 22,6</td>
+<td align="center">115 57,8</td>
+<td align="center">185 93,0</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Apgar 5<sup>o</sup> minuto</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">9 - 10</td>
+<td align="center">398 99,2</td>
+<td align="center">95 23,9</td>
+<td align="center">229 57,5</td>
+<td align="center">371 93,2</td>
+<td align="center">0,8687</td>
+</tr>
+<tr>
+<td align="left">7 - 8</td>
+<td align="center">3 0,8</td>
+<td align="center">1 33,3</td>
+<td align="center">2 66,7</td>
+<td align="center">3 100,0</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Peso ao nascer</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Adequado</td>
+<td align="center">335 83,5</td>
+<td align="center">83 24,8</td>
+<td align="center">188 56,1</td>
+<td align="center">313 93,4</td>
+<td align="center">0,7728</td>
+</tr>
+<tr>
+<td align="left">Inadequado</td>
+<td align="center">66 16,5</td>
+<td align="center">13 19,7</td>
+<td align="center">43 65,1</td>
+<td align="center">61 92,4</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Comprimento ao nascer</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Adequado</td>
+<td align="center">319 79,6</td>
+<td align="center">75 23,5</td>
+<td align="center">174 54,5</td>
+<td align="center">292 91,5</td>
+<td align="center">0,5440</td>
+</tr>
+<tr>
+<td align="left">Inadequado</td>
+<td align="center">82 20,4</td>
+<td align="center">21 25,6</td>
+<td align="center">57 69,5</td>
+<td align="center">82 100,0</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">AME aos 6 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">112 27,9</td>
+<td align="center">18 16,1</td>
+<td align="center">52 46,4</td>
+<td align="center">86 76,8</td>
+<td align="center">0,6141</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">289 72,1</td>
+<td align="center">78 30,0</td>
+<td align="center">179 61,9</td>
+<td align="center">288 99,6</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">AM aos 12 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">336 83,8</td>
+<td align="center">81 24,1</td>
+<td align="center">187 55,6</td>
+<td align="center">309 92,0</td>
+<td align="center">0,8184</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">65 16,2</td>
+<td align="center">15 23,1</td>
+<td align="center">44 67,7</td>
+<td align="center">65 100,0</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">AM aos 24 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">177 44,1</td>
+<td align="center">37 20,9</td>
+<td align="center">95 53,7</td>
+<td align="center">151 85,3</td>
+<td align="center">0,9984</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">224 55,9</td>
+<td align="center">59 26,3</td>
+<td align="center">136 60,7</td>
+<td align="center">223 99,6</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Peso aos 12 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Adequado</td>
+<td align="center">266 66,3</td>
+<td align="center">62 23,3</td>
+<td align="center">147 55,3</td>
+<td align="center">240 90,2</td>
+<td align="center">0,9892</td>
+</tr>
+<tr>
+<td align="left">Inadequado</td>
+<td align="center">135 33,7</td>
+<td align="center">34 25,2</td>
+<td align="center">84 62,2</td>
+<td align="center">134 99,3</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Peso aos 24 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Adequado</td>
+<td align="center">179 44,6</td>
+<td align="center">38 21,2</td>
+<td align="center">96 53,6</td>
+<td align="center">154 86,0</td>
+<td align="center">0,9576</td>
+</tr>
+<tr>
+<td align="left">Inadequado</td>
+<td align="center">222 55,4</td>
+<td align="center">58 26,1</td>
+<td align="center">135 60,8</td>
+<td align="center">220 99,1</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Vacina atualizada</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">372 92,8</td>
+<td align="center">92 24,7</td>
+<td align="center">212 57,0</td>
+<td align="center">349 93,8</td>
+<td align="center">0,8551</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">29 7,2</td>
+<td align="center">4 13,8</td>
+<td align="center">19 65,5</td>
+<td align="center">25 86,2</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Frequenta centro infantil</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">340 84,8</td>
+<td align="center">84 24,7</td>
+<td align="center">191 56,2</td>
+<td align="center">317 93,2</td>
+<td align="center">0,8095</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">61 15,2</td>
+<td align="center">12 19,7</td>
+<td align="center">40 65,6</td>
+<td align="center">57 93,4</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Foi hospitalizada</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">99 24,7</td>
+<td align="center">21 21,2</td>
+<td align="center">62 62,6</td>
+<td align="center">96 97,0</td>
+<td align="center">0,9309</td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">302 75,3</td>
+<td align="center">75 24,8</td>
+<td align="center">169 55,9</td>
+<td align="center">278 92,0</td>
+<td align="left"></td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><i>AME - aleitamento materno exclusivo; AM - aleitamento materno.</i></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet7" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 2</strong>    Atendimentos médicos nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<thead>
+<tr>
+<th align="left" rowspan="2">Atendimento médico</th>
+<th align="center" colspan="3" valign="top">Aleitamento materno exclusivo</th>
+<th align="center" rowspan="2">Valor de <i>p</i>
+</th>
+</tr>
+<tr>
+<th align="center" valign="top">Sim<br>n %</th>
+<th align="center" valign="top">Não<br>n %</th>
+<th align="center" valign="top">Total<br>n %</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">Puericultura</td>
+<td align="center" valign="top">15 55,5</td>
+<td align="center" valign="top">12 44,5</td>
+<td align="center" valign="top">27 6,7</td>
+<td align="center" valign="top">0,0009</td>
+</tr>
+<tr>
+<td align="left">Puericultura + 01 episódios</td>
+<td align="center" valign="top">23 42,6</td>
+<td align="center" valign="top">31 57,4</td>
+<td align="center" valign="top">54 13,5</td>
+<td align="center" valign="top">0,0098</td>
+</tr>
+<tr>
+<td align="left">02 a 05 episódios de doenças</td>
+<td align="center" valign="top">45 31,7</td>
+<td align="center" valign="top">97 68,3</td>
+<td align="center" valign="top">142 35,4</td>
+<td align="center" valign="top">0,2140</td>
+</tr>
+<tr>
+<td align="left">06 a 10 episódios de doenças</td>
+<td align="center" valign="top">15 14,7</td>
+<td align="center" valign="top">87 85,3</td>
+<td align="center" valign="top">102 25,4</td>
+<td align="center" valign="top">0,0006</td>
+</tr>
+<tr>
+<td align="left">11 a 15 episódios de doenças</td>
+<td align="center" valign="top">10 16,7</td>
+<td align="center" valign="top">50 83,3</td>
+<td align="center" valign="top">60 15,0</td>
+<td align="center" valign="top">0,0350</td>
+</tr>
+<tr>
+<td align="left">≥ 16 episódios de doenças</td>
+<td align="center" valign="top">04 25,0</td>
+<td align="center" valign="top">12 75,0</td>
+<td align="center" valign="top">16 4,0</td>
+<td align="center" valign="top">0,7898</td>
+</tr>
+<tr>
+<td align="left">Total</td>
+<td align="center" valign="top">112</td>
+<td align="center" valign="top">289</td>
+<td align="center" valign="top">401</td>
+<td align="left" valign="top"></td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet8" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 3</strong>    Doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<thead>
+<tr>
+<th align="left" rowspan="2">Doenças prevalentes da infância</th>
+<th align="center" colspan="3">Aleitamento materno exclusivo</th>
+<th align="center" rowspan="2">Valor de <i>p</i>
+</th>
+</tr>
+<tr>
+<th align="center">Sim (112)<br>n %</th>
+<th align="center">Não (289)<br>n %</th>
+<th align="center">Total (401)<br>n %</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">Trato gastrointestinal</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Diarreia e gastroenterite de origem infecciosa presumível</td>
+<td align="center">20 17,9</td>
+<td align="center">152 52,6</td>
+<td align="center">172 42,9</td>
+<td align="center">0,0001</td>
+</tr>
+<tr>
+<td align="left">Doença de refluxo gastroesofágico</td>
+<td align="center">20 17,9</td>
+<td align="center">108 37,4</td>
+<td align="center">128 31,9</td>
+<td align="center">0,0002</td>
+</tr>
+<tr>
+<td align="left">Transtornos funcionais do intestino</td>
+<td align="center">8 7,1</td>
+<td align="center">81 28,0</td>
+<td align="center">89 22,2</td>
+<td align="center">0,0001</td>
+</tr>
+<tr>
+<td align="left">Trato respiratório</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Infecções agudas das vias aéreas superiores de localizações múltiplas</td>
+<td align="center">23 20,5</td>
+<td align="center">112 38,7</td>
+<td align="center">135 33,7</td>
+<td align="center">0,0005</td>
+</tr>
+<tr>
+<td align="left">Tosse</td>
+<td align="center">18 16,1</td>
+<td align="center">116 40,1</td>
+<td align="center">134 33,4</td>
+<td align="center">0,0001</td>
+</tr>
+<tr>
+<td align="left">Otite média supurativa e as não especificadas</td>
+<td align="center">21 18,7</td>
+<td align="center">42 14,5</td>
+<td align="center">63 15,7</td>
+<td align="center">0,2978</td>
+</tr>
+<tr>
+<td align="left">Outros</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Dor abdominal e pélvica</td>
+<td align="center">22 19,6</td>
+<td align="center">129 44,6</td>
+<td align="center">161 40,1</td>
+<td align="center">0,0001</td>
+</tr>
+<tr>
+<td align="left">Dermatite das fraldas</td>
+<td align="center">16 14,3</td>
+<td align="center">123 42,6</td>
+<td align="center">139 34,7</td>
+<td align="center">0,0001</td>
+</tr>
+<tr>
+<td align="left">Febre de origem desconhecida</td>
+<td align="center">25 22,3</td>
+<td align="center">112 38,7</td>
+<td align="center">137 34,2</td>
+<td align="center">0,0019</td>
+</tr>
+<tr>
+<td align="left">Outros transtornos do trato urinário</td>
+<td align="center">14 12,5</td>
+<td align="center">32 11,1</td>
+<td align="center">46 11,5</td>
+<td align="center">0,6874</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet9" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 4</strong>    Razão de prevalência bruta da presença de doenças nos 24 meses de vida segundo variáveis sociodemográficas, do nascimento, estado nutricional, aleitamento materno e imunização de crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<thead>
+<tr>
+<th align="left" rowspan="2">Variáveis</th>
+<th align="center" colspan="2">Teve doença prevalente nos 24 meses</th>
+<th align="center" rowspan="2">RP bruta</th>
+<th align="center" rowspan="2">IC 95 %</th>
+<th align="center" rowspan="2">Valor de p</th>
+</tr>
+<tr>
+<th align="center">Sim</th>
+<th align="center">%</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">Sexo</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Feminino</td>
+<td align="center">159</td>
+<td align="center">93,5</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,85</td>
+</tr>
+<tr>
+<td align="left">Masculino</td>
+<td align="center">215</td>
+<td align="center">93,1</td>
+<td align="center">0,99</td>
+<td align="center">0,94-1,04</td>
+</tr>
+<tr>
+<td align="left">Raça/cor</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Branco/amarelo</td>
+<td align="center">189</td>
+<td align="center">93,6</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,99</td>
+</tr>
+<tr>
+<td align="left">Pardo/ negro</td>
+<td align="center">185</td>
+<td align="center">93,0</td>
+<td align="center">0,99</td>
+<td align="center">0,94-1,05</td>
+</tr>
+<tr>
+<td align="left">Apgar 1º minuto</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Normal</td>
+<td align="center">364</td>
+<td align="center">93,3</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,78</td>
+</tr>
+<tr>
+<td align="left">Alterado</td>
+<td align="center">10</td>
+<td align="center">90,9</td>
+<td align="center">0,97</td>
+<td align="center">0,82-1,15</td>
+</tr>
+<tr>
+<td align="left">Apgar 5º minuto</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Normal</td>
+<td align="center">313</td>
+<td align="center">93,3</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Alterado</td>
+<td align="center">30</td>
+<td align="center">100,0</td>
+<td align="center">1,07</td>
+<td align="center">1,04-1,09</td>
+</tr>
+<tr>
+<td align="left">Peso ao nascer</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Normal</td>
+<td align="center">313</td>
+<td align="center">93,4</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="center" rowspan="2">0,77</td>
+</tr>
+<tr>
+<td align="left">Alterado</td>
+<td align="center">61</td>
+<td align="center">92,4</td>
+<td align="center">0,99</td>
+<td align="center">0,24-1,06</td>
+</tr>
+<tr>
+<td align="left">Comprimento ao nascer</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Normal</td>
+<td align="center">292</td>
+<td align="center">91,5</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Alterado</td>
+<td align="center">82</td>
+<td align="center">100,0</td>
+<td align="center">1,08</td>
+<td align="center">1,05-1,12</td>
+</tr>
+<tr>
+<td align="left">AME até 6 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">112</td>
+<td align="center">76,7</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">65</td>
+<td align="center">77,5</td>
+<td align="center">1,22</td>
+<td align="center">1,15-1,30</td>
+</tr>
+<tr>
+<td align="left">AM até 12 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">309</td>
+<td align="center">92,0</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">65</td>
+<td align="center">100,0</td>
+<td align="center">1,08</td>
+<td align="center">1,05-1,11</td>
+</tr>
+<tr>
+<td align="left">AM até 24 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Sim</td>
+<td align="center">152</td>
+<td align="center">85,5</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Não</td>
+<td align="center">223</td>
+<td align="center">99,6</td>
+<td align="center">1,15</td>
+<td align="center">1,09-1,21</td>
+<td align="center">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Peso 12 meses</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Normal</td>
+<td align="center">240</td>
+<td align="center">90,2</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Alterado</td>
+<td align="center">134</td>
+<td align="center">99,3</td>
+<td align="center">1,09</td>
+<td align="center">1,05-1,13</td>
+</tr>
+<tr>
+<td align="left">Estado vacinal</td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+<td align="left"></td>
+</tr>
+<tr>
+<td align="left">Completo</td>
+<td align="center">349</td>
+<td align="center">93,8</td>
+<td align="center">1</td>
+<td align="center">-</td>
+<td align="center" rowspan="2">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left">Incompleto</td>
+<td align="center">25</td>
+<td align="center">86,2</td>
+<td align="center">0,92</td>
+<td align="center">0,81-1,05</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN3">
+<sup class="xref big">*</sup><div>
+                <i>valor de p significativo; IC - intervalo de confiança; AM - aleitamento materno; AME - aleitamento materno exclusivo.</i>
+              </div>
+</li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalTables" id="ModalTablet10" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog modal-lg"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">
+<span class="sci-ico-fileTable"></span><strong>Tabela 5</strong>    Razão de prevalência ajustada da presença de doenças aos seis, 12 e 24 meses segundo variáveis tipo de amamentação aos seis, 12 e 24 meses, Apgar 5<sup>0</sup> minuto, peso aos 12 meses e comprimento ao nascer alterado das crianças nascidas em Maringá, Paraná, Brasil, 2020<br>
+</h4>
+</div>
+<div class="modal-body"><div class="table table-hover"><table>
+<thead><tr>
+<th align="left" valign="top">Variáveis</th>
+<th align="center" valign="top">RP ajustada</th>
+<th align="center" valign="top">IC 95%</th>
+<th align="center" valign="top">Valor de <i>p</i>
+</th>
+</tr></thead>
+<tbody>
+<tr>
+<td align="left" valign="top">Não amamentados, exclusivamente, até 6 meses</td>
+<td align="center" valign="top">1,21</td>
+<td align="center" valign="top">1,14-1,29</td>
+<td align="center" valign="top">0,000<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left" valign="top">Não amamentados até 12 meses</td>
+<td align="center" valign="top">1,10</td>
+<td align="center" valign="top">0,996-1,01</td>
+<td align="center" valign="top">0,020<strong>*</strong> </td>
+</tr>
+<tr>
+<td align="left" valign="top">Não amamentados até 24 meses</td>
+<td align="center" valign="top">0,99</td>
+<td align="center" valign="top">0,990-1,01</td>
+<td align="center" valign="top">0,544</td>
+</tr>
+<tr>
+<td align="left" valign="top">Apgar 5º min alterado</td>
+<td align="center" valign="top">0,85</td>
+<td align="center" valign="top">0,988-1,01</td>
+<td align="center" valign="top">0,854</td>
+</tr>
+<tr>
+<td align="left" valign="top">Peso aos 12 meses inadequado</td>
+<td align="center" valign="top">1,01</td>
+<td align="center" valign="top">0,99-1,047</td>
+<td align="center" valign="top">0,182</td>
+</tr>
+<tr>
+<td align="left" valign="top">Comprimento ao nascer alterado</td>
+<td align="center" valign="top">1,01</td>
+<td align="center" valign="top">1,00-1,031</td>
+<td align="center" valign="top">0,055</td>
+</tr>
+</tbody>
+</table></div></div>
+<div class="modal-footer"><div class="ref-list"><ul class="refList footnote"><li id="TFN4">
+<sup class="xref big">*</sup><div>
+                <i>valor de p significativo; IC - intervalo de confiança; RP - razão de prevalência.</i>
+              </div>
+</li></ul></div></div>
+</div></div></div>
+<div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
+<div class="modal-header">
+<button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button><h4 class="modal-title">Como citar</h4>
+</div>
+<div class="modal-body">
+<p id="citation"></p>
+<input id="citationCut" type="text" value=""><a class="copyLink" data-clipboard-target="#citationCut"><span class="glyphBtn copyIcon"></span>copiar</a>
+</div>
+</div></div></div>
+<script type="text/javascript">
+            function currentDate() {
+            var today = new Date();
+            var months = ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
+            today.setTime(today.getTime());
+            return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+            }
+            var citation = 'Nass, Evelin Matilde Arcain et al. ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Breastfeeding and diseases prevalent in the first two years of a child’s life: a cross-sectional study. Revista Brasileira de Enfermagem [online]. 2022, v. 75, n. 06 [Acessado CURRENTDATE] , e20210534. Disponível em: &lt;https://doi.org/10.1590/0034-7167-2021-0534 https://doi.org/10.1590/0034-7167-2021-0534pt&gt;. Epub 06 Jun 2022. ISSN 1984-0446. https://doi.org/10.1590/0034-7167-2021-0534.'.replace('CURRENTDATE', currentDate());
+            document.getElementById('citation').innerHTML = citation;
+            document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+        </script>
+</div>
+<ul class="floatingMenu fm-slidein" data-fm-toogle="hover"><li class="fm-wrap">
+<a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a><ul class="fm-list">
+<li><a class="fm-button-child" data-fm-label="Tabelas" data-toggle="modal" data-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+<li><a class="fm-button-child" data-toggle="modal" data-target="#ModalArticles" data-fm-label="How to
+                                          cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+</ul>
+</li></ul>
+<script src="/Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js"></script>
+</body>
+</html>

--- a/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.xml
+++ b/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.xml
@@ -1,0 +1,2311 @@
+
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="nlm-ta">Rev Bras Enferm</journal-id>
+      <journal-id journal-id-type="publisher-id">reben</journal-id>
+      <journal-title-group>
+        <journal-title>Revista Brasileira de Enfermagem</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">Rev. Bras. Enferm.</abbrev-journal-title>
+      </journal-title-group>
+      <issn pub-type="ppub">0034-7167</issn>
+      <issn pub-type="epub">1984-0446</issn>
+      <publisher>
+        <publisher-name>Associação Brasileira de Enfermagem</publisher-name>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id specific-use="scielo-v3" pub-id-type="publisher-id">hxcB3n9hzmSGz4v6dgzDsxp</article-id>
+      <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S0034-71672022000700152</article-id>
+      <article-id pub-id-type="other">00152</article-id>
+      <article-id pub-id-type="doi">10.1590/0034-7167-2021-0534</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>ORIGINAL ARTICLE</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Breastfeeding and diseases prevalent in the first two years of a child’s life: a cross-sectional study</article-title>
+        <trans-title-group xml:lang="es">
+          <trans-title>Lactancia materna y enfermedades prevalentes en los dos primeros años de vida del niño: un estudio transversal</trans-title>
+        </trans-title-group>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-5140-3104</contrib-id>
+          <name>
+            <surname>Nass</surname>
+            <given-names>Evelin Matilde Arcain</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+          <xref ref-type="corresp" rid="c1"/>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-6607-362X</contrib-id>
+          <name>
+            <surname>Marcon</surname>
+            <given-names>Sonia Silva</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-6835-0574</contrib-id>
+          <name>
+            <surname>Teston</surname>
+            <given-names>Elen Ferraz</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff2">II</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0003-3776-0997</contrib-id>
+          <name>
+            <surname>Leal</surname>
+            <given-names>Luciana Pedrosa</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff3">III</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-6008-2795</contrib-id>
+          <name>
+            <surname>Ichisato</surname>
+            <given-names>Sueli Mutsumi Tsukuda</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-7366-077X</contrib-id>
+          <name>
+            <surname>Toso</surname>
+            <given-names>Beatriz Rosana Gonçalves de Oliveira</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff4">IV</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-8607-0020</contrib-id>
+          <name>
+            <surname>Moreira</surname>
+            <given-names>Mariana Angela Rossaneis</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff5">V</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0003-0339-9451</contrib-id>
+          <name>
+            <surname>Bernardino</surname>
+            <given-names>Fabiane Blanco Silva</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff6">VI</xref>
+        </contrib>
+      </contrib-group>
+      <aff id="aff1">
+        <label>I</label>
+        <institution content-type="orgname">Universidade Estadual de Maringá</institution>
+        <addr-line>
+          <city>Maringá</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Estadual de Maringá. Maringá, Paraná. Brazil.</institution>
+      </aff>
+      <aff id="aff2">
+        <label>II</label>
+        <institution content-type="orgname">Universidade Federal de Mato Grosso do Sul</institution>
+        <addr-line>
+          <city>Mato Grosso do Sul</city>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brazil.</institution>
+      </aff>
+      <aff id="aff3">
+        <label>III</label>
+        <institution content-type="orgname">Universidade Federal de Pernambuco</institution>
+        <addr-line>
+          <city>Recife</city>
+          <state>Pernambuco</state>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Federal de Pernambuco. Recife, Pernambuco. Brazil.</institution>
+      </aff>
+      <aff id="aff4">
+        <label>IV</label>
+        <institution content-type="orgname">Universidade Estadual do Oeste do Paraná</institution>
+        <addr-line>
+          <city>Cascavel</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brazil.</institution>
+      </aff>
+      <aff id="aff5">
+        <label>V</label>
+        <institution content-type="orgname">Universidade Estadual de Londrina</institution>
+        <addr-line>
+          <city>Londrina</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Estadual de Londrina. Londrina, Paraná. Brazil.</institution>
+      </aff>
+      <aff id="aff6">
+        <label>VI</label>
+        <institution content-type="orgname">Universidade Federal de Mato Grosso</institution>
+        <addr-line>
+          <city>Cuiabá</city>
+          <state>Mato Grosso</state>
+        </addr-line>
+        <country country="BR">Brazil</country>
+        <institution content-type="original">Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brazil.</institution>
+      </aff>
+      <author-notes>
+        <corresp id="c1"><bold>Corresponding author:</bold> Evelin Matilde Arcain Nass <email>evelinmarcain@gmail.com</email> </corresp>
+        <fn fn-type="edited-by">
+          <p>EDITOR IN CHIEF: Antonio José de Almeida Filho</p>
+        </fn>
+        <fn fn-type="edited-by">
+          <p>ASSOCIATE EDITOR: Alexandre Balsanelli</p>
+        </fn>
+      </author-notes>
+      <pub-date date-type="pub" publication-format="electronic">
+        <day>06</day>
+        <month>06</month>
+        <year>2022</year>
+      </pub-date>
+      <pub-date date-type="collection" publication-format="electronic">
+        <year>2022</year>
+      </pub-date>
+      <volume>75</volume>
+      <issue>06</issue>
+      <elocation-id>e20210534</elocation-id>
+      <supplementary-material xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://minio.scielo.br/documentstore/1984-0446/hxcB3n9hzmSGz4v6dgzDsxp/523b172ce6fd9f25222bb49056b1a7e3b525019b.xlsx">
+        <label>0034-7167-reben-75-06-e20210534-sup01</label>
+      </supplementary-material>
+      <supplementary-material xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://minio.scielo.br/documentstore/1984-0446/hxcB3n9hzmSGz4v6dgzDsxp/6c9f473da74901318554fb5b6b5ae4d0faad430c.xlsx">
+        <label>0034-7167-reben-75-06-e20210534-sup02</label>
+      </supplementary-material>
+      <supplementary-material xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://minio.scielo.br/documentstore/1984-0446/hxcB3n9hzmSGz4v6dgzDsxp/482be9eb2cd0d6b6ea9d737bf1167e86cb257a2a.xlsx">
+        <label>0034-7167-reben-75-06-e20210534-sup03</label>
+      </supplementary-material>
+      <supplementary-material xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://minio.scielo.br/documentstore/1984-0446/hxcB3n9hzmSGz4v6dgzDsxp/6ace595769daa0e017c3c2a54a7a5f6aa7335493.pdf">
+        <label>0034-7167-reben-75-06-e20210534-sup04</label>
+      </supplementary-material>
+      <history>
+        <date date-type="received">
+          <day>23</day>
+          <month>08</month>
+          <year>2021</year>
+        </date>
+        <date date-type="accepted">
+          <day>11</day>
+          <month>02</month>
+          <year>2022</year>
+        </date>
+      </history>
+      <permissions>
+        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/" xml:lang="en">
+          <license-p>This is an Open Access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
+        </license>
+      </permissions>
+      <abstract>
+        <title>ABSTRACT</title>
+        <sec>
+          <title>Objectives:</title>
+          <p>to assess the association between breastfeeding and diseases prevalent in the first two years of a child’s life.</p>
+        </sec>
+        <sec>
+          <title>Methods:</title>
+          <p>a retrospective cross-sectional study that analyzed electronic medical records of 401 children. Data on birth, growth, breastfeeding and medical care in the first two years of life were collected. In the analysis, Poisson regression with robust variance was used.</p>
+        </sec>
+        <sec>
+          <title>Results:</title>
+          <p>27.9% of children were exclusively breastfed until six months, and, at 24 months, 93.3% had already had some prevalent childhood disease. In the crude analysis, 5-minute Apgar association, length, weight at 12 months, exclusive and non-exclusive breastfeeding time had association. In the adjusted analysis, only the variable breastfeeding at six months maintained the association with prevalent childhood diseases.</p>
+        </sec>
+        <sec>
+          <title>Conclusions:</title>
+          <p>children who were not breastfed, exclusively or not, up to six months of age, had a higher prevalence of diseases compared to breastfed children.</p>
+        </sec>
+      </abstract>
+      <trans-abstract xml:lang="es">
+        <title>RESUMEN</title>
+        <sec>
+          <title>Objetivos:</title>
+          <p>evaluar la asociación entre lactancia materna y enfermedades prevalentes en los dos primeros años de vida del niño.</p>
+        </sec>
+        <sec>
+          <title>Métodos:</title>
+          <p>estudio transversal retrospectivo que analizó las historias clínicas electrónicas de 401 niños. Se recogieron datos sobre nacimiento, crecimiento, lactancia y atención médica en los dos primeros años de vida. En el análisis se utilizó la regresión de Poisson con varianza robusta.</p>
+        </sec>
+        <sec>
+          <title>Resultados:</title>
+          <p>el 27,9% de los niños fueron amamantados exclusivamente hasta los seis meses de edad y, a los 24 meses, el 93,3% ya había tenido alguna enfermedad infantil prevalente. En el análisis crudo presentaron asociación de Apgar al minuto 5, longitud, peso a los 12 meses, tiempo de lactancia materna exclusiva y no exclusiva. En el análisis ajustado, sólo la variable lactancia materna a los seis meses mantuvo la asociación con las enfermedades prevalentes de la infancia.</p>
+        </sec>
+        <sec>
+          <title>Conclusiones:</title>
+          <p>los niños que no fueron amamantados, exclusivamente o no, hasta los seis meses de edad, presentaron mayor prevalencia de enfermedades en comparación con los niños amamantados.</p>
+        </sec>
+      </trans-abstract>
+      <kwd-group xml:lang="en">
+        <title>Descriptors:</title>
+        <kwd>Breast Feeding</kwd>
+        <kwd>Integrated Management of Childhood Illness</kwd>
+        <kwd>Comprehensive Health Care</kwd>
+        <kwd>Education</kwd>
+        <kwd>Nursing</kwd>
+        <kwd>Child Health Services</kwd>
+      </kwd-group>
+      <kwd-group xml:lang="es">
+        <title>Descriptores:</title>
+        <kwd>Lactancia Materna</kwd>
+        <kwd>Atención Integrada a las Enfermedades Prevalentes de la Infancia</kwd>
+        <kwd>Atención Integral de Salud</kwd>
+        <kwd>Enfermería Perioperatoria</kwd>
+        <kwd>Servicios de Salud Infantil</kwd>
+      </kwd-group>
+      <funding-group>
+        <award-group>
+          <funding-source>CAPES</funding-source>
+          <award-id>001</award-id>
+        </award-group>
+        <funding-statement>The present study was carried out with support from the Higher Education Personnel Improvement Coordination - Brazil (CAPES - <italic>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior</italic>) - Financing Code 001.</funding-statement>
+      </funding-group>
+    </article-meta>
+  </front>
+  <body>
+    
+    <sec sec-type="supplementary-material">
+      <title>SUPPLEMENTARY MATERIAL</title>
+      <p>The research database was deposited in SCIELO Data: Arcain, Evelin, 2021, “<italic>Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal</italic>”, <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.48331/scielodata.XPWWYD">https://doi.org/10.48331/scielodata.XPWWYD,</ext-link> SciELO Data, DRAFT VERSION, UNF:6:rWHWyqc8p/Ef7BQh3BLfwQ== [fileUNF].</p>
+    </sec>
+  </body>
+  <back>
+    <fn-group>
+      <fn fn-type="financial-disclosure">
+        <p>
+          <bold>FUNDING</bold>
+        </p>
+        <p>The present study was carried out with support from the Higher Education Personnel Improvement Coordination - Brazil (CAPES - <italic>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior</italic>) - Financing Code 001.</p>
+      </fn>
+    </fn-group>
+    <ref-list>
+      <title>REFERENCES</title>
+      <ref id="B1">
+        <label>1</label>
+        <mixed-citation>1 Ministério da Saúde (BR). Manual AIDPI Criança: 2 meses a 5 anos[Internet]. Brasília, DF: SVS; 2017[cited 2020 Mar 23]. Available from: portalarquivos.saude.gov.br/imagens/pdf/2017/julho/12/17-0056-Online.pdf</mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <collab>Ministério da Saúde (BR)</collab>
+          </person-group>
+          <source>Manual AIDPI Criança: 2 meses a 5 anos[Internet]</source>
+          <publisher-loc>Brasília, DF</publisher-loc>
+          <publisher-name> SVS</publisher-name>
+          <year>2017</year>
+          <date-in-citation>cited 2020 Mar 23</date-in-citation>
+          <comment>Available from: portalarquivos.saude.gov.br/imagens/pdf/2017/julho/12/17-0056-Online.pdf</comment>
+        </element-citation>
+      </ref>
+      <ref id="B2">
+        <label>2</label>
+        <mixed-citation>2 Ministério da Saúde (BR). Portaria nº 2.436, de 21 de setembro de 2017. Aprova a Política Nacional de Atenção Básica, estabelecendo a revisão de diretrizes para a organização da Atenção Básica, no âmbito do Sistema Único de Saúde[Internet]. Brasília, DF: 2017[cited 2020 Mar 20]. Available from: <ext-link ext-link-type="uri" xlink:href="https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html">https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html</ext-link> </mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <collab>Ministério da Saúde (BR)</collab>
+          </person-group>
+          <article-title>Portaria nº 2.436, de 21 de setembro de 2017</article-title>
+          <source>Aprova a Política Nacional de Atenção Básica, estabelecendo a revisão de diretrizes para a organização da Atenção Básica, no âmbito do Sistema Único de Saúde[Internet]</source>
+          <publisher-loc>Brasília, DF</publisher-loc>
+          <year>2017</year>
+          <date-in-citation>cited 2020 Mar 20</date-in-citation>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html">https://bvsms.saude.gov.br/bvs/saudelegis/gm/2017/prt2436¬-_22_09_2017.html</ext-link> </comment>
+        </element-citation>
+      </ref>
+      <ref id="B3">
+        <label>3</label>
+        <mixed-citation>3 World Health Organization (WHO). Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]. 2017[cited 2020 Mar 25]. Available from: <ext-link ext-link-type="uri" xlink:href="https://apps.who.int/iris/handle/10665/259386">https://apps.who.int/iris/handle/10665/259386</ext-link> </mixed-citation>
+        <element-citation publication-type="database">
+          <person-group person-group-type="author">
+            <collab>World Health Organization (WHO)</collab>
+          </person-group>
+          <source>Protecting, promoting and supporting breastfeeding in facilities providing maternity and newborn services [Internet]</source>
+          <year>2017</year>
+          <date-in-citation>cited 2020 Mar 25</date-in-citation>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="https://apps.who.int/iris/handle/10665/259386">https://apps.who.int/iris/handle/10665/259386</ext-link> </comment>
+        </element-citation>
+      </ref>
+      <ref id="B4">
+        <label>4</label>
+        <mixed-citation>4 Leal MC, Szwarcwald CL, Almeida PVB, Aquino EML, Barreto ML, Barros F, et al. Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS). Ciên Saúde Colet. 2018;23(6):1915-1928. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1413-81232018236.03942018">https://doi.org/10.1590/1413-81232018236.03942018</ext-link> </mixed-citation>
+        <element-citation publication-type="data">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Leal</surname>
+              <given-names>MC</given-names>
+            </name>
+            <name>
+              <surname>Szwarcwald</surname>
+              <given-names>CL</given-names>
+            </name>
+            <name>
+              <surname>Almeida</surname>
+              <given-names>PVB</given-names>
+            </name>
+            <name>
+              <surname>Aquino</surname>
+              <given-names>EML</given-names>
+            </name>
+            <name>
+              <surname>Barreto</surname>
+              <given-names>ML</given-names>
+            </name>
+            <name>
+              <surname>Barros</surname>
+              <given-names>F</given-names>
+            </name>
+            <etal/>
+          </person-group>
+          <article-title>Reproductive, maternal, neonatal and child health in the 30 years since the creation of the Unified Health System (SUS)</article-title>
+          <source>Ciên Saúde Colet</source>
+          <year>2018</year>
+          <volume>23</volume>
+          <issue>6</issue>
+          <fpage>1915</fpage>
+          <lpage>1928</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1413-81232018236.03942018">https://doi.org/10.1590/1413-81232018236.03942018</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B5">
+        <label>5</label>
+        <mixed-citation>5 Videholm S, Wallby T, Silfverdal SA. Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden. BMJ Open. 2021;11:e046583. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1136/bmjopen-2020-046583">https://doi.org/10.1136/bmjopen-2020-046583</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Videholm</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Wallby</surname>
+              <given-names>T</given-names>
+            </name>
+            <name>
+              <surname>Silfverdal</surname>
+              <given-names>SA.</given-names>
+            </name>
+          </person-group>
+          <article-title>Breastfeeding practice, breastfeeding policy and hospitalisations for infectious diseases in early and later childhood: a register-based study in Uppsala County, Sweden</article-title>
+          <source>BMJ Open</source>
+          <year>2021</year>
+          <volume>11</volume>
+          <fpage>e046583</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1136/bmjopen-2020-046583">https://doi.org/10.1136/bmjopen-2020-046583</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B6">
+        <label>6</label>
+        <mixed-citation>6 Baye A, Adane M, Sisay T, Hailemeskel HS. Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study. BMC Pediatrics. 2021;21:155. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1186/s12887-021-02592-5">https://doi.org/10.1186/s12887-021-02592-5</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Baye</surname>
+              <given-names>A</given-names>
+            </name>
+            <name>
+              <surname>Adane</surname>
+              <given-names>M</given-names>
+            </name>
+            <name>
+              <surname>Sisay</surname>
+              <given-names>T</given-names>
+            </name>
+            <name>
+              <surname>Hailemeskel</surname>
+              <given-names>HS.</given-names>
+            </name>
+          </person-group>
+          <article-title>Priorities for intervention to prevent diarrhea among children aged 0-23 months in northeastern Ethiopia: a matched case-control study</article-title>
+          <source>BMC Pediatrics</source>
+          <year>2021</year>
+          <volume>21</volume>
+          <fpage>155</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1186/s12887-021-02592-5">https://doi.org/10.1186/s12887-021-02592-5</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B7">
+        <label>7</label>
+        <mixed-citation>7 Vijay J, Patel KK. Risk factors of infant mortality in Bangladesh. Clin Epidemiol Global Health. 2020;8(1):211-4. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.cegh.2019.07.003">https://doi.org/10.1016/j.cegh.2019.07.003</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Vijay</surname>
+              <given-names>J</given-names>
+            </name>
+            <name>
+              <surname>Patel</surname>
+              <given-names>KK.</given-names>
+            </name>
+          </person-group>
+          <article-title>Risk factors of infant mortality in Bangladesh</article-title>
+          <source>Clin Epidemiol Global Health</source>
+          <year>2020</year>
+          <volume>8</volume>
+          <issue>1</issue>
+          <fpage>211</fpage>
+          <lpage>4</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.cegh.2019.07.003">https://doi.org/10.1016/j.cegh.2019.07.003</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B8">
+        <label>8</label>
+        <mixed-citation>8 Costa BR, Cevallos M, Altman DG, Rutjes AWS, Egger M. Uses and misuses of the STROBE statement: bibliographic study. BMJ Open. 2011;1:e 000048. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1136/bmjopen-2010-000048">https://doi.org/10.1136/bmjopen-2010-000048</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Costa</surname>
+              <given-names>BR</given-names>
+            </name>
+            <name>
+              <surname>Cevallos</surname>
+              <given-names>M</given-names>
+            </name>
+            <name>
+              <surname>Altman</surname>
+              <given-names>DG</given-names>
+            </name>
+            <name>
+              <surname>Rutjes</surname>
+              <given-names>AWS</given-names>
+            </name>
+            <name>
+              <surname>Egger</surname>
+              <given-names>M.</given-names>
+            </name>
+          </person-group>
+          <article-title>Uses and misuses of the STROBE statement: bibliographic study</article-title>
+          <source>BMJ Open</source>
+          <year>2011</year>
+          <volume>1</volume>
+          <fpage>e 000048</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1136/bmjopen-2010-000048">https://doi.org/10.1136/bmjopen-2010-000048</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B9">
+        <label>9</label>
+        <mixed-citation>9 Lopes WC, Marques FKS, Oliveira CF, Rodrigues JÁ, Silveira MF, Caldeira AP, et al. Infant feeding in the first two years of life. Rev Paul Pediatr. 2018;36(2):164-70. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1984-0462/;2018;36;2;00004">https://doi.org/10.1590/1984-0462/;2018;36;2;00004</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Lopes</surname>
+              <given-names>WC</given-names>
+            </name>
+            <name>
+              <surname>Marques</surname>
+              <given-names>FKS</given-names>
+            </name>
+            <name>
+              <surname>Oliveira</surname>
+              <given-names>CF</given-names>
+            </name>
+            <name>
+              <surname>Rodrigues</surname>
+              <given-names>JÁ</given-names>
+            </name>
+            <name>
+              <surname>Silveira</surname>
+              <given-names>MF</given-names>
+            </name>
+            <name>
+              <surname>Caldeira</surname>
+              <given-names>AP</given-names>
+            </name>
+            <etal/>
+          </person-group>
+          <article-title>Infant feeding in the first two years of life</article-title>
+          <source>Rev Paul Pediatr</source>
+          <year>2018</year>
+          <volume>36</volume>
+          <issue>2</issue>
+          <fpage>164</fpage>
+          <lpage>70</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1984-0462/;2018;36;2;00004">https://doi.org/10.1590/1984-0462/;2018;36;2;00004</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B10">
+        <label>10</label>
+        <mixed-citation>10 Ministério da Saúde (BR), Secretaria de Vigilância em Saúde. Sistema de informações sobre nascidos vivos (SINASC) [Internet]. Brasília, DF: SVS; 2017 [cited 2020 Feb 10]. Available from: <ext-link ext-link-type="uri" xlink:href="http://www2.datasus.gov.br/DATASUS/index.php?area=060702">www2.datasus.gov.br/DATASUS/index.php?area=060702</ext-link> </mixed-citation>
+        <element-citation publication-type="book">
+          <person-group person-group-type="author">
+            <collab>Ministério da Saúde (BR), Secretaria de Vigilância em Saúde</collab>
+          </person-group>
+          <source>Sistema de informações sobre nascidos vivos (SINASC) [Internet]</source>
+          <publisher-loc>Brasília, DF</publisher-loc>
+          <publisher-name>SVS</publisher-name>
+          <year>2017</year>
+          <date-in-citation>cited 2020 Feb 10</date-in-citation>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="http://www2.datasus.gov.br/DATASUS/index.php?area=060702">www2.datasus.gov.br/DATASUS/index.php?area=060702</ext-link> </comment>
+        </element-citation>
+      </ref>
+      <ref id="B11">
+        <label>11</label>
+        <mixed-citation>11 Ministério da Saúde (BR). Caderneta de Saúde da Criança[Internet]. Brasília, DF: 2018[cited 2021 Jan 22]. Available from: <ext-link ext-link-type="uri" xlink:href="https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf">https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf</ext-link> </mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <collab>Ministério da Saúde (BR)</collab>
+          </person-group>
+          <source>Caderneta de Saúde da Criança[Internet]</source>
+          <publisher-loc>Brasília, DF</publisher-loc>
+          <year>2018</year>
+          <date-in-citation>cited 2021 Jan 22</date-in-citation>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf">https://bvsms.saude.gov.br/bvs/publicacoes/caderneta_saude_crianca_menina_12ed.pdf</ext-link> </comment>
+        </element-citation>
+      </ref>
+      <ref id="B12">
+        <label>12</label>
+        <mixed-citation>12 Brahma P, Valdés V. Benefits of breastfeeding and risks associated with not breastfeeding. Rev Child Pediatr. 2017;88(1):15-21. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.4067/S0370-4106201700010000001">https://doi.org/10.4067/S0370-4106201700010000001</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Brahma</surname>
+              <given-names>P</given-names>
+            </name>
+            <name>
+              <surname>Valdés</surname>
+              <given-names>V.</given-names>
+            </name>
+          </person-group>
+          <article-title>Benefits of breastfeeding and risks associated with not breastfeeding</article-title>
+          <source>Rev Child Pediatr</source>
+          <year>2017</year>
+          <volume>88</volume>
+          <issue>1</issue>
+          <fpage>15</fpage>
+          <lpage>21</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.4067/S0370-4106201700010000001">https://doi.org/10.4067/S0370-4106201700010000001</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B13">
+        <label>13</label>
+        <mixed-citation>13 Prezotto KH, Lentsck MH, Aidar T, Fertonani HP, Mathias TAF. Hospitalizations of children for preventable conditions in the state of Parana: causes and trends. Acta Paul Enferm. 2017;30(3):254-61. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-0194201700039">https://doi.org/10.1590/1982-0194201700039</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Prezotto</surname>
+              <given-names>KH</given-names>
+            </name>
+            <name>
+              <surname>Lentsck</surname>
+              <given-names>MH</given-names>
+            </name>
+            <name>
+              <surname>Aidar</surname>
+              <given-names>T</given-names>
+            </name>
+            <name>
+              <surname>Fertonani</surname>
+              <given-names>HP</given-names>
+            </name>
+            <name>
+              <surname>Mathias</surname>
+              <given-names>TAF.</given-names>
+            </name>
+          </person-group>
+          <article-title>Hospitalizations of children for preventable conditions in the state of Parana: causes and trends</article-title>
+          <source>Acta Paul Enferm</source>
+          <year>2017</year>
+          <volume>30</volume>
+          <issue>3</issue>
+          <fpage>254</fpage>
+          <lpage>61</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-0194201700039">https://doi.org/10.1590/1982-0194201700039</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B14">
+        <label>14</label>
+        <mixed-citation>14 Flores TR, Nunes BP, Neves RG, Wendt AT, Costa CS, Wehrmeister FC, et al. Maternal breastfeeding and associated factors in children under two years: the Brazilian National Health Survey, 2013. Cad Saúde Pública. 2017;33(11):e00068816. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311x00068816">https://doi.org/10.1590/0102-311x00068816</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Flores</surname>
+              <given-names>TR</given-names>
+            </name>
+            <name>
+              <surname>Nunes</surname>
+              <given-names>BP</given-names>
+            </name>
+            <name>
+              <surname>Neves</surname>
+              <given-names>RG</given-names>
+            </name>
+            <name>
+              <surname>Wendt</surname>
+              <given-names>AT</given-names>
+            </name>
+            <name>
+              <surname>Costa</surname>
+              <given-names>CS</given-names>
+            </name>
+            <name>
+              <surname>Wehrmeister</surname>
+              <given-names>FC</given-names>
+            </name>
+            <etal/>
+          </person-group>
+          <article-title>Maternal breastfeeding and associated factors in children under two years: the Brazilian National Health Survey, 2013</article-title>
+          <source>Cad Saúde Pública</source>
+          <year>2017</year>
+          <volume>33</volume>
+          <issue>11</issue>
+          <fpage>e00068816</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311x00068816">https://doi.org/10.1590/0102-311x00068816</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B15">
+        <label>15</label>
+        <mixed-citation>15 Boccolini CS, Boccolini PMM, Monteiro FR, Venâncio SI, Giugliani ERJ. Breastfeeding indicators trends in Brazil for three decades. Rev Saude Publica. 2017;51:108. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.11606/S1518-8787.2017051000029">https://doi.org/10.11606/S1518-8787.2017051000029</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Boccolini</surname>
+              <given-names>CS</given-names>
+            </name>
+            <name>
+              <surname>Boccolini</surname>
+              <given-names>PMM</given-names>
+            </name>
+            <name>
+              <surname>Monteiro</surname>
+              <given-names>FR</given-names>
+            </name>
+            <name>
+              <surname>Venâncio</surname>
+              <given-names>SI</given-names>
+            </name>
+            <name>
+              <surname>Giugliani</surname>
+              <given-names>ERJ.</given-names>
+            </name>
+          </person-group>
+          <article-title>Breastfeeding indicators trends in Brazil for three decades</article-title>
+          <source>Rev Saude Publica</source>
+          <year>2017</year>
+          <volume>51</volume>
+          <fpage>108</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.11606/S1518-8787.2017051000029">https://doi.org/10.11606/S1518-8787.2017051000029</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B16">
+        <label>16</label>
+        <mixed-citation>16 Garcez JCD, Oliveira Jr EN, Nunes MDS, Pinto LS, Soares TB, Silva MM, et al. Clinical and epidemiological profile in the first year of life. Rev Enferm UFPE. 2019;13:e241564. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5205/1981-8963.2019.241564">https://doi.org/10.5205/1981-8963.2019.241564</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Garcez</surname>
+              <given-names>JCD</given-names>
+            </name>
+            <name>
+              <surname>Oliveira</surname>
+              <given-names>EN</given-names>
+              <suffix>Jr</suffix>
+            </name>
+            <name>
+              <surname>Nunes</surname>
+              <given-names>MDS</given-names>
+            </name>
+            <name>
+              <surname>Pinto</surname>
+              <given-names>LS</given-names>
+            </name>
+            <name>
+              <surname>Soares</surname>
+              <given-names>TB</given-names>
+            </name>
+            <name>
+              <surname>Silva</surname>
+              <given-names>MM</given-names>
+            </name>
+            <etal/>
+          </person-group>
+          <article-title>Clinical and epidemiological profile in the first year of life</article-title>
+          <source>Rev Enferm UFPE</source>
+          <year>2019</year>
+          <volume>13</volume>
+          <fpage>e241564</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.5205/1981-8963.2019.241564">https://doi.org/10.5205/1981-8963.2019.241564</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B17">
+        <label>17</label>
+        <mixed-citation>17 Peres JF, Carvalho ARS, Viera CS, Christoffel MM, Toso BRGO. Percepções dos profissionais de saúde acerca dos fatores biopsicossocioculturais relacionados com o aleitamento materno. Saúde Debate. 2021;45(128):141051. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0103-1104202112811">https://doi.org/10.1590/0103-1104202112811</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Peres</surname>
+              <given-names>JF</given-names>
+            </name>
+            <name>
+              <surname>Carvalho</surname>
+              <given-names>ARS</given-names>
+            </name>
+            <name>
+              <surname>Viera</surname>
+              <given-names>CS</given-names>
+            </name>
+            <name>
+              <surname>Christoffel</surname>
+              <given-names>MM</given-names>
+            </name>
+            <name>
+              <surname>Toso</surname>
+              <given-names>BRGO.</given-names>
+            </name>
+          </person-group>
+          <article-title>Percepções dos profissionais de saúde acerca dos fatores biopsicossocioculturais relacionados com o aleitamento materno</article-title>
+          <source>Saúde Debate</source>
+          <year>2021</year>
+          <volume>45</volume>
+          <issue>128</issue>
+          <fpage>141051</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0103-1104202112811">https://doi.org/10.1590/0103-1104202112811</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B18">
+        <label>18</label>
+        <mixed-citation>18 Tronco CS, Bonilha ALL, Teles JM. Rede de apoio para o aleitamento materno na prematuridade tardia. Cienc Cuid Saude. 2020;19:e46479. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.4025/cienccuidsaude.v19i0.46479">https://doi.org/10.4025/cienccuidsaude.v19i0.46479</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Tronco</surname>
+              <given-names>CS</given-names>
+            </name>
+            <name>
+              <surname>Bonilha</surname>
+              <given-names>ALL</given-names>
+            </name>
+            <name>
+              <surname>Teles</surname>
+              <given-names>JM.</given-names>
+            </name>
+          </person-group>
+          <article-title>Rede de apoio para o aleitamento materno na prematuridade tardia</article-title>
+          <source>Cienc Cuid Saude</source>
+          <year>2020</year>
+          <volume>19</volume>
+          <fpage>e46479</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.4025/cienccuidsaude.v19i0.46479">https://doi.org/10.4025/cienccuidsaude.v19i0.46479</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B19">
+        <label>19</label>
+        <mixed-citation>19 Contarato AAPF, Rocha EDM, Czarnobay SA, Mastroeni SSBS, Veugelers PJ, Mastroeni MF. Independent effect of type of breastfeeding on overweight and obesity in children aged 12-24 months. Cad Saúde Pública. 2016;32(12):e00119015. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311X00119015">https://doi.org/10.1590/0102-311X00119015</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Contarato</surname>
+              <given-names>AAPF</given-names>
+            </name>
+            <name>
+              <surname>Rocha</surname>
+              <given-names>EDM</given-names>
+            </name>
+            <name>
+              <surname>Czarnobay</surname>
+              <given-names>SA</given-names>
+            </name>
+            <name>
+              <surname>Mastroeni</surname>
+              <given-names>SSBS</given-names>
+            </name>
+            <name>
+              <surname>Veugelers</surname>
+              <given-names>PJ</given-names>
+            </name>
+            <name>
+              <surname>Mastroeni</surname>
+              <given-names>MF.</given-names>
+            </name>
+          </person-group>
+          <article-title>Independent effect of type of breastfeeding on overweight and obesity in children aged 12-24 months</article-title>
+          <source>Cad Saúde Pública</source>
+          <year>2016</year>
+          <volume>32</volume>
+          <issue>12</issue>
+          <fpage>e00119015</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311X00119015">https://doi.org/10.1590/0102-311X00119015</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B20">
+        <label>20</label>
+        <mixed-citation>20 Frank NM, Lynch KF, Uusitalo U, Yang J, Lonnrot M, Virtanen SM, et al. The relationship between breastfeeding and reported respiratory and gastrointestinal infection rates in young children. BMC Pediatrics. 2019;19:339. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1186/s12887-019-1693-2">https://doi.org/10.1186/s12887-019-1693-2</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Frank</surname>
+              <given-names>NM</given-names>
+            </name>
+            <name>
+              <surname>Lynch</surname>
+              <given-names>KF</given-names>
+            </name>
+            <name>
+              <surname>Uusitalo</surname>
+              <given-names>U</given-names>
+            </name>
+            <name>
+              <surname>Yang</surname>
+              <given-names>J</given-names>
+            </name>
+            <name>
+              <surname>Lonnrot</surname>
+              <given-names>M</given-names>
+            </name>
+            <name>
+              <surname>Virtanen</surname>
+              <given-names>SM</given-names>
+            </name>
+            <etal/>
+          </person-group>
+          <article-title>The relationship between breastfeeding and reported respiratory and gastrointestinal infection rates in young children</article-title>
+          <source>BMC Pediatrics</source>
+          <year>2019</year>
+          <volume>19</volume>
+          <fpage>339</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1186/s12887-019-1693-2">https://doi.org/10.1186/s12887-019-1693-2</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B21">
+        <label>21</label>
+        <mixed-citation>21 Oliveira RKL, Oliveira BSB, Bezerra JC, Silva MJN, Melo FMS, Joventino ES. Influence of socio-economic conditions and maternal knowledge in self-effectiveness for prevention of childhood diarrhea. Esc Anna Nery. 2017;21(4):e20160361. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/2177-9465-ean-2016-0361">https://doi.org/10.1590/2177-9465-ean-2016-0361</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Oliveira</surname>
+              <given-names>RKL</given-names>
+            </name>
+            <name>
+              <surname>Oliveira</surname>
+              <given-names>BSB</given-names>
+            </name>
+            <name>
+              <surname>Bezerra</surname>
+              <given-names>JC</given-names>
+            </name>
+            <name>
+              <surname>Silva</surname>
+              <given-names>MJN</given-names>
+            </name>
+            <name>
+              <surname>Melo</surname>
+              <given-names>FMS</given-names>
+            </name>
+            <name>
+              <surname>Joventino</surname>
+              <given-names>ES.</given-names>
+            </name>
+          </person-group>
+          <article-title>Influence of socio-economic conditions and maternal knowledge in self-effectiveness for prevention of childhood diarrhea</article-title>
+          <source>Esc Anna Nery</source>
+          <year>2017</year>
+          <volume>21</volume>
+          <issue>4</issue>
+          <fpage>e20160361</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/2177-9465-ean-2016-0361">https://doi.org/10.1590/2177-9465-ean-2016-0361</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B22">
+        <label>22</label>
+        <mixed-citation>22 Monteiro ATA, Ferrari RAP, Tacla MTGM, Souza ALDM. Pediatric nursing consultation after maternity discharge: follow-up in primary care. Rev Soc Bras Enferm Ped. 2017;17(1):7-13. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.31508/1676-3793201700002">https://doi.org/10.31508/1676-3793201700002</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Monteiro</surname>
+              <given-names>ATA</given-names>
+            </name>
+            <name>
+              <surname>Ferrari</surname>
+              <given-names>RAP</given-names>
+            </name>
+            <name>
+              <surname>Tacla</surname>
+              <given-names>MTGM</given-names>
+            </name>
+            <name>
+              <surname>Souza</surname>
+              <given-names>ALDM.</given-names>
+            </name>
+          </person-group>
+          <article-title>Pediatric nursing consultation after maternity discharge: follow-up in primary care</article-title>
+          <source>Rev Soc Bras Enferm Ped</source>
+          <year>2017</year>
+          <volume>17</volume>
+          <issue>1</issue>
+          <fpage>7</fpage>
+          <lpage>13</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.31508/1676-3793201700002">https://doi.org/10.31508/1676-3793201700002</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B23">
+        <label>23</label>
+        <mixed-citation>23 Pinheiro JGA, Rodrigues NS, Silveira AO, Martins G. Mother and nursing academic: experience with intestinal constipation. Rev Enferm UFPE [Internet]. 2019[cited 2020 Feb 10];13(5):1520-1519. Available from: <ext-link ext-link-type="uri" xlink:href="https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782">https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Pinheiro</surname>
+              <given-names>JGA</given-names>
+            </name>
+            <name>
+              <surname>Rodrigues</surname>
+              <given-names>NS</given-names>
+            </name>
+            <name>
+              <surname>Silveira</surname>
+              <given-names>AO</given-names>
+            </name>
+            <name>
+              <surname>Martins</surname>
+              <given-names>G.</given-names>
+            </name>
+          </person-group>
+          <article-title>Mother and nursing academic: experience with intestinal constipation</article-title>
+          <source>Rev Enferm UFPE [Internet]</source>
+          <year>2019</year>
+          <date-in-citation>cited 2020 Feb 10</date-in-citation>
+          <volume>13</volume>
+          <issue>5</issue>
+          <fpage>1520</fpage>
+          <lpage>1519</lpage>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782">https://pesquisa.bvsalud.org/portal/resource/pt/biblio-1024782#fulltext_urls_biblio-1024782</ext-link> </comment>
+        </element-citation>
+      </ref>
+      <ref id="B24">
+        <label>24</label>
+        <mixed-citation>24 Melo KM, Cruz ACP, Brito MFSF, Pinho L. Influence of parents' behavior during the meal and on overweight in childhood. Esc Anna Nery. 2017;21(4):e20170102. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/2177-9465-EAN-2017-0102">https://doi.org/10.1590/2177-9465-EAN-2017-0102</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Melo</surname>
+              <given-names>KM</given-names>
+            </name>
+            <name>
+              <surname>Cruz</surname>
+              <given-names>ACP</given-names>
+            </name>
+            <name>
+              <surname>Brito</surname>
+              <given-names>MFSF</given-names>
+            </name>
+            <name>
+              <surname>Pinho</surname>
+              <given-names>L.</given-names>
+            </name>
+          </person-group>
+          <article-title>Influence of parents' behavior during the meal and on overweight in childhood</article-title>
+          <source>Esc Anna Nery</source>
+          <year>2017</year>
+          <volume>21</volume>
+          <issue>4</issue>
+          <fpage>e20170102</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/2177-9465-EAN-2017-0102">https://doi.org/10.1590/2177-9465-EAN-2017-0102</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B25">
+        <label>25</label>
+        <mixed-citation>25 Nadal LF, Rodrigues AH, Costa CC, Godoi VC, Klossowski DG, Fujinaga CI. Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media. Rev CEFAC. 2017;19(3):387-94. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-0216201719314916">https://doi.org/10.1590/1982-0216201719314916</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Nadal</surname>
+              <given-names>LF</given-names>
+            </name>
+            <name>
+              <surname>Rodrigues</surname>
+              <given-names>AH</given-names>
+            </name>
+            <name>
+              <surname>Costa</surname>
+              <given-names>CC</given-names>
+            </name>
+            <name>
+              <surname>Godoi</surname>
+              <given-names>VC</given-names>
+            </name>
+            <name>
+              <surname>Klossowski</surname>
+              <given-names>DG</given-names>
+            </name>
+            <name>
+              <surname>Fujinaga</surname>
+              <given-names>CI.</given-names>
+            </name>
+          </person-group>
+          <article-title>Investigation of maternal practices of breastfeeding and their relation with the infection of the upper airways and otitis media</article-title>
+          <source>Rev CEFAC</source>
+          <year>2017</year>
+          <volume>19</volume>
+          <issue>3</issue>
+          <fpage>387</fpage>
+          <lpage>94</lpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/1982-0216201719314916">https://doi.org/10.1590/1982-0216201719314916</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B26">
+        <label>26</label>
+        <mixed-citation>26 Silva VLS, França GVA, Santos IS, Barros FC, Matijasevich A. Characteristics and factors associated with hospitalization in early childhood: 2004 Pelotas (Brazil) birth cohort. Cad Saúde Pública. 2017;33(10):e00035716. <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311X00035716">https://doi.org/10.1590/0102-311X00035716</ext-link> </mixed-citation>
+        <element-citation publication-type="journal">
+          <person-group person-group-type="author">
+            <name>
+              <surname>Silva</surname>
+              <given-names>VLS</given-names>
+            </name>
+            <name>
+              <surname>França</surname>
+              <given-names>GVA</given-names>
+            </name>
+            <name>
+              <surname>Santos</surname>
+              <given-names>IS</given-names>
+            </name>
+            <name>
+              <surname>Barros</surname>
+              <given-names>FC</given-names>
+            </name>
+            <name>
+              <surname>Matijasevich</surname>
+              <given-names>A.</given-names>
+            </name>
+          </person-group>
+          <article-title>Characteristics and factors associated with hospitalization in early childhood: 2004 Pelotas (Brazil) birth cohort</article-title>
+          <source>Cad Saúde Pública</source>
+          <year>2017</year>
+          <volume>33</volume>
+          <issue>10</issue>
+          <fpage>e00035716</fpage>
+          <comment>
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1590/0102-311X00035716">https://doi.org/10.1590/0102-311X00035716</ext-link>
+          </comment>
+        </element-citation>
+      </ref>
+      <ref id="B27">
+        <label>27</label>
+        <mixed-citation>27 Alive &amp; Thrive. The economic costs of not breastfeeding in Brazil [Internet]. 2020[cited 2020 Oct 20]. Available from: <ext-link ext-link-type="uri" xlink:href="https://aliveandthrive.org/country-stat/brazil/#ec__children">https://aliveandthrive.org/country-stat/brazil/#ec__children</ext-link> </mixed-citation>
+        <element-citation publication-type="webpage">
+          <person-group person-group-type="author">
+            <collab>Alive &amp; Thrive</collab>
+          </person-group>
+          <source>The economic costs of not breastfeeding in Brazil [Internet]</source>
+          <year>2020</year>
+          <date-in-citation>cited 2020 Oct 20</date-in-citation>
+          <comment>Available from: <ext-link ext-link-type="uri" xlink:href="https://aliveandthrive.org/country-stat/brazil/#ec__children">https://aliveandthrive.org/country-stat/brazil/#ec__children</ext-link> </comment>
+        </element-citation>
+      </ref>
+    </ref-list>
+  </back>
+  <sub-article article-type="translation" id="s1" xml:lang="pt">
+    <front-stub>
+      <article-id pub-id-type="doi">10.1590/0034-7167-2021-0534pt</article-id>
+      <article-categories>
+        <subj-group subj-group-type="heading">
+          <subject>ARTIGO ORIGINAL</subject>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>ARQUIVO MODIFICADO PARA VERIFICAR FUNCIONALIDADE DE APRESENTAÇÃO DE DISPONIBILIDADE DE DADOS Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-5140-3104</contrib-id>
+          <name>
+            <surname>Nass</surname>
+            <given-names>Evelin Matilde Arcain</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+          <xref ref-type="corresp" rid="c2"/>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-6607-362X</contrib-id>
+          <name>
+            <surname>Marcon</surname>
+            <given-names>Sonia Silva</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-6835-0574</contrib-id>
+          <name>
+            <surname>Teston</surname>
+            <given-names>Elen Ferraz</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff2">II</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0003-3776-0997</contrib-id>
+          <name>
+            <surname>Leal</surname>
+            <given-names>Luciana Pedrosa</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff3">III</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-6008-2795</contrib-id>
+          <name>
+            <surname>Ichisato</surname>
+            <given-names>Sueli Mutsumi Tsukuda</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff1">I</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0001-7366-077X</contrib-id>
+          <name>
+            <surname>Toso</surname>
+            <given-names>Beatriz Rosana Gonçalves de Oliveira</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff4">IV</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0002-8607-0020</contrib-id>
+          <name>
+            <surname>Moreira</surname>
+            <given-names>Mariana Angela Rossaneis</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff5">V</xref>
+        </contrib>
+        <contrib contrib-type="author">
+          <contrib-id contrib-id-type="orcid">0000-0003-0339-9451</contrib-id>
+          <name>
+            <surname>Bernardino</surname>
+            <given-names>Fabiane Blanco Silva</given-names>
+          </name>
+          <xref ref-type="aff" rid="aff6">VI</xref>
+        </contrib>
+      </contrib-group>
+      <aff id="aff7">
+        <label>I</label>
+        <institution content-type="orgname">Universidade Estadual de Maringá</institution>
+        <addr-line>
+          <city>Maringá</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Estadual de Maringá. Maringá, Paraná. Brasil.</institution>
+      </aff>
+      <aff id="aff8">
+        <label>II</label>
+        <institution content-type="orgname">Universidade Federal de Mato Grosso do Sul</institution>
+        <addr-line>
+          <city>Mato Grosso do Sul</city>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Federal de Mato Grosso do Sul. Campo Grande, Mato Grosso do Sul. Brasil.</institution>
+      </aff>
+      <aff id="aff9">
+        <label>III</label>
+        <institution content-type="orgname">Universidade Federal de Pernambuco</institution>
+        <addr-line>
+          <city>Recife</city>
+          <state>Pernambuco</state>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Federal de Pernambuco. Recife, Pernambuco. Brasil.</institution>
+      </aff>
+      <aff id="aff10">
+        <label>IV</label>
+        <institution content-type="orgname">Universidade Estadual do Oeste do Paraná</institution>
+        <addr-line>
+          <city>Cascavel</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Estadual do Oeste do Paraná. Cascavel, Paraná. Brasil.</institution>
+      </aff>
+      <aff id="aff11">
+        <label>V</label>
+        <institution content-type="orgname">Universidade Estadual de Londrina</institution>
+        <addr-line>
+          <city>Londrina</city>
+          <state>Paraná</state>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Estadual de Londrina. Londrina, Paraná. Brasil.</institution>
+      </aff>
+      <aff id="aff12">
+        <label>VI</label>
+        <institution content-type="orgname">Universidade Federal de Mato Grosso</institution>
+        <addr-line>
+          <city>Cuiabá</city>
+          <state>Mato Grosso</state>
+        </addr-line>
+        <country country="BR">Brasil</country>
+        <institution content-type="original">Universidade Federal de Mato Grosso. Cuiabá, Mato Grosso. Brasil.</institution>
+      </aff>
+      <author-notes>
+        <corresp id="c2"><bold>Autor Correspondente:</bold> Evelin Matilde Arcain Nass <email>evelinmarcain@gmail.com</email> </corresp>
+        <fn fn-type="edited-by">
+          <p>EDITOR CHEFE: Antonio José de Almeida Filho</p>
+        </fn>
+        <fn fn-type="edited-by">
+          <p>EDITOR ASSOCIADO: Alexandre Balsanelli</p>
+        </fn>
+      </author-notes>
+      <abstract>
+        <title>RESUMO</title>
+        <sec>
+          <title>Objetivos:</title>
+          <p>avaliar a associação do aleitamento materno e as doenças prevalentes nos primeiros dois anos de vida da criança.</p>
+        </sec>
+        <sec>
+          <title>Métodos:</title>
+          <p>estudo transversal retrospectivo, que analisou prontuários eletrônicos de 401 crianças. Foram coletados dados sobre nascimento, crescimento, aleitamento materno e atendimentos médicos nos dois primeiros anos de vida. Na análise, utilizou-se Regressão de Poisson com variância robusta.</p>
+        </sec>
+        <sec>
+          <title>Resultados:</title>
+          <p>receberam aleitamento exclusivo até os seis meses 27,9% das crianças, e, aos 24 meses de vida, 93,3% já haviam tido alguma doença prevalente da infância. Na análise bruta, apresentaram associação Apgar no 5º minuto, comprimento, peso aos 12 meses, tempo de aleitamento exclusivo e não exclusivo. Na análise ajustada, apenas a variável aleitamento materno aos seis meses manteve a associação com as doenças prevalentes da infância.</p>
+        </sec>
+        <sec>
+          <title>Conclusões:</title>
+          <p>as crianças que não foram amamentadas, exclusivamente ou não, até os seis meses, apresentaram maior prevalência de doenças em relação às amamentadas.</p>
+        </sec>
+      </abstract>
+      <kwd-group xml:lang="pt">
+        <title>Descritores:</title>
+        <kwd>Aleitamento Materno</kwd>
+        <kwd>Atenção Integrada às Doenças Prevalentes na Infância</kwd>
+        <kwd>Assistência Integral à Saúde da Criança</kwd>
+        <kwd>Enfermagem Pediátrica</kwd>
+        <kwd>Serviços de Saúde Infantil</kwd>
+      </kwd-group>
+      <funding-group>
+        <award-group>
+          <funding-source>CAPES</funding-source>
+          <award-id>001</award-id>
+        </award-group>
+        <funding-statement>O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES), Código de Financiamento 001.</funding-statement>
+      </funding-group>
+    </front-stub>
+    <body>
+      <sec sec-type="intro">
+        <title>INTRODUÇÃO</title>
+        <p>A estratégia de Atenção Integrada às Doenças Prevalentes na Infância (AIDPI), desenvolvida pela Organização Mundial da Saúde (OMS), Organização Panamericana da Saúde e Fundo das Nações Unidas para a Infância, visa diminuir a morbimortalidade em crianças entre dois meses e cinco anos de idade<sup>(<xref ref-type="bibr" rid="B1">1</xref>)</sup>, mediante a melhoria da qualidade da assistência ofertada pela Atenção Básica<sup>(<xref ref-type="bibr" rid="B2">2</xref>)</sup>.</p>
+        <p>Uma das principais ações preconizadas pela AIDPI relativas à promoção da saúde é a recomendação do aleitamento materno exclusivo (AME) nos primeiros seis meses de vida e complementado até os dois anos ou mais, uma vez que o leite materno (LM) constitui importante fator de proteção para a saúde da criança, estando relacionado à prevenção de anemias, fortalecimento do sistema imunológico, redução dos casos de infecção, diarreias e desnutrição<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup> e inclusive mortalidade infantil<sup>(<xref ref-type="bibr" rid="B4">4</xref>)</sup>.</p>
+        <p>No que se refere às doenças prevalentes, um estudo de coorte realizado na Suécia, com o objetivo de avaliar a associação entre a prática de amamentação e as hospitalizações por doenças infecciosas em crianças de até quatro anos, revelou que o risco de internações por doenças infecciosas diminuiu com a duração do AME. Na primeira infância, o aleitamento materno foi associado a uma diminuição do risco de infecções entéricas e respiratórias e, nas crianças de dois a quatro anos, a um menor risco de infecções respiratórias<sup>(<xref ref-type="bibr" rid="B5">5</xref>)</sup>.</p>
+        <p>Pesquisa, cujo objetivo foi avaliar os determinantes da diarreia em crianças de 0 a 23 meses na cidade de Dessie, nordeste da Etiópia, evidenciou que a redução da doença diarreica aguda entre crianças menores de dois anos se concentra na melhoria das práticas exclusivas de amamentação<sup>(<xref ref-type="bibr" rid="B6">6</xref>)</sup>.</p>
+        <p>Apesar da notoriedade em relação aos benefícios do AME e seus desfechos, fortalecer as evidências atuais acerca da ocorrência de doenças prevalentes da infância nos dois primeiros anos de vida e sua associação com a proteção conferida pelo aleitamento materno poderá reiterar a hipótese de que aqueles bebês que foram amamentados terão maior proteção em relação àqueles que não receberam AME. Dessa forma, os resultados deste estudo podem conferir a possibilidade para o enfermeiro discutir e apoiar as mulheres que desejam amamentar, uma vez que os subsídios teóricos e práticos produzidos trarão exemplos da relação direta entre o aleitamento e a proteção contra algumas doenças, além de implementar intervenções seguras que permitirão o aperfeiçoamento de medidas de promoção e proteção à amamentação.</p>
+        <p>A atenção à saúde da criança no Brasil, enquanto uma das prioridades no âmbito das políticas públicas, passou por um extenso processo de construção ao longo da história, partindo de um modelo centrado na doença e em ações curativas para outro baseado em uma visão ampliada da saúde, com foco em ações preventivas e de promoção e proteção da saúde, em que a prática do enfermeiro está ancorada<sup>(<xref ref-type="bibr" rid="B5">5</xref>)</sup>. Além disso, o segundo e o quarto eixo da Política Nacional de Atenção Integral à Saúde da Criança (PNAISC) orientam o aleitamento materno (AM) e alimentação complementar saudável, e a atenção integral a crianças com agravos prevalentes na infância e com doenças crônicas, respectivamente<sup>(<xref ref-type="bibr" rid="B6">6</xref>)</sup>.</p>
+        <p>Contudo, salienta-se que, mesmo com o progresso em relação à sobrevivência e à saúde infantil em países em desenvolvimento, como o Brasil, a desigualdade socioeconômica ainda é presente e tem se acentuado nos últimos anos, o que constitui um fator determinante no processo saúde-doença infantil e influência nas ações de prevenção do adoecimento e das mortes por causas evitáveis na infância<sup>(<xref ref-type="bibr" rid="B7">7</xref>)</sup>. Nesse contexto, pesquisas que reiteradamente avaliam a influência do AM na promoção da saúde das crianças colaboram para direcionar políticas públicas e as próprias práticas profissionais, a partir de evidências recentes e confiáveis.</p>
+      </sec>
+      <sec>
+        <title>OBJETIVOS</title>
+        <p>Avaliar a associação do AM e as doenças prevalentes nos primeiros dois anos de vida da criança.</p>
+      </sec>
+      <sec sec-type="methods">
+        <title>MÉTODOS</title>
+        <sec>
+          <title>Aspectos éticos</title>
+          <p>O estudo ocorreu em conformidade com o preconizado pela Resolução 466/2012 da Comissão Nacional de Ética em Pesquisa (CONEP). Seu projeto foi autorizado pela Secretaria Municipal de Saúde e aprovado pelo Comitê de Ética da instituição signatária, que autorizou a dispensa de assinatura do Termo de consentimento Livre e Esclarecido, por utilizar dados secundários.</p>
+        </sec>
+        <sec>
+          <title>Desenho, período e local do estudo</title>
+          <p>Estudo transversal, recorte de pesquisa matricial, realizada em dois hospitais que realizam o parto pelo Sistema Único de Saúde (SUS) no munícipio de Maringá, PR, sul do Brasil, sendo somente um deles Hospital Amigo da Criança. O estudo matricial objetivou avaliar o ganho de peso gestacional e a retenção de peso pós-parto e possível relação com as condições de vida e saúde da criança. Para elaboração e descrição do estudo, consideraram-se as orientações do <italic>Strengthening the Reporting of Observational studies in Epidemiology</italic> (STROBE)<sup>(<xref ref-type="bibr" rid="B8">8</xref>)</sup>.</p>
+        </sec>
+        <sec>
+          <title>População ou amostra; critérios de inclusão e exclusão</title>
+          <p>A população do estudo foi composta pelos filhos de mães que participaram da pesquisa matricial. Na delimitação do tamanho amostral, ponderaram-se a prevalência de 30,2% de desmame antes dos 180 dias de vida<sup>(<xref ref-type="bibr" rid="B9">9</xref>)</sup>, o número de 5157 crianças nascidas em 2017 no municípiosegundo o Sistema de Informações sobre Nascidos Vivos (SINASC-DATASUS)<sup>(<xref ref-type="bibr" rid="B10">10</xref>)</sup>, o nível de significância de 5%, o intervalo de confiança de 95% e o erro de 5%, o que resultou em uma amostra de 334 crianças que, acrescida de 20% para possíveis perdas e descontinuidade, totalizando 401 crianças.</p>
+          <p>Foram incluídos no estudo prontuários de crianças que residiam em Maringá, PR, que nasceram com idade gestacional ≥ 37 semanas e que, no puerpério imediato, estavam em AME. Por sua vez, não foram incluídos os gemelares, os neonatos que interromperam o AME antes da alta hospitalar e as crianças que, à época da coleta de dados, ainda não haviam completado 24 meses de vida.</p>
+        </sec>
+        <sec>
+          <title>Protocolo do estudo</title>
+          <p>Os dados foram coletados no período de março a outubro de 2020, mediante consulta ao prontuário eletrônico das crianças no sistema Gestor da Secretaria Municipal de Saúde. Esse sistema é utilizado, de forma integrada, por todas as Unidades Básicas de Saúde do município, o que possibilitou que os participantes fossem localizados a partir das informações obtidas na pesquisa matricial.</p>
+          <p>A consulta e coleta de dados no sistema gestor foi realizada por uma única pessoa (pesquisadora principal) que, mediante agendamento prévio, compareceu durante oito meses, duas vezes na semana, na sala do CECAPS - Assessoria de Formação e Capacitação dos Trabalhadores da Saúde - da Secretaria de Saúde e acessava o sistema mediante autorização do setor.</p>
+          <p>Os dados de interesse foram os referentes à alimentação, crescimento e atendimentos médicos prestados à criança nos serviços de saúde do município.</p>
+          <p>Foram consideradas como variáveis de exposição:</p>
+          <list list-type="alpha-lower">
+            <list-item>
+              <p>características sociodemográficas: sexo (feminino, masculino); raça/cor (branco, amarelo, pardo, preto).</p>
+            </list-item>
+            <list-item>
+              <p>dados do nascimento: Apgar 1° minuto e 5° minuto (pontuação); peso e comprimento ao nascer (utilizadas as curvas de crescimento de zero a dois anos segundo o sexo (meninos/meninas), e considerado peso adequado para a idade o padrão de escore-z ≥-2 e ≤ +2 e peso inadequado quando elevado para a idade (&gt; + 2), baixo para a idade (≥-3 e &lt;-2) e muito baixo para idade (&lt;-3); comprimento adequado para idade o padrão de escore-z ≥-2 e ≤ +2 e comprimento inadequado quando elevado para a idade (&gt; + 2), baixo para a idade (≥-3 e &lt;-2) e muito baixo para idade (&lt;-3), conforme recomendado pela OMS)<sup>(<xref ref-type="bibr" rid="B11">11</xref>)</sup>.</p>
+            </list-item>
+            <list-item>
+              <p>dados de crescimento: peso corporal aos 12 e 24 meses (parâmetros adotados nas curvas de crescimento<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup>.</p>
+            </list-item>
+            <list-item>
+              <p>condições de vida e saúde - alimentação: AME até os seis meses (somente LM, direto da mama ou ordenhado, ou leite humano de outra fonte, sem outros líquidos ou sólidos, com exceção de gotas ou xaropes contendo vitaminas, sais de reidratação oral, suplementos minerais ou medicamentos)<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup>; AM aos 12 e 24 meses (LM direto da mama ou ordenhado, independentemente de receber outros alimentos)<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup>; atualização do calendário vacinal aos 24 meses de idade; histórico de hospitalização (sim/não); frequência a centro de educação infantil (sim/não).</p>
+            </list-item>
+          </list>
+          <p>A variável de desfecho primário sob investigação foi a presença (registro em prontuário) de doenças prevalentes da infância nos primeiros dois anos de vida e sua associação com o AME, identificada a partir do diagnóstico registrado pelo médico no prontuário. Este registro é acompanhado do número identificado na Classificação Internacional de Doenças (CID-10). Consideraram-se, para análise, os diagnósticos com frequência ≥ 10,0%, quais sejam: CID J06 - infecção aguda de vias áreas; CID 05 - tosse; CID H66 - otite; CID R50 - febre; CID A09 - diarreia e gastroenterite; CID R10 - dor abdominal e pélvica; CID K59 - transtorno funcionais do intestino; CID K21 - refluxo gastroesofágico; CID N39 - transtorno trato urinário; e CID L22 - dermatite das fraldas. Para categorização, considerou-se “presença” quando as crianças apresentaram ao menos um episódio das doenças acima mencionadas. Os desfechos secundários foram a associação da alimentação e do crescimento e as referidas doenças, ambos vinculados às recomendações da OMS<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup>.</p>
+        </sec>
+        <sec>
+          <title>Análise dos resultados e estatística</title>
+          <p>As análises estatísticas foram realizadas no programa <italic>Statistical Package for the Social Sciences</italic> (SPSS), 21.0. Primeiramente, realizou-se a análise bivariada entre as variáveis independentes com a variável de desfecho doenças prevalentes nos dois primeiros anos de vida. A normalidade dos dados foi testada por meio do Teste de Shapiro Wilk e de Kolmogorov-Smirnov. Variáveis com valor de p &lt; 0,20 na análise bivariada foram selecionadas para compor o modelo ajustado por regressão de Poisson, pelo método <italic>stepwise</italic>, com variância robusta. Possíveis variáveis confundidoras foram testadas no modelo estatístico para poder explicar a associação de interesse. A medida de associação empregada foi à razão de prevalência (RP) tanto para a análise bivariada quanto para a regressão de Poisson. Para ambas as análises, adotou-se o nível de significância de 5% no Teste do Qui-Quadrado de Wald, e foram apresentados o valor de p e o intervalo de confiança de 95% (IC95%).</p>
+        </sec>
+      </sec>
+      <sec sec-type="results">
+        <title>RESULTADOS</title>
+        <p>Das 401 crianças cujos prontuários integraram o estudo, a maioria era do sexo masculino (57,6%) e nasceu com peso adequado (83,5%), mas este percentual foi decaindo ao longo do tempo, de modo que, aos 12 meses, 66,3% tinham o peso adequado, e, aos 24 meses, este percentual caiu para 44,6%. Aos dois anos, 92,8% das crianças estavam com o esquema vacinal atualizado, e 84,8% frequentavam centro de educação infantil.</p>
+        <p>Em relação à alimentação, 27,9% receberam AME até os seis meses, 83,8% mantiveram AM até os 12 meses, e, 44,1%, até os 24 meses. Referente à saúde, 81,5% já tinha apresentado algum problema de saúde aos 12 meses, e, aos 24, este percentual aumentou para 93,3%. Por fim, aos 24 meses, 99 (24,7%) crianças já haviam passado por pelo menos um episódio de hospitalização.</p>
+        <p>Na <xref ref-type="table" rid="t6">Tabela 1</xref>, observa-se que ocorreu maior frequência de adoecimento nas crianças sem AME aos seis meses e naquelas sem AM e com peso inadequado aos 24 meses.</p>
+        <table-wrap id="t6">
+          <label>Tabela 1</label>
+          <caption>
+            <title>Condições de nascimento, crescimento e saúde segundo a presença de doenças nos dois primeiros anos de vida de crianças nascidas em Maringá, Paraná, Brasil, 2020</title>
+          </caption>
+          <table>
+            <thead>
+              <tr>
+                <th align="left" rowspan="2">Variáveis</th>
+                <th align="center">Total <break/>(401)</th>
+                <th align="center">Doenças em menores de <break/>6 meses (96)</th>
+                <th align="center">Doenças <break/>de 7 a 11 <break/>meses (231)</th>
+                <th align="center">Doenças <break/>de 12 a 24 <break/>meses (374)</th>
+                <th align="center" rowspan="2">Valor de <italic>p</italic></th>
+              </tr>
+              <tr>
+                <th align="center">n %</th>
+                <th align="center">n %</th>
+                <th align="center">n %</th>
+                <th align="center">n %</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left">Sexo</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Feminino</td>
+                <td align="center">170 42,4</td>
+                <td align="center">41 24,1</td>
+                <td align="center">93 54,7</td>
+                <td align="center">159 93,5</td>
+                <td align="center">0,6811</td>
+              </tr>
+              <tr>
+                <td align="left">Masculino</td>
+                <td align="center">231 57,6</td>
+                <td align="center">55 23,8</td>
+                <td align="center">138 59,7</td>
+                <td align="center">215 93,1</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Raça/cor</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Branca/amarela</td>
+                <td align="center">202 50,4</td>
+                <td align="center">51 25,5</td>
+                <td align="center">116 57,4</td>
+                <td align="center">189 93,6</td>
+                <td align="center">0,8875</td>
+              </tr>
+              <tr>
+                <td align="left">Parda/preta</td>
+                <td align="center">199 49,6</td>
+                <td align="center">45 22,6</td>
+                <td align="center">115 57,8</td>
+                <td align="center">185 93,0</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Apgar 5<sup>o</sup> minuto</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">9 - 10</td>
+                <td align="center">398 99,2</td>
+                <td align="center">95 23,9</td>
+                <td align="center">229 57,5</td>
+                <td align="center">371 93,2</td>
+                <td align="center">0,8687</td>
+              </tr>
+              <tr>
+                <td align="left">7 - 8</td>
+                <td align="center">3 0,8</td>
+                <td align="center">1 33,3</td>
+                <td align="center">2 66,7</td>
+                <td align="center">3 100,0</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Peso ao nascer</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Adequado</td>
+                <td align="center">335 83,5</td>
+                <td align="center">83 24,8</td>
+                <td align="center">188 56,1</td>
+                <td align="center">313 93,4</td>
+                <td align="center">0,7728</td>
+              </tr>
+              <tr>
+                <td align="left">Inadequado</td>
+                <td align="center">66 16,5</td>
+                <td align="center">13 19,7</td>
+                <td align="center">43 65,1</td>
+                <td align="center">61 92,4</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Comprimento ao nascer</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Adequado</td>
+                <td align="center">319 79,6</td>
+                <td align="center">75 23,5</td>
+                <td align="center">174 54,5</td>
+                <td align="center">292 91,5</td>
+                <td align="center">0,5440</td>
+              </tr>
+              <tr>
+                <td align="left">Inadequado</td>
+                <td align="center">82 20,4</td>
+                <td align="center">21 25,6</td>
+                <td align="center">57 69,5</td>
+                <td align="center">82 100,0</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">AME aos 6 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">112 27,9</td>
+                <td align="center">18 16,1</td>
+                <td align="center">52 46,4</td>
+                <td align="center">86 76,8</td>
+                <td align="center">0,6141</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">289 72,1</td>
+                <td align="center">78 30,0</td>
+                <td align="center">179 61,9</td>
+                <td align="center">288 99,6</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">AM aos 12 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">336 83,8</td>
+                <td align="center">81 24,1</td>
+                <td align="center">187 55,6</td>
+                <td align="center">309 92,0</td>
+                <td align="center">0,8184</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">65 16,2</td>
+                <td align="center">15 23,1</td>
+                <td align="center">44 67,7</td>
+                <td align="center">65 100,0</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">AM aos 24 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">177 44,1</td>
+                <td align="center">37 20,9</td>
+                <td align="center">95 53,7</td>
+                <td align="center">151 85,3</td>
+                <td align="center">0,9984</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">224 55,9</td>
+                <td align="center">59 26,3</td>
+                <td align="center">136 60,7</td>
+                <td align="center">223 99,6</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Peso aos 12 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Adequado</td>
+                <td align="center">266 66,3</td>
+                <td align="center">62 23,3</td>
+                <td align="center">147 55,3</td>
+                <td align="center">240 90,2</td>
+                <td align="center">0,9892</td>
+              </tr>
+              <tr>
+                <td align="left">Inadequado</td>
+                <td align="center">135 33,7</td>
+                <td align="center">34 25,2</td>
+                <td align="center">84 62,2</td>
+                <td align="center">134 99,3</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Peso aos 24 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Adequado</td>
+                <td align="center">179 44,6</td>
+                <td align="center">38 21,2</td>
+                <td align="center">96 53,6</td>
+                <td align="center">154 86,0</td>
+                <td align="center">0,9576</td>
+              </tr>
+              <tr>
+                <td align="left">Inadequado</td>
+                <td align="center">222 55,4</td>
+                <td align="center">58 26,1</td>
+                <td align="center">135 60,8</td>
+                <td align="center">220 99,1</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Vacina atualizada</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">372 92,8</td>
+                <td align="center">92 24,7</td>
+                <td align="center">212 57,0</td>
+                <td align="center">349 93,8</td>
+                <td align="center">0,8551</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">29 7,2</td>
+                <td align="center">4 13,8</td>
+                <td align="center">19 65,5</td>
+                <td align="center">25 86,2</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Frequenta centro infantil</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">340 84,8</td>
+                <td align="center">84 24,7</td>
+                <td align="center">191 56,2</td>
+                <td align="center">317 93,2</td>
+                <td align="center">0,8095</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">61 15,2</td>
+                <td align="center">12 19,7</td>
+                <td align="center">40 65,6</td>
+                <td align="center">57 93,4</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Foi hospitalizada</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">99 24,7</td>
+                <td align="center">21 21,2</td>
+                <td align="center">62 62,6</td>
+                <td align="center">96 97,0</td>
+                <td align="center">0,9309</td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">302 75,3</td>
+                <td align="center">75 24,8</td>
+                <td align="center">169 55,9</td>
+                <td align="center">278 92,0</td>
+                <td align="left"/>
+              </tr>
+            </tbody>
+          </table>
+          <table-wrap-foot>
+            <attrib>
+              <italic>AME - aleitamento materno exclusivo; AM - aleitamento materno.</italic>
+            </attrib>
+          </table-wrap-foot>
+        </table-wrap>
+        <p>Na <xref ref-type="table" rid="t7">Tabela 2</xref>, consta-se o número de atendimentos médicos nos dois primeiros anos de vida, para puericultura ou problemas de saúde segundo AME. Observa-se que ausência ou apenas um episódio de doença prevalente está estatisticamente associado à maior frequência de AME (valor de p 0,0098), enquanto presença de seis a 15 episódios está significativamente associado à ausência de AME até o sexto mês de vida (valor de p= 0,0350).</p>
+        <table-wrap id="t7">
+          <label>Tabela 2</label>
+          <caption>
+            <title>Atendimentos médicos nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020</title>
+          </caption>
+          <table>
+            <thead>
+              <tr>
+                <th align="left" rowspan="2">Atendimento médico</th>
+                <th align="center" colspan="3" valign="top">Aleitamento materno exclusivo</th>
+                <th align="center" rowspan="2">Valor de <italic>p</italic></th>
+              </tr>
+              <tr>
+                <th align="center" valign="top">Sim<break/>n %</th>
+                <th align="center" valign="top">Não<break/>n %</th>
+                <th align="center" valign="top">Total<break/>n %</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left">Puericultura</td>
+                <td align="center" valign="top">15 55,5</td>
+                <td align="center" valign="top">12 44,5</td>
+                <td align="center" valign="top">27 6,7</td>
+                <td align="center" valign="top">0,0009</td>
+              </tr>
+              <tr>
+                <td align="left">Puericultura + 01 episódios</td>
+                <td align="center" valign="top">23 42,6</td>
+                <td align="center" valign="top">31 57,4</td>
+                <td align="center" valign="top">54 13,5</td>
+                <td align="center" valign="top">0,0098</td>
+              </tr>
+              <tr>
+                <td align="left">02 a 05 episódios de doenças</td>
+                <td align="center" valign="top">45 31,7</td>
+                <td align="center" valign="top">97 68,3</td>
+                <td align="center" valign="top">142 35,4</td>
+                <td align="center" valign="top">0,2140</td>
+              </tr>
+              <tr>
+                <td align="left">06 a 10 episódios de doenças</td>
+                <td align="center" valign="top">15 14,7</td>
+                <td align="center" valign="top">87 85,3</td>
+                <td align="center" valign="top">102 25,4</td>
+                <td align="center" valign="top">0,0006</td>
+              </tr>
+              <tr>
+                <td align="left">11 a 15 episódios de doenças</td>
+                <td align="center" valign="top">10 16,7</td>
+                <td align="center" valign="top">50 83,3</td>
+                <td align="center" valign="top">60 15,0</td>
+                <td align="center" valign="top">0,0350</td>
+              </tr>
+              <tr>
+                <td align="left">≥ 16 episódios de doenças</td>
+                <td align="center" valign="top">04 25,0</td>
+                <td align="center" valign="top">12 75,0</td>
+                <td align="center" valign="top">16 4,0</td>
+                <td align="center" valign="top">0,7898</td>
+              </tr>
+              <tr>
+                <td align="left">Total</td>
+                <td align="center" valign="top">112</td>
+                <td align="center" valign="top">289</td>
+                <td align="center" valign="top">401</td>
+                <td align="left" valign="top"/>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>Na <xref ref-type="table" rid="t8">Tabela 3</xref>, são apresentadas as doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento nos primeiros seis meses de vida, na qual se observa que a proporção de crianças com AME acometidas por alguma doença prevalente da infância foi significativamente menor, com exceção dos casos de otite média supurativa e outros transtornos do trato urinário, cujo valor de p não foi estatisticamente significante em relação à AME.</p>
+        <table-wrap id="t8">
+          <label>Tabela 3</label>
+          <caption>
+            <title>Doenças prevalentes da infância nos dois primeiros anos de vida segundo o tipo de aleitamento aos seis meses, Maringá, Paraná, Brasil, 2020</title>
+          </caption>
+          <table>
+            <thead>
+              <tr>
+                <th align="left" rowspan="2">Doenças prevalentes da infância</th>
+                <th align="center" colspan="3">Aleitamento materno exclusivo</th>
+                <th align="center" rowspan="2">Valor de <italic>p</italic></th>
+              </tr>
+              <tr>
+                <th align="center">Sim (112)<break/>n %</th>
+                <th align="center">Não (289)<break/>n %</th>
+                <th align="center">Total (401)<break/>n %</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left">Trato gastrointestinal</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Diarreia e gastroenterite de origem infecciosa presumível</td>
+                <td align="center">20 17,9</td>
+                <td align="center">152 52,6</td>
+                <td align="center">172 42,9</td>
+                <td align="center">0,0001</td>
+              </tr>
+              <tr>
+                <td align="left">Doença de refluxo gastroesofágico</td>
+                <td align="center">20 17,9</td>
+                <td align="center">108 37,4</td>
+                <td align="center">128 31,9</td>
+                <td align="center">0,0002</td>
+              </tr>
+              <tr>
+                <td align="left">Transtornos funcionais do intestino</td>
+                <td align="center">8 7,1</td>
+                <td align="center">81 28,0</td>
+                <td align="center">89 22,2</td>
+                <td align="center">0,0001</td>
+              </tr>
+              <tr>
+                <td align="left">Trato respiratório</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Infecções agudas das vias aéreas superiores de localizações múltiplas</td>
+                <td align="center">23 20,5</td>
+                <td align="center">112 38,7</td>
+                <td align="center">135 33,7</td>
+                <td align="center">0,0005</td>
+              </tr>
+              <tr>
+                <td align="left">Tosse</td>
+                <td align="center">18 16,1</td>
+                <td align="center">116 40,1</td>
+                <td align="center">134 33,4</td>
+                <td align="center">0,0001</td>
+              </tr>
+              <tr>
+                <td align="left">Otite média supurativa e as não especificadas</td>
+                <td align="center">21 18,7</td>
+                <td align="center">42 14,5</td>
+                <td align="center">63 15,7</td>
+                <td align="center">0,2978</td>
+              </tr>
+              <tr>
+                <td align="left">Outros</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Dor abdominal e pélvica</td>
+                <td align="center">22 19,6</td>
+                <td align="center">129 44,6</td>
+                <td align="center">161 40,1</td>
+                <td align="center">0,0001</td>
+              </tr>
+              <tr>
+                <td align="left">Dermatite das fraldas</td>
+                <td align="center">16 14,3</td>
+                <td align="center">123 42,6</td>
+                <td align="center">139 34,7</td>
+                <td align="center">0,0001</td>
+              </tr>
+              <tr>
+                <td align="left">Febre de origem desconhecida</td>
+                <td align="center">25 22,3</td>
+                <td align="center">112 38,7</td>
+                <td align="center">137 34,2</td>
+                <td align="center">0,0019</td>
+              </tr>
+              <tr>
+                <td align="left">Outros transtornos do trato urinário</td>
+                <td align="center">14 12,5</td>
+                <td align="center">32 11,1</td>
+                <td align="center">46 11,5</td>
+                <td align="center">0,6874</td>
+              </tr>
+            </tbody>
+          </table>
+        </table-wrap>
+        <p>Destaca-se que, no prontuário de 27 (6,7%) crianças, os registros médicos eram relacionados apenas com puericultura. Ou seja, essas crianças não procuraram os serviços públicos de saúde do município por queixas relacionadas à intercorrência na saúde.</p>
+        <p>As <xref ref-type="table" rid="t4">Tabelas 4</xref> to <xref ref-type="table" rid="t5">5</xref> apresentam a Regressão de Poisson. Observa-se que, na análise bruta (<xref ref-type="table" rid="t9">Tabela 4</xref>), sete variáveis evidenciaram associação com as doenças prevalentes, sendo duas delas relacionadas às características do nascimento (Apgar no 5º minuto e comprimento ao nascer alterados), ao tipo de alimentação (AME aos seis meses e AM aos 12 e 24 meses), peso aos 12 meses de vida e estado vacinal.</p>
+        <table-wrap id="t9">
+          <label>Tabela 4</label>
+          <caption>
+            <title>Razão de prevalência bruta da presença de doenças nos 24 meses de vida segundo variáveis sociodemográficas, do nascimento, estado nutricional, aleitamento materno e imunização de crianças nascidas em Maringá, Paraná, Brasil, 2020</title>
+          </caption>
+          <table>
+            <thead>
+              <tr>
+                <th align="left" rowspan="2">Variáveis</th>
+                <th align="center" colspan="2">Teve doença prevalente nos 24 meses</th>
+                <th align="center" rowspan="2">RP bruta</th>
+                <th align="center" rowspan="2">IC 95 %</th>
+                <th align="center" rowspan="2">Valor de p</th>
+              </tr>
+              <tr>
+                <th align="center">Sim</th>
+                <th align="center">%</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left">Sexo</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Feminino</td>
+                <td align="center">159</td>
+                <td align="center">93,5</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,85</td>
+              </tr>
+              <tr>
+                <td align="left">Masculino</td>
+                <td align="center">215</td>
+                <td align="center">93,1</td>
+                <td align="center">0,99</td>
+                <td align="center">0,94-1,04</td>
+              </tr>
+              <tr>
+                <td align="left">Raça/cor</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Branco/amarelo</td>
+                <td align="center">189</td>
+                <td align="center">93,6</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,99</td>
+              </tr>
+              <tr>
+                <td align="left">Pardo/ negro</td>
+                <td align="center">185</td>
+                <td align="center">93,0</td>
+                <td align="center">0,99</td>
+                <td align="center">0,94-1,05</td>
+              </tr>
+              <tr>
+                <td align="left">Apgar 1º minuto</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Normal</td>
+                <td align="center">364</td>
+                <td align="center">93,3</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,78</td>
+              </tr>
+              <tr>
+                <td align="left">Alterado</td>
+                <td align="center">10</td>
+                <td align="center">90,9</td>
+                <td align="center">0,97</td>
+                <td align="center">0,82-1,15</td>
+              </tr>
+              <tr>
+                <td align="left">Apgar 5º minuto</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Normal</td>
+                <td align="center">313</td>
+                <td align="center">93,3</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Alterado</td>
+                <td align="center">30</td>
+                <td align="center">100,0</td>
+                <td align="center">1,07</td>
+                <td align="center">1,04-1,09</td>
+              </tr>
+              <tr>
+                <td align="left">Peso ao nascer</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Normal</td>
+                <td align="center">313</td>
+                <td align="center">93,4</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="center" rowspan="2">0,77</td>
+              </tr>
+              <tr>
+                <td align="left">Alterado</td>
+                <td align="center">61</td>
+                <td align="center">92,4</td>
+                <td align="center">0,99</td>
+                <td align="center">0,24-1,06</td>
+              </tr>
+              <tr>
+                <td align="left">Comprimento ao nascer</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Normal</td>
+                <td align="center">292</td>
+                <td align="center">91,5</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Alterado</td>
+                <td align="center">82</td>
+                <td align="center">100,0</td>
+                <td align="center">1,08</td>
+                <td align="center">1,05-1,12</td>
+              </tr>
+              <tr>
+                <td align="left">AME até 6 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">112</td>
+                <td align="center">76,7</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">65</td>
+                <td align="center">77,5</td>
+                <td align="center">1,22</td>
+                <td align="center">1,15-1,30</td>
+              </tr>
+              <tr>
+                <td align="left">AM até 12 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">309</td>
+                <td align="center">92,0</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">65</td>
+                <td align="center">100,0</td>
+                <td align="center">1,08</td>
+                <td align="center">1,05-1,11</td>
+              </tr>
+              <tr>
+                <td align="left">AM até 24 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Sim</td>
+                <td align="center">152</td>
+                <td align="center">85,5</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Não</td>
+                <td align="center">223</td>
+                <td align="center">99,6</td>
+                <td align="center">1,15</td>
+                <td align="center">1,09-1,21</td>
+                <td align="center">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Peso 12 meses</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Normal</td>
+                <td align="center">240</td>
+                <td align="center">90,2</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Alterado</td>
+                <td align="center">134</td>
+                <td align="center">99,3</td>
+                <td align="center">1,09</td>
+                <td align="center">1,05-1,13</td>
+              </tr>
+              <tr>
+                <td align="left">Estado vacinal</td>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+                <td align="left"/>
+              </tr>
+              <tr>
+                <td align="left">Completo</td>
+                <td align="center">349</td>
+                <td align="center">93,8</td>
+                <td align="center">1</td>
+                <td align="center">-</td>
+                <td align="center" rowspan="2">0,000<xref ref-type="table-fn" rid="TFN3">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left">Incompleto</td>
+                <td align="center">25</td>
+                <td align="center">86,2</td>
+                <td align="center">0,92</td>
+                <td align="center">0,81-1,05</td>
+              </tr>
+            </tbody>
+          </table>
+          <table-wrap-foot>
+            <fn id="TFN3">
+              <label>*</label>
+              <p>
+                <italic>valor de p significativo; IC - intervalo de confiança; AM - aleitamento materno; AME - aleitamento materno exclusivo.</italic>
+              </p>
+            </fn>
+          </table-wrap-foot>
+        </table-wrap>
+        <p>Na análise de RP ajustada (<xref ref-type="table" rid="t10">Tabela 5</xref>), observa-se que, independentemente de qualquer outra variável analisada, as crianças que não foram amamentadas exclusivamente até os seis meses ou não receberam LM até 12 meses apresentaram maior prevalência de doenças prevalentes em relação às amamentadas (RP&gt;1; valor de p &lt;0,05).</p>
+        <table-wrap id="t10">
+          <label>Tabela 5</label>
+          <caption>
+            <title>Razão de prevalência ajustada da presença de doenças aos seis, 12 e 24 meses segundo variáveis tipo de amamentação aos seis, 12 e 24 meses, Apgar 5<sup>0</sup> minuto, peso aos 12 meses e comprimento ao nascer alterado das crianças nascidas em Maringá, Paraná, Brasil, 2020</title>
+          </caption>
+          <table>
+            <thead>
+              <tr>
+                <th align="left" valign="top">Variáveis</th>
+                <th align="center" valign="top">RP ajustada</th>
+                <th align="center" valign="top">IC 95%</th>
+                <th align="center" valign="top">Valor de <italic>p</italic></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td align="left" valign="top">Não amamentados, exclusivamente, até 6 meses</td>
+                <td align="center" valign="top">1,21</td>
+                <td align="center" valign="top">1,14-1,29</td>
+                <td align="center" valign="top">0,000<xref ref-type="table-fn" rid="TFN4">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Não amamentados até 12 meses</td>
+                <td align="center" valign="top">1,10</td>
+                <td align="center" valign="top">0,996-1,01</td>
+                <td align="center" valign="top">0,020<xref ref-type="table-fn" rid="TFN4">*</xref> </td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Não amamentados até 24 meses</td>
+                <td align="center" valign="top">0,99</td>
+                <td align="center" valign="top">0,990-1,01</td>
+                <td align="center" valign="top">0,544</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Apgar 5º min alterado</td>
+                <td align="center" valign="top">0,85</td>
+                <td align="center" valign="top">0,988-1,01</td>
+                <td align="center" valign="top">0,854</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Peso aos 12 meses inadequado</td>
+                <td align="center" valign="top">1,01</td>
+                <td align="center" valign="top">0,99-1,047</td>
+                <td align="center" valign="top">0,182</td>
+              </tr>
+              <tr>
+                <td align="left" valign="top">Comprimento ao nascer alterado</td>
+                <td align="center" valign="top">1,01</td>
+                <td align="center" valign="top">1,00-1,031</td>
+                <td align="center" valign="top">0,055</td>
+              </tr>
+            </tbody>
+          </table>
+          <table-wrap-foot>
+            <fn id="TFN4">
+              <label>*</label>
+              <p>
+                <italic>valor de p significativo; IC - intervalo de confiança; RP - razão de prevalência.</italic>
+              </p>
+            </fn>
+          </table-wrap-foot>
+        </table-wrap>
+      </sec>
+      <sec sec-type="discussion">
+        <title>DISCUSSÃO</title>
+        <p>Os resultados do modelo de análise múltipla reiteram a associação entre a duração do AME menor que seis meses e sua manutenção até os 12 meses e a presença de doenças prevalentes na infância nos dois primeiros anos de vida. Esse fato corrobora a indicação de manter o AME nos primeiros seis meses, como recomendado, reforçando as evidências que ancoram as orientações dos enfermeiros na atenção primária à família para a promoção da saúde da criança.</p>
+        <p>Os enfermeiros na atenção primária, a partir desses dados, podem demonstrar que a maior prevalência de doenças está associada com ausência de AME aos seis meses e sua manutenção até os 12 meses de vida, e, desse modo, durante a consulta de enfermagem e as ações coletivas, de posse da compreensão das complicações preveníveis, encorajarem a prática e a manutenção do aleitamento.</p>
+        <p>A baixa prevalência de AME aos seis meses no estudo (27,9%) indica a necessidade de, apesar de todos os investimentos e pesquisas em AM, buscar-se estratégias de apoio à família e à nutriz que possam aumentar a adesão e a manutenção dessa prática.</p>
+        <p>Para aumentar a prevalência de AME, o apoio à família e à nutriz deve estar presente durante o período gestacional, no puerpério e nos primeiros anos de vida da criança. Neste sentido, é preciso considerar que as crianças em estudo nasceram em um dos dois hospitais do município que realizam partos (normais e cesáreas) financiados pelo SUS e que apenas um deles é certificado como Hospital Amigo da Criança. O hospital responsável por mais de 70% dos partos pelo SUS no município não tinha esta certificação por ocasião da coleta de dados do estudo matricial.</p>
+        <p>Ressalta-se que os benefícios do AM envolvem os fatores de diminuição dos gastos com a saúde, redução de 36% do risco de morte súbita e 13% da mortalidade infantil mundial, resultando no aumento da expectativa e qualidade de vida<sup>(<xref ref-type="bibr" rid="B12">12</xref>)</sup>. Frente a isso, na prática de enfermagem, discutir com a mulher os desafios da amamentação, os mitos e as possibilidades de manejo mediante as dificuldades vivenciadas podem favorecer maior adesão e permanência das mulheres nesse processo.</p>
+        <p>Cabe destacar que as causas das doenças prevalentes na infância podem ser identificadas precocemente, o que reforça a importância da puericultura para o adequado acompanhamento do crescimento e desenvolvimento da criança. Por meio dela, os profissionais de saúde, mediante a realização sistemática de exames físico/clínico, orientações à família sobre os cuidados específicos para cada idade e identificação precoce de sinais dos principais agravos na infância<sup>(<xref ref-type="bibr" rid="B13">13</xref>)</sup>, podem recomendar à família as ações mais efetivas, como enfatizar a importância de manter o AME. Salienta-se que, devido à capacidade em construir vínculo com os pacientes, o enfermeiro tem uma oportunidade singular de educar, apoiar e motivar.</p>
+        <p>Na análise bruta deste estudo, associaram-se significativamente com doenças prevalentes da infância as variáveis Apgar 5º minuto entre sete e oito, comprimento inadequado ao nascer, ausência de AME até seis meses, AM aos seis, 12 e 24 meses e peso inadequado aos 12 meses, mas, na análise ajustada, a maior prevalência de doenças se associou significativamente com ausência de AME aos seis meses e de sua manutenção até os 12 meses de vida.</p>
+        <p>A pesquisa evidenciou que a prevalência do AME até seis meses identificada foi inferior ao preconizado pela OMS<sup>(<xref ref-type="bibr" rid="B3">3</xref>)</sup>. Este resultado corrobora os dados de estudo realizado na Região Sul do Brasil, com crianças menores de dois anos, o qual constatou prevalência de AME de 20,6%<sup>(<xref ref-type="bibr" rid="B14">14</xref>)</sup>. No entanto, os índices de AM aos 12 e 24 meses se encontraram acima dos valores identificados em inquéritos nacionais anteriores (1986, 1996, 2006 e 2013), em que a prevalência de AM no primeiro ano de vida subiu de 22,7% em 1986 para 45,4% em 2013, e, aos dois anos de idade, em torno de 25% entre 1986 e 2006, chegando a 31,8% em 2013<sup>(<xref ref-type="bibr" rid="B15">15</xref>)</sup>.</p>
+        <p>A introdução alimentar tem importância ímpar no crescimento da criança e no surgimento de doenças, dependendo da época em que é iniciada e dos tipos de alimentos introduzidos. O fornecimento de alimentos inadequados de forma precoce poderá acarretar na manifestação de doenças na infância e também na fase adulta<sup>(<xref ref-type="bibr" rid="B16">16</xref>)</sup>.</p>
+        <p>A manutenção do AME até os seis meses e do AM por tempo prolongado não deve ser compreendido como uma responsabilidade única da mãe. A atuação dos membros da rede social da mulher e as orientações dos profissionais de saúde sobre a importância do AM desde o pré-natal são fundamentais<sup>(<xref ref-type="bibr" rid="B17">17</xref>)</sup>. Na prática assistencial, nas maternidades e Unidades Básicas de Saúde, a simples incorporação da conduta de orientar e realizar a ordenha mamária e de oferecer o leite ordenhado poderá contribuir significativamente para a promoção e manutenção do AM<sup>(<xref ref-type="bibr" rid="B18">18</xref>)</sup>. Do mesmo modo, durante o processo de formação do enfermeiro, torna-se necessária a utilização de diferentes estratégias que, de fato, aproximem o futuro profissional da realidade prática na realização de ações de incentivo e manutenção do aleitamento que vão além do conhecimento teórico. Assim, atividades direcionadas, por exemplo, pela simulação, podem desenvolver a capacidade de lidar com situações de amamentação mais complexas.</p>
+        <p>O peso adequado estava presente em mais da metade das crianças que receberam AME, semelhante a estudo realizado em Santa Catarina com 303 crianças, avaliadas dois anos após o parto, o qual identificou que as crianças não amamentas de maneira exclusiva apresentaram maior risco de desenvolver excesso de peso corporal<sup>(<xref ref-type="bibr" rid="B19">19</xref>)</sup>.</p>
+        <p>No que concerne aos problemas de saúde, os mais frequentes foram os relacionados aos sistemas digestivo e respiratório, caracterizando-se com uma frequência significativamente menor nas crianças que receberam AME. Esse resultado corrobora a coorte realizada com 6.861 crianças pertencentes a seis centros de pesquisa clínica nos Estados Unidos e na Europa, que identificou episódio infeccioso gastrointestinal e respiratório significativamente reduzidos entre as crianças em AME<sup>(<xref ref-type="bibr" rid="B20">20</xref>)</sup>.</p>
+        <p>Referente às doenças do sistema digestivo nas crianças que não receberam AME, a diarreia e a gastroenterite podem estar relacionadas à ausência de higienização adequada de mamadeiras e demais utensílios de cozinha, além da possibilidade de intolerância alimentar relacionada ao tipo de leite oferecido<sup>(<xref ref-type="bibr" rid="B21">21</xref>)</sup>, as quais poderiam ser consideradas variáveis confundidoras, entretanto não foram avaliadas neste estudo. A dor abdominal e pélvica, por sua vez, sofre influência dos mitos e tabus que acompanham a amamentação, uma vez que as mães são culturalmente persuadidas pela família e conhecidos a introduzirem líquidos, como água e chás, acreditando que a criança está com sede e que sua atuação diminuirá a dor, e, desta forma, irá acalmá-la e fará com que durma mais<sup>(<xref ref-type="bibr" rid="B22">22</xref>)</sup>.</p>
+        <p>Os transtornos funcionais do intestino se apresentam como uma doença característica da introdução alimentar precoce, e isso ocorre devido ao fornecimento de alimentos sólidos, associados a uma baixa ingestão de líquidos. Destaca-se que o desenvolvimento da alimentação pode ser reflexo dos hábitos alimentares dos pais e cuidadores<sup>(<xref ref-type="bibr" rid="B23">23</xref>-<xref ref-type="bibr" rid="B24">24</xref>)</sup>.</p>
+        <p>Em relação às doenças do sistema respiratório, as infecções agudas das vias aéreas superiores, na maioria dos casos, encontram-se associadas às práticas das mães durante o aleitamento e ao posicionamento do bebê. Estudo realizado na Região Centro-Oeste do Paraná, com 60 mães de crianças com idades entre quatro e 180 dias (média de 40 dias), identificou que, entre os 49 bebês com AME, nove (18,4%) tiveram infecções de vias aéreas superiores ou otites, proporção muito menor do que a encontrada entre as 11 sem AME, visto que sete delas (63,6%) manifestaram estes episódios<sup>(<xref ref-type="bibr" rid="B25">25</xref>)</sup>.</p>
+        <p>A otite média em crianças pode estar relacionada ao posicionamento anatômico, uma vez que a tuba auditiva nos lactentes se encontra em uma posição mais horizontalizada. Dessa forma, a fisiologia da sucção durante o AM difere da que ocorre durante o fornecimento de bebidas lácteas por meio da mamadeira, em que a contração muscular é reduzida, com consequente flacidez da musculatura do palato mole, e, assim, o leite entra pela orofaringe e atinge a tuba auditiva. Uma vez que o leite artificial não possui anticorpos, como o LM, é favorecida a rápida proliferação de bactérias<sup>(<xref ref-type="bibr" rid="B25">25</xref>)</sup>.</p>
+        <p>A frequência de hospitalização neste estudo (24,7%) se assemelha à taxa encontrada no estudo de coorte realizado no Rio Grande do Sul, com 4.231 crianças acompanhadas com um, dois, quatro e seis anos de vida. Durante o primeiro ano de vida, a frequência de hospitalização foi de 19,1%, observando-se que os grupos “influenza e pneumonia” e “doenças crônicas das vias aéreas inferiores” estiveram presentes entre as três principais causas de hospitalização, e o grupo das “doenças infecciosas intestinais” esteve classificado entre a terceira e a quinta posições<sup>(<xref ref-type="bibr" rid="B26">26</xref>)</sup>.</p>
+        <p>No Brasil, mais de 3.000 mortes anuais de crianças poderiam ser evitadas se as mesmas fossem amamentadas exclusivamente ao seio materno até os seis meses de vida. Em termos financeiros, poderiam ser economizados quase um bilhão e meio de dólares por amamentação inadequada e mortes evitáveis, mais de 42 milhões de dólares, no tratamento de diarreia e infecção respiratória aguda/pneumonia em crianças, e mais de 12 bilhões dólares poderiam ser otimizados por perdas cognitivas decorrentes da falta de amamentação. Ou seja, para além da vida, que não tem preço, a economia decorrente da combinação de gastos com saúde, mortalidade e perdas cognitivas totalizaria mais de 14 bilhões de dólares, o que reforça a importância do AM para economia e qualidade de vida de toda a sociedade<sup>(<xref ref-type="bibr" rid="B27">27</xref>)</sup>.</p>
+        <sec>
+          <title>Limitações do estudo</title>
+          <p>Destaca-se como limitação do estudo a utilização de dados secundários, uma vez que são circunscritos à fidedignidade das informações obtidas, pois a digitação no sistema é realizada de forma descentralizada e pelo profissional responsável pelo atendimento. Contudo, seus resultados reiteram a importância em enfatizar o AM como fator de proteção paras as doenças mais frequentes na infância, subsidiando reflexões quanto à necessidade de os profissionais de saúde fazerem uso de estratégias práticas de incentivo ao mesmo.</p>
+          <p>Outra limitação diz respeito aos dados serem provenientes de registro dos atendimentos médicos, o que se justifica pelo fato do diagnóstico de doença ser uma atribuição médica. Ressalta-se que as consultas de puericultura realizadas pelas enfermeiras não foram avaliadas no estudo, pois, nestas, o foco está nos diagnósticos de enfermagem e nas intervenções/orientações realizadas. Contudo, é importante considerar que o prontuário na unidade de saúde engloba dados de atendimento multiprofissional, e o enfermeiro, pelo menos nos prontuários analisados, não efetuou registro de atividades desenvolvidas referente às ações de cuidado e/ou orientação. Destarte, muitas vezes, as intercorrências são inicialmente identificadas ou relatadas à equipe de enfermagem, mas isto não é registrado em prontuário, o que contribui para pouca visibilidade da atuação do enfermeiro na atenção primária.</p>
+        </sec>
+        <sec>
+          <title>Contribuições para a área de enfermagem e saúde</title>
+          <p>Os resultados do estudo indicam que na prática do enfermeiro, de acompanhamento do crescimento e desenvolvimento infantil no âmbito da atenção primária, por meio das consultas de puericultura, segue sendo fundamental para apoiar e promover o AM para a nutrição infantil, devido à sua relação com os resultados de saúde nos primeiros anos de vida. Esse conhecimento é primordial para desenvolver e direcionar intervenções que objetivam reduzir a morbimortalidade e melhorar a saúde infantil e a qualidade de vida das crianças.</p>
+          <p>A baixa prevalência do AME aos seis meses e a prevalência de doenças infecciosas nos primeiros anos de vida, especialmente do trato respiratório e gastrointestinal, observadas neste estudo, são elementos que despertam a necessidade de se discutir a qualidade do atendimento às crianças e famílias na atenção primária. Doenças preveníveis por meio de cuidados de higiene pessoal, dos alimentos, do ambiente, reforço em orientações adequadas de alimentação, imunização, entre outros, deveriam ser cada vez menos frequentes na população. A capacitação de enfermeiros e a aplicação da estratégia AIDPI neonatal e criança na atenção básica poderiam contribuir para essa redução.</p>
+        </sec>
+      </sec>
+      <sec sec-type="conclusions">
+        <title>CONCLUSÕES</title>
+        <p>Concluiu-se que, independentemente de qualquer outra variável analisada, as crianças que não foram amamentadas exclusivamente até os seis meses e não mantiveram o AM até os 12 meses apresentaram maior prevalência de doenças em relação às amamentadas.</p>
+      </sec>
+      <sec sec-type="supplementary-material">
+        <title>MATERIAL SUPLEMENTAR</title>
+        <p>O banco de dados da pesquisa foi depositado no SCIELO Data: Arcain, Evelin, 2021, “Amamentação e as doenças prevalentes nos primeiros dois anos de vida da criança: estudo transversal”, <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.48331/scielodata.XPWWYD">https://doi.org/10.48331/scielodata.XPWWYD,</ext-link> SciELO Data, DRAFT VERSION, UNF:6:rWHWyqc8p/Ef7BQh3BLfwQ== [fileUNF].</p>
+      </sec>
+    </body>
+    <back>
+      <fn-group>
+        <fn fn-type="financial-disclosure">
+          <p>
+            <bold>FOMENTO</bold>
+          </p>
+          <p>O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES), Código de Financiamento 001.</p>
+        </fn>
+      </fn-group>
+    </back>
+  </sub-article>
+</article>


### PR DESCRIPTION
#### O que esse PR faz?
Cria na página do artigo a seção "Dados de Pesquisa" para dar destaque às citações do tipo `data` ou `database` e também de material suplementar identificados dentro de `article-meta`.


#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o comando:

```console
htmlgenerator --nonetwork --nochecks tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.xml
```

#### Algum cenário de contexto que queira dar?
Não foram incluídos na seção "Dados de pesquisa", as notas de rodapé nem qualquer menção de dados suplementares no decorrer do texto, pois em ambos os casos, estes já fazem parte do texto corrido.

### Screenshots
<img width="902" alt="Captura de Tela 2022-11-18 às 11 14 18" src="https://user-images.githubusercontent.com/505143/202726315-dd436098-7ba2-424f-af00-d9e8f6ba1f96.png">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2506

### Referências
https://wp.scielo.org/wp-content/uploads/dados.pdf
