### PR TITLE
Corrige fn and related article

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -9,31 +9,33 @@
     <xsl:template match="article" mode="article-meta-related-article">
         <!-- seleciona dados de article ou sub-article -->
         <xsl:if test=".//related-article">
-            <xsl:choose>
-                <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article">
-                    <!-- sub-article -->
-                    <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']" mode="article-meta-related-article-box"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <!-- article -->
-                    <xsl:apply-templates select=".//article-meta" mode="article-meta-related-article-box"/>
-                </xsl:otherwise>
-            </xsl:choose>
+            <!-- caixa amarela -->
+            <div class="panel article-correction-title">
+                <xsl:choose>
+                    <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article">
+                        <!-- sub-article -->
+                        <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article" mode="article-meta-related-article-box-item"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <!-- article -->
+                        <xsl:apply-templates select=".//article-meta//related-article" mode="article-meta-related-article-box-item"/>
+                        <xsl:apply-templates select="body//related-article" mode="article-meta-related-article-box-item"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </div>            
         </xsl:if>
     </xsl:template>
 
-     <xsl:template match="article-meta | sub-article" mode="article-meta-related-article-box">
-        <!-- APRESENTA CAIXA DE TEXTO DESTACANDO O RELACIONAMENTO ENTRE DOCUMENTOS -->
-        <div class="panel article-correction-title">
-            <xsl:apply-templates select=".//related-article[1]" mode="article-meta-related-article-message"/>
-            <div class="panel-body">
-                <ul>
-                    <xsl:apply-templates select=".//related-article" mode="article-meta-related-article-item"/>
-                </ul>
-            </div>
+    <xsl:template match="related-article" mode="article-meta-related-article-box-item">
+        <xsl:apply-templates select="." mode="article-meta-related-article-message"/>
+        <div class="panel-body">
+            <ul>
+                <xsl:apply-templates select="." mode="article-meta-related-article-item"/>
+            </ul>
         </div>
     </xsl:template>
 
+            
     <xsl:template match="@related-article-type" mode="article-meta-related-article-message">
         <!-- MESSAGE -->
         <!-- 

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
@@ -33,23 +33,27 @@
     </xsl:template>
 
     <xsl:template match="fn">
-        <xsl:variable name="title"><xsl:apply-templates select="label"/></xsl:variable>
         <li>
-            <xsl:choose>
-                <xsl:when test="string-length(normalize-space($title)) &gt; 3">
-                    <div>
-                        <xsl:attribute name="class">articleSection</xsl:attribute>
-                        <xsl:attribute name="data-anchor"><xsl:value-of select="translate($title, ':', '')"/></xsl:attribute>
-                        <h3><xsl:value-of select="translate($title, ':', '')"/></h3>
-                        <xsl:apply-templates select="*[name()!='label']|text()"/>
-                    </div>
-                </xsl:when>
-                <xsl:otherwise>
-                    <span class="xref big"><xsl:apply-templates select="label"/></span>
-                    <xsl:apply-templates select="*[name()!='label']|text()"/>
-                </xsl:otherwise>
-            </xsl:choose>
+            <xsl:apply-templates select="*|text()"/>
         </li>
+    </xsl:template>
+
+    <xsl:template match="fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']">
+        <li>
+            <xsl:apply-templates select="." mode="open-science-notes"/>
+        </li>
+    </xsl:template>
+
+    <xsl:template match="fn/label">
+        <xsl:variable name="title"><xsl:apply-templates select="*|text()"/></xsl:variable>
+        <xsl:choose>
+            <xsl:when test="string-length(normalize-space($title)) &gt; 3">
+                <h3><xsl:apply-templates select="*|text()"/></h3>
+            </xsl:when>
+            <xsl:otherwise>
+                <span class="xref big"><xsl:apply-templates select="*|text()"/></span>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="fn/p">
@@ -70,7 +74,7 @@
             </div>
     </xsl:template>
 
-    <xsl:template match="article" mode="author-notes-as-sections">  
+    <xsl:template match="article" mode="author-notes-as-sections">
         <xsl:choose>
             <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
                 <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//author-notes" mode="author-notes-as-sections"/>
@@ -82,16 +86,13 @@
     </xsl:template>
 
     <xsl:template match="author-notes" mode="author-notes-as-sections">
-        <xsl:if test=".//fn">
-            <xsl:apply-templates select=".//fn" mode="author-notes-as-sections"/>
-        </xsl:if>
+        <!--
+            destaca algumas notas de autores, colocando-as no menu esquerdo
+        -->  
+        <xsl:apply-templates select="fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']" mode="open-science-notes"/>
     </xsl:template>
-    
-    <xsl:template match="author-notes/fn" mode="author-notes-as-sections">
-        <!-- não faz nada -->
-    </xsl:template>
-    
-    <xsl:template match="author-notes/fn[@fn-type='edited-by']" mode="author-notes-as-sections">
+
+    <xsl:template match="fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']" mode="open-science-notes">
         <xsl:variable name="title"><xsl:apply-templates select="label"/><xsl:if test="not(label)"><xsl:apply-templates select="." mode="text-labels">
                  <xsl:with-param name="text"><xsl:value-of select="@fn-type"/></xsl:with-param>
              </xsl:apply-templates></xsl:if></xsl:variable>

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.17.4'
+__version__ = '2.17.5'

--- a/tests/fixtures/htmlgenerator/affiliations/0006-8705-brag-81-e2022.en.html
+++ b/tests/fixtures/htmlgenerator/affiliations/0006-8705-brag-81-e2022.en.html
@@ -192,16 +192,14 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote">
-<li>
-<span class="xref big"></span><div>
+<li><div>
 <b>How to cite</b>: Callili, D., Silva, M. J. R., Sanchez, C. A. P. C., Watanabe, C. Y., Macedo, B. M. P., Domingues Neto, F. J., Teixeira, L. A. J. and Tecchio, M. A. (2022). Rootstock and potassium fertilization, in terms of phenology, thermal demand and chemical evolution, of berries on Niagara Rosada grapevine under subtropical conditions. Bragantia, 81, e2022. <a href="https://doi.org/10.1590/1678-4499.20210245" target="_blank">https://doi.org/10.1590/1678-4499.20210245</a>
-</div>
-</li>
-<li><div class="articleSection" data-anchor="DATA AVAILABILITY STATEMENT">
+</div></li>
+<li>
 <h3>DATA AVAILABILITY STATEMENT</h3>
 <div>All dataset were generated and analyzed in the current study.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="FUNDING">
+</li>
+<li>
 <h3>FUNDING</h3>
 <div>Fundação de Amparo à Pesquisa do Estado de São Paulo</div>
 <div>[<a href="https://doi.org/10.13039/501100001807" target="_blank">https://doi.org/10.13039/501100001807</a>]</div>
@@ -212,7 +210,7 @@
 <div>Conselho Nacional de Desenvolvimento Científico e Tecnológico</div>
 <div>[<a href="https://doi.org/10.13039/501100002322" target="_blank">https://doi.org/10.13039/501100002322</a>]</div>
 <div>Grants Nos. 05724/2018-5 and 307571/2019-0</div>
-</div></li>
+</li>
 </ul></div>
 </div>
 <div class="articleSection" data-anchor="REFERENCES">

--- a/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.en.html
+++ b/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.en.html
@@ -89,7 +89,7 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote"><li>
-<span class="xref big"></span><div>
+<div>
           <b>FUNDING</b>
         </div>
 <div>The present study was carried out with support from the Higher Education Personnel Improvement Coordination - Brazil (CAPES - <i>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior</i>) - Financing Code 001.</div>

--- a/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.pt.html
+++ b/tests/fixtures/htmlgenerator/data-availability/hxcB3n9hzmSGz4v6dgzDsxp.pt.html
@@ -235,7 +235,7 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote"><li>
-<span class="xref big"></span><div>
+<div>
             <b>FOMENTO</b>
           </div>
 <div>O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES), Código de Financiamento 001.</div>

--- a/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.en.html
+++ b/tests/fixtures/htmlgenerator/editor/1807-0205-paz-62-e202262026.en.html
@@ -324,10 +324,10 @@
 </div>
 <div>
 <h1></h1>
-<div class="ref-list"><ul class="refList footnote"><li><div class="articleSection" data-anchor="FUNDING INFORMATION">
-<h3>FUNDING INFORMATION</h3>
+<div class="ref-list"><ul class="refList footnote"><li>
+<h3><b>FUNDING INFORMATION:</b></h3>
 <div> The first author is grateful to Coordenação de Aperfeiçoamento de Pessoal de Nível Superior - Brasil (CAPES) - Finance Code 001, for the Master’s degree scholarship to support this research project. </div>
-</div></li></ul></div>
+</li></ul></div>
 </div>
 <div class="articleSection" data-anchor="Edited by">
 <h3>Edited by</h3>

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.en.html
@@ -745,37 +745,37 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote">
-<li><div class="articleSection" data-anchor="JEL Code">
-<h3>JEL Code</h3>
+<li>
+<h3>JEL Code:</h3>
 <div>M1, M10.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Peer Review Report">
-<h3>Peer Review Report</h3>
+</li>
+<li>
+<h3>Peer Review Report:</h3>
 <div>The Peer Review Report is available at this <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">external URL</a>.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Funding">
+</li>
+<li>
 <h3>Funding</h3>
 <div> The authors thank the Ministry of Science, Technology and Innovation, National Council for Scientific and Technological Development (CNPq) (CHSSA, Process nr. 445434/2015-5) for the financial support to the research project, from which this study was developed.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Plagiarism Check">
+</li>
+<li>
 <h3>Plagiarism Check</h3>
 <div> The RAC maintains the practice of submitting all documents approved for publication to the plagiarism check, using specific tools, e.g.: iThenticate.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Copyrights">
+</li>
+<li>
 <h3>Copyrights</h3>
 <div> RAC owns the copyright to this content.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Peer Review Method">
+</li>
+<li>
 <h3>Peer Review Method</h3>
 <div> This content was evaluated using the double-blind peer review process. The disclosure of the reviewers' information on the first page, as well as the Peer Review Report, is made only after concluding the evaluation process, and with the voluntary consent of the respective reviewers and authors.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Data Availability">
+</li>
+<li>
 <h3>Data Availability</h3>
 <div>The authors claim that all data used in the research have been made publicly available through the Harvard Dataverse platform and can be accessed at:</div>
 <div>
 <img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>
 <div>RAC encourages data sharing but, in compliance with ethical principles, it does not demand the disclosure of any means of identifying research subjects, preserving the privacy of research subjects. The practice of open data is to enable the reproducibility of results, and to ensure the unrestricted transparency of the results of the published research, without requiring the identity of research subjects. </div>
-</div></li>
+</li>
 </ul></div>
 </div>
 <div class="articleSection" data-anchor="Editors-in-chief">

--- a/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
+++ b/tests/fixtures/htmlgenerator/editor/1982-7849-rac-26-06-e190379.pt.html
@@ -744,37 +744,37 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote">
-<li><div class="articleSection" data-anchor="Classificação JEL">
-<h3>Classificação JEL</h3>
+<li>
+<h3>Classificação JEL:</h3>
 <div>M1, M10.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Relatório de Revisão por Pares">
-<h3>Relatório de Revisão por Pares</h3>
+</li>
+<li>
+<h3>Relatório de Revisão por Pares:</h3>
 <div>O Relatório de Revisão por Pares está disponível neste <a href="https://doi.org/10.5281/zenodo.6608808" target="_blank">link externo</a>.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Financiamento">
+</li>
+<li>
 <h3>Financiamento</h3>
 <div> Os autores agradecem o Ministério da Ciência, Tecnologia e Inovação, Conselho Nacional de Desenvolvimento Científico e Tecnológico (CHSSA, Processo nr. 445434/2015-5) pelo suporte financeiro ao projeto de pesquisa, a partir do qual o presente estudo foi desenvolvido.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Verificação de Plágio">
+</li>
+<li>
 <h3>Verificação de Plágio</h3>
 <div> A RAC mantém a prática de submeter todos os documentos aprovados para publicação à verificação de plágio, mediante o emprego de ferramentas específicas, e.g.: iThenticate.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Direitos Autorais">
+</li>
+<li>
 <h3>Direitos Autorais</h3>
 <div> A RAC detém os direitos autorais deste conteúdo.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Método de Revisão por Pares">
+</li>
+<li>
 <h3>Método de Revisão por Pares</h3>
 <div> Este conteúdo foi avaliado utilizando o processo de revisão por pares duplo-cego (<i>double-blind peer-review</i>). A divulgação das informações dos pareceristas constantes na primeira página e do Relatório de Revisão por Pares (Peer Review Report) é feita somente após a conclusão do processo avaliativo, e com o consentimento voluntário dos respectivos pareceristas e autores.</div>
-</div></li>
-<li><div class="articleSection" data-anchor="Disponibilidade dos Dados">
+</li>
+<li>
 <h3>Disponibilidade dos Dados</h3>
 <div>Os autores afirmam que todos os dados utilizados na pesquisa foram disponibilizados publicamente, e podem ser acessados por meio da plataforma Harvard Dataverse:</div>
 <div>
 <img style="max-width:100%" src="1982-7849-rac-26-06-e190379-i001qr-pt.jpg">Ames, Maria Clara Figueiredo Dalla Costa; Serafim, Mauricio C.; Martins, Felipe Flôres, 2021, "Replication Data for "Analysis of scales and measures of moral virtues: A systematic review" published by RAC - Revista de Administração Contemporânea", Harvard Dataverse, V1. https://doi.org/10.7910/DVN/NGOPMM</div>
 <div>A RAC incentiva o compartilhamento de dados mas, por observância a ditames éticos, não demanda a divulgação de qualquer meio de identificação de sujeitos de pesquisa, preservando a privacidade dos sujeitos de pesquisa. A prática de <i>open data</i> é viabilizar a reproducibilidade de resultados, e assegurar a irrestrita transparência dos resultados da pesquisa publicada, sem que seja demandada a identidade de sujeitos de pesquisa. </div>
-</div></li>
+</li>
 </ul></div>
 </div>
 <div class="articleSection" data-anchor="Editores-chefes">

--- a/tests/fixtures/htmlgenerator/howtocite_without_foot_note/howtocite.en.html
+++ b/tests/fixtures/htmlgenerator/howtocite_without_foot_note/howtocite.en.html
@@ -589,22 +589,14 @@ Research developed at Universidade do Estado de Santa Catarina/Núcleo de Proces
 <div class="articleSection" data-anchor="Highlights: ">
 <h1 class="articleSectionTitle">Highlights: </h1>
 <div class="ref-list"><ul class="refList footnote">
-<li>
-<span class="xref big"></span><div>Study presents design and production of an LED lamp for photovoltaic light traps.</div>
-</li>
-<li>
-<span class="xref big"></span><div>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</div>
-</li>
-<li>
-<span class="xref big"></span><div>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</div>
-</li>
+<li><div>Study presents design and production of an LED lamp for photovoltaic light traps.</div></li>
+<li><div>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</div></li>
+<li><div>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</div></li>
 </ul></div>
 </div>
 <div>
 <h1></h1>
-<div class="ref-list"><ul class="refList footnote"><li>
-<span class="xref big"></span><div>Edited by: Walter Esfrain Pereira</div>
-</li></ul></div>
+<div class="ref-list"><ul class="refList footnote"><li><div>Edited by: Walter Esfrain Pereira</div></li></ul></div>
 </div>
 <div class="articleSection" data-anchor="Publication Dates">
 <h1 class="articleSectionTitle">Publication Dates</h1>

--- a/tests/fixtures/htmlgenerator/image_in_table/img_in_table.en.html
+++ b/tests/fixtures/htmlgenerator/image_in_table/img_in_table.en.html
@@ -152,7 +152,7 @@
 <div>
 <h1></h1>
 <div class="ref-list"><ul class="refList footnote"><li>
-<span class="xref big"></span><div>
+<div>
           <b>Supplementary Information</b>
         </div>
 <div>Supplementary information (chromatograms from chiral GC analysis) is available free of charge at <a href="http://jbcs.sbq.org.br" target="_blank">http://jbcs.sbq.org.br</a> as <a target="_blank" href="https://minio.scielo.br/documentstore/1678-4790/LgRcS7ZYYQ5wSDKw8wKytSp/818bf2b94169513756c9f4734c24d9bc774a3795.pdf">PDF</a> file.</div>

--- a/tests/fixtures/htmlgenerator/modal_authors/96fDfzSqzxPF9cPxxPNYFmk.en.html
+++ b/tests/fixtures/htmlgenerator/modal_authors/96fDfzSqzxPF9cPxxPNYFmk.en.html
@@ -231,10 +231,10 @@
 </div>
 <div>
 <h1></h1>
-<div class="ref-list"><ul class="refList footnote"><li><div class="articleSection" data-anchor="FINANCIAL SUPPORT">
+<div class="ref-list"><ul class="refList footnote"><li>
 <h3>FINANCIAL SUPPORT</h3>
 <div> “This work was carried out with support from the Coordination for the Improvement of Higher Education Personnel - Brazil (CAPES) - Funding Code 001, Doctoral Scholarship granted to Glicinia Elaine Rosilho Pedroso), Process No. 38P-4071/2019.</div>
-</div></li></ul></div>
+</li></ul></div>
 </div>
 <div class="articleSection" data-anchor="References">
 <h1 class="articleSectionTitle">References</h1>

--- a/tests/fixtures/htmlgenerator/modal_authors/96fDfzSqzxPF9cPxxPNYFmk.pt.html
+++ b/tests/fixtures/htmlgenerator/modal_authors/96fDfzSqzxPF9cPxxPNYFmk.pt.html
@@ -232,10 +232,10 @@
 </div>
 <div>
 <h1></h1>
-<div class="ref-list"><ul class="refList footnote"><li><div class="articleSection" data-anchor="FINANCIAMENTO">
+<div class="ref-list"><ul class="refList footnote"><li>
 <h3>FINANCIAMENTO</h3>
 <div> “O presente trabalho foi realizado com apoio da Coordenação de Aperfeiçoamento de Pessoal de Nível Superior – Brasil (CAPES) - Código de Financiamento 001, Bolsa de Doutorado concedida a Glicinia Elaine Rosilho Pedroso), Processo nº 38P-4071/2019.</div>
-</div></li></ul></div>
+</li></ul></div>
 </div>
 <div class="articleSection" data-anchor="REFERÊNCIAS">
 <h1 class="articleSectionTitle">REFERÊNCIAS</h1>

--- a/tests/fixtures/htmlgenerator/related-article/varias_erratas.en.html
+++ b/tests/fixtures/htmlgenerator/related-article/varias_erratas.en.html
@@ -21,17 +21,31 @@
 <div class="panel article-correction-title">
 <div class="panel-heading">This erratum corrects:
         </div>
-<div class="panel-body"><ul>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100001">10.1590/s1413-65382620000100001</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100002">10.1590/s1413-65382620000100002</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100003">10.1590/s1413-65382620000100003</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100004">10.1590/s1413-65382620000100004</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100005">10.1590/s1413-65382620000100005</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100006">10.1590/s1413-65382620000100006</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100007">10.1590/s1413-65382620000100007</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100008">10.1590/s1413-65382620000100008</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100009">10.1590/s1413-65382620000100009</a></li>
-</ul></div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100001">10.1590/s1413-65382620000100001</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100002">10.1590/s1413-65382620000100002</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100003">10.1590/s1413-65382620000100003</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100004">10.1590/s1413-65382620000100004</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100005">10.1590/s1413-65382620000100005</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100006">10.1590/s1413-65382620000100006</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100007">10.1590/s1413-65382620000100007</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100008">10.1590/s1413-65382620000100008</a></li></ul></div>
+<div class="panel-heading">This erratum corrects:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100009">10.1590/s1413-65382620000100009</a></li></ul></div>
 </div>
 <h1 class="article-title">
 <span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Errata<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>

--- a/tests/fixtures/htmlgenerator/related-article/varias_erratas.pt.html
+++ b/tests/fixtures/htmlgenerator/related-article/varias_erratas.pt.html
@@ -21,17 +21,31 @@
 <div class="panel article-correction-title">
 <div class="panel-heading">Esta errata corrige:
         </div>
-<div class="panel-body"><ul>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100001">10.1590/s1413-65382620000100001</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100002">10.1590/s1413-65382620000100002</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100003">10.1590/s1413-65382620000100003</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100004">10.1590/s1413-65382620000100004</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100005">10.1590/s1413-65382620000100005</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100006">10.1590/s1413-65382620000100006</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100007">10.1590/s1413-65382620000100007</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100008">10.1590/s1413-65382620000100008</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100009">10.1590/s1413-65382620000100009</a></li>
-</ul></div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100001">10.1590/s1413-65382620000100001</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100002">10.1590/s1413-65382620000100002</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100003">10.1590/s1413-65382620000100003</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100004">10.1590/s1413-65382620000100004</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100005">10.1590/s1413-65382620000100005</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100006">10.1590/s1413-65382620000100006</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100007">10.1590/s1413-65382620000100007</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100008">10.1590/s1413-65382620000100008</a></li></ul></div>
+<div class="panel-heading">Esta errata corrige:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/s1413-65382620000100009">10.1590/s1413-65382620000100009</a></li></ul></div>
 </div>
 <h1 class="article-title">
 <span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Errata<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>

--- a/tests/fixtures/htmlgenerator/related-article/x.pt.html
+++ b/tests/fixtures/htmlgenerator/related-article/x.pt.html
@@ -21,10 +21,10 @@
 <div class="panel article-correction-title">
 <div class="panel-heading">Este documento comenta:
         </div>
-<div class="panel-body"><ul>
-<li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en <i>El coraje de la verdad</i> de Foucault. <b>Trans/form/ação</b>: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.</a></li>
-<li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en <i>El coraje de la verdad</i> de Foucault. <b>Trans/form/ação</b>: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.</a></li>
-</ul></div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en <i>El coraje de la verdad</i> de Foucault. <b>Trans/form/ação</b>: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.</a></li></ul></div>
+<div class="panel-heading">Este documento comenta:
+        </div>
+<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en <i>El coraje de la verdad</i> de Foucault. <b>Trans/form/ação</b>: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.</a></li></ul></div>
 </div>
 <h1 class="article-title">
 <span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Comentário a “Cinismo e indiferenciación: la huella de Glucksmann en El coraje de la verdad de Foucault”: por uma indiferenciação cínica<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>

--- a/tests/fixtures/htmlgenerator/translator/dqR6y8bPFVVQnxnFHY66ZZK.pt.html
+++ b/tests/fixtures/htmlgenerator/translator/dqR6y8bPFVVQnxnFHY66ZZK.pt.html
@@ -411,21 +411,11 @@
 <div class="articleSection" data-anchor="Fontes das imagens">
 <h1 class="articleSectionTitle">Fontes das imagens</h1>
 <div class="ref-list"><ul class="refList footnote">
-<li>
-<span class="xref big"></span><div>Dominique Auzel, <b>Émile Reynaud et l’image s’anima</b>, Paris: Du May, 1992.</div>
-</li>
-<li>
-<span class="xref big"></span><div>Erik Barnouw, <b>The Magician and the Cinema</b>, New York: Oxford University Press, 1981.</div>
-</li>
-<li>
-<span class="xref big"></span><div>C.W. Ceram, <b>Archaeology of the Cinema</b>, London: Thames and Hudson, 1965.</div>
-</li>
-<li>
-<span class="xref big"></span><div>L’Office Français d’Edition (ed.), <b>Émile Reynaud, Peintre de films 1844-1918</b>, Paris: Cinémathèque Française, 1945.</div>
-</li>
-<li>
-<span class="xref big"></span><div>Emmanuelle Toulet, <b>Cinema is 100 Years Old</b>, trad. Susan Emanuel, London: Thames and Hudson, 1995.</div>
-</li>
+<li><div>Dominique Auzel, <b>Émile Reynaud et l’image s’anima</b>, Paris: Du May, 1992.</div></li>
+<li><div>Erik Barnouw, <b>The Magician and the Cinema</b>, New York: Oxford University Press, 1981.</div></li>
+<li><div>C.W. Ceram, <b>Archaeology of the Cinema</b>, London: Thames and Hudson, 1965.</div></li>
+<li><div>L’Office Français d’Edition (ed.), <b>Émile Reynaud, Peintre de films 1844-1918</b>, Paris: Cinémathèque Française, 1945.</div></li>
+<li><div>Emmanuelle Toulet, <b>Cinema is 100 Years Old</b>, trad. Susan Emanuel, London: Thames and Hudson, 1995.</div></li>
 </ul></div>
 </div>
 <div class="articleSection" data-anchor="Referências">


### PR DESCRIPTION
#### O que esse PR faz?
Corrige fn and related article
- Apresenta somente fn do tipo edited-by e data-availability, de author notes
- Apresenta somente fn do tipo edited-by e data-availability, encontrados também em back e body 
- Apresenta 1 rótulo para cada related-article

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
htmlgenerator --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/data-availability/back.xml
htmlgenerator --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/related-article/varias_erratas.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
correções de #354 

### Referências
n/a
