### PR TITLE
Article license

### DIFF
--- a/packtools/sps/models/article_license.py
+++ b/packtools/sps/models/article_license.py
@@ -26,23 +26,20 @@ class ArticleLicense:
         self.xmltree = xmltree
 
     @property
-    def link(self):
-        _links = []
-        for _link in self.xmltree.xpath('//article-meta//permissions//license'):
-            d = {
-                'text': _link.attrib.get('{http://www.w3.org/1999/xlink}href'),
-                'lang': _link.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
-            }
-            _links.append(d)
-        return _links
-
-    @property
-    def license_p(self):
+    def licenses(self):
         _licenses = []
         for _license in self.xmltree.xpath('//article-meta//permissions//license'):
             d = {
-                'text': _license.find('license-p').text,
-                'lang': _license.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
+                'lang': _license.attrib.get('{http://www.w3.org/XML/1998/namespace}lang'),
+                'link': _license.attrib.get('{http://www.w3.org/1999/xlink}href'),
+                'licence_p': _license.find('license-p').text
             }
             _licenses.append(d)
         return _licenses
+
+    @property
+    def licenses_by_lang(self):
+        return {
+            item['lang']: item
+            for item in self.licenses
+        }

--- a/packtools/sps/models/article_license.py
+++ b/packtools/sps/models/article_license.py
@@ -1,0 +1,48 @@
+"""
+<article-meta>
+    <permissions>
+        <license license-type="open-access"
+                 xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                 xml:lang="en">
+            <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+        </license>
+        <license license-type="open-access"
+                 xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                 xml:lang="pt">
+            <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+        </license>
+        <license license-type="open-access"
+                 xlink:href="http://creativecommons.org/licenses/by/4.0/"
+                 xml:lang="es">
+            <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+        </license>
+    </permissions>
+</article-meta>
+"""
+
+
+class ArticleLicense:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def link(self):
+        _links = []
+        for _link in self.xmltree.xpath('//article-meta//permissions//license'):
+            d = {
+                'text': _link.attrib.get('{http://www.w3.org/1999/xlink}href'),
+                'lang': _link.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
+            }
+            _links.append(d)
+        return _links
+
+    @property
+    def license_p(self):
+        _licenses = []
+        for _license in self.xmltree.xpath('//article-meta//permissions//license'):
+            d = {
+                'text': _license.find('license-p').text,
+                'lang': _license.attrib.get('{http://www.w3.org/XML/1998/namespace}lang')
+            }
+            _licenses.append(d)
+        return _licenses

--- a/packtools/sps/validation/article_license.py
+++ b/packtools/sps/validation/article_license.py
@@ -30,19 +30,18 @@ class ArticleLicenseValidation:
         })
         return resp
 
-    def validate_license_code(self, expected_value):
+    def validate_license_code(self, expected_code, expected_version):
         links = self.article_license.licenses
         codes = []
         for code in links:
-            finding = code['link'].find('/by/')
-            if finding:
-                version = code['link'][finding + 4:finding + 7]
-                codes.append(('by', version))
+            finding = code['link'].find(f'/{expected_code}/{expected_version}')
+            if finding != -1:
+                codes.append((expected_code, expected_version))
         resp = {
                     "obtained_value": codes,
-                    "expected_value": expected_value
+                    "expected_value": (expected_code, expected_version)
         }
-        if expected_value in codes:
+        if (expected_code, expected_version) in codes:
             resp.update({
                 "result": "ok"
             })

--- a/packtools/sps/validation/article_license.py
+++ b/packtools/sps/validation/article_license.py
@@ -31,23 +31,19 @@ class ArticleLicenseValidation:
         return resp
 
     def validate_license_code(self, expected_code, expected_version):
-        links = self.article_license.licenses
-        codes = []
-        for code in links:
-            finding = code['link'].find(f'/{expected_code}/{expected_version}')
-            if finding != -1:
-                codes.append((expected_code, expected_version))
-        resp = {
-                    "obtained_value": codes,
-                    "expected_value": (expected_code, expected_version)
-        }
-        if (expected_code, expected_version) in codes:
-            resp.update({
-                "result": "ok"
-            })
-        else:
-            resp.update({
-                "result": "error",
-                "message": "the license code provided do not match the ones found"
-            })
+        resp = []
+        for license in self.article_license.licenses:
+            if f'/{expected_code}/{expected_version}' in license['link']:
+                resp.append({
+                    "obtained_value": (expected_code, expected_version),
+                    "expected_value": (expected_code, expected_version),
+                    "result": "ok"
+                })
+            else:
+                resp.append({
+                    "obtained_value": (),
+                    "expected_value": (expected_code, expected_version),
+                    "result": "error",
+                    "message": "the license code provided do not match the ones found"
+                })
         return resp

--- a/packtools/sps/validation/article_license.py
+++ b/packtools/sps/validation/article_license.py
@@ -1,0 +1,45 @@
+from packtools.sps.models.article_license import ArticleLicense
+
+
+class ArticleLicenseValidation:
+    def __init__(self, xmltree):
+        self.article_license = ArticleLicense(xmltree)
+
+    def validate_license(self, expected_value):
+        obtained_value = self.article_license.license_p
+        resp = {
+            "obtained_value": obtained_value,
+            "expected_value": expected_value
+        }
+        if obtained_value == expected_value:
+            resp.update({
+                "result": "ok"
+            })
+        else:
+            resp.update({
+                "result": "error",
+                "message": "the license text does not match the license text adopted by the journal"
+            })
+        return resp
+
+    def validate_license_code(self, expected_value):
+        links = self.article_license.link
+        codes = []
+        for code in links:
+            start_code = code['text'].find('/by/') + 4
+            end_code = start_code + 3
+            codes.append((code['text'][start_code:end_code]))
+        resp = {
+                    "obtained_value": codes,
+                    "expected_value": expected_value
+        }
+        if codes == expected_value:
+            resp.update({
+                "result": "ok"
+            })
+        else:
+            resp.update({
+                "result": "error",
+                "message": "the license codes provided do not match the ones found"
+            })
+        return resp

--- a/tests/sps/test_article_license.py
+++ b/tests/sps/test_article_license.py
@@ -1,0 +1,72 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from packtools.sps.models.article_license import ArticleLicense
+
+
+class ArticleLicenseTest(TestCase):
+    def setUp(self):
+        xml = ("""
+                <article xmlns:xlink="http://www.w3.org/1999/xlink">
+                <front>
+                <article-meta>
+                    <permissions>
+                        <license license-type="open-access" 
+                        xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                        xml:lang="en">
+                            <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                        </license>
+                        <license license-type="open-access" 
+                        xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                        xml:lang="pt">
+                            <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+                        </license>
+                        <license license-type="open-access" 
+                        xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                        xml:lang="es">
+                            <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+                        </license>
+                    </permissions>
+                </article-meta>
+                </front>
+                </article>
+                """)
+        xmltree = etree.fromstring(xml)
+        self.article_license = ArticleLicense(xmltree)
+
+    def test_get_link(self):
+        expected = [
+            {
+                'text': 'http://creativecommons.org/licenses/by/4.0/',
+                'lang': 'en'
+            },
+            {
+                'text': 'http://creativecommons.org/licenses/by/4.0/',
+                'lang': 'pt'
+            },
+            {
+                'text': 'http://creativecommons.org/licenses/by/4.0/',
+                'lang': 'es'
+            }
+        ]
+
+        self.assertEqual(expected, self.article_license.link)
+
+    def test_get_license_p(self):
+        expected = [
+            {
+                'text': 'This is an article published in open access under a Creative Commons license.',
+                'lang': 'en'
+            },
+            {
+                'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                'lang': 'pt'
+            },
+            {
+                'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
+                'lang': 'es'
+            }
+        ]
+
+        self.assertEqual(expected, self.article_license.license_p)

--- a/tests/sps/test_article_license.py
+++ b/tests/sps/test_article_license.py
@@ -35,38 +35,44 @@ class ArticleLicenseTest(TestCase):
         xmltree = etree.fromstring(xml)
         self.article_license = ArticleLicense(xmltree)
 
-    def test_get_link(self):
+    def test_get_licenses(self):
         expected = [
             {
-                'text': 'http://creativecommons.org/licenses/by/4.0/',
-                'lang': 'en'
+                'lang': 'en',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'This is an article published in open access under a Creative Commons license.'
             },
             {
-                'text': 'http://creativecommons.org/licenses/by/4.0/',
-                'lang': 'pt'
+                'lang': 'pt',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
             },
             {
-                'text': 'http://creativecommons.org/licenses/by/4.0/',
-                'lang': 'es'
+                'lang': 'es',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
             }
         ]
 
-        self.assertEqual(expected, self.article_license.link)
+        self.assertEqual(expected, self.article_license.licenses)
 
     def test_get_license_p(self):
-        expected = [
-            {
-                'text': 'This is an article published in open access under a Creative Commons license.',
-                'lang': 'en'
-            },
-            {
-                'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                'lang': 'pt'
-            },
-            {
-                'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
-                'lang': 'es'
-            }
-        ]
+        expected = {
+            'en': {
+                'lang': 'en',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                },
+            'pt': {
+                'lang': 'pt',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                },
+            'es': {
+                'lang': 'es',
+                'link': 'http://creativecommons.org/licenses/by/4.0/',
+                'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                }
+        }
 
-        self.assertEqual(expected, self.article_license.license_p)
+        self.assertEqual(expected, self.article_license.licenses_by_lang)

--- a/tests/sps/validation/test_article_license.py
+++ b/tests/sps/validation/test_article_license.py
@@ -344,7 +344,7 @@ class ArticleLicenseValidationTest(TestCase):
             "result": "ok"
         }
         obtained = self.article_license.validate_license_code(
-            ('by', '4.0')
+            'by', '4.0'
         )
         self.assertEqual(expected, obtained)
 
@@ -378,12 +378,12 @@ class ArticleLicenseValidationTest(TestCase):
         )
         self.article_license = ArticleLicenseValidation(xmltree)
         expected = {
-            "obtained_value": [('by', '4.0'), ('by', '4.0'), ('by', '4.0')],
+            "obtained_value": [],
             "expected_value": ('by', '3.0'),
             "result": "error",
             "message": "the license code provided do not match the ones found"
         }
         obtained = self.article_license.validate_license_code(
-            ('by', '3.0')
+            'by', '3.0'
         )
         self.assertEqual(expected, obtained)

--- a/tests/sps/validation/test_article_license.py
+++ b/tests/sps/validation/test_article_license.py
@@ -338,11 +338,23 @@ class ArticleLicenseValidationTest(TestCase):
             """
         )
         self.article_license = ArticleLicenseValidation(xmltree)
-        expected = {
-            "obtained_value": [('by', '4.0'), ('by', '4.0'), ('by', '4.0')],
-            "expected_value": ('by', '4.0'),
-            "result": "ok"
-        }
+        expected = [
+            {
+                "obtained_value": ('by', '4.0'),
+                "expected_value": ('by', '4.0'),
+                "result": "ok"
+            },
+            {
+                "obtained_value": ('by', '4.0'),
+                "expected_value": ('by', '4.0'),
+                "result": "ok"
+            },
+            {
+                "obtained_value": ('by', '4.0'),
+                "expected_value": ('by', '4.0'),
+                "result": "ok"
+            },
+            ]
         obtained = self.article_license.validate_license_code(
             'by', '4.0'
         )
@@ -377,12 +389,26 @@ class ArticleLicenseValidationTest(TestCase):
             """
         )
         self.article_license = ArticleLicenseValidation(xmltree)
-        expected = {
-            "obtained_value": [],
-            "expected_value": ('by', '3.0'),
-            "result": "error",
-            "message": "the license code provided do not match the ones found"
-        }
+        expected = [
+            {
+                "obtained_value": (),
+                "expected_value": ('by', '3.0'),
+                "result": "error",
+                "message": "the license code provided do not match the ones found"
+            },
+            {
+                "obtained_value": (),
+                "expected_value": ('by', '3.0'),
+                "result": "error",
+                "message": "the license code provided do not match the ones found"
+            },
+            {
+                "obtained_value": (),
+                "expected_value": ('by', '3.0'),
+                "result": "error",
+                "message": "the license code provided do not match the ones found"
+            },
+            ]
         obtained = self.article_license.validate_license_code(
             'by', '3.0'
         )

--- a/tests/sps/validation/test_article_license.py
+++ b/tests/sps/validation/test_article_license.py
@@ -1,0 +1,144 @@
+from unittest import TestCase
+from lxml import etree
+
+from packtools.sps.validation.article_license import ArticleLicenseValidation
+
+
+class ArticleLicenseValidationTest(TestCase):
+    def setUp(self):
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="pt">
+                        <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="es">
+                        <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(self.xmltree)
+
+    def test_validate_license_ok(self):
+        expected = {
+            "obtained_value": [
+                {
+                    'text': 'This is an article published in open access under a Creative Commons license.',
+                    'lang': 'en'
+                },
+                {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                },
+                {
+                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
+                    'lang': 'es'
+                }
+            ],
+            "expected_value": [
+                {
+                    'text': 'This is an article published in open access under a Creative Commons license.',
+                    'lang': 'en'
+                },
+                {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                },
+                {
+                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
+                    'lang': 'es'
+                }
+            ],
+            "result": "ok"
+        }
+        obtained = self.article_license.validate_license(
+            [
+                {
+                    'text': 'This is an article published in open access under a Creative Commons license.',
+                    'lang': 'en'
+                },
+                {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                },
+                {
+                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
+                    'lang': 'es'
+                }
+            ]
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_validate_license_not_ok(self):
+        expected = {
+            "obtained_value": [
+                {
+                    'text': 'This is an article published in open access under a Creative Commons license.',
+                    'lang': 'en'
+                },
+                {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                },
+                {
+                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
+                    'lang': 'es'
+                }
+            ],
+            "expected_value": [
+                {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                },
+            ],
+            "result": "error",
+            "message": "the license text does not match the license text adopted by the journal"
+        }
+        obtained = self.article_license.validate_license(
+            [
+               {
+                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
+                    'lang': 'pt'
+                }
+            ]
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_validate_license_code_ok(self):
+        expected = {
+            "obtained_value": ['4.0', '4.0', '4.0'],
+            "expected_value": ['4.0', '4.0', '4.0'],
+            "result": "ok"
+        }
+        obtained = self.article_license.validate_license_code(
+            ['4.0', '4.0', '4.0']
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_validate_license_code_not_ok(self):
+        expected = {
+            "obtained_value": ['4.0', '4.0', '4.0'],
+            "expected_value": ['4.0', '4.0'],
+            "result": "error",
+            "message": "the license codes provided do not match the ones found"
+        }
+        obtained = self.article_license.validate_license_code(
+            ['4.0', '4.0']
+        )
+        self.assertEqual(expected, obtained)

--- a/tests/sps/validation/test_article_license.py
+++ b/tests/sps/validation/test_article_license.py
@@ -5,8 +5,8 @@ from packtools.sps.validation.article_license import ArticleLicenseValidation
 
 
 class ArticleLicenseValidationTest(TestCase):
-    def setUp(self):
-        self.xmltree = etree.fromstring(
+    def test_validate_license_3_expected_3_obtained_ok(self):
+        xmltree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <front>
@@ -33,112 +33,357 @@ class ArticleLicenseValidationTest(TestCase):
             </article>
             """
         )
-        self.article_license = ArticleLicenseValidation(self.xmltree)
-
-    def test_validate_license_ok(self):
+        self.article_license = ArticleLicenseValidation(xmltree)
         expected = {
-            "obtained_value": [
-                {
-                    'text': 'This is an article published in open access under a Creative Commons license.',
-                    'lang': 'en'
-                },
-                {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
-                },
-                {
-                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
-                    'lang': 'es'
-                }
-            ],
-            "expected_value": [
-                {
-                    'text': 'This is an article published in open access under a Creative Commons license.',
-                    'lang': 'en'
-                },
-                {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
-                },
-                {
-                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
-                    'lang': 'es'
-                }
-            ],
-            "result": "ok"
+            "obtained_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                    },
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                    },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                    }
+            },
+            "expected_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                    },
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                    },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                    }
+            },
+            "result": "ok",
+            "message": [
+                'ok, the license text for en does match the license text adopted by the journal',
+                'ok, the license text for pt does match the license text adopted by the journal',
+                'ok, the license text for es does match the license text adopted by the journal'
+            ]
         }
         obtained = self.article_license.validate_license(
-            [
-                {
-                    'text': 'This is an article published in open access under a Creative Commons license.',
-                    'lang': 'en'
+            {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
                 },
-                {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
                 },
-                {
-                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
-                    'lang': 'es'
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
                 }
-            ]
+            }
         )
         self.assertEqual(expected, obtained)
 
-    def test_validate_license_not_ok(self):
+    def test_validate_license_3_expected_1_obtained_ok(self):
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(xmltree)
         expected = {
-            "obtained_value": [
-                {
-                    'text': 'This is an article published in open access under a Creative Commons license.',
-                    'lang': 'en'
-                },
-                {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
-                },
-                {
-                    'text': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.',
-                    'lang': 'es'
+            "obtained_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
                 }
-            ],
-            "expected_value": [
-                {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
+            },
+            "expected_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
                 },
-            ],
-            "result": "error",
-            "message": "the license text does not match the license text adopted by the journal"
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                }
+            },
+            "result": "ok",
+            "message": [
+                'ok, the license text for en does match the license text adopted by the journal'
+            ]
         }
         obtained = self.article_license.validate_license(
-            [
-               {
-                    'text': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.',
-                    'lang': 'pt'
+            {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                },
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
                 }
+            }
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_validate_license_3_expected_3_obtained_not_ok(self):
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="pt">
+                        <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="es">
+                        <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(xmltree)
+        expected = {
+            "obtained_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                    },
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                    },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                    }
+            },
+            "expected_value": {
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                    },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                    }
+            },
+            "result": "error",
+            "message": [
+                'error, the language en is not foreseen by the journal',
+                'ok, the license text for pt does match the license text adopted by the journal',
+                'ok, the license text for es does match the license text adopted by the journal'
             ]
+        }
+        obtained = self.article_license.validate_license(
+            {
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                }
+            }
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_validate_license_3_expected_1_obtained_not_ok(self):
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(xmltree)
+        expected = {
+            "obtained_value": {
+                'en': {
+                    'lang': 'en',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'This is an article published in open access under a Creative Commons license.'
+                    }
+            },
+            "expected_value": {
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                    },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                    }
+            },
+            "result": "error",
+            "message": [
+                'error, the language en is not foreseen by the journal'
+            ]
+        }
+        obtained = self.article_license.validate_license(
+            {
+                'pt': {
+                    'lang': 'pt',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.'
+                },
+                'es': {
+                    'lang': 'es',
+                    'link': 'http://creativecommons.org/licenses/by/4.0/',
+                    'licence_p': 'Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.'
+                }
+            }
         )
         self.assertEqual(expected, obtained)
 
     def test_validate_license_code_ok(self):
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="pt">
+                        <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="es">
+                        <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(xmltree)
         expected = {
-            "obtained_value": ['4.0', '4.0', '4.0'],
-            "expected_value": ['4.0', '4.0', '4.0'],
+            "obtained_value": [('by', '4.0'), ('by', '4.0'), ('by', '4.0')],
+            "expected_value": ('by', '4.0'),
             "result": "ok"
         }
         obtained = self.article_license.validate_license_code(
-            ['4.0', '4.0', '4.0']
+            ('by', '4.0')
         )
         self.assertEqual(expected, obtained)
 
     def test_validate_license_code_not_ok(self):
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+            <article-meta>
+                <permissions>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="en">
+                        <license-p>This is an article published in open access under a Creative Commons license.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="pt">
+                        <license-p>Este é um artigo publicado em acesso aberto sob uma licença Creative Commons.</license-p>
+                    </license>
+                    <license license-type="open-access" 
+                    xlink:href="http://creativecommons.org/licenses/by/4.0/" 
+                    xml:lang="es">
+                        <license-p>Este es un artículo publicado en acceso abierto bajo una licencia Creative Commons.</license-p>
+                    </license>
+                </permissions>
+            </article-meta>
+            </front>
+            </article>
+            """
+        )
+        self.article_license = ArticleLicenseValidation(xmltree)
         expected = {
-            "obtained_value": ['4.0', '4.0', '4.0'],
-            "expected_value": ['4.0', '4.0'],
+            "obtained_value": [('by', '4.0'), ('by', '4.0'), ('by', '4.0')],
+            "expected_value": ('by', '3.0'),
             "result": "error",
-            "message": "the license codes provided do not match the ones found"
+            "message": "the license code provided do not match the ones found"
         }
         obtained = self.article_license.validate_license_code(
-            ['4.0', '4.0']
+            ('by', '3.0')
         )
         self.assertEqual(expected, obtained)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona uma classe para acessar os dados de licença de uso, bem como a respectiva classe de validação e testes.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Rodar os testes:
`python3 -m unittest -v tests/sps/test_article_license.py`
`python3 -m unittest -v tests/sps/validation/test_article_license.py` 

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #385 e TK #343 

### Referências
NA.
