### PR TITLE
Corrige a apresentação de relacionamento do artigo para a sua versão preprint

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -51,7 +51,7 @@
             <xsl:when test=".='addendum'">This document has an addendum</xsl:when>
             <xsl:when test=".='retraction'">This document was retracted by</xsl:when>
             <xsl:when test=".='correction'">This document has corrections</xsl:when>
-            <xsl:when test=".='preprint'">This document has the publication of reviewers' recommendation</xsl:when>
+            <xsl:when test=".='preprint'">This document has a preprint version</xsl:when>
             <xsl:when test=".='peer-reviewed-material'">This recommendation refers to the article</xsl:when>
             <xsl:otherwise>This document is related to</xsl:otherwise>
         </xsl:choose>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -9,6 +9,7 @@
     <xsl:template match="article" mode="article-meta-related-article">
         <!-- seleciona dados de article ou sub-article -->
         <xsl:if test=".//related-article[@related-article-type!='preprint']">
+            <!-- preprint não deve tanto destaque quanto os demais tipos -->
             <!-- caixa amarela -->
             <div class="panel article-correction-title">
                 <xsl:choose>
@@ -120,4 +121,8 @@
         <xsl:apply-templates select="." mode="article-meta-related-article-link"/>
     </xsl:template>
 
+    <xsl:template match="related-article[@related-article-type='preprint']" mode="hidden-box">
+        <!-- para evitar que a caixa seja inserida via javascript -->
+        <div class="panel article-correction-title" style="visibility: hidden"></div>
+    </xsl:template>
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-related-article.xsl
@@ -8,18 +8,18 @@
 
     <xsl:template match="article" mode="article-meta-related-article">
         <!-- seleciona dados de article ou sub-article -->
-        <xsl:if test=".//related-article">
+        <xsl:if test=".//related-article[@related-article-type!='preprint']">
             <!-- caixa amarela -->
             <div class="panel article-correction-title">
                 <xsl:choose>
                     <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article">
                         <!-- sub-article -->
-                        <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article" mode="article-meta-related-article-box-item"/>
+                        <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//related-article[@related-article-type!='preprint']" mode="article-meta-related-article-box-item"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <!-- article -->
-                        <xsl:apply-templates select=".//article-meta//related-article" mode="article-meta-related-article-box-item"/>
-                        <xsl:apply-templates select="body//related-article" mode="article-meta-related-article-box-item"/>
+                        <xsl:apply-templates select=".//article-meta//related-article[@related-article-type!='preprint']" mode="article-meta-related-article-box-item"/>
+                        <xsl:apply-templates select="body//related-article[@related-article-type!='preprint']" mode="article-meta-related-article-box-item"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </div>            
@@ -34,7 +34,6 @@
             </ul>
         </div>
     </xsl:template>
-
             
     <xsl:template match="@related-article-type" mode="article-meta-related-article-message">
         <!-- MESSAGE -->

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -266,6 +266,7 @@
                     </div>
                 </div>
             </section>
+            <xsl:apply-templates select=".//related-article[@related-article-type='preprint']" mode="hidden-box"/>
         </article>
     </xsl:template>
 

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -256,6 +256,7 @@
             <xsl:apply-templates select="." mode="article-text-sub-articles"/>
 
             <xsl:apply-templates select="." mode="data-availability"/>
+
             <xsl:apply-templates select="front/article-meta" mode="generic-pub-date"/>
             <xsl:apply-templates select="front/article-meta" mode="generic-history"/>
             <section class="documentLicense">

--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -452,10 +452,10 @@
         <name lang="es">Este documento es un anexo de</name>
     </term>
     <term>
-        <name>This article has preprint version</name>
-        <name lang="en">This article has preprint version</name>
-        <name lang="pt">Este artigo tem versão preprint</name>
-        <name lang="es">Este artículo tiene versión preprint</name>
+        <name>This document has a preprint version</name>
+        <name lang="en">This document has a preprint version</name>
+        <name lang="pt">Este documento possui uma versão em preprint</name>
+        <name lang="es">Este documento tiene una versión preprint</name>
     </term>
     <term>
         <name>This recommendation refers to the article</name>

--- a/packtools/catalogs/htmlgenerator/v2.0/generic-history.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/generic-history.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
-
+    <xsl:variable name="related_preprint" select="//related-article[@related-article-type='preprint']"/>
     <xsl:template match="article-meta | sub-article | response" mode="generic-history">
        <xsl:if test=".//history">
         <div class="articleSection">
@@ -43,6 +43,10 @@
                 <xsl:apply-templates select="@date-type" mode="history-item-label"/>
             </strong><br/>
             <xsl:apply-templates select="."></xsl:apply-templates>
+            <xsl:if test="@date-type='preprint' and $related_preprint">
+                <br/>
+                <xsl:apply-templates select="$related_preprint[1]" mode="article-meta-related-article-link"/>
+            </xsl:if>
         </li>
     </xsl:template>
 

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '2.17.5'
+__version__ = '2.17.6'

--- a/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
+++ b/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
@@ -277,7 +277,7 @@
 <section class="documentLicense"><div class="container-license"><div class="row">
 <div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
 <div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">Este é um artigo publicado em acesso aberto sob uma licença Creative Commons</a></div>
-</div></div></section></article>
+</div></div></section><div class="panel article-correction-title" style="visibility: hidden"></div></article>
 </div>
 </div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
 <div class="modal-header">

--- a/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
+++ b/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
@@ -16,11 +16,6 @@
          
         <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/2236-8906-76-2021"><span class="sci-ico-link"></span>copiar</a></span>
 </div>
-<div class="panel article-correction-title">
-<div class="panel-heading">Este documento possui uma versão em preprint:
-        </div>
-<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/2236-8906-76/2021">10.1590/2236-8906-76/2021</a></li></ul></div>
-</div>
 <h1 class="article-title">
 <span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span><i>Campylocentrum</i> Benth. (Orchidaceae, Epidendroideae) no Distrito Federal e no Estado de Goiás, Brasil<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
 </h1>
@@ -275,7 +270,8 @@
 <li>
 <strong>Aceito</strong><br>11 Out 2022</li>
 <li>
-<strong>Preprint depositado em</strong><br>14 Out 2022</li>
+<strong>Preprint depositado em</strong><br>14 Out 2022<br><a target="_blank" href="https://doi.org/10.1590/2236-8906-76/2021">10.1590/2236-8906-76/2021</a>
+</li>
 </ul></div></div>
 </div>
 <section class="documentLicense"><div class="container-license"><div class="row">

--- a/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
+++ b/tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.pt.html
@@ -17,7 +17,7 @@
         <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/2236-8906-76-2021"><span class="sci-ico-link"></span>copiar</a></span>
 </div>
 <div class="panel article-correction-title">
-<div class="panel-heading">Este documento tem a publicação de recomendação de pareceristas:
+<div class="panel-heading">Este documento possui uma versão em preprint:
         </div>
 <div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/2236-8906-76/2021">10.1590/2236-8906-76/2021</a></li></ul></div>
 </div>

--- a/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
+++ b/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
@@ -85,7 +85,7 @@
 <section class="documentLicense"><div class="container-license"><div class="row">
 <div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
 <div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">Este é um artigo publicado em acesso aberto sob uma licença Creative Commons</a></div>
-</div></div></section></article>
+</div></div></section><div class="panel article-correction-title" style="visibility: hidden"></div></article>
 </div>
 </div></div></section><div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog"><div class="modal-content">
 <div class="modal-header">

--- a/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
+++ b/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
@@ -19,7 +19,7 @@
         <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/0101-3173.2022.v45n1.p159"><span class="sci-ico-link"></span>copiar</a></span>
 </div>
 <div class="panel article-correction-title">
-<div class="panel-heading">Este documento tem a publicação de recomendação de pareceristas:
+<div class="panel-heading">Este documento possui uma versão em preprint:
         </div>
 <div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">preprint version</a></li></ul></div>
 </div>

--- a/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
+++ b/tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.pt.html
@@ -18,11 +18,6 @@
          
         <a class="copyLink" data-clipboard-text="https://doi.org/10.1590/0101-3173.2022.v45n1.p159"><span class="sci-ico-link"></span>copiar</a></span>
 </div>
-<div class="panel article-correction-title">
-<div class="panel-heading">Este documento possui uma versão em preprint:
-        </div>
-<div class="panel-body"><ul><li><a target="_blank" href="https://doi.org/10.1590/0101-3173.2022.v45n1.p139">preprint version</a></li></ul></div>
-</div>
 <h1 class="article-title">
 <span class="sci-ico-openAccess showTooltip" data-toggle="tooltip" data-original-title="by 4.0 "></span>Este documento é um artigo que tem preprint<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
 </h1>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a apresentação de relacionamento do artigo para a sua versão preprint. Não apresenta a caixa amarela. Apresenta o link junto com a data do tipo `preprint`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
htmlgenerator --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/history_preprint/2236-8906-hoehnea-49-e762021.xml
htmlgenerator --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/related-article/related_article_fake_preprint.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#2424

### Referências
n/a
