### PR TITLE
Referencias artigo modo leitura Firefox

### DIFF
--- a/tests/fixtures/htmlgenerator/affiliations/artigo-ref-rascunho.html
+++ b/tests/fixtures/htmlgenerator/affiliations/artigo-ref-rascunho.html
@@ -1,0 +1,1700 @@
+<!doctype html>
+<html lang="pt-br" class="example">
+    <!--=include ./_parts/_headTag.html -->
+
+    <!--
+    <link href="../../dist/css/article.css" rel="stylesheet">
+    -->
+    <link href="../../aplicacao-design-system/css/bootstrap.css" rel="stylesheet">
+    <link href="../../aplicacao-design-system/css/article.css" rel="stylesheet">
+
+    <style>
+        .ref sup{
+            display: none;
+        }
+        .articleReferenceFootNotes{
+            display: none;
+        }
+        .ref sup a{
+            text-decoration: none;
+            margin-left: .25rem;
+        }
+        .ref sup a::before{
+            content:"[";
+        }
+        .ref sup a::after{
+            content:"]";
+        }
+    </style>
+    <body class="journal article">
+
+        <a name="top"></a>
+        <div id="standalonearticle">
+           <section class="articleCtt">
+              <div class="container">
+                 <div class="articleTxt">
+                    <div class="articleBadge-editionMeta-doi-copyLink">
+                       <span class="_articleBadge">Artigo</span><span class="_separator"> • </span><span class="_editionMeta">Hoehnea 49 <span class="_separator"> • </span>2022</span><span class="_separator"> • </span><span class="group-doi"><a href="https://doi.org/10.1590/2236-8906-111/2020" class="_doi" target="_blank">https://doi.org/10.1590/2236-8906-111/2020</a>
+                       
+                    <!--
+                       <a class="btn btn-sm copyLink" data-clipboard-text="https://doi.org/10.1590/2236-8906-111/2020"><span class="sci-ico-link"></span>copiar</a></span>
+                    -->
+                       <a href="javascript:;" class="btn btn-secondary btn-sm scielo__btn-with-icon--left copyLink" data-clipboard-text="https://doi.org/10.1590/2236-8906-111/2020"><span class="material-icons-outlined">link</span>Copiar</a>
+                    </div>
+                    <h1 class="article-title">
+                        <img src="./img/logo-open-access.svg" alt="Open-access" class="logo-open-access"  data-bs-toggle="tooltip" data-bs-original-title="by 4.0 "> Prospecção química, atividade antioxidante, anticolinesterásica e antifúngica de extratos etanólicos de espécies de <i>Senna</i> Mill. (Fabaceae)<a id="shorten" href="#" class="short-link"><span class="sci-ico-link"></span></a>
+                    </h1>
+                    <h2 class="article-title">Chemical prospecting and antioxidant, anticholinesterase and antifungal activity of ethanol extracts from <i>Senna</i> Mill. species. (Fabaceae)</h2>
+                    <div class="articleMeta"></div>
+                <!--   
+                    <div class="scielo__contribGroup">
+                       <span class="dropdown">
+                          <a id="contribGroupTutor1" class="dropdown-toggle" data-toggle="dropdown"><span> Andréa Maria Neves </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor1">
+                             <strong></strong> Universidade Estadual do Ceará, Centro de Ciências e Tecnologia, Programa de Pós-graduação em Biotecnologia, Avenida Doutor Silas Muguba, 1700, Itaperi, 60740-000 Fortaleza, CE, Brasil
+                             <div class="corresp">
+                                <h3><sup>4</sup></h3>
+                                Autor para correspondência: <a href="mailto:andreamarianeves@gmail.com">andreamarianeves@gmail.com</a>
+                             </div>
+                             <a href="http://orcid.org/0000-0002-7388-1844" class="btnContribLinks orcid">http://orcid.org/0000-0002-7388-1844</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor2" class="dropdown-toggle" data-toggle="dropdown"><span> Selene Maia de Morais </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor2">
+                             <strong></strong> Universidade Estadual do Ceará, Centro de Ciências e Tecnologia, Programa de Pós-graduação em Biotecnologia, Avenida Doutor Silas Muguba, 1700, Itaperi, 60740-000 Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0002-2766-3790" class="btnContribLinks orcid">http://orcid.org/0000-0002-2766-3790</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor3" class="dropdown-toggle" data-toggle="dropdown"><span> Hélcio Silva dos Santos </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor3">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Exatas e Tecnologia, Curso de Química, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0001-5527-164X" class="btnContribLinks orcid">http://orcid.org/0000-0001-5527-164X</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor4" class="dropdown-toggle" data-toggle="dropdown"><span> Marcílio Matos Ferreira </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor4">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0003-2503-9772" class="btnContribLinks orcid">http://orcid.org/0000-0003-2503-9772</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor5" class="dropdown-toggle" data-toggle="dropdown"><span> Ricardo Carneiro Vera Cruz </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor5">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0002-2035-0425" class="btnContribLinks orcid">http://orcid.org/0000-0002-2035-0425</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor6" class="dropdown-toggle" data-toggle="dropdown"><span> Elnatan Bezerra de Souza </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor6">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0002-5222-4378" class="btnContribLinks orcid">http://orcid.org/0000-0002-5222-4378</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor7" class="dropdown-toggle" data-toggle="dropdown"><span> Lúcia Betânia da Silva Andrade </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor7">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0002-4384-5738" class="btnContribLinks orcid">http://orcid.org/0000-0002-4384-5738</a>
+                          </ul>
+                       </span>
+                       <span class="dropdown">
+                          <a id="contribGroupTutor8" class="dropdown-toggle" data-toggle="dropdown"><span> Raquel Oliveira dos Santos Fontenelle </span></a>
+                          <ul class="dropdown-menu" role="menu" aria-labelledby="contribGrupoTutor8">
+                             <strong></strong> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil<a href="http://orcid.org/0000-0002-8865-5954" class="btnContribLinks orcid">http://orcid.org/0000-0002-8865-5954</a>
+                          </ul>
+                       </span>
+                       <a href="" class="outlineFadeLink" data-bs-toggle="modal" data-bs-target="#ModalTutors">Sobre os autores</a>
+                    </div>
+                -->
+                <div class="scielo__contribGroup">
+                 
+                    <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton9" data-bs-toggle="dropdown" aria-expanded="false">
+                          Manoel Odorico DE-MORAES
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton9">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0003-3378-8722" class="btnContribLinks orcid">http://orcid.org/0000-0003-3378-8722</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton2" data-bs-toggle="dropdown" aria-expanded="false">
+                          Luiz Gonzaga de MOURA-JR
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton2">
+                          <li>
+                             Unidade de Cirurgia Bariátrica, Hospital Geral Dr. César Cals, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0003-0092-648X" class="btnContribLinks orcid">http://orcid.org/0000-0003-0092-648X</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton3" data-bs-toggle="dropdown" aria-expanded="false">
+                          Vagnaldo FECHINE
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton3">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0002-8893-5323" class="btnContribLinks orcid">http://orcid.org/0000-0002-8893-5323</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                     <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+                          Rodrigo Feitosa de Albuquerque Lima BABADOPULOS
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                          <li>
+                             Unidade de Cirurgia Bariátrica, Hospital Geral Dr. César Cals, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0002-2651-4419" class="btnContribLinks orcid">http://orcid.org/0000-0002-2651-4419</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton4" data-bs-toggle="dropdown" aria-expanded="false">
+                          Marina Becker Sales ROCHA
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton4">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0001-7197-4599" class="btnContribLinks orcid">http://orcid.org/0000-0001-7197-4599</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton5" data-bs-toggle="dropdown" aria-expanded="false">
+                          Natalícia ANTUNES
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton5">
+                          <li>
+                             Departamento de Farmacologia, Faculdade de Ciências Médicas, Universidade Estadual de Campinas - Unicamp, Campinas, São Paulo - SP, Brasil<a href="http://orcid.org/0000-0002-7820-552X" class="btnContribLinks orcid">http://orcid.org/0000-0002-7820-552X</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton6" data-bs-toggle="dropdown" aria-expanded="false">
+                          Thomaz Alexandre COSTA
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton6">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0003-1789-6694" class="btnContribLinks orcid">http://orcid.org/0000-0003-1789-6694</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton7" data-bs-toggle="dropdown" aria-expanded="false">
+                          Bruno Almeida COSTA
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton7">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0002-1816-4498" class="btnContribLinks orcid">http://orcid.org/0000-0002-1816-4498</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                      <div class="dropdown">
+                       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton8" data-bs-toggle="dropdown" aria-expanded="false">
+                          Manoel Odorico DE-MORAES
+                       </button>
+                       <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton8">
+                          <li>
+                             Centro de Pesquisa e Desenvolvimento de Medicamentos, Unidade de Farmacologia Clínica, Universidade Federal do Ceará, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0003-3378-8722" class="btnContribLinks orcid">http://orcid.org/0000-0003-3378-8722</a>
+                          </li>
+                       </ul>
+                     </div>
+  
+                       
+  
+                        <div class="dropdown">
+                          <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton10" data-bs-toggle="dropdown" aria-expanded="false">
+                             Rodrigo Feitosa de Albuquerque Lima BABADOPULOS
+                          </button>
+                          <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton10">
+                             <li>
+                                Unidade de Cirurgia Bariátrica, Hospital Geral Dr. César Cals, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0002-2651-4419" class="btnContribLinks orcid">http://orcid.org/0000-0002-2651-4419</a>
+                             </li>
+                          </ul>
+                        </div>
+     
+                         <div class="dropdown">
+                          <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton11" data-bs-toggle="dropdown" aria-expanded="false">
+                             Luiz Gonzaga de MOURA-JR
+                          </button>
+                          <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton11">
+                             <li>
+                                Unidade de Cirurgia Bariátrica, Hospital Geral Dr. César Cals, Fortaleza, CE, Brasil<a href="http://orcid.org/0000-0003-0092-648X" class="btnContribLinks orcid">http://orcid.org/0000-0003-0092-648X</a>
+                             </li>
+                          </ul>
+                        </div>
+  
+                      <a href="" class="btn btn-secondary btn-sm outlineFadeLink" data-bs-toggle="modal" data-bs-target="#ModalTutors">Sobre os autores</a>
+                   </div>
+
+                    <div class="row">
+                        <!--
+                       <ul class="col-md-2 hidden-sm articleMenu"></ul>
+                        -->
+                        <ul class="d-none d-lg-block col-lg-2 articleMenu"><li class="selected">	<a href="#articleSection0">RESUMO</a></li><li class="">	<a href="#articleSection1">ABSTRACT</a></li><li>	<a href="#articleSection2">Text</a><ul><li class="">	<a href="#as2-heading0">Introdução</a></li><li class="">	<a href="#as2-heading1">Materiais e métodos</a></li><li class="">	<a href="#as2-heading2">Resultados e discussãoTabela 3
+                        </a></li></ul></li><li class="">	<a href="#articleSection3">Agradecimentos</a></li><li class="">	<a href="#articleSection4">Literatura citada</a></li><li>	<a href="#articleSection5">Datas de Publicação </a></li><li>	<a href="#articleSection6">Histórico</a></li></ul>
+                       <article id="articleText" class="col-sm-12 col-lg-10 offset-lg-2">
+                          <div class="articleSection" data-anchor="RESUMO">
+                             <h3 class="articleSectionTitle">RESUMO</h3>
+                             <p>O objetivo deste trabalho foi avaliar o perfil químico, teor de fenóis totais e as atividades antioxidante, antiacetilcolinesterásica e antifúngica dos extratos etanólicos das folhas (EEF) e do caule (EEC) de cinco espécies de <i>Senna</i>, bem como avaliar a correlação entre o conteúdo de fenóis totais com a atividade sequestradora do radical livre DPPH e com a inibição da enzima acetilcolinesterase AChEI. No teste fitoquímico, evidenciou-se a presença de metabólitos secundários em todos os extratos. Os EEF e EEC de <i>Senna trachypus</i>, destacaram-se por apresentar os maiores valores de fenóis totais. Os EEF e EEC de <i>S. trachypus</i> mostraram a melhor ação sobre a enzima acetilcolinesterase. Todas as espécies apresentaram atividade antioxidante, em especial o EEF de <i>S. trachypus</i>. Foi observado correlação forte para as variáveis fenóis totais e atividade antioxidante (r = -0,71), muito forte para fenóis totais e antiacetilcolinesterase (r = -0,84) e atividade moderada para atividade antioxidante e antiacetilcolinesterase (0,43). Apenas os extratos de <i>S. trachypus</i> apresentaram atividade contra todos os dermatófitos, quando comparado às demais espécies. A espécie <i>S. trachypus</i> foi considerada a planta mais promissora para estudos subsequentes, a fim de encontrar compostos com ações farmacológicas. </p>
+                             <p><strong>Palavras-chave:</strong><br>acetilcolinesterase; dermatófitos; fitoquímica; produtos naturais; radicais livres</p>
+                          </div>
+                          <div class="articleSection" data-anchor="ABSTRACT">
+                             <h3 class="articleSectionTitle">ABSTRACT</h3>
+                             <p>The objective of this work was to evaluate the chemical profile, total phenol content and the antioxidant, antiacetylcholinesterase and antifungal activities of ethanol extracts from leaves (EEF) and stem (EEC) of five species of <i>Senna</i>, as well as to evaluate the correlation between the content of total phenols with the DPPH free radical scavenging activity and with the inhibition of the acetylcholinesterase AChEI enzyme. The phytochemical test showed the presence of secondary metabolites in all extracts. The EEF and EEC of <i>Senna trachypus</i>, stood out for presenting the highest values of total phenols. <i>S. trachypus</i> EEF and EEC showed the best action on the acetylcholinesterase enzyme. All species showed antioxidant activity, especially the EEF from <i>S. trachypus</i>. A strong correlation was observed for the variables total phenols and antioxidant activity (r = -0.71), very strong for total phenols and anti-acetylcholinesterase (r = -0.84) and moderate activity for antioxidant and anti-acetylcholinesterase activity (r = 0.43). Only <i>S. trachypus</i> extracts showed activity against all dermatophytes, when compared to the other species. The species <i>S. trachypus</i> was considered the most promising plant for further studies, in order to find compounds with pharmacological actions.</p>
+                             <p><strong>Keywords:</strong><br>acetylcholinesterase; dermatophytes; phytochemistry; natural products; free radicals</p>
+                          </div>
+                          <div class="articleSection" data-anchor="Text">
+                             <h3 class="articleSectionTitle">Introdução</h3>
+                             <p><i>Senna</i> Mill. é um gênero monofilético com distribuição pantropical e ampla variedade morfológica (
+                                
+                                <!-- #01
+                                <span class="ref"><strong class="xref xrefblue">Pellerin <i>et al</i>. 2019</strong><span class="refCtt closed"><span>Pellerin, R.J., Waminal, N.E. &amp; Kim, H.H. 2019. FISH mapping of rDNA and telomeric repeats in 10 Senna species. Horticulture, Environment, and Biotechnology 60: 253-260.</span></span></span>
+                                -->
+                                <span class="ref" id="refId_1"><strong class="xref xrefblue">Pellerin <i>et al</i>. 2019</strong><sup><a title="Pellerin, R.J., Waminal, N.E. & Kim, H.H. 2019. FISH mapping of rDNA and telomeric repeats in 10 Senna species. Horticulture, Environment, and Biotechnology 60: 253-260." name="" class="" href="#1_ref">1</a></sup></span>
+                                
+
+                                ). Possuindo aproximadamente 300 espécies, das quais 200 nas Américas, este gênero é o segundo maior da família Fabaceae (
+                                
+                                <!--#02
+                                <span class="ref"><strong class="xref xrefblue">Queiroz 2009</strong><span class="refCtt closed"><span>Queiroz, L.P. 2009. Leguminosas da Caatinga. Universidade Estadual de Feira de Santana, Feira de Santana, 467 p.</span></span></span>, 
+                                -->
+                                <span class="ref" id="refId_2"><strong class="xref xrefblue">Queiroz 2009</strong><sup><a title="Queiroz, L.P. 2009. Leguminosas da Caatinga. Universidade Estadual de Feira de Santana, Feira de Santana, 467 p." name="" class="" href="#2_ref">2</a></sup></span>, 
+                                
+
+                                <!--#03
+                                <span class="ref"><strong class="xref xrefblue">Kim <i>et al</i>. 2018</strong><span class="refCtt closed"><span>Kim, M.S., Lee, D.Y., Sung, S.H. &amp; Jeon, W.K. 2018. Anti-cholinesterase activities of hydrolysable tannins and polyhydroxytriterpenoid derivatives from Terminalia chebula Retz. fruit. Fruit Rec Nat Prod 12: 284-289.</span></span></span>, 
+                                -->
+                                <span class="ref" id="refId_3"><strong class="xref xrefblue">Kim <i>et al</i>. 2018</strong><sup><a title="Kim, M.S., Lee, D.Y., Sung, S.H. &amp; Jeon, W.K. 2018. Anti-cholinesterase activities of hydrolysable tannins and polyhydroxytriterpenoid derivatives from Terminalia chebula Retz. fruit. Fruit Rec Nat Prod 12: 284-289." name="" class="" href="#3_ref">3</a></sup></span>, 
+                                
+
+                                <!--#04
+                                <span class="ref"><strong class="xref xrefblue">Souza &amp; Silva 2016</strong><span class="refCtt closed"><span>Souza, A.O. &amp; Silva, M.J. 2016. Senna (Leguminosae, Caesalpinioideae) na Floresta Nacional de Silvânia, Goiás, Brasil. Rodriguésia 67: 773-784. </span></span></span>
+                                -->
+                                <span class="ref" id="refId_4"><strong class="xref xrefblue">Souza &amp; Silva 2016</strong><sup><a title="Souza, A.O. &amp; Silva, M.J. 2016. Senna (Leguminosae, Caesalpinioideae) na Floresta Nacional de Silvânia, Goiás, Brasil. Rodriguésia 67: 773-784." name="" class="" href="#4_ref">4</a></sup></span>
+                                
+
+                                ). O gênero é representado no Brasil por 79 espécies, onde 29 são endêmicas, sendo a região Nordeste a que apresenta a maior riqueza de espécies com 53 registros (
+                                
+                                <!--#05
+                                <span class="ref"><strong class="xref xrefblue">BFG 2018</strong><span class="refCtt closed"><span>BFG. 2018. Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC). Rodriguésia 1513-1527. </span></span></span>
+                                -->
+                                <span class="ref"><strong class="xref xrefblue">BFG 2018</strong><sup><a title="BFG. 2018. Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC). Rodriguésia 1513-1527." name="" class="" href="#5_ref">5</a></sup></span>
+                                
+                                
+                                ). </p>
+                             
+                             <!--
+                             <p>Trata-se de um gênero muito expressivo na flora do semiárido, alcançando destaque no Domínio Fitogeográfico da Caatinga, onde são catalogadas 42 espécies (<span class="ref"><strong class="xref xrefblue">Souza &amp; Bortoluzzi 2015</strong><span class="refCtt closed"><span>Souza, V.C.; Bortoluzzi, R.L.C. 2015. Senna in Lista de Espécies da Flora do Brasil. Jardim Botânico do Rio de Janeiro. </span></span></span>). As espécies de <i>Senna</i> são geralmente arbustos ou arvoretas, raramente ervas ou subarbustos anuais. Entre as suas características diagnósticas estão os nectários extraflorais convexos, interfoliolares, flores vistosas, com pétalas amarelo-brilhantes, anteras amarelas, rígidas, com deiscência abrindo por poros ou fendas, ausência de bractéolas no pedicelo, frutos deiscentes plano-compressos ou indeiscentes e cilíndricos (<span class="ref"><strong class="xref xrefblue">Queiroz 2009</strong><span class="refCtt closed"><span>Queiroz, L.P. 2009. Leguminosas da Caatinga. Universidade Estadual de Feira de Santana, Feira de Santana, 467 p.</span></span></span>).</p>
+                             <p>As espécies de <i>Senna</i> têm diversas aplicações medicinais e são eficazes no tratamento para uma série de doenças, como malária, micose, dengue, eczema, hepatite e dermatite, sendo também indicadas como anti-hipertensivo, vermífugo, laxante, abortivo e antitussígeno (<span class="ref"><strong class="xref xrefblue">Macedo <i>et al.</i> 2016</strong><span class="refCtt closed"><span>Macedo, E.M., Alan, J.G., &amp; Silva, M.G.V. 2016. Quimiodiversidade e propriedades biofarmacológicas de espécies de Senna nativas do Nordeste do Brasil. Revista Virtual de Química 8: 169-195.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Bieski <i>et al</i>. 2015</strong><span class="refCtt closed"><span>Bieski, I.G.C., Leonti, M., Arnason, J.T., Ferrier, J., Rapinski, M., Violante, I.M.P., Balogun,S.O., Pereira, J.F.C.A., Figueiredo, R.D.C.F., Lopes, C.R.A.S., Silva, D.R.D., Pacini, A., Albuquerque, U.P. &amp; Martins, D.T.D.O. 2015. Ethnobotanical study of medicinal plants by population of valley of Juruena region, legal amazon, Mato Grosso, Brazil. Journal of Ethnopharmacology 173: 383-423.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Kabir <i>et al.</i> 2014</strong><span class="refCtt closed"><span>Kabir, M.H., Hasan, N., Rahman, M.M., Rahman, M.A., Khan, J.A., Hoque, N.T., Bhuiyan, M.R.Q., Mou, S.M.; Jahan, R. &amp; Rahmatullah, M. 2014. A survey of medicinal plants used by the Deb barma clan of the Tripura tribe of Moulvibazar district, Bangladesh. Journal of Ethnobiology and Ethnomedicine 10: 1-19.</span></span></span>). Além de suas aplicações farmacológicas, estudos têm revelado que espécies pertencentes a este gênero possuem, em sua composição, uma vasta diversidade de princípios bioativos que estão associadas a diferentes atividades biológicas. Neste sentido, podemos citar como exemplo as atividades antioxidantes, antitumoral, antibacterianas, antifúngicas e anti-inflamatórias (<span class="ref"><strong class="xref xrefblue">Neves <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Neves, A.M., Costa, O.S., Coutinho, M.G.S., Souza, E.B., Santos, H.S., Silva, M.G.V. &amp; Fontenelle, R.O.S. 2017. Caracterização química e o potencial antimicrobiano de espécies do gênero Senna Mill (Fabaceae). Rev. Virtual Quim 9: 2506-2538.</span></span></span>).</p>
+                             <p>As plantas são fontes alternativas promissoras de substâncias de interesse biológico e farmacológico, já que podem produzir, a partir de seu metabolismo secundário, uma enorme diversidade de substâncias, dentre estas, os compostos fenólicos. Alguns estudos têm revelado que os compostos fenólicos são responsáveis por várias atividades biológicas, incluindo atividade antifúngica. Esta atividade pode ser direta nos micro-organismos, ou sobre outros fatores necessários para a expressão da virulência ou patogenicidade (<span class="ref"><strong class="xref xrefblue">Rodrigues <i>et al</i>. 2019</strong><span class="refCtt closed"><span>Rodrigues, F.C., Dos Santos, A.T.L., Machado, A.J.T., Bezerra, C.F., de Freitas, T.S., Coutinho, H.D.M., Morais-Braga, M.F.B., Bezerra, J.W.A., Duarte, A.E., Kamdem, J.P., Boligon, A.A., Campos, M.M.A., Barros, L.M. 2019. Chemical composition and anti-Candida potencial of the extracts of Tarenaya spinosa (Jacq.) Raf.(Cleomaceae). Comparative immunology, microbiology and infectious diseases 64: 14-19.</span></span></span>).</p>
+                             <p>Os compostos fenólicos estão entre os metabólitos secundários mais estudados, notadamente por possuírem grande potencial para atividades antioxidantes, atuando na redução do risco de algumas doenças agudas e crônicas relacionadas ao estado redox do corpo humano, ocasionadas pelos radicais livres. Estas moléculas apresentam uma alta capacidade reativa, sendo consideradas perigosas para os organismos vivos, causando doenças prejudiciais, incluindo doenças neurodegenerativas, como o mal de Alzheimer (DA). Atualmente, uma das teorias mais aceitas na abordagem padrão no tratamento sintomático dessa demência é a “hipótese colinérgica”. Portanto, os inibidores da enzima acetilcolinesterase (AChEI) preservam os níveis de acetilcolina, melhorando a eficiência da transmissão colinérgica (<span class="ref"><strong class="xref xrefblue">Bardakci <i>et al</i>. 2019</strong><span class="refCtt closed"><span>Bardakci, H., CeleP, E., Gözet, T., Kan, Y. &amp; Kirmizibekmez, H. 2019. Phytochemical characterization and antioxidant activities of the fruit extracts of several Crataegus taxa. South African Journal of Botany 124: 5-13. </span></span></span>, <span class="ref"><strong class="xref xrefblue">Lim <i>et al</i>. 2019</strong><span class="refCtt closed"><span>Lim, S., Choi, A.H., Kwon, M., Joung, E.J., Shin, T., Lee, S.G., Kim, NG. &amp; Kim, H. R. 2019. Evaluation of antioxidant activities of various solvent extract from Sargassum serratifolium and its major antioxidant components. Food Chemistry 278: 178-184.</span></span></span>; <span class="ref"><strong class="xref xrefblue">Neagu <i>et al</i>. 2016</strong><span class="refCtt closed"><span>Neagu, E., Radu, G.L., Albu, C., &amp; Paun, G. 2016. Antioxidant activity, acetylcholinesterase and tyrosinase inhibitory potential of Pulmonaria officinalis and Centarium umbellatum extracts. Saudi Journal of Biological Sciences, 3: 578-585.</span></span></span>).</p>
+                             <p>Por este motivo, a utilização de dietas ricas ou enriquecidas com antioxidantes podem prevenir, ou pelo menos amenizar, a deterioração orgânica por um excessivo estresse oxidativo. Além disso, o crescimento sobre a investigação científica envolvendo os efeitos antioxidantes de extratos brutos, frações purificadas, ou mesmo de compostos isolados, onde estão classificados os compostos fenólicos, são demonstrados em muitos estudos (<span class="ref"><strong class="xref xrefblue">Penido <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Penido, A.B., De Morais, S.M., Ribeiro, A.B., Alves, D.R., Rodrigues, A.L.M., dos Santos, L.H. &amp; de Menezes, J.E.S.A. 2017. Medicinal plants from northeastern Brazil against Alzheimer’s disease. Evidence-Based Complementary and Alternative Medicine 2017: 1-7. </span></span></span>, <span class="ref"><strong class="xref xrefblue">Morais <i>et al.</i> 2013</strong><span class="refCtt closed"><span>Morais, S.M., Lima, K.S.B., Siqueira, S.M.C., Cavalcanti, E.S.B., Souza, M.S.T., Menezes, J.E.S.A., Trevisan, M.T.S. 2013. Correlação entre as atividades antiradical, antiacetilcolinesterase e teor de fenóis totais de extratos de plantas medicinais de farmácias vivas. Revista Brasileira de Plantas Medicinais 15: 575-582. </span></span></span>).</p>
+                             <p>Desta forma, investigar a atividade antifúngica e anticolinesterásica de extratos de espécies de <i>Senna</i>, analisando o seu potencial antioxidante, o seu teor de fenóis totais e o seu perfil fitoquímico, são maneiras de promover tanto o conhecimento acerca dessas espécies, como também potencializar o descobrimento de novos fitofármacos para o combate de inúmeras enfermidades. Assim, este trabalho avaliou o perfil fitoquímico, o teor de fenóis totais e as atividades antioxidante, anticolinesterásica e antifúngica dos extratos etanólicos de <i>S. alata</i> (L.) Roxb., <i>S. obtusifolia</i> (L.) H.S.Irwin &amp; Barneby, <i>S. occidentalis</i> (L.) Link, <i>S. siamea</i> (Lam.) H.S.Irwin &amp; Barneby e <i>S. trachypus</i> (Benth.) H.S.Irwin &amp; Barneby, e a correlação entre o teor de fenóis totais e as atividades antioxidante e anticolinesterásica. </p>
+                             <h3 class="articleSectionTitle">Materiais e métodos</h3>
+                             <p>Material vegetal e preparação dos extratos - Foram selecionadas para este estudo cinco espécies de <i>Senna</i>, sendo uma exótica naturalizada e quatro nativas, das quais uma é endêmica do Brasil, ocorrendo no Cerrado e na Caatinga (<span class="ref"><strong class="xref xrefblue">BFG 2018</strong><span class="refCtt closed"><span>BFG. 2018. Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC). Rodriguésia 1513-1527. </span></span></span>) (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet1"><span class="material-icons-outlined">table_chart</span>Tabela 1</a>). As folhas e caules de <i>Senna</i> spp. foram coletados em diferentes locais da região Noroeste do Ceará. A identificação botânica das espécies foi realizada no Herbário Francisco José de Abreu Matos da Universidade Estadual Vale do Acaraú (HUVA), pelo professor Dr. Elnatan Bezerra de Souza. Para o preparo dos extratos, 200g das folhas e caule secos de cada espécie de um mesmo indivíduo foram triturados e imersos durante 10 dias em 500 mL de etanol e, na sequência o extrato foi filtrado e concentrado em um evaporador rotativo a (60°C) durante 2 h. Após este processo, foi mantido em banho-maria (40°C) até a eliminação total do solvente, obtendo-se o extrato etanólico das folhas (EEF) e extrato etanólico do caule (EEC) (<span class="ref"><strong class="xref xrefblue">Matos 2009</strong><span class="refCtt closed"><span>Matos, F.J.A. 2009. Introdução à Fitoquímica Experimental. 3 ed. Fortaleza: UFC. 150p.</span></span></span>).</p>
+                             <div>
+                                <div class="row table" id="t1">
+                                   <a name="t1"></a>
+                                   <div class="col-md-4 col-sm-4">
+                                      <a data-bs-toggle="modal" data-bs-target="#ModalTablet1">
+                                         <div class="thumbOff">
+                                            Thumbnail
+                                            <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                         </div>
+                                      </a>
+                                   </div>
+                                   <div class="col-md-8 col-sm-8">
+                                      <strong><strong>Tabela 1.</strong></strong><br> Identificação das espécies de <i>Senna</i> Mill. (Fabaceae) coletadas em diferentes locais da região noroeste do Estado do Ceará. <sup>*</sup>Exótica, <sup>**</sup>Endêmica do Brasil. Fonte: Herbário Francisco José de Abreu Matos (HUVA).<br>
+                                   </div>
+                                </div>
+                             </div>
+                             <p>Triagem fitoquímica - Os extratos etanólicos foram submetidos a triagem fitoquímica, tomando como referência a metodologia descrita por <span class="ref"><strong class="xref xrefblue">Matos (2009</strong><span class="refCtt closed"><span>Matos, F.J.A. 2009. Introdução à Fitoquímica Experimental. 3 ed. Fortaleza: UFC. 150p.</span></span></span>). Através deste ensaio preliminar, foi possível verificar as principais classes de metabólitos secundários por meio de reações químicas que resultaram no aparecimento de coloração e/ou precipitado, característico para cada classe de substância. Os ensaios foram conduzidos para as seguintes classes de substâncias: fenóis, taninos, flavonoides, saponinas, esteroides, triterpenoides e alcaloides. Todos os testes foram realizados em triplicata procedimentais. </p>
+                             <p>Determinação do teor de fenóis totais - O teor de fenóis totais nos extratos etanólicos foi determinado pelo método espectrofotométrico de Folin-Ciocateau, utilizando ácido gálico como padrão de referência (<span class="ref"><strong class="xref xrefblue">Kim <i>et al.</i> 2006</strong><span class="refCtt closed"><span>Kim, K.H., Tsao, R., Yang, R. &amp; Cui, S.W. 2006. Phenolic acid profiles and antioxidant activities of wheat bran extracts and the effect of hydrolysis conditions. Food Chemistry 95: 466-473.</span></span></span>). Em cada tubo adicionou-se 0,2 mL de cada extrato nas concentrações (0,62; 0,31 e 0,15 mg mL<sup>-1</sup>) com 1 mL do reagente Folin-Ciocalteau agitado por 2 minutos e adicionado 0,8 mL de carbonato de sódio (Na<sub>2</sub>CO<sub>3</sub>) 7,5% (m/v). Para o tubo controle foi utilizado 1 mL do reagente Folin- Ciocalteau com 0,8 mL de Na<sub>2</sub>CO<sub>3</sub> e 0,2 mL de etanol, em triplicata. Os tubos foram deixados em banho-maria a 37 ̊C por 30 minutos na ausência de luz. Logo em seguida, foi realizado a leitura dos tubos em comprimento de onda de 765 nm. O teor de fenóis foi calculado e expresso em mg de equivalente de ácido gálico por grama de extrato (EAG.g<sup>-1</sup>), com base numa curva padrão preparada com ácido gálico. Todos os testes foram realizados em triplicata.</p>
+                             <p>Atividade antioxidante - A atividade antioxidante dos extratos foi determinada pelo método de redução do radical 2,2’-difenil-1-picril-hidrazil (DPPH), segundo a metodologia modificada por <span class="ref"><strong class="xref xrefblue">Brand-Williams <i>et al.</i> (1995</strong><span class="refCtt closed"><span>Brand-Williams, W., Cuvelier, M.E. &amp; Berset, C.L.W.T. 1995. Use of a free radical method to evaluate antioxidant activity. LWT-Food Science and Technology 1: 25-30.</span></span></span>), <span class="ref"><strong class="xref xrefblue">Sanchez-Moreno <i>et al</i>. (1998</strong><span class="refCtt closed"><span>Sánchez‐Moreno, C., Larrauri, J.A. &amp; Saura‐Calixto, F. 1998. A procedure to measure the antiradical efficiency of polyphenols. Journal of the Science of Food and Agriculture 76: 270-276.</span></span></span>). Foram preparadas soluções etanólicas das amostras nas concentrações de 5,0; 2,5; 1,25; 0,62; 0,31 e 0,15 mg mL<sup>-1</sup>. Foram utilizados 100 µL dos extratos com 2,4 mL de DPPH (0,04 mg mL<sup>-1</sup>). Para o tubo controle foram utilizados 100 µL de etanol com 2,4 mL de DPPH em triplicata. O meio reacional ficou por 30 minutos na ausência da luz, e posteriormente foi realizada a leitura em comprimento de onda 515 nm. A atividade sequestradora do radical DPPH pelos extratos nas diferentes concentrações foi calculada pela expressão do índice de varredura em porcentagem (IV%): IV% = (Abs <sub>DPPH</sub> - Abs <sub>Amostra</sub> / Abs <sub>DPPH</sub>) x 100. A concentração efetiva para inibir 50% do radical livre DPPH (CE<sub>50</sub>) foi obtida com auxílio do Software Excel 2019, onde, a partir dos valores das concentrações finais da amostra e o índice de varredura (IV%), foram originados gráficos de dispersão cujas equações das retas foram utilizadas para se obter os valores da média e desvio padrão. Para fins de comparação, foi construída uma curva de calibração com diferentes porcentagens do flavonoide quercetina, que apresenta elevada atividade antioxidante em radical livre DPPH.</p>
+                             <p>Avaliação da atividade anticolinesterásica <i>in vitro</i> - O ensaio para verificação da inibição da enzima acetilcolinesterase (AChE) dos extratos foi realizado de acordo com a metodologia descrita por <span class="ref"><strong class="xref xrefblue">Ellman <i>et al.</i> (1961</strong><span class="refCtt closed"><span>Ellman, G.L., Courtney, K.D., Andres Jr, V. &amp; Featherstone, R.M. 1961. A new and rapid colorimetric determination of acetylcholinesterase activity. Biochemical Pharmacology: 7: 88-95.</span></span></span>). Em placas estéreis de 96 poços, foram adicionados 25 µL de iodeto de acetiltiocolina (15 mM), 125 µL de 5,5’-ditiobis-[2-nitrobenzóico] na solução Tris/HCL (50 nM, pH 8, com 0,1 M de NaCL e 0,02 M de MgCL<sub>2</sub> .6H<sub>2</sub>O. (3 mM, DTNB ou reagente de Ellman)), 50 µL da solução Tris/HCL (50 nM, pH 8, com 0,1% de albumina sérica bovina (BSA) e 25 µL dos extratos de <i>Senna</i> spp. na concentraçao de 0,2 mg.mL<sup>-1</sup> em tampão Tris/HCL (50 mM, pH 8) de 0,2 mg.mL<sup>-1</sup> (<span class="ref"><strong class="xref xrefblue">Rhee <i>et al.</i> 2001</strong><span class="refCtt closed"><span>Rhee, I.K., van de Meent, M., Ingkaninan, K. &amp; Verpoorte, R. 2001. Screening for acetylcholinesterase inhibitors from Amaryllidaceae using silica gel thin-layer chromatography in combination with bioactivity staining. Journal of Chromatography A 915: 217-223.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Trevisan <i>et al.</i> 2003</strong><span class="refCtt closed"><span>Trevisan, M.T.S., Macedo, F.V.V., Meent, M.V.D., Rhee, I.K. &amp; Verpoorte, R. 2003. Seleção de plantas com atividade anticolinesterase para tratamento da doença de Alzheimer. Química Nova 26: 301-304.</span></span></span>). </p>
+                             <p>A absorbância foi aferida a 405 nm durante 30 segundos. Em seguida, foram adicionados 25 µL da enzima acetilcolinesterase (0,25 U.mL<sup>-1</sup>) e a absorbância foi aferida por minuto até o total de 25 minutos de incubação da enzima. Como padrão negativo foram utilizadas todas as soluções, excetuando-se a amostra. O padrão utilizado como controle positivo foi a fisostigmina (0,22 mg.mL<sup>-1</sup>.) e todas as amostras foram analisadas em triplicata. A atividade anticolinesterásica dos extratos vegetais foi determinada de acordo com os valores de CI<sub>50</sub> (Concentração inibitória capaz de inibir 50% da enzima acetilcolinesterase) como: alta potência (CI<sub>50</sub> &lt; 20 μg. mL<sup>-1</sup>); potência moderada (20 &lt; CI<sub>50</sub> &lt; 200 μg.mL<sup>-1</sup>) e baixa potência (200 &lt; CI<sub>50</sub> &lt; 1000 μg.mL<sup>-1</sup>) (<span class="ref"><strong class="xref xrefblue">Santos <i>et al</i>. 2018</strong><span class="refCtt closed"><span>Santos, G.H.F., Amaral, A. &amp; Da Silva, E.B. 2018. Antibacterial activity of irradiated extracts of Anacardium occidentale L. on multiresistant strains of Staphylococcus aureus. Applied Radiation and Isotopes 140: 327-332.</span></span></span>).</p>
+                             <p>Ensaio antifúngico <i>in vitro</i> - No ensaio para verificação da concentração inibitória mínima (CIM) dos EE das espécies de <i>Senna</i>, foram utilizadas cepas de <i>Trichophyton rubrum</i> obtidas a partir da micoteca da Universidade Federal de Pernambuco e do Centro Especializado de Micologia Médica (CEMM) da Universidade Federal do Ceará<i>.</i> Para este ensaio foi utilizado o método de microdiluição em caldo<i>,</i> de acordo com a metodologia descrita por (<span class="ref"><strong class="xref xrefblue">Neves <i>et al.</i> 2019</strong><span class="refCtt closed"><span>Neves, A.M., Silva, H.S., Souza, E.B., Fontenelle, R.O.S., Silva, A.C.S., Morais, S.M. 2019. Perfil fitoquímico e avaliação da atividade antifúngica da fração hexânica de Mitracarpus baturitensis (Rubiaceae). Essentia 20: 96-101. </span></span></span>) com as normas do protocolo <span class="ref"><strong class="xref xrefblue">Clinical Laboratory Standards Insitute do documento M38-A (CLSI M38-A2, 2008</strong><span class="refCtt closed"><span>Clinical and Laboratory Standards Institute. 2008. Reference Method for Broth Dilution Antifungal Susceptibility Testing of Filamentous Fungi (Approved Standard Document M38. CLSI), vol. M38-A2, Second ed. Clinical and Laboratory Standards Institute, Wayne, PA.</span></span></span>)<i>.</i> Em placas de 96 poços estéreis, foram adicionados 100 µL de meio RPMI em todos os poços e 10 mg mL<sup>-1</sup> dos extratos de <i>Senna</i> spp. foi acrescentado a todos os poços da primeira coluna e, em sequência foram efetuadas as diluições seriadas. Finalmente, 100 µL do inóculo foi adicionado aos poços da placa. Como controle foi utilizado o Cetoconazol (Sigma, Chemical Co., USA). Para as análises de susceptibilidade, os extratos etanólicos foram testados em concentrações variando de 0,002 a 2,5 mg mL<sup>-1</sup>. As placas foram cobertas com parafilme e incubadas a 37 °C e a leitura visual foi realizada após cinco dias para <i>T. rubrum</i>. Procedimento realizado em duplicata. A CIM é definida como a menor concentração do extrato capaz de inibir 100% do crescimento fúngico visível (<span class="ref"><strong class="xref xrefblue">Fontenelle <i>et al.</i> 2007</strong><span class="refCtt closed"><span>Fontenelle, R.O.S., Morais, S.M., Brito, E.H.S., Kerntopf, M.R., Brilhante, R.S.N., Cordeiro, R.A., Tomé, A.R., Queiroz, M.G.R., Nascimento, N.R.F. &amp; Sidrim, J.J.C. 2007. Chemical composition, toxicological aspects and antifungal activity of essential oil from Lippia sidoides Cham. Journal of Antimicrobial Chemotherapy 59: 934-940. </span></span></span>). A concentração fungicida mínima (CFM) foi determinada por subcultura de 100 μL da solução de poços sem turbidez no meio Ágar Dextrose de Batata, a 28 °C. (<span class="ref"><strong class="xref xrefblue">Fontenelle <i>et al.</i> 2008</strong><span class="refCtt closed"><span>Fontenelle, R.O.S., Morais, S.M., Brito, E.H.S., Brilhante, R.S.N., Cordeiro, R.A., Nascimento, N.R.F., Kerntopf, M.R., Sidrim, J.J.C. &amp; Rocha, M.F.G. 2008. Antifungal activity of essential oils of Croton species from the Brazilian caatinga biome. Journal of Applied Microbiology 104: 1383-1390.</span></span></span>).</p>
+                             <p>Análise estatística - Todas as determinações foram realizadas em triplicata e todos os resultados foram apresentados como média ± desvio-padrão (DP). Foram realizadas análises de variância (ANOVA) com duas repetições e o Teste Tukey, ao nível de significância de 5%, usando programa Graph Pad Prism<sup>®</sup> v5.01 (GraphPadSoftware, San Diego, CA, E.U.A.). As diferenças entre as médias foram consideradas significativas quando o valor obtido para "<i>p</i>" foi menor que 0,05 (<i>p</i> &lt; 0,05). </p>
+                             <p>Para análises da correlação entre os dados, foi utilizado o coeficiente de correlação de Pearson no software Microsoft Excel 2019, a qual mede o grau da correlação linear entre duas variáveis quantitativas. A intensidade dessa correlação é dada pelo “r”, que é um índice adimensional com valores situados entre -1,0 e 1,0. Quando o valor de r estiver entre 0,00-0,19 a correlação é muito fraca; entre 0,20-0,39 é fraca; 0,40-0,59 é uma correlação moderada; entre 0,60-0,79 é forte e finalmente entre 0,80-1,0 diz-se que é uma correlação muito forte (<span class="ref"><strong class="xref xrefblue">Mukaka 2012</strong><span class="refCtt closed"><span>Mukaka, M.M. 2012. Statistics corner: A guide to appropriate use of correlation coefficient in medical research. Malawi Med J. 24:69-71.</span></span></span>).</p>
+                             <h3 class="articleSectionTitle">Resultados e discussão<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet3"><span class="material-icons-outlined">table_chart</span>Tabela 3</a></h3>
+                             <p>Os fito-constituintes ou fitoquímicos são compostos químicos que desempenham importantes funções nas plantas. A triagem fitoquímica em materiais vegetais é geralmente o ponto de partida para o isolamento e purificação de compostos naturais com bioatividade (<span class="ref"><strong class="xref xrefblue">Omoregie &amp; Oikeh 2015</strong><span class="refCtt closed"><span>Omoregie, E.S. &amp; Oikeh, E.I. 2015. Comparative studies on the phytochemical composition, phenolic content and antioxidant activities of methanol leaf extracts of Spondias mombin and Polyathia longifolia. Jordan Journal of Biological Sciences 147: 1-5.</span></span></span>). A triagem fitoquímica preliminar revelou a presença de fenóis, taninos, flavonoides e esteroides para todos os extratos estudados (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet2"><span class="material-icons-outlined">table_chart</span>Tabela 2</a>). Entretanto, a presença de saponinas foi constatada apenas no EEF e EEC de <i>S. alata</i> e no EEF de <i>S. trachypus</i>. Já os alcaloides foram encontrados exclusivamente no EEF de <i>S. alata</i> e nenhuma das espécies apresentou triterpenoides. </p>
+                             <div>
+                                <div class="row table" id="t2">
+                                   <a name="t2"></a>
+                                   <div class="col-md-4 col-sm-4">
+                                      <a data-bs-toggle="modal" data-bs-target="#ModalTablet2">
+                                         <div class="thumbOff">
+                                            Thumbnail
+                                            <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                         </div>
+                                      </a>
+                                   </div>
+                                   <div class="col-md-8 col-sm-8">
+                                      <strong><strong>Tablela 2</strong></strong><br> Triagem fitoquímica do EEF e do EEC de espécies de <i>Senna</i> Mill. (Fabaceae)<i>.</i> Presente: + Ausente: - EEF: Extrato etanólico da folha. EEC: Extrato etanólico do caule.<br>
+                                   </div>
+                                </div>
+                             </div>
+                             <p>Os metabólitos detectados nas espécies estudadas são consistentes com os metabólitos descritos na literatura para o gênero <i>Senna</i>, conhecido por apresentar flavonoides, alcaloides, taninos, esteroides e saponinas em sua composição (<span class="ref"><strong class="xref xrefblue">Onyegeme-Okerenta <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Onyegeme-Okerenta, B.M., Nwosu, T. &amp; Wegwu, M.O. 2017. Proximate and phytochemical composition of leaf extract of Senna alata (L) Roxb. Journal of Pharmacognosy and Phytochemistry 6: 320-326.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Ishaku <i>et al.</i> 2016</strong><span class="refCtt closed"><span>Ishaku, G.A., Arabo, A.A., Bassey, E.E., Uwem, A.A.U.M. &amp; Godwin, E.U. 2016. Physicochemical characterization and antibacterial activity of Senna occidentalis Linn. Journal of Chemistryand Chemical Sciences 6: 9-18. </span></span></span>, <span class="ref"><strong class="xref xrefblue">Silva <i>et al.</i> 2014</strong><span class="refCtt closed"><span>Silva, G.A., Monteiro, J.A., Ferreira, E.B., Fernandes, M.I.B., Pessoa, C.; Sampaio, C.G. &amp; Silva, M.G.V. 2014. Total phenolic content, antioxidant and anticancer activities of four species of Senna Mill. From northeast Brazil. Int. J. Pharm. Pharm. Sci 6: 199-202.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Sudi <i>et al</i>. 2011</strong><span class="refCtt closed"><span>Sudi, I.Y., Ksgbiya, D.M., Muluh, E.K. &amp; Clement, A. 2011. Nutritional and phytochemical screening of Senna obtusifolia indigenous to Mubi, Nigeria. Advances in Applied Science Research 2: 432-437.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Bukar <i>et al.</i> 2009</strong><span class="refCtt closed"><span>Bukar, A., Mukhtar, M. &amp; HASSAN, A. 2009. Phytochemical screening and antibacterial activity of leaf extracts of Senna siamea (Lam) on Pseudomonas aeruginosa. Bayero Journal of Pure and Applied Sciences 1: 139-142. </span></span></span>). É possível perceber que na análise de prospecção química dos extratos houve uma variação de metabólitos secundários. Este fato pode estar atribuído a vários fatores, entre eles estão as diferentes condições ambientais, tais como clima, radiação solar, nutrição mineral, sazonalidade, ritmo circadiano, temperatura, disponibilidade hídrica, e também os tipos de solvente e a metodologia empregada no processo de extração, que podem interferir consideravelmente no conteúdo de praticamente todas as classes de metabólitos secundários (<span class="ref"><strong class="xref xrefblue">Gomes <i>et al</i>. 2016</strong><span class="refCtt closed"><span>Gomes, E.M.C., Pena, R.D.C.M. &amp; da Silva, S.S.S.M. 2016. Composição fitoquímica e ação fungicida de extratos brutos de Cinnamomum zeylanicum sobre Quambalaria eucalypti. Biota Amazônia. 6: 54-58.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Bezerra <i>et al.</i> 2013</strong><span class="refCtt closed"><span>Bezerra, A.S., Nörnberg, J.L., Lima, F.O., Rosa, M.B.D. &amp; Carvalho, L.M.D. 2013. Parâmetros climáticos e variação de compostos fenólicos em cevada. Ciência Rural 9: 1546-1552.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Gobbo-Neto &amp; Lopes 2007</strong><span class="refCtt closed"><span>Gobbo-Neto, L. &amp; Lopes, N.P. 2007. Plantas medicinais: Fatores de influência no conteúdo de metabólitos secundários. Química Nova 30: 374-381.</span></span></span>).</p>
+                             <p>Os teores de fenóis totais apresentaram diferenças significativas entre os extratos etanólicos das diferentes partes e espécies vegetais estudadas (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet3"><span class="material-icons-outlined">table_chart</span>Tabela 3</a>). O conteúdo de fenóis totais para os EEF variou de 32,60 ± 0,53 a 184,8 ± 5,09 EAG/g, enquanto que para o EEC foram de 30,03± 1,00 a 191,3 ± 0,47 EAG/g. Os maiores níveis de fenóis totais foram detectados na espécie <i>S. trachypus</i>. Os dados da literatura sobre o conteúdo de compostos fenólicos obtidos a partir do extrato aquoso, etanólico e acetona da raiz de <i>S. alata</i>, apresentaram uma concentração de fenóis de 46,3, 78,21 e 21,42 mg EAG/g, respectivamente, e de flavonoides de 26,17, 39,29 e 9,65 mg de equivalente de quercetina por grama de extrato (EQ/g), respectivamente (<span class="ref"><strong class="xref xrefblue">Ita &amp; Ndukwe 2017</strong><span class="refCtt closed"><span>Ita, B.N., &amp; Ndukwe, G.I. Antioxidant activity of Senna alata root extracts. 2017. J Nat Prod Resour 3: 94-96. </span></span></span>). Já o extrato etanólico preparado a partir das folhas de <i>S. obtusifolia</i> por <span class="ref"><strong class="xref xrefblue">Ali <i>et al</i>. (2019</strong><span class="refCtt closed"><span>Ali, I., Yisa, J. &amp; Jacob, J.O. 2019. Corrosion inhibitory potential of ethanol extract of Senna obtusifolia on Mild Steel in 5M HCl. Journal of Chemical Society of Nigeria 44: 187-198. </span></span></span>), apresentou um teor de fenóis e de flavonoides de 14,39 mg/g e 2,85 mg/g, respectivamente, demonstrando possuir teor de compostos fenólicos inferior ao das mostras de <i>S. obtusifolia</i> encontradas no presente estudo. Além disso, o conteúdo de polifenóis encontrado no extrato etanólico e nas frações obtidas a partir das folhas de <i>S. occidentalis</i> por <span class="ref"><strong class="xref xrefblue">Yakubu <i>et al.</i> (2018</strong><span class="refCtt closed"><span>Yakubu, O.E., Otitoju, O., Imarenezor, E.P.K., Tatah, S.V. &amp; Habibu, B. 2018. Fractionation and determination of antioxidant activities, of the Leaves of Senna Occidentalis ethanol extract. Pharmacology, 6: 26-30.</span></span></span>) variou de 139 mg/mL a 206 mg/mL e de flavonoides de 104 a 142 mg/mL. Já para os extratos preparados a partir das folhas e casca do caule de <i>S. siamea</i> revelaram um teor de fenóis totais de 10,21 ± 0,25 g/g e 24,77 ± 0,15 g/g, respectivamente. Por outro lado, o teor de flavonoides foi de 0,08 ± 0,01 g/g para as folhagens, e de 0,04 ± 0,01 g/g para a casca do caule (<span class="ref"><strong class="xref xrefblue">Kwada &amp; Tella 2009</strong><span class="refCtt closed"><span>Kwada, A.D. &amp; Tella, I.O. 2009. Determination of infochemicals and the phytochemical screening of the foliage and stem-bark of Senna siamea (lam.) in Yola, Adamawa State. Journal of Medicinal Plants Research 3: 630-640.</span></span></span>). Para os extratos etanólicos das folhas e raízes de <i>S. trachypus</i> o teor de fenóis totais encontrado foi de 322,09 ± 2,83 EAG/g e de 1277,34 ± 79,54 EAG/g, respectivamente (<span class="ref"><strong class="xref xrefblue">Silva <i>et al.</i> 2014</strong><span class="refCtt closed"><span>Silva, G.A., Monteiro, J.A., Ferreira, E.B., Fernandes, M.I.B., Pessoa, C.; Sampaio, C.G. &amp; Silva, M.G.V. 2014. Total phenolic content, antioxidant and anticancer activities of four species of Senna Mill. From northeast Brazil. Int. J. Pharm. Pharm. Sci 6: 199-202.</span></span></span>).<i>Senna</i>.</p>
+                             <div>
+                                <div class="row table" id="t3">
+                                   <a name="t3"></a>
+                                   <div class="col-md-4 col-sm-4">
+                                      <a data-bs-toggle="modal" data-bs-target="#ModalTablet3">
+                                         <div class="thumbOff">
+                                            Thumbnail
+                                            <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                         </div>
+                                      </a>
+                                   </div>
+                                   <div class="col-md-8 col-sm-8">
+                                      <strong><strong>Table 3.</strong></strong><br> Teor de fenóis totais, atividade antioxidante e inibição da enzima acetilcolinesterase de espécies de Senna Mill. (Fabaceae).<br>
+                                   </div>
+                                </div>
+                             </div>
+                             <p>Os resultados da atividade antioxidante dos extratos de <i>Senna</i> spp. mostraram que os valores de CE<sub>50</sub> para o EEF variaram de 0,63 ± 0,01 a 8,20 ± 0,07 µg/mL, sendo o EEF de <i>S. trachypus</i> o que apresentou menor CE<sub>50</sub> com atividade antirradicalar superior ao da quercetina e, portanto, maior potencial antioxidante (<span class="ref"><strong class="xref xrefblue">Villano <i>et al</i>. 2007</strong><span class="refCtt closed"><span>Villano, D., Fernandez-Pachón, M.S., Moya, M.L., Troncoso, A.M. &amp; García-Parrilla, M.C. 2007. Radical scavenging ability of polyphenolic compounds towards DPPH free radical. Talanta, 71: 230-235. </span></span></span>). Já para o EEC os valores de CE<sub>50</sub> variaram de 0,83 ± 0,01 a 11,19 ± 0,15 µg/mL (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet3"><span class="material-icons-outlined">table_chart</span>Tabela 3</a>). Foi observado que o EEC de <i>S. siamea</i> apresentou capacidade antirradicalar próximo à quercetina. Semelhantes aos nossos resultados, estudos anteriores revelaram que as espécies de <i>S. alata, S. obtusifolia, S. occidentalis, S. siamea</i> e <i>S. trachypus</i>, apresentaram potencial antioxidante e que esta atividade está atribuída à presença de compostos fenólicos (<span class="ref"><strong class="xref xrefblue">Coelho <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Coelho, E.M.P., Barbosa, M.C., Mito, M.S., Mantovanelli, G.C., Oliveira, R.S., &amp; Ishii-Iwamoto, E.L. 2017. The activity of the antioxidant defense system of the weed species Senna obtusifolia L. and its resistance to allelochemical stress. Journal of Chemical Ecology 7: 725-738.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Ita &amp; Ndukwe 2017</strong><span class="refCtt closed"><span>Ita, B.N., &amp; Ndukwe, G.I. Antioxidant activity of Senna alata root extracts. 2017. J Nat Prod Resour 3: 94-96. </span></span></span>, <span class="ref"><strong class="xref xrefblue">Barnaby <i>et al.</i> 2016</strong><span class="refCtt closed"><span>Barnaby, A.G., Reid, R. &amp; Warren, D. 2016. Antioxidant activity, total phenolics and fatty acid profile of Delonix regia, Cassia fistula, Spathodea campanulata, Senna siamea and Tibouchina granulosa. J Anal Pharm Res 3: 00056.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Odeja <i>et al.</i> 2015</strong><span class="refCtt closed"><span>Odeja, O., Obi, G., Ogwuche, C.E., Elemike, E.E. &amp; Oderinlo, Y. 2015. Phytochemical Screening, Antioxidant and Antimicrobial activities of Senna occidentalis (L.) leaves Extract. Clinical Phytoscience 1: 1-6.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Silva <i>et al.</i> 2014</strong><span class="refCtt closed"><span>Silva, G.A., Monteiro, J.A., Ferreira, E.B., Fernandes, M.I.B., Pessoa, C.; Sampaio, C.G. &amp; Silva, M.G.V. 2014. Total phenolic content, antioxidant and anticancer activities of four species of Senna Mill. From northeast Brazil. Int. J. Pharm. Pharm. Sci 6: 199-202.</span></span></span>). </p>
+                             <p>Os resultados obtidos na análise de inibição da enzima acetilcolinesterase foram comparados ao do alcaloide fisostigmina que foi o primeiro inibidor descoberto. Os experimentos de inibição da enzima acetilcolinesterase <i>in vitro</i> para as espécies de <i>Senna</i> produziram apenas resultados com potência moderada (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet3"><span class="material-icons-outlined">table_chart</span>Tabela 3</a>). Relatos confirmam a atividade antiacetilcolinesterásica de vários taninos isolados do fruto <i>Terminalia chebula</i> Retz.<i>,</i> (Combretaceae) que exibiram um efeito de inibição contra a enzima acetilcolinesterase <i>in vitro</i> (<span class="ref"><strong class="xref xrefblue">Kim <i>et al.</i> 2018</strong><span class="refCtt closed"><span>Kim, M.S., Lee, D.Y., Sung, S.H. &amp; Jeon, W.K. 2018. Anti-cholinesterase activities of hydrolysable tannins and polyhydroxytriterpenoid derivatives from Terminalia chebula Retz. fruit. Fruit Rec Nat Prod 12: 284-289.</span></span></span>). Outros compostos, como saponinas, alcaloides e compostos fenólicos, também são relatados na literatura como inibidores da enzima acetilcolinesterase (<span class="ref"><strong class="xref xrefblue">Paiva <i>et al</i>. 2021</strong><span class="refCtt closed"><span>Paiva, J.R., Queiroz, S.A.S., Pereira, R.D.C.A., Ribeiro, P.R.V., Alves, F.E.G., Silva, L.M.A., Zocolo, G.J., Brito, E.S., Alves, D.R., Morais, S.M., Tavares, J., Pinto, F.C.L., Andrade, G.M., Pessoa, O.D.L., &amp; Canuto, K.M. 2021. Chemical composition and anticholinesterase activity of cultivated bulbs from Hippeastrum elegans, a potential tropical source of bioactive alkaloids. Phytochemistry Letters 43: 27-34.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Kozachok <i>et al</i>. 2020</strong><span class="refCtt closed"><span>Kozachok, S., Pecio, Ł., Orhan, I.E., Deniz, F.S.S., Marchyshyn, S., &amp; Oleszek, W. 2020. Reinvestigation of Herniaria glabra L. saponins and their biological activity. Phytochemistry 169: 112162.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Adedayo <i>et al</i>. 2015</strong><span class="refCtt closed"><span>Adedayo, B.C., Oboh, G., Oyeleye, S.I., Ejakpovi, I.I., Boligon, A.A., &amp; Athayde, M.L. 2015. Blanching alters the phenolic constituents and in vitro antioxidant and anticholinesterases properties of fireweed (Crassocephalum crepidioides). Journal of Taibah University Medical Sciences 10: 419-426.</span></span></span>). Estas classes de compostos foram detectadas na triagem fitoquímica, embora provavelmente as concentrações nos extratos eram muito baixas para dar resultados satisfatórios no ensaio. Os extratos foliares e do caule de <i>S. trachypus</i> apresentaram os valores mais satisfatórios de inibição da enzima acetilcolinesterase, indicando que o isolamento de metabólitos pode levar a potenciais agentes antiacetilcolinesterásicos. Na literatura, não foram encontrados estudos do potencial anticolinesterásico paras as espécies de <i>Senna</i> referenciadas, sendo este o primeiro relato de estudo de atividade de inibição para esta enzima. </p>
+                             <p>Para os extratos de <i>Senna</i> spp., foi observada forte correlação negativa entre os valores de fenóis totais e CE<sub>50</sub> (r = - 0,71), mostrando que quanto maior os teores de fenóis totais, menor a CE<sub>50</sub> e, consequentemente, maior o potencial antioxidante, uma vez que a CE<sub>50</sub> está inversamente relacionada à capacidade antioxidante de um composto (<span class="ref"><strong class="xref xrefblue">Villano <i>et al</i>. 2007</strong><span class="refCtt closed"><span>Villano, D., Fernandez-Pachón, M.S., Moya, M.L., Troncoso, A.M. &amp; García-Parrilla, M.C. 2007. Radical scavenging ability of polyphenolic compounds towards DPPH free radical. Talanta, 71: 230-235. </span></span></span>). Dentre os extratos analisados podemos observar na figura 1 o EEF de <i>S. trachypus.</i></p>
+                             <p>
+                             <div class="row fig" id="">
+                                <a name=""></a>
+                                <div class="col-md-4 col-sm-4">
+                                   <a href="" data-bs-toggle="modal" data-bs-target="#ModalFig">
+                                      <div class="thumbImg">
+                                         <img src="https://minio.scielo.br/documentstore/2236-8906/CwtYQgLwtLfnySNgLkWnYQg/f511ef871f25bcb6c6b2345e9787686c5bd6e963.jpg">
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8 col-sm-8">
+                                   <strong>Figura 1.</strong><br>Correlação entre o teor de fenóis totais e CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.<br>
+                                </div>
+                             </div>
+                             </p>
+                             <p>Na correlação da atividade de inibição da enzima acetilcolinesterase, representada pelo CI<sub>50</sub> com teor de fenóis totais, observou-se uma correlação muito forte (r = -0,84) entre estas duas variáveis, evidenciando que ambas são inversamente proporcionais entre si, ou seja, à medida que o teor de fenóis totais aumenta o valor de CI<sub>50</sub> diminui, como pode ser observado para o EEF de <i>S. occidentalis</i> (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Figura 2</a>). Isso demonstra que os compostos fenólicos podem ser determinantes nessa atividade, de modo que alguns estudos evidenciaram que flavonoides e outros compostos fenólicos possuem atividade anticolinesterásica (<span class="ref"><strong class="xref xrefblue">Amessis-Ouchemoukh <i>et al</i>. 2014</strong><span class="refCtt closed"><span>Amessis-Ouchemoukh, N., Madani, K., Falé, P.L., Serralheiro, M.L., Araújo, M.E.M. 2014. Antioxidant capacity and phenolic contents of some Mediterranean medicinal plants and their potential role in the inhibition of cyclooxygenase-1 and acetylcholinesterase activities. Industrial Crops and Products, 53: 6-15.</span></span></span>). </p>
+                             <p>
+                             <div class="row fig" id="f2">
+                                <a name="f2"></a>
+                                <div class="col-md-4 col-sm-4">
+                                   <a href="" data-bs-toggle="modal" data-bs-target="#ModalFigf2">
+                                      <div class="thumbImg">
+                                         <img src="2236-8906-hoehnea-49-e1112020-gf2.jpg">
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8 col-sm-8">
+                                   <strong>Figura 2.</strong><br>Correlação entre o teor de fenóis totais e CI50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.<br>
+                                </div>
+                             </div>
+                             </p>
+                             <p>Houve uma correlação moderada (r = 0,43) entre a CI<sub>50</sub> e a CE<sub>50</sub>. Analisando a <a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalFigf3"><span class="sci-ico-fileFigure"></span>figura 3</a>, é possível perceber que o EEF e EEC de <i>S. alata</i> e EEF de <i>S. obtusifolia</i> se destacam no gráfico<i>,</i> o que sugere uma grande capacidade dos antioxidantes, como os compostos fenólicos, presentes nos extratos analisados, de atuarem não só através da inibição da acetilcolinesterase (AChEI) mas também por mecanismos de redução de radicais livres.</p>
+                             <p>
+                             <div class="row fig" id="f3">
+                                <a name="f3"></a>
+                                <div class="col-md-4 col-sm-4">
+                                   <a href="" data-bs-toggle="modal" data-bs-target="#ModalFigf3">
+                                      <div class="thumbImg">
+                                         <img src="2236-8906-hoehnea-49-e1112020-gf3.jpg">
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8 col-sm-8">
+                                   <strong>Figura 3.</strong><br>Correlação entre CI50 e a CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.<br>
+                                </div>
+                             </div>
+                             </p>
+                             <p>Os extratos etanólicos das folhas e caule de <i>S. alata, S. obtusifolia, S. occidentalis</i> e <i>S. siamea,</i> apresentaram efeito inibitório contra algumas cepas de <i>T. rubrum</i>. A maioria dos extratos foram eficazes em diferentes concentrações, com CIM que variaram de 0,07 mg/mL à 2,5 mg/mL e CFM de 0,15 a 5,0 mg/mL contra a grande maioria das cepas fúngicas testadas. Dentre os extratos testados, os de <i>S. trachypus</i> foram eficazes contra todas as cepas de <i>T. rubrum</i> com CIM que variaram de 0,31 a 0,62 mg/mL e o CFM de 0,62 a 1,25 mg/mL, para ambos os extratos (<a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet4"><span class="material-icons-outlined">table_chart</span>Tabela 4</a>). A presença de compostos fitoquímicos tem sido associada às atividades antimicrobianas da maioria dos materiais vegetais. Algumas classes de metabólitos foram identificadas nesse estudo e podem ser associadas à atividade antimicrobiana (<span class="ref"><strong class="xref xrefblue">Santos <i>et al.</i> 2018</strong><span class="refCtt closed"><span>Santos, T.C.D., Gomes, T.M., Pinto, B.A.S., Camara, A.L. &amp; Paes, A.M.D.A. 2018. Naturally occurring acetylcholinesterase inhibitors and their potential use for Alzheimer's disease therapy. Frontiers in Pharmacology 9: 1192.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Odeja <i>et al.</i> 2015</strong><span class="refCtt closed"><span>Odeja, O., Obi, G., Ogwuche, C.E., Elemike, E.E. &amp; Oderinlo, Y. 2015. Phytochemical Screening, Antioxidant and Antimicrobial activities of Senna occidentalis (L.) leaves Extract. Clinical Phytoscience 1: 1-6.</span></span></span>). </p>
+                             <div>
+                                <div class="row table" id="t4">
+                                   <a name="t4"></a>
+                                   <div class="col-md-4 col-sm-4">
+                                      <a data-bs-toggle="modal" data-bs-target="#ModalTablet4">
+                                         <div class="thumbOff">
+                                            Thumbnail
+                                            <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                         </div>
+                                      </a>
+                                   </div>
+                                   <div class="col-md-8 col-sm-8">
+                                      <strong><strong>Tabela 4. </strong></strong><br> Concentração Inibitória Mínima (CIM) e Concentração Fungicida Mínima (CFM) de extratos etanólicos (EEs) de espécies de <i>Senna</i> Mill. (Fabaceae) frente às espécies de <i>Trichophyton rubrum</i>. LABIMIC: Laboratório de Microbiologia; EEF: Extrato etanólico da folha; EEC: Extrato etanólico do caule; NI: Não inibiu.<br>
+                                   </div>
+                                </div>
+                             </div>
+                             <p>Estudos anteriores realizados com o extrato etanólico da casca do caule de <i>S. alata</i> contra fungos dermatofíticos, entre eles espécies de <i>Trychophyton,</i> revelou um CIM de 5,0 mg/mL para todos os dermatófitos testados (<span class="ref"><strong class="xref xrefblue">Sule <i>et al.</i> 2011</strong><span class="refCtt closed"><span>Sule, W.F., Okonko, I.O., Omo-Ogun, S., Nwanze, J.C., Ojezele, M.O., Ojezele, O.J., Alli, J.A., Soyemi, E.T. &amp; Olaonipekun, T.O. 2011. Phytochemical properties and in-vitro antifungal activity of Senna alata Linn. crude stem bark extract. Journal of Medicinal Plants Research, 5: 176-183.</span></span></span>). A capacidade antifúngica de extratos de diferentes polaridades preparados a partir das folhas de <i>S. obtusifolia</i> apresentaram um CIM que variou de 500 a 2000 µg/mL contra diferentes espécies de fungos filamentosos (<span class="ref"><strong class="xref xrefblue">Doughari <i>et al.</i> 2008</strong><span class="refCtt closed"><span>Doughari, J.H., El-mahmood, A.M. &amp; Tyoyina, I. 2008. Antimicrobial activity of leaf extracts of Senna obtusifolia (L). African Journal of Pharmacy and Pharmacology 2: 7-13.</span></span></span>). Os resultados obtidos de extratos foliares de polaridades diferentes de <i>S. occidentalis</i> revelaram que o extrato metanólico mostrou maior atividade antifúngica entre os demais extratos testados, em uma concentração inibitória mínima de 25 mg/mL (<span class="ref"><strong class="xref xrefblue">Odeja <i>et al.</i> 2015</strong><span class="refCtt closed"><span>Odeja, O., Obi, G., Ogwuche, C.E., Elemike, E.E. &amp; Oderinlo, Y. 2015. Phytochemical Screening, Antioxidant and Antimicrobial activities of Senna occidentalis (L.) leaves Extract. Clinical Phytoscience 1: 1-6.</span></span></span>). Testes utilizando extratos preparados com solventes de diferentes polaridades a partir das folhas de <i>S. siamea</i> apresentaram CIM que variaram de 0,032 a 0,128 mg/mL contra o fungo <i>Cryptococcus gattii</i> (<span class="ref"><strong class="xref xrefblue">Nnadi <i>et al.</i> 2019</strong><span class="refCtt closed"><span>Nnadi, N.E., Anukam, N.C., Ayika, P.D., Rotdung, K., Gokum, S.S., Ayanbimpe, G.M., Nvau, J. &amp; Enweani, I. 2019. The in Vitro antifungal activity of some Nigeria medicinal plants against Cryptococcus gattii. IOSR Journal of Pharmacy 9: 16-24. </span></span></span>). Na literatura, não foram encontrados estudos do potencial antifúngico para a espécie de <i>S. trachypus</i>, sendo este o primeiro registro de atividade antifúngica para a referida espécie. </p>
+                             <p>Pesquisas têm revelado que o potencial antifúngico de extratos vegetais está intimamente relacionado, entre outros fatores, com as suas variações quantitativas de compostos fenólicos, dentre eles os flavonoides. Nosso estudo confirmou que as espécies estudadas possuem propriedades antifúngicas, e que seus efeitos sobre os dermatófitos fundamentam-se em seus teores de compostos fenólicos encontrados, e os demais outros metabólitos secundários aqui não estudados. Os efeitos antifúngicos atribuídos aos compostos fenólicos podem resultar na ruptura da membrana celular, ou ainda, inibir a divisão celular e o desenvolvimento das hifas por meio de genes específicos, além de interferir nas vias metabólicas e/ou induzir a apoptose por perturbar a homeostase redox (<span class="ref"><strong class="xref xrefblue">Lagrouh <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Lagrouh, F., Dakka, N. &amp; Bakri, Y. 2017.The antifungal activity of Moroccan plants and the mechanism of action of secondary metabolites from plants. Journal de Mycologie Medicale 27: 303-311.</span></span></span>, <span class="ref"><strong class="xref xrefblue">Mohamed <i>et al.</i> 2017</strong><span class="refCtt closed"><span>Mohamed, M.S., Saleh, A.M., Abdel-Farid, I.B. &amp; El-Naggar, S.A. 2017. Growth, hydrolases and ultrastructure of Fusarium oxysporum as affected by phenolic rich extracts from several xerophytic plants. Pesticide Biochemistry and Physiology 141: 57-64. </span></span></span>).</p>
+                             <p>Foram detectados, nos EEF e EEC das espécies de <i>Senna</i>, a presença de metabólitos secundários, alto teor de fenóis totais e capacidade antioxidante para todas as espécies, em especial <i>S. trachypus</i>. Para a atividade anticolinesterase apenas a espécie de <i>S. trachypus</i> manifestou uma melhor ação inibitória. Nas condições experimentais utilizadas, evidenciou-se atividade antifúngica das espécies frente a maioria dos dermatófitos testados, em especial os extratos de <i>S. trachypus</i>. Foi observada também correlação forte, muito forte e moderada entre as variáveis fenóis totais e atividade antioxidante, fenóis totais e antiacetilcolinesterase e atividade antioxidante e antiacetilcolinesterase, respectivamente<i>.</i> Os resultados apontam que <i>S. trachypus</i>, espécie endêmica da Caatinga, é a mais promissora entre todas as plantas estudadas, representando uma fonte potencial para a obtenção de compostos químicos úteis para estudos clínicos e farmacológicos, visando o desenvolvimento de novos agentes farmacológicos naturais. </p>
+                            -->
+                          </div>
+
+                          <!--
+                          <div class="articleSection" data-anchor="Agradecimentos">
+                             <h3 class="articleSectionTitle">Agradecimentos</h3>
+                             <p>Os autores agradecem a Universidade Estadual do Ceará (UECE) e a Universidade Estadual Vale do Acaraú (UVA) pelo apoio técnico, e a Fundação Cearense de Apoio ao Desenvolvimento Científico e Tecnológico (FUNCAP) pelo apoio financeiro concedido (processos PBI3-0139-00252.01.00/18; BP4-0172-00170.01.00/20). </p>
+                          </div>
+                          <div class="articleSection" data-anchor="Literatura citada">
+                             <h3 class="articleSectionTitle">Literatura citada</h3>
+                             <div class="ref-list">
+                                <ul class="refList">
+                                   <li>
+                                      <div>Ali, I., Yisa, J. &amp; Jacob, J.O. 2019. Corrosion inhibitory potential of ethanol extract of <i>Senna obtusifolia</i> on Mild Steel in 5M HCl. Journal of Chemical Society of Nigeria 44: 187-198. </div>
+                                   </li>
+                                   <li>
+                                      <div>Adedayo, B.C., Oboh, G., Oyeleye, S.I., Ejakpovi, I.I., Boligon, A.A., &amp; Athayde, M.L. 2015. Blanching alters the phenolic constituents and <i>in vitro</i> antioxidant and anticholinesterases properties of fireweed (<i>Crassocephalum crepidioides</i>). Journal of Taibah University Medical Sciences 10: 419-426.</div>
+                                   </li>
+                                   <li>
+                                      <div>Amessis-Ouchemoukh, N., Madani, K., Falé, P.L., Serralheiro, M.L., Araújo, M.E.M. 2014. Antioxidant capacity and phenolic contents of some Mediterranean medicinal plants and their potential role in the inhibition of cyclooxygenase-1 and acetylcholinesterase activities. Industrial Crops and Products, 53: 6-15.</div>
+                                   </li>
+                                   <li>
+                                      <div>Bardakci, H., CeleP, E., Gözet, T., Kan, Y. &amp; Kirmizibekmez, H. 2019. Phytochemical characterization and antioxidant activities of the fruit extracts of several <i>Crataegus taxa</i> South African Journal of Botany 124: 5-13. </div>
+                                   </li>
+                                   <li>
+                                      <div>Barnaby, A.G., Reid, R. &amp; Warren, D. 2016. Antioxidant activity, total phenolics and fatty acid profile of <i>Delonix regia</i>, <i>Cassia fistula</i>, <i>Spathodea campanulata</i>, <i>Senna siamea</i> and <i>Tibouchina granulosa</i> J Anal Pharm Res 3: 00056.</div>
+                                   </li>
+                                   <li>
+                                      <div>Bezerra, A.S., Nörnberg, J.L., Lima, F.O., Rosa, M.B.D. &amp; Carvalho, L.M.D. 2013. Parâmetros climáticos e variação de compostos fenólicos em cevada. Ciência Rural 9: 1546-1552.</div>
+                                   </li>
+                                   <li>
+                                      <div>BFG. 2018. Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC). Rodriguésia 1513-1527. </div>
+                                   </li>
+                                   <li>
+                                      <div>Bieski, I.G.C., Leonti, M., Arnason, J.T., Ferrier, J., Rapinski, M., Violante, I.M.P., Balogun,S.O., Pereira, J.F.C.A., Figueiredo, R.D.C.F., Lopes, C.R.A.S., Silva, D.R.D., Pacini, A., Albuquerque, U.P. &amp; Martins, D.T.D.O. 2015. Ethnobotanical study of medicinal plants by population of valley of Juruena region, legal amazon, Mato Grosso, Brazil. Journal of Ethnopharmacology 173: 383-423.</div>
+                                   </li>
+                                   <li>
+                                      <div>Brand-Williams, W., Cuvelier, M.E. &amp; Berset, C.L.W.T. 1995. Use of a free radical method to evaluate antioxidant activity. <i>LWT</i>-Food Science and Technology 1: 25-30.</div>
+                                   </li>
+                                   <li>
+                                      <div>Bukar, A., Mukhtar, M. &amp; HASSAN, A. 2009. Phytochemical screening and antibacterial activity of leaf extracts of <i>Senna siamea</i> (Lam) on <i>Pseudomonas aeruginosa</i> Bayero Journal of Pure and Applied Sciences 1: 139-142. </div>
+                                   </li>
+                                   <li>
+                                      <div>Coelho, E.M.P., Barbosa, M.C., Mito, M.S., Mantovanelli, G.C., Oliveira, R.S., &amp; Ishii-Iwamoto, E.L. 2017. The activity of the antioxidant defense system of the weed species <i>Senna obtusifolia</i> L. and its resistance to allelochemical stress. Journal of Chemical Ecology 7: 725-738.</div>
+                                   </li>
+                                   <li>
+                                      <div>Clinical and Laboratory Standards Institute. 2008. Reference Method for Broth Dilution Antifungal Susceptibility Testing of Filamentous Fungi (Approved Standard Document M38. CLSI), vol. M38-A2, Second ed. Clinical and Laboratory Standards Institute, Wayne, PA.</div>
+                                   </li>
+                                   <li>
+                                      <div>Doughari, J.H., El-mahmood, A.M. &amp; Tyoyina, I. 2008. Antimicrobial activity of leaf extracts of <i>Senna obtusifolia</i> (L). African Journal of Pharmacy and Pharmacology 2: 7-13.</div>
+                                   </li>
+                                   <li>
+                                      <div>Ellman, G.L., Courtney, K.D., Andres Jr, V. &amp; Featherstone, R.M. 1961. A new and rapid colorimetric determination of acetylcholinesterase activity. Biochemical Pharmacology: 7: 88-95.</div>
+                                   </li>
+                                   <li>
+                                      <div>Fontenelle, R.O.S., Morais, S.M., Brito, E.H.S., Brilhante, R.S.N., Cordeiro, R.A., Nascimento, N.R.F., Kerntopf, M.R., Sidrim, J.J.C. &amp; Rocha, M.F.G. 2008. Antifungal activity of essential oils of <i>Croton</i> species from the Brazilian caatinga biome. Journal of Applied Microbiology 104: 1383-1390.</div>
+                                   </li>
+                                   <li>
+                                      <div>Fontenelle, R.O.S., Morais, S.M., Brito, E.H.S., Kerntopf, M.R., Brilhante, R.S.N., Cordeiro, R.A., Tomé, A.R., Queiroz, M.G.R., Nascimento, N.R.F. &amp; Sidrim, J.J.C. 2007. Chemical composition, toxicological aspects and antifungal activity of essential oil from <i>Lippia sidoides</i> Cham. Journal of Antimicrobial Chemotherapy 59: 934-940. </div>
+                                   </li>
+                                   <li>
+                                      <div>Gobbo-Neto, L. &amp; Lopes, N.P. 2007. Plantas medicinais: Fatores de influência no conteúdo de metabólitos secundários. Química Nova 30: 374-381.</div>
+                                   </li>
+                                   <li>
+                                      <div>Gomes, E.M.C., Pena, R.D.C.M. &amp; da Silva, S.S.S.M. 2016. Composição fitoquímica e ação fungicida de extratos brutos de <i>Cinnamomum zeylanicum</i> sobre <i>Quambalaria eucalypti</i> Biota Amazônia. 6: 54-58.</div>
+                                   </li>
+                                   <li>
+                                      <div>Ishaku, G.A., Arabo, A.A., Bassey, E.E., Uwem, A.A.U.M. &amp; Godwin, E.U. 2016. Physicochemical characterization and antibacterial activity of <i>Senna occidentalis</i> Linn. Journal of Chemistryand Chemical Sciences 6: 9-18. </div>
+                                   </li>
+                                   <li>
+                                      <div>Ita, B.N., &amp; Ndukwe, G.I. Antioxidant activity of <i>Senna alata</i> root extracts. 2017. J Nat Prod Resour 3: 94-96. </div>
+                                   </li>
+                                   <li>
+                                      <div>Kabir, M.H., Hasan, N., Rahman, M.M., Rahman, M.A., Khan, J.A., Hoque, N.T., Bhuiyan, M.R.Q., Mou, S.M.; Jahan, R. &amp; Rahmatullah, M. 2014. A survey of medicinal plants used by the Deb barma clan of the Tripura tribe of Moulvibazar district, Bangladesh. Journal of Ethnobiology and Ethnomedicine 10: 1-19.</div>
+                                   </li>
+                                   <li>
+                                      <div>Kim, M.S., Lee, D.Y., Sung, S.H. &amp; Jeon, W.K. 2018. Anti-cholinesterase activities of hydrolysable tannins and polyhydroxytriterpenoid derivatives from <i>Terminalia chebula</i> Retz. fruit. Fruit Rec Nat Prod 12: 284-289.</div>
+                                   </li>
+                                   <li>
+                                      <div>Kim, K.H., Tsao, R., Yang, R. &amp; Cui, S.W. 2006. Phenolic acid profiles and antioxidant activities of wheat bran extracts and the effect of hydrolysis conditions. Food Chemistry 95: 466-473.</div>
+                                   </li>
+                                   <li>
+                                      <div>Kozachok, S., Pecio, Ł., Orhan, I.E., Deniz, F.S.S., Marchyshyn, S., &amp; Oleszek, W. 2020. Reinvestigation of <i>Herniaria glabra</i> L. saponins and their biological activity. Phytochemistry 169: 112162.</div>
+                                   </li>
+                                   <li>
+                                      <div>Kwada, A.D. &amp; Tella, I.O. 2009. Determination of infochemicals and the phytochemical screening of the foliage and stem-bark of <i>Senna siamea</i> (lam.) in Yola, Adamawa State. Journal of Medicinal Plants Research 3: 630-640.</div>
+                                   </li>
+                                   <li>
+                                      <div>Lagrouh, F., Dakka, N. &amp; Bakri, Y. 2017.The antifungal activity of Moroccan plants and the mechanism of action of secondary metabolites from plants. Journal de Mycologie Medicale 27: 303-311.</div>
+                                   </li>
+                                   <li>
+                                      <div>Lim, S., Choi, A.H., Kwon, M., Joung, E.J., Shin, T., Lee, S.G., Kim, NG. &amp; Kim, H. R. 2019. Evaluation of antioxidant activities of various solvent extract from <i>Sargassum serratifolium</i> and its major antioxidant components. Food Chemistry 278: 178-184.</div>
+                                   </li>
+                                   <li>
+                                      <div>Macedo, E.M., Alan, J.G., &amp; Silva, M.G.V. 2016. Quimiodiversidade e propriedades biofarmacológicas de espécies de Senna nativas do Nordeste do Brasil. Revista Virtual de Química 8: 169-195.</div>
+                                   </li>
+                                   <li>
+                                      <div>Matos, F.J.A. 2009. Introdução à Fitoquímica Experimental. 3 ed. Fortaleza: UFC. 150p.</div>
+                                   </li>
+                                   <li>
+                                      <div>Morais, S.M., Lima, K.S.B., Siqueira, S.M.C., Cavalcanti, E.S.B., Souza, M.S.T., Menezes, J.E.S.A., Trevisan, M.T.S. 2013. Correlação entre as atividades antiradical, antiacetilcolinesterase e teor de fenóis totais de extratos de plantas medicinais de farmácias vivas. Revista Brasileira de Plantas Medicinais 15: 575-582. </div>
+                                   </li>
+                                   <li>
+                                      <div>Mohamed, M.S., Saleh, A.M., Abdel-Farid, I.B. &amp; El-Naggar, S.A. 2017. Growth, hydrolases and ultrastructure of <i>Fusarium oxysporum</i> as affected by phenolic rich extracts from several xerophytic plants. Pesticide Biochemistry and Physiology 141: 57-64. </div>
+                                   </li>
+                                   <li>
+                                      <div>Mukaka, M.M. 2012. Statistics corner: A guide to appropriate use of correlation coefficient in medical research. Malawi Med J. 24:69-71.</div>
+                                   </li>
+                                   <li>
+                                      <div>Neves, A.M., Silva, H.S., Souza, E.B., Fontenelle, R.O.S., Silva, A.C.S., Morais, S.M. 2019. Perfil fitoquímico e avaliação da atividade antifúngica da fração hexânica de <i>Mitracarpus baturitensis</i> (Rubiaceae). Essentia 20: 96-101. </div>
+                                   </li>
+                                   <li>
+                                      <div>Neves, A.M., Costa, O.S., Coutinho, M.G.S., Souza, E.B., Santos, H.S., Silva, M.G.V. &amp; Fontenelle, R.O.S. 2017. Caracterização química e o potencial antimicrobiano de espécies do gênero <i>Senna</i> Mill (Fabaceae). Rev. Virtual Quim 9: 2506-2538.</div>
+                                   </li>
+                                   <li>
+                                      <div>Neagu, E., Radu, G.L., Albu, C., &amp; Paun, G. 2016. Antioxidant activity, acetylcholinesterase and tyrosinase inhibitory potential of <i>Pulmonaria officinalis</i> and <i>Centarium umbellatum</i> extracts. Saudi Journal of Biological Sciences, 3: 578-585.</div>
+                                   </li>
+                                   <li>
+                                      <div>Nnadi, N.E., Anukam, N.C., Ayika, P.D., Rotdung, K., Gokum, S.S., Ayanbimpe, G.M., Nvau, J. &amp; Enweani, I. 2019. The <i>in Vitro</i> antifungal activity of some Nigeria medicinal plants against <i>Cryptococcus gattii</i> IOSR Journal of Pharmacy 9: 16-24. </div>
+                                   </li>
+                                   <li>
+                                      <div>Odeja, O., Obi, G., Ogwuche, C.E., Elemike, E.E. &amp; Oderinlo, Y. 2015. Phytochemical Screening, Antioxidant and Antimicrobial activities of <i>Senna occidentalis</i> (L.) leaves Extract. Clinical Phytoscience 1: 1-6.</div>
+                                   </li>
+                                   <li>
+                                      <div>Onyegeme-Okerenta, B.M., Nwosu, T. &amp; Wegwu, M.O. 2017. Proximate and phytochemical composition of leaf extract of <i>Senna alata</i> (L) Roxb. Journal of Pharmacognosy and Phytochemistry 6: 320-326.</div>
+                                   </li>
+                                   <li>
+                                      <div>Omoregie, E.S. &amp; Oikeh, E.I. 2015. Comparative studies on the phytochemical composition, phenolic content and antioxidant activities of methanol leaf extracts of <i>Spondias mombin</i> and <i>Polyathia longifolia</i> Jordan Journal of Biological Sciences 147: 1-5.</div>
+                                   </li>
+                                   <li>
+                                      <div>Paiva, J.R., Queiroz, S.A.S., Pereira, R.D.C.A., Ribeiro, P.R.V., Alves, F.E.G., Silva, L.M.A., Zocolo, G.J., Brito, E.S., Alves, D.R., Morais, S.M., Tavares, J., Pinto, F.C.L., Andrade, G.M., Pessoa, O.D.L., &amp; Canuto, K.M. 2021. Chemical composition and anticholinesterase activity of cultivated bulbs from <i>Hippeastrum elegans</i>, a potential tropical source of bioactive alkaloids. Phytochemistry Letters 43: 27-34.</div>
+                                   </li>
+                                   <li>
+                                      <div>Pellerin, R.J., Waminal, N.E. &amp; Kim, H.H. 2019. FISH mapping of rDNA and telomeric repeats in 10 <i>Senna</i> species. Horticulture, Environment, and Biotechnology 60: 253-260.</div>
+                                   </li>
+                                   <li>
+                                      <div>Penido, A.B., De Morais, S.M., Ribeiro, A.B., Alves, D.R., Rodrigues, A.L.M., dos Santos, L.H. &amp; de Menezes, J.E.S.A. 2017. Medicinal plants from northeastern Brazil against Alzheimer’s disease. Evidence-Based Complementary and Alternative Medicine 2017: 1-7. </div>
+                                   </li>
+                                   <li>
+                                      <div>Queiroz, L.P. 2009. Leguminosas da Caatinga. Universidade Estadual de Feira de Santana, Feira de Santana, 467 p.</div>
+                                   </li>
+                                   <li>
+                                      <div>Rhee, I.K., van de Meent, M., Ingkaninan, K. &amp; Verpoorte, R. 2001. Screening for acetylcholinesterase inhibitors from Amaryllidaceae using silica gel thin-layer chromatography in combination with bioactivity staining. Journal of Chromatography A 915: 217-223.</div>
+                                   </li>
+                                   <li>
+                                      <div>Rodrigues, F.C., Dos Santos, A.T.L., Machado, A.J.T., Bezerra, C.F., de Freitas, T.S., Coutinho, H.D.M., Morais-Braga, M.F.B., Bezerra, J.W.A., Duarte, A.E., Kamdem, J.P., Boligon, A.A., Campos, M.M.A., Barros, L.M. 2019. Chemical composition and anti-<i>Candida</i> potencial of the extracts of <i>Tarenaya spinosa</i> (Jacq.) Raf.(Cleomaceae). Comparative immunology, microbiology and infectious diseases 64: 14-19.</div>
+                                   </li>
+                                   <li>
+                                      <div>Santos, G.H.F., Amaral, A. &amp; Da Silva, E.B. 2018. Antibacterial activity of irradiated extracts of <i>Anacardium occidentale</i> L. on multiresistant strains of <i>Staphylococcus aureus</i> Applied Radiation and Isotopes 140: 327-332.</div>
+                                   </li>
+                                   <li>
+                                      <div>Santos, T.C.D., Gomes, T.M., Pinto, B.A.S., Camara, A.L. &amp; Paes, A.M.D.A. 2018. Naturally occurring acetylcholinesterase inhibitors and their potential use for Alzheimer's disease therapy. Frontiers in Pharmacology 9: 1192.</div>
+                                   </li>
+                                   <li>
+                                      <div>Sánchez‐Moreno, C., Larrauri, J.A. &amp; Saura‐Calixto, F. 1998. A procedure to measure the antiradical efficiency of polyphenols. Journal of the Science of Food and Agriculture 76: 270-276.</div>
+                                   </li>
+                                   <li>
+                                      <div>Silva, G.A., Monteiro, J.A., Ferreira, E.B., Fernandes, M.I.B., Pessoa, C.; Sampaio, C.G. &amp; Silva, M.G.V. 2014. Total phenolic content, antioxidant and anticancer activities of four species of <i>Senna</i> Mill. From northeast Brazil. Int. J. Pharm. Pharm. Sci 6: 199-202.</div>
+                                   </li>
+                                   <li>
+                                      <div>Souza, V.C.; Bortoluzzi, R.L.C. 2015. <i>Senna</i> in Lista de Espécies da Flora do Brasil. Jardim Botânico do Rio de Janeiro. </div>
+                                   </li>
+                                   <li>
+                                      <div>Sudi, I.Y., Ksgbiya, D.M., Muluh, E.K. &amp; Clement, A. 2011. Nutritional and phytochemical screening of <i>Senna obtusifolia</i> indigenous to Mubi, Nigeria. Advances in Applied Science Research 2: 432-437.</div>
+                                   </li>
+                                   <li>
+                                      <div>Sule, W.F., Okonko, I.O., Omo-Ogun, S., Nwanze, J.C., Ojezele, M.O., Ojezele, O.J., Alli, J.A., Soyemi, E.T. &amp; Olaonipekun, T.O. 2011. Phytochemical properties and <i>in-vitro</i> antifungal activity of <i>Senna alata</i> Linn. crude stem bark extract. Journal of Medicinal Plants Research, 5: 176-183.</div>
+                                   </li>
+                                   <li>
+                                      <div>Souza, A.O. &amp; Silva, M.J. 2016. <i>Senna</i> (Leguminosae, Caesalpinioideae) na Floresta Nacional de Silvânia, Goiás, Brasil. Rodriguésia 67: 773-784. </div>
+                                   </li>
+                                   <li>
+                                      <div>Trevisan, M.T.S., Macedo, F.V.V., Meent, M.V.D., Rhee, I.K. &amp; Verpoorte, R. 2003. Seleção de plantas com atividade anticolinesterase para tratamento da doença de Alzheimer. Química Nova 26: 301-304.</div>
+                                   </li>
+                                   <li>
+                                      <div>Villano, D., Fernandez-Pachón, M.S., Moya, M.L., Troncoso, A.M. &amp; García-Parrilla, M.C. 2007. Radical scavenging ability of polyphenolic compounds towards DPPH free radical. Talanta, 71: 230-235. </div>
+                                   </li>
+                                   <li>
+                                      <div>Yakubu, O.E., Otitoju, O., Imarenezor, E.P.K., Tatah, S.V. &amp; Habibu, B. 2018. Fractionation and determination of antioxidant activities, of the Leaves of <i>Senna Occidentalis</i> ethanol extract. Pharmacology, 6: 26-30.</div>
+                                   </li>
+                                </ul>
+                             </div>
+                          </div>
+                          <div class="articleSection" data-anchor="Datas de Publicação ">
+                             <h3 class="articleSectionTitle">Datas de Publicação </h3>
+                             <div class="row">
+                                <div class="col-md-12 col-sm-12">
+                                   <ul class="articleTimeline">
+                                      <li>
+                                         <strong>Publicação nesta coleção</strong><br>21 Fev 2022
+                                      </li>
+                                      <li>
+                                         <strong>Data do Fascículo</strong><br>2022
+                                      </li>
+                                   </ul>
+                                </div>
+                             </div>
+                          </div>
+                          <div class="articleSection" data-anchor="Histórico">
+                             <h3 class="articleSectionTitle">Histórico</h3>
+                             <div class="row">
+                                <div class="col-md-12 col-sm-12">
+                                   <ul class="articleTimeline">
+                                      <li>
+                                         <strong>Recebido</strong><br>14 Out 2020
+                                      </li>
+                                      <li>
+                                         <strong>Aceito</strong><br>03 Dez 2021
+                                      </li>
+                                   </ul>
+                                </div>
+                             </div>
+                          </div>
+                          -->
+
+
+                          <!--
+                              Início referencias em modo leitura
+                          -->
+                          <div class="articleSection articleReferenceFootNotes" data-anchor="NotasRodape">
+                           <hr>
+                            <div class="row">
+                               <div class="col-md-12 col-sm-12">
+                                  <ol class="articleFootnotes">
+                                     <li>
+                                        <a class="" name="1_ref"></a>
+                                        Pellerin, R.J., Waminal, N.E. & Kim, H.H. 2019. FISH mapping of rDNA and telomeric repeats in 10 Senna species. Horticulture, Environment, and Biotechnology 60: 253-260. <a href="#refId_1">↩</a>
+                                     </li>
+                                     <li>
+                                        <a class="" name="2_ref"></a>
+                                        Queiroz, L.P. 2009. Leguminosas da Caatinga. Universidade Estadual de Feira de Santana, Feira de Santana, 467 p. <a href="#refId_2">↩</a>
+                                     </li>
+                                     <li>
+                                        <a class="" name="3_ref"></a>
+                                        Kim, M.S., Lee, D.Y., Sung, S.H. &amp; Jeon, W.K. 2018. Anti-cholinesterase activities of hydrolysable tannins and polyhydroxytriterpenoid derivatives from Terminalia chebula Retz. fruit. Fruit Rec Nat Prod 12: 284-289. <a href="#refId_3">↩</a>
+                                     </li>
+                                     <li>
+                                        <a class="" name="4_ref"></a>
+                                        Souza, A.O. &amp; Silva, M.J. 2016. Senna (Leguminosae, Caesalpinioideae) na Floresta Nacional de Silvânia, Goiás, Brasil. Rodriguésia 67: 773-784. <a href="#refId_4">↩</a>
+                                     </li>
+                                     <li>
+                                        <a class="" name="5_ref"></a>
+                                        BFG. 2018. Brazilian Flora 2020: Innovation and collaboration to meet Target 1 of the Global Strategy for Plant Conservation (GSPC). Rodriguésia 1513-1527. <a href="#refId_5">↩</a>
+                                     </li>
+                                  </ol>
+                               </div>
+                            </div>
+                         </div>
+                        <!--
+                            Fim referencias em modo leitura
+                        -->
+
+                          <section class="documentLicense">
+                             <div class="container-license">
+                                <div class="row">
+                                   <div class="col-sm-3 col-md-2"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title=""><img src="https://licensebuttons.net/l/by/4.0//88x31.png" alt="Creative Common - by 4.0 "></a></div>
+                                   <div class="col-sm-9 col-md-10"><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" title="">Este é um artigo publicado em acesso aberto sob uma licença Creative Commons</a></div>
+                                </div>
+                             </div>
+                          </section>
+                       </article>
+                    </div>
+                 </div>
+              </div>
+           </section>
+           <div class="modal fade ModalDefault ModalTutors" id="ModalTutors" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title">Sobre os autores</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <div class="info">
+                          <div class="tutors">
+                             <strong> Andréa Maria Neves </strong><strong>4</strong><br>
+                             <div> Universidade Estadual do Ceará, Centro de Ciências e Tecnologia, Programa de Pós-graduação em Biotecnologia, Avenida Doutor Silas Muguba, 1700, Itaperi, 60740-000 Fortaleza, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-7388-1844" class="btnContribLinks orcid">http://orcid.org/0000-0002-7388-1844</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Selene Maia de Morais </strong><br>
+                             <div> Universidade Estadual do Ceará, Centro de Ciências e Tecnologia, Programa de Pós-graduação em Biotecnologia, Avenida Doutor Silas Muguba, 1700, Itaperi, 60740-000 Fortaleza, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-2766-3790" class="btnContribLinks orcid">http://orcid.org/0000-0002-2766-3790</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Hélcio Silva dos Santos </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Exatas e Tecnologia, Curso de Química, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0001-5527-164X" class="btnContribLinks orcid">http://orcid.org/0000-0001-5527-164X</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Marcílio Matos Ferreira </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0003-2503-9772" class="btnContribLinks orcid">http://orcid.org/0000-0003-2503-9772</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Ricardo Carneiro Vera Cruz </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-2035-0425" class="btnContribLinks orcid">http://orcid.org/0000-0002-2035-0425</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Elnatan Bezerra de Souza </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-5222-4378" class="btnContribLinks orcid">http://orcid.org/0000-0002-5222-4378</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Lúcia Betânia da Silva Andrade </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-4384-5738" class="btnContribLinks orcid">http://orcid.org/0000-0002-4384-5738</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                          <div class="tutors">
+                             <strong> Raquel Oliveira dos Santos Fontenelle </strong><br>
+                             <div> Universidade Estadual Vale do Acaraú, Centro de Ciências Agrárias e Biológicas, Curso de Ciências Biológicas, Avenida da Universidade, 850, Betânia, 62040-370 Sobral, CE, Brasil</div>
+                             <ul class="md-list inline">
+                                <li><a href="http://orcid.org/0000-0002-8865-5954" class="btnContribLinks orcid">http://orcid.org/0000-0002-8865-5954</a></li>
+                             </ul>
+                             <div class="clearfix"></div>
+                          </div>
+                       </div>
+                       <div class="info">
+                          <h3><sup>4</sup></h3>
+                          Autor para correspondência: <a href="mailto:andreamarianeves@gmail.com">andreamarianeves@gmail.com</a>
+                       </div>
+                       <div class="info">
+                          <h3>Editora Associada:</h3>
+                          <div> Catarina Carvalho Nievola</div>
+                       </div>
+                       <div class="info">
+                          <h3>Contribuição dos autores</h3>
+                          <div>
+                             <b>Andréa Maria Neves:</b> Contribuição substancial em todas as etapas da pesquisa e para a confecção do manuscrito. <b>Selene Maia de Morais:</b> Contribuição na realização do teste de acetilcolinesterase; Contribuição na revisão crítica do manuscrito, agregando conteúdo intelectual. <b>Hélcio Silva dos Santos:</b> Contribuição na preparação dos extratos; Contribuição na revisão crítica do manuscrito, agregando conteúdo intelectual. <b>Marcílio Matos Ferreira:</b> Contribuição para a coleta das espécies e preparação dos extratos. <b>Ricardo Carneiro Vera Cruz:</b> Contribuição na realização dos testes fitoquímicos e quantificação de fenóis totais. <b>Elnatan Bezerra de Souza:</b> Contribuição na coleta e identificação das espécies; Contribuição na revisão crítica do manuscrito, agregando conteúdo intelectual. <b>Lúcia Betânia da Silva Andrade:</b> Contribuição na realização da atividade antioxidante, para a interpretação dos dados, e para revisão crítica, agregando conteúdo intelectual. <b>Raquel Oliveira dos Santos Fontenelle:</b> Contribuição nos testes antifúngicos e para revisão crítica, agregando conteúdo intelectual. 
+                          </div>
+                       </div>
+                       <div class="info">
+                          <h3>Conflitos de interesse</h3>
+                          <div> Os autores declaram não haver conflitos de interesse a informar.</div>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalDefault" id="ModalTablesFigures" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog">
+                 <div class="modal-content">
+          <div class="modal-header">
+              <h5 class="modal-title">Figuras | Tabelas</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <ul class="nav nav-tabs md-tabs" role="tablist">
+                          <li role="presentation" class="col-md-4 col-sm-4 active"><a href="#figures" aria-controls="figures" role="tab" data-toggle="tab">Figuras
+                             (3)
+                             </a>
+                          </li>
+                          <li role="presentation" class="col-md-4 col-sm-4 "><a href="#tables" aria-controls="tables" role="tab" data-toggle="tab">Tabelas
+                             (4)
+                             </a>
+                          </li>
+                       </ul>
+                       <div class="clearfix"></div>
+                       <div class="tab-content">
+                          <div role="tabpanel" class="tab-pane active" id="figures">
+                             <div class="row fig">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalFig">
+                                      <div class="thumbImg">
+                                         <img src="2236-8906-hoehnea-49-e1112020-gf1.jpg">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong>Figura 1.</strong><br>Correlação entre o teor de fenóis totais e CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.
+                                </div>
+                             </div>
+                             <div class="row fig">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalFigf2">
+                                      <div class="thumbImg">
+                                         <img src="2236-8906-hoehnea-49-e1112020-gf2.jpg">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong>Figura 2.</strong><br>Correlação entre o teor de fenóis totais e CI50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.
+                                </div>
+                             </div>
+                             <div class="row fig">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalFigf3">
+                                      <div class="thumbImg">
+                                         <img src="2236-8906-hoehnea-49-e1112020-gf3.jpg">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong>Figura 3.</strong><br>Correlação entre CI50 e a CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule.
+                                </div>
+                             </div>
+                          </div>
+                          <div role="tabpanel" class="tab-pane " id="tables">
+                             <div class="row table">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalTablet1">
+                                      <div class="thumbOff">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong><strong>Tabela 1.</strong></strong><br> Identificação das espécies de <i>Senna</i> Mill. (Fabaceae) coletadas em diferentes locais da região noroeste do Estado do Ceará. <sup>*</sup>Exótica, <sup>**</sup>Endêmica do Brasil. Fonte: Herbário Francisco José de Abreu Matos (HUVA).
+                                </div>
+                             </div>
+                             <div class="row table">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalTablet2">
+                                      <div class="thumbOff">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong><strong>Tablela 2</strong></strong><br> Triagem fitoquímica do EEF e do EEC de espécies de <i>Senna</i> Mill. (Fabaceae)<i>.</i> Presente: + Ausente: - EEF: Extrato etanólico da folha. EEC: Extrato etanólico do caule.
+                                </div>
+                             </div>
+                             <div class="row table">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalTablet3">
+                                      <div class="thumbOff">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong><strong>Table 3.</strong></strong><br> Teor de fenóis totais, atividade antioxidante e inibição da enzima acetilcolinesterase de espécies de Senna Mill. (Fabaceae).
+                                </div>
+                             </div>
+                             <div class="row table">
+                                <div class="col-md-4">
+                                   <a data-bs-toggle="modal" data-bs-target="#ModalTablet4">
+                                      <div class="thumbOff">
+                                         Thumbnail
+                                         <div class="zoom"><span class="material-icons-outlined">zoom_in</span></div>
+                                      </div>
+                                   </a>
+                                </div>
+                                <div class="col-md-8">
+                                   <strong><strong>Tabela 4. </strong></strong><br> Concentração Inibitória Mínima (CIM) e Concentração Fungicida Mínima (CFM) de extratos etanólicos (EEs) de espécies de <i>Senna</i> Mill. (Fabaceae) frente às espécies de <i>Trichophyton rubrum</i>. LABIMIC: Laboratório de Microbiologia; EEF: Extrato etanólico da folha; EEC: Extrato etanólico do caule; NI: Não inibiu.
+                                </div>
+                             </div>
+                          </div>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalFigs" id="ModalFig" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">image</span> Figura 1.   Correlação entre o teor de fenóis totais e CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule. <a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Abrir em nova janela" href="2236-8906-hoehnea-49-e1112020-gf1.jpg"><span class="material-icons-outlined">open_in_new</span></a></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <a href="2236-8906-hoehnea-49-e1112020-gf1.jpg"><img style="max-width:100%" src="https://minio.scielo.br/documentstore/2236-8906/CwtYQgLwtLfnySNgLkWnYQg/dda3af6106b7042314211cf0c687c0a6882d99dc.jpg"></a><small><a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalFigf1"><span class="sci-ico-fileFigure"></span>Figure 1</a>. Correlation between total phenol content and EC50 of Senna Mill species. (Fabaceae). Symbols filled: leaves. Hollow symbols: stem.</small>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalFigs" id="ModalFigf2" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">image</span> Figura 2.   Correlação entre o teor de fenóis totais e CI50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule. <a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Abrir em nova janela" href="2236-8906-hoehnea-49-e1112020-gf2.jpg"><span class="material-icons-outlined">open_in_new</span></a><br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <a href="2236-8906-hoehnea-49-e1112020-gf2.jpg"><img style="max-width:100%" src="2236-8906-hoehnea-49-e1112020-gf2.jpg"></a><small><a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalFigf2"><span class="sci-ico-fileFigure"></span>Figure 2</a>. Correlation between total phenol content and IC50 of Senna Mill species. (Fabaceae). Symbols filled: leaves. Hollow symbols: stem.</small>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalFigs" id="ModalFigf3" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+          <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">image</span> Figura 3.   Correlação entre CI50 e a CE50 de espécies de <i>Senna</i> Mill. (Fabaceae). Símbolos cheios: folhas. Símbolos vazados: caule. <a class="link-newWindow showTooltip" target="_blank" data-placement="left" title="Abrir em nova janela" href="2236-8906-hoehnea-49-e1112020-gf3.jpg"><span class="material-icons-outlined">open_in_new</span></a><br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <a href="2236-8906-hoehnea-49-e1112020-gf3.jpg"><img style="max-width:100%" src="2236-8906-hoehnea-49-e1112020-gf3.jpg"></a><small><a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalFigf3"><span class="sci-ico-fileFigure"></span>Figure 3</a>. Correlation between IC50 and EC50 of Senna Mill species. (Fabaceae). Symbols filled: leaves. Hollow symbols: stem.</small>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalTables" id="ModalTablet1" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">table_chart</span> <strong>Tabela 1.</strong>    Identificação das espécies de <i>Senna</i> Mill. (Fabaceae) coletadas em diferentes locais da região noroeste do Estado do Ceará. <sup>*</sup>Exótica, <sup>**</sup>Endêmica do Brasil. Fonte: Herbário Francisco José de Abreu Matos (HUVA).<br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <div class="table table-hover">
+                          <table>
+                             <colgroup>
+                                <col>
+                                <col>
+                                <col>
+                                <col>
+                             </colgroup>
+                             <thead>
+                                <tr>
+                                   <th align="left">Espécies</th>
+                                   <th align="left">Nome popular</th>
+                                   <th align="center">Local de coleta</th>
+                                   <th align="center">No. HUVA</th>
+                                </tr>
+                             </thead>
+                             <tbody>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. alata</i> (L.) Roxb.
+                                   </td>
+                                   <td align="left">fedegoso-gigante</td>
+                                   <td align="center">Sobral</td>
+                                   <td align="center">21547</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. obtusifolia</i> (L.) H.S.Irwin &amp; Barneby
+                                   </td>
+                                   <td align="left">fedegoso-brando</td>
+                                   <td align="center">Graça</td>
+                                   <td align="center">21775</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. occidentalis</i> (L.) Link
+                                   </td>
+                                   <td align="left">café-negro</td>
+                                   <td align="center">Graça</td>
+                                   <td align="center">21774</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. siamea</i> (Lam.) H.S.Irwin &amp; Barneby<sup>*</sup>
+                                   </td>
+                                   <td align="left">cássia-de-sião</td>
+                                   <td align="center">Sobral</td>
+                                   <td align="center">21578</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. trachypus</i> (Benth.) H.S.Irwin &amp; Barneby<sup>**</sup>
+                                   </td>
+                                   <td align="left">pau-de-besouro</td>
+                                   <td align="center">Graça</td>
+                                   <td align="center">21776</td>
+                                </tr>
+                             </tbody>
+                          </table>
+                       </div>
+                    </div>
+                    <div class="modal-footer">
+                       <div class="ref-list">
+                          <ul class="refList footnote">
+                             <li>
+                                <div>
+                                   <a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet1"><span class="material-icons-outlined">table_chart</span>Table 1</a>Identification of <i>Senna Senna</i> Mill. (Fabaceae) species collected in different locations in northwestern Ceará State. <sup>*</sup> Exotic, <sup>**</sup> Endemic to Brazil. Source: Herbário Francisco José de Abreu Matos (HUVA).
+                                </div>
+                             </li>
+                          </ul>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalTables" id="ModalTablet2" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">table_chart</span> <strong>Tablela 2</strong>    Triagem fitoquímica do EEF e do EEC de espécies de <i>Senna</i> Mill. (Fabaceae)<i>.</i> Presente: + Ausente: - EEF: Extrato etanólico da folha. EEC: Extrato etanólico do caule.<br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <div class="table table-hover">
+                          <table>
+                             <colgroup>
+                                <col span="11">
+                             </colgroup>
+                             <thead>
+                                <tr>
+                                   <th align="center" colspan="11">Espécies </th>
+                                </tr>
+                                <tr>
+                                   <th align="left">Metabólitos</th>
+                                   <th align="left" colspan="2"><i>S. alata</i></th>
+                                   <th align="left" colspan="2"><i>S. obtusifolia</i></th>
+                                   <th align="left" colspan="2"><i>S. occidentalis</i></th>
+                                   <th align="left" colspan="2"><i>S. siamea</i></th>
+                                   <th align="left" colspan="2"><i>S. trachypus</i></th>
+                                </tr>
+                                <tr>
+                                   <th align="left">Extratos</th>
+                                   <th align="left">EEF</th>
+                                   <th align="left">EEC</th>
+                                   <th align="left">EEF</th>
+                                   <th align="left">EEC</th>
+                                   <th align="left">EEF</th>
+                                   <th align="left">EEC</th>
+                                   <th align="left">EEF</th>
+                                   <th align="left">EEC</th>
+                                   <th align="left">EEF</th>
+                                   <th align="left">EEC</th>
+                                </tr>
+                             </thead>
+                             <tbody>
+                                <tr>
+                                   <td align="left">Flavonoides</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Fenóis</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Saponinas</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">+</td>
+                                   <td align="left">-</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Taninos</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Esteroides</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                   <td align="left">+</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Alcaloides</td>
+                                   <td align="left">+</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Triterpenoides</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                   <td align="left">-</td>
+                                </tr>
+                             </tbody>
+                          </table>
+                       </div>
+                    </div>
+                    <div class="modal-footer">
+                       <div class="ref-list">
+                          <ul class="refList footnote">
+                             <li>
+                                <div>
+                                   <a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet2"><span class="material-icons-outlined">table_chart</span>Table 2</a>. Phytochemical screening of EEF and EEC of <i>Senna</i> Mill. (Fabaceae) species. Present: + Absent: - EEF: Ethanol extract of the leaf. EEC: Ethanol extract from the stem.
+                                </div>
+                             </li>
+                          </ul>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalTables" id="ModalTablet3" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">table_chart</span> <strong>Table 3.</strong>    Teor de fenóis totais, atividade antioxidante e inibição da enzima acetilcolinesterase de espécies de Senna Mill. (Fabaceae).<br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <div class="table table-hover">
+                          <table>
+                             <colgroup>
+                                <col>
+                                <col span="2">
+                                <col span="2">
+                                <col span="2">
+                             </colgroup>
+                             <thead>
+                                <tr>
+                                   <th align="left" rowspan="2">Espécies</th>
+                                   <th align="center" colspan="2">Fenois<sup>1</sup> mg EAG.g<sup>-1</sup> de extrato </th>
+                                   <th align="center" colspan="2">DPPH<sup>2</sup> CE<sub>50</sub> (μg.mL<sup>-1</sup>)</th>
+                                   <th align="center" colspan="2"> AChEI<sup>3</sup> CI<sub>50</sub> (μg.mL<sup>-1</sup>)</th>
+                                </tr>
+                                <tr>
+                                   <th align="center">Média</th>
+                                   <th align="center">Despad</th>
+                                   <th align="center">Média</th>
+                                   <th align="center">Despad</th>
+                                   <th align="center">Média</th>
+                                   <th align="center">Despad</th>
+                                </tr>
+                             </thead>
+                             <tbody>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. alata</i> (Folhas)
+                                   </td>
+                                   <td align="center">53,76 <sup>f</sup></td>
+                                   <td align="center">± 0,74</td>
+                                   <td align="center">3,70 <sup>e</sup></td>
+                                   <td align="center">± 0,04</td>
+                                   <td align="center">49,42 <sup>f</sup></td>
+                                   <td align="center">± 0,02</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. alata</i> (Caule)
+                                   </td>
+                                   <td align="center">43,44 <sup>g</sup></td>
+                                   <td align="center">± 0,21</td>
+                                   <td align="center">5,41 <sup>c</sup></td>
+                                   <td align="center">± 0,06</td>
+                                   <td align="center">53,25 <sup>d</sup></td>
+                                   <td align="center">± 0,02</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. obtusifolia</i> (Folhas)
+                                   </td>
+                                   <td align="center">76,32 <sup>e</sup></td>
+                                   <td align="center">± 0,41</td>
+                                   <td align="center">4,24 <sup>d</sup></td>
+                                   <td align="center">± 0,06</td>
+                                   <td align="center">50,37 <sup>e</sup></td>
+                                   <td align="center">± 0,32</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. obtusifolia</i> (Caule)
+                                   </td>
+                                   <td align="center">86,20 <sup>d</sup></td>
+                                   <td align="center">± 0,99</td>
+                                   <td align="center">3,00 <sup>g</sup></td>
+                                   <td align="center">± 0,05</td>
+                                   <td align="center">56,90 <sup>c</sup></td>
+                                   <td align="center">± 0,02</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. occidentalis</i> (Folhas)
+                                   </td>
+                                   <td align="center">32,60 <sup>h</sup></td>
+                                   <td align="center">± 0,53</td>
+                                   <td align="center">8,20 <sup>b</sup></td>
+                                   <td align="center">± 0,07</td>
+                                   <td align="center">58,76 <sup>b</sup></td>
+                                   <td align="center">± 0,78</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. occidentalis</i> (Caule)
+                                   </td>
+                                   <td align="center">30,03 <sup>h</sup></td>
+                                   <td align="center">± 1,00</td>
+                                   <td align="center">11,19 <sup>a</sup></td>
+                                   <td align="center">± 0,15</td>
+                                   <td align="center">57,26 <sup>c</sup></td>
+                                   <td align="center">± 0,02</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. siamea</i> (Folhas)
+                                   </td>
+                                   <td align="center">51,73 <sup>f</sup></td>
+                                   <td align="center">± 0,85</td>
+                                   <td align="center">3,34 <sup>f</sup></td>
+                                   <td align="center">± 0,05</td>
+                                   <td align="center">59,77 <sup>a</sup></td>
+                                   <td align="center">± 0,26</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. siamea</i> (Caule)
+                                   </td>
+                                   <td align="center">111,7 <sup>c</sup></td>
+                                   <td align="center">± 3,43</td>
+                                   <td align="center">0,83 <sup>i</sup></td>
+                                   <td align="center">± 0,01</td>
+                                   <td align="center">59,52 <sup>ab</sup></td>
+                                   <td align="center">± 0,15</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. trachypus</i> (Folhas)
+                                   </td>
+                                   <td align="center">184,80 <sup>b</sup></td>
+                                   <td align="center">± 5,09</td>
+                                   <td align="center">0,63 <sup>k</sup></td>
+                                   <td align="center">± 0,01</td>
+                                   <td align="center">32,40 <sup>g</sup></td>
+                                   <td align="center">± 0,12</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">
+                                      <i>S. trachypus</i> (Caule)
+                                   </td>
+                                   <td align="center">191,3 <sup>a</sup></td>
+                                   <td align="center">± 0,47</td>
+                                   <td align="center">2,52 <sup>h</sup></td>
+                                   <td align="center">± 0,03</td>
+                                   <td align="center">31,44 <sup>h</sup></td>
+                                   <td align="center">± 0,14</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Quercetina</td>
+                                   <td align="center">-</td>
+                                   <td align="center">-</td>
+                                   <td align="center">1,03 <sup>i</sup></td>
+                                   <td align="center">± 0,00</td>
+                                   <td align="center">-</td>
+                                   <td align="center">-</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Fisiostigmina</td>
+                                   <td align="center">-</td>
+                                   <td align="center">-</td>
+                                   <td align="center">-</td>
+                                   <td align="center">-</td>
+                                   <td align="center">1,15 <sup>i</sup></td>
+                                   <td align="center">± 0,00</td>
+                                </tr>
+                             </tbody>
+                          </table>
+                       </div>
+                    </div>
+                    <div class="modal-footer">
+                       <div class="ref-list">
+                          <ul class="refList footnote">
+                             <li>
+                                <div>Total phenol content, antioxidant activity and acetylcholinesterase enzyme inhibition of <i>Senna</i> Mill. (Fabaceae) species. </div>
+                             </li>
+                             <li>
+                                <div>Todas as análises foram realizadas em triplicada e os resultados foram expressos como média ± desvio padrão. As diferenças entre os valores foram examinadas usando análise de variância (ANOVA) e os resultados foram comparados usando o teste de Tukey com 95% nível de confiança. Letras diferentes denotam diferença estatística entre os valores de cada coluna (p &lt; 0,05). <sup>1</sup>Miligrama equivalente ao Ácido Gálico por grama de extrato; <sup>2</sup>Concentração efetiva para inibir 50% do radical livre DPPH (2,2 -difenil-1-picril-hidrazil); <sup>3</sup>Concentração inibitória capaz de inibir 50% da acetilcolinesterase. (-) Testes não realizados.</div>
+                             </li>
+                             <li>
+                                <div>All analyzes were performed in triplicate and the results were expressed as mean ± standard deviation. The differences between the values ​​were examined using analysis of variance (ANOVA) and the results were compared using the Tukey test at 95% confidence level. Different letters denote statistical difference between the values ​​of each column (p &lt;0.05). <sup>1</sup> milligram Equivalent to Gallic Acid per gram of extract; <sup>2</sup>Effective concentration to inhibit 50% of the free radical DPPH (2,2 - diphenyl - 1 - picryl - hydrazil); <sup>3</sup>Inhibitory concentration capable of inhibiting 50% of acetylcholinesterase. (-) Tests not performed.</div>
+                             </li>
+                          </ul>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalTables" id="ModalTablet4" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog modal-lg">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title"><span class="material-icons-outlined">table_chart</span> <strong>Tabela 4. </strong>    Concentração Inibitória Mínima (CIM) e Concentração Fungicida Mínima (CFM) de extratos etanólicos (EEs) de espécies de <i>Senna</i> Mill. (Fabaceae) frente às espécies de <i>Trichophyton rubrum</i>. LABIMIC: Laboratório de Microbiologia; EEF: Extrato etanólico da folha; EEC: Extrato etanólico do caule; NI: Não inibiu.<br></h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+                       <div class="table table-hover">
+                          <table>
+                             <colgroup>
+                                <col>
+                                <col>
+                                <col span="2">
+                                <col span="2">
+                                <col span="2">
+                                <col span="2">
+                             </colgroup>
+                             <thead>
+                                <tr>
+                                   <th align="left" rowspan="4">Espécies</th>
+                                   <th align="center" rowspan="4">Extrato</th>
+                                   <th align="center" colspan="2"><i>T. rubrum</i></th>
+                                   <th align="center" colspan="2"><i>T. rubrum</i></th>
+                                   <th align="center" colspan="2"><i>T. rubrum</i></th>
+                                   <th align="center" colspan="2"><i>T. rubrum</i></th>
+                                </tr>
+                                <tr>
+                                   <th align="center" colspan="2">LABIMIC 5906 </th>
+                                   <th align="center" colspan="2">LABIMIC 6213 </th>
+                                   <th align="center" colspan="2">LABIMIC 6205 </th>
+                                   <th align="center" colspan="2">LABIMIC 6753 </th>
+                                </tr>
+                                <tr>
+                                   <th align="center">CIM</th>
+                                   <th align="center">CFM </th>
+                                   <th align="center">CIM </th>
+                                   <th align="center">CFM</th>
+                                   <th align="center">CIM</th>
+                                   <th align="center">CFM</th>
+                                   <th align="center">CIM</th>
+                                   <th align="center">CFM</th>
+                                </tr>
+                                <tr>
+                                   <th align="center" colspan="2">(mg/mL) </th>
+                                   <th align="center" colspan="2">(mg/mL) </th>
+                                   <th align="center" colspan="2">(mg/mL) </th>
+                                   <th align="center" colspan="2">(mg/mL) </th>
+                                </tr>
+                             </thead>
+                             <tbody>
+                                <tr>
+                                   <td align="left" rowspan="2"><i>S. alata</i></td>
+                                   <td align="center">EEF</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">5,0</td>
+                                </tr>
+                                <tr>
+                                   <td align="center">EEC</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">5,0</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                </tr>
+                                <tr>
+                                   <td align="left" rowspan="2"><i>S. obtusifolia</i></td>
+                                   <td align="center">EEF</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">5,0</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                </tr>
+                                <tr>
+                                   <td align="center">EEC</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                </tr>
+                                <tr>
+                                   <td align="left" rowspan="2"><i>S. occidentalis</i></td>
+                                   <td align="center">EEF</td>
+                                   <td align="center">0,07</td>
+                                   <td align="center">0,15</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                </tr>
+                                <tr>
+                                   <td align="center">EEC</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                </tr>
+                                <tr>
+                                   <td align="left" rowspan="2"><i>S. siamea</i></td>
+                                   <td align="center">EEF</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">2,5</td>
+                                </tr>
+                                <tr>
+                                   <td align="center">EEC</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">5,0</td>
+                                   <td align="center">NI</td>
+                                   <td align="center">-</td>
+                                   <td align="center">2,5</td>
+                                   <td align="center">5,0</td>
+                                </tr>
+                                <tr>
+                                   <td align="left" rowspan="2"><i>S. trachypus</i></td>
+                                   <td align="center">EEF</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                </tr>
+                                <tr>
+                                   <td align="center">EEC</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">1,25</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                   <td align="center">0,31</td>
+                                   <td align="center">0,62</td>
+                                </tr>
+                                <tr>
+                                   <td align="left">Cetoconazol</td>
+                                   <td align="center"> </td>
+                                   <td align="center">2,0</td>
+                                   <td align="center"> </td>
+                                   <td align="center">1,0</td>
+                                   <td align="center"> </td>
+                                   <td align="center">1,0</td>
+                                   <td align="center"> </td>
+                                   <td align="center">0,5</td>
+                                   <td align="center"> </td>
+                                </tr>
+                             </tbody>
+                          </table>
+                       </div>
+                    </div>
+                    <div class="modal-footer">
+                       <div class="ref-list">
+                          <ul class="refList footnote">
+                             <li>
+                                <div>
+                                   <a href="" class="open-asset-modal" data-bs-toggle="modal" data-bs-target="#ModalTablet4"><span class="material-icons-outlined">table_chart</span>Table 4</a>.  Minimum Inhibitory Concentration (MIC) and Minimum Fungicidal Concentration (MFC) of ethanolic extracts (EEs) from <i>Senna</i> Mill. LABIMIC: Microbiology Laboratory; EEF: Ethanol extract of the leaf; EEC: Ethanol extract from the stem; NI: It didn't inhibit. (Fabaceae) species compared to <i>Trichophyton rubrum</i> species.
+                                </div>
+                             </li>
+                          </ul>
+                       </div>
+                    </div>
+                 </div>
+              </div>
+           </div>
+           <div class="modal fade ModalDefault" id="ModalArticles" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog">
+                 <div class="modal-content">
+                    <div class="modal-header">
+              <h5 class="modal-title">Como citar</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+                    <div class="modal-body">
+              <p id="citation"></p>
+              <input id="citationCut" type="text" value="">
+              <!--
+              <a class="copyLink" data-clipboard-target="#citationCut">
+                  <span class="material-icons-outlined">content_copy</span>copiar
+              </a>
+              -->
+              <button type="button" class="btn btn-sm copyLink">copiar</button>
+          </div>
+                 </div>
+              </div>
+           </div>
+           <script type="text/javascript">
+              function currentDate() {
+              var today = new Date();
+              var months = ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
+              today.setTime(today.getTime());
+              return today.getDate() + " " + months[today.getMonth()] + " " + today.getFullYear();
+              }
+              var citation = 'Neves, Andréa Maria et al. Prospecção química, atividade antioxidante, anticolinesterásica e antifúngica de extratos etanólicos de espécies de Senna Mill. (Fabaceae). Hoehnea [online]. 2022, v. 49 [Acessado CURRENTDATE] , e1112020. Disponível em: &lt;https://doi.org/10.1590/2236-8906-111/2020&gt;. Epub 21 Fev 2022. ISSN 2236-8906. https://doi.org/10.1590/2236-8906-111/2020.'.replace('CURRENTDATE', currentDate());
+              document.getElementById('citation').innerHTML = citation;
+              document.getElementById('citationCut').value = citation.replace('&lt;', '<').replace('&gt;', ">");
+           </script>
+        </div>
+        <ul class="scielo__floatingMenu fm-slidein" data-fm-toogle="hover">
+           <li class="fm-wrap">
+              <a href="javascript:;" class="fm-button-main"><span class="sci-ico-floatingMenuDefault glyphFloatMenu"></span><span class="sci-ico-floatingMenuClose glyphFloatMenu"></span></a>
+              <ul class="fm-list">
+                 <li><a class="fm-button-child" data-fm-label="Figuras | Tabelas" data-bs-toggle="modal" data-bs-target="#ModalTablesFigures"><span class="sci-ico-figures glyphFloatMenu"></span></a></li>
+                 <li><a class="fm-button-child" data-bs-toggle="modal" data-bs-target="#ModalArticles" data-fm-label="How to
+                    cite"><span class="sci-ico-citation glyphFloatMenu"></span></a></li>
+              </ul>
+           </li>
+        </ul>
+
+        
+        <!--=include ./_parts/_scripts.html -->
+
+        <script>
+              /*
+            Comportamento com foco em link com a classe copylink
+            - prever elementos diferente de botoes na hora de criar o js genérico
+            */
+            var linkTrigger = document.querySelector('a.copyLink');
+
+            linkTrigger.addEventListener('click', function () {
+                this.classList.add('copyFeedback');
+
+                setTimeout(function() {
+                    linkTrigger.classList.remove('copyFeedback');
+                },2000);
+            });
+        </script>
+
+         <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+         <script type="text/javascript" src="https://scielo.parati.design/aberto-ds-scielo/dist/js/bootstrap.bundle.min.js"></script>
+        
+         <script>
+            $(document).ready(function(){
+               
+               
+               // inicia tooltip bootstrap 5
+               var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+               var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+                  return new bootstrap.Tooltip(tooltipTriggerEl)
+               })
+            
+               var RefToolTip = {
+
+                     open: function(t) {
+
+                        var s = $(".xref",t),
+                           d = s.next("span:eq(0)")
+                           p = t.position(),
+                           supHeight = s.outerHeight(),
+                           supPositionLeft = p.left,
+                           li = t.closest("li"),
+
+                           refTxt = s.parent().find("sup a").attr("title");
+
+                           s.parent().append("<span class='refCtt closed'><span>" + refTxt + "</span></span>");
+
+                        if(li.length > 0)
+                           li.addClass("zindexFix");
+                        
+                        s.parent().find(".refCtt").removeClass("closed").addClass("opened").css({
+                           "left": (supPositionLeft > 300) ? (-supPositionLeft/3) : 0
+                        }).fadeIn("fast");
+
+                     },
+                     close: function(t) {
+
+                        var s = $(".xref",t),
+                           d = s.next("span:eq(0)"),
+                           li = t.closest("li");
+
+                        if(li.length > 0)
+                           li.removeClass("zindexFix");
+
+                        s.parent().find(".refCtt").removeClass("opened").addClass("closed");
+                        s.parent().find(".refCtt").remove();
+                     }
+               };
+
+               // Tablet or Mobile
+               $(".ref").on("mouseenter mouseleave",function(e) {
+                     e.preventDefault();
+
+                     var t = $(this);
+
+                     if(e.type === "mouseenter") {
+
+                        RefToolTip.open(t);
+
+                     } else {
+
+                        RefToolTip.close(t);
+                     }
+               });
+            });
+
+            
+         </script>
+     </body>
+</html>

--- a/tests/fixtures/htmlgenerator/affiliations/artigo-ref-rascunho.html
+++ b/tests/fixtures/htmlgenerator/affiliations/artigo-ref-rascunho.html
@@ -1633,7 +1633,7 @@
          <script>
             $(document).ready(function(){
                
-               
+                
                // inicia tooltip bootstrap 5
                var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
                var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona um template (artigo-ref-rascunho.html) que contém instruções de como deve ser feita a alteração das referencias do corpo do artigo para que este passe a funcionar corretamente quando estiver no modo leitura do firefox.

Leia a explicação abaixo:
Arquivo:
htmlgenerator/affiliations/artigo-ref-rascunho.html

Linhas:
a partir da linha 254.

Explicação:
A partira da linha 254 inicia o parágrafo da introdução. Nesa único parágrafo que está visivel ao abrir o documento existem algumas referências.

Ao visualizar o código é possível observar que há alguns comentários indicados com as pontuações #1, #2...

Os códigos comentados mostram a forma antiga de como a referência é exibida no corpo do artigo. Logo abaixo está a forma nova sugerida. Essa nova forma remove o conteúdo da referência do corpo do html mas a mantém no title. 

O que deve ser feito pela equipe SciELO?
Substituir a forma antiga da inclusão da referência pela nova.
Deve ser criado um script que passe por todas as referencias e substitua a forma antiga pela nova. Além da substituição é importante observar que é colocado um id #refId_1, #refId_2... no novo código. Esse id é responsável pela ancoragem da lista de referencias para o corpo do texto.

Outro ponto importante é que deve ser criada dinamicamente uma lista contendo as referências. Dessa forma, ao clicar sobre a referência em modo leitura, é feita a ancoragem para o item da lista e do item da lista novamente para o corpo do texto.
No arquivo artigo-ref-rascunho.html que é usado como exemplo aqui, a lista está localizada a partir da linha 653.


Pontos importantes:

1 - A lista que deve ser criada ficará visível somente em modo leitura. Isso é possível através da classe .articleReferenceFootNotes que está colocada no div articleSection (linha 653) que contém toda a lista. Essa classe CSS estará inserida diretamente no design system, não se fazendo necessário manter sua criação conforme consta nesse documento (artigo-ref-rascunho.html - linha 15) de exemplo.
*Para que seja possível testar, mantenha as classes CSS criadas das linhas 11 até 28 pois estas ainda não estão inseridas na última versão do scielo-design-system disponível para download. 

2 - Por se tratar de um arquivo de exemplo, este contém scrits javascript necessários para exibir o bom funcionamento dos tooltips a fim de se fazer entender o funcionamento do ajuste. Estes scripts javascript estarão inseridos nos devidos scripts do design system e portanto não devem estar no corpo do artigo.

3 - Esta tarefa consiste apenas em substituir a forma antigo da chamada das referências e em criar a lista das referencias no final do artigo para que possam ser feitas as ancoragens tanto da referencia para a lista quanto da lista para a referencia no corpo do artigo.

#### Onde a revisão poderia começar?
htmlgenerator/affiliations/artigo-ref-rascunho.html

Acesse o arquivo citado acima no firefox para ver o comportamento em ação.
O arquivo apresentará apenas um parágrafo de texto no grupo introdução. Estas referencias mostradas nesse parágrafo devem ser exibidas normalmente no evento de mouseover quando estiver no modo padrão. 
Para acessar o modo somente leitura do firefox, clique no ícone existente no lado direito da barra de endereços no navegador firefox.
Ao ativar o modo somente leitura será possível ver que as referencias do parágrafo introdução serão adicionado por um item sup 1, 2, 3... contendo um link que ancorará para o item de lista específico da referencia.

#### Como este poderia ser testado manualmente?
Siga os passos já citados anteriormente.

#### Algum cenário de contexto que queira dar?
Leia atentamente os textos colocado aqui neste PR a fim de entender o contexto de testes.

### Screenshots
modo padrão
![Screen Shot 2022-12-14 at 14 19 24](https://user-images.githubusercontent.com/22373640/207663503-35a09938-5bb7-4071-bba6-991a3003743e.png)

modo leitura
![Screen Shot 2022-12-14 at 14 19 02](https://user-images.githubusercontent.com/22373640/207663550-36377a84-c466-455a-a7df-e6526e80bb09.png)


#### Quais são tickets relevantes?
#2512
https://github.com/scieloorg/opac/issues/2512

### Referências
[Indique as referências utilizadas para a elaboração do pull request.](https://trilux.org/2022/11/tipografia-cms-axe-e-o-tema-rocket.html#4_tipografia-cms-axe-e-o-tema-rocket)

