### PR TITLE
Adicionada a extração da tag role com namespace na classe Authors

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -33,5 +33,14 @@ class Authors:
                 )
             except IndexError:
                 pass
+
+            if node.xpath(".//role"):
+                _author['role'] = []
+
+            for role in node.xpath(".//role"):
+                _role = role.text
+                _content_type = role.get('content-type')
+                _author['role'].append({"text": _role, "content-type": _content_type})
+            
             _data.append(_author)
         return _data

--- a/tests/sps/test_article_authors.py
+++ b/tests/sps/test_article_authors.py
@@ -55,7 +55,7 @@ class AuthorsTest(TestCase):
         """)
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
-
+        
     def test_contribs(self):
         expected = [
             {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
@@ -68,6 +68,9 @@ class AuthorsTest(TestCase):
         self.assertDictEqual(expected[0], result[0])
         self.assertDictEqual(expected[1], result[1])
 
+    def test_collab(self):
+    	self.assertIsNone(self.authors.collab) 
+  
     def test_role_with_role_content_type(self):
         xml = ("""
         <article>

--- a/tests/sps/test_article_authors.py
+++ b/tests/sps/test_article_authors.py
@@ -62,14 +62,144 @@ class AuthorsTest(TestCase):
              "prefix": "Prof", "suffix": "Nieto"},
             {"surname": "Higa", "given_names": "Vanessa M.",
              "orcid": "0000-0001-5518-4853"
-            },
+             },
         ]
         result = self.authors.contribs
         self.assertDictEqual(expected[0], result[0])
         self.assertDictEqual(expected[1], result[1])
 
-    def test_collab(self):
-        self.assertIsNone(self.authors.collab)
+    def test_role_with_role_content_type(self):
+        xml = ("""
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                  <xref ref-type="aff" rid="aff1"/>
+                    <xref ref-type="aff" rid="aff1">a</xref>
+					<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Role 1</role>
+					<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Role 2</role>
+					<role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Role 3</role>
+					<role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Role 4</role>
+                </contrib>
+                <contrib contrib-type="author">
+                  <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                  <name>
+                    <surname>Higa</surname>
+                    <given-names>Vanessa M.</given-names>
+                  </name>
+                  <xref ref-type="aff" rid="aff1">a</xref>
+					<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+					<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+					<role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Formal Analysis</role>
+					<role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Writing &#x2013; original draft</role>
+                </contrib>
+              </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """)
+
+        data = etree.fromstring(xml)
+        xmldata = Authors(data).contribs
+		
+        expect_output = [
+            {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
+             "prefix": "Prof", "suffix": "Nieto",
+             'role': [
+				{'text': 'Role 1',
+					'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
+				{'text': 'Role 2',
+					'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
+				{'text': 'Role 3',
+					'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
+				{'text': 'Role 4',
+					'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
+                            ]
+                },
+            {"surname": "Higa", "given_names": "Vanessa M.",
+             "orcid": "0000-0001-5518-4853",
+                     'role': [
+                         {'text': 'Conceptualization',
+                  'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
+                         {'text': 'Data curation',
+                  'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
+                         {'text': 'Formal Analysis',
+                  'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
+                         {'text': 'Writing – original draft',
+                  'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
+                         ]
+             },
+        ]
+        
+        self.assertEqual(xmldata, expect_output)
+
+    def test_role_wihtout_content_type(self):
+        xml = ("""
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                  <xref ref-type="aff" rid="aff1"/>
+                  <role>Role 1</role>
+                  <role>Role 2</role>
+                  <role>Role 3</role>
+                  <role>Role 4</role>
+                </contrib>
+                <contrib contrib-type="author">
+                  <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                  <name>
+                    <surname>Higa</surname>
+                    <given-names>Vanessa M.</given-names>
+                  </name>
+                  <xref ref-type="aff" rid="aff1">a</xref>
+                  <role>Conceptualization</role>
+                  <role>Data curation</role>
+                  <role>Formal Analysis</role>
+                  <role>Writing &#x2013; original draft</role>
+                </contrib>
+              </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """)
+        data = etree.fromstring(xml)
+        xmldata = Authors(data).contribs
+
+        expected_output = [
+            {
+                'surname': 'VENEGAS-MARTÍNEZ', 'prefix': 'Prof', 'suffix': 'Nieto', 'given_names': 'FRANCISCO',
+                'role': [
+                    {'text': 'Role 1', 'content-type': None},
+                    {'text': 'Role 2', 'content-type': None},
+                    {'text': 'Role 3', 'content-type': None},
+                    {'text': 'Role 4', 'content-type': None}]
+            },
+            {
+                'surname': 'Higa', 'given_names': 'Vanessa M.', 'orcid': '0000-0001-5518-4853',
+                'role': [
+                    {'text': 'Conceptualization', 'content-type': None},
+                    {'text': 'Data curation', 'content-type': None},
+                    {'text': 'Formal Analysis', 'content-type': None},
+                    {'text': 'Writing – original draft', 'content-type': None}
+                ]
+            }
+        ]
+
+        self.assertEqual(xmldata, expected_output)
 
 
 class AuthorsCollabTest(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Adicionada a extração da tag role com namespace na classe Authors para obter informações sobre o papel do autor.

#### Onde a revisão poderia começar?
Por commit

#### Como este poderia ser testado manualmente?
`python setup.py test -s .\tests\sps\test_article_authors.py`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A


### Referências
N/A

