### PR TITLE
Criado classe extracao para Figuras, Tabelas e Formulas

### DIFF
--- a/packtools/sps/models/figures.py
+++ b/packtools/sps/models/figures.py
@@ -1,0 +1,72 @@
+from packtools.sps.utils import xml_utils
+
+
+def get_node_without_subtag(node):
+    """
+        Função que retorna nó sem subtags. 
+    """
+    return "".join(node.xpath(".//text()"))
+
+
+class Figure:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+
+    def extract_figures(self, subtag):
+        fig_node = self.xmltree.xpath('.//fig-group') or self.xmltree.xpath('.//fig')
+        extract_node_text = xml_utils.node_text_without_xref if subtag else get_node_without_subtag
+
+        if fig_node:
+            if self.xmltree.xpath('.//fig-group'):
+                return self._extract_figures_with_fig_group(node=fig_node, extract_node_text=extract_node_text)
+            else:
+                return self._extract_figures_without_fig_group(node=fig_node, extract_node_text=extract_node_text)
+        else:
+            return 'No figures found.'
+
+
+    def _extract_figures_with_fig_group(self, node, extract_node_text):
+        figures = []
+        
+        for fig_group_node in node:
+            fig_group_id = fig_group_node.get('id', '')
+            
+            try:
+                fig_group_title = extract_node_text(fig_group_node.xpath('.//title')[0])
+            except IndexError:
+                fig_group_title = ''
+            
+            fig_group = {'fig_group_id': fig_group_id, 'fig_group_title': fig_group_title}
+
+            data = self._extract_figures_without_fig_group(node=fig_group_node.xpath('fig'), extract_node_text=extract_node_text)
+            fig_group.update(data)
+            
+            figures.append(fig_group)
+        return figures
+
+
+    def _extract_figures_without_fig_group(self, node, extract_node_text):
+        figures = {'figs': []}
+        data_fig = ['label', 'title']
+
+        for fig in node:
+            fig_id = fig.get('id', '')
+            data = {'id': fig_id}
+
+            for field in data_fig:
+                try:
+                    data[field] = extract_node_text(fig.xpath(f'.//{field}')[0])
+                except IndexError:
+                    data[field] = ''
+        
+            try:
+                fig_graphic = fig.xpath('graphic')[0].get('{http://www.w3.org/1999/xlink}href')
+            except IndexError:
+                fig_graphic = ''
+
+            data['graphic'] = fig_graphic
+            figures['figs'].append(data)
+        return figures
+               
+        

--- a/packtools/sps/models/formula.py
+++ b/packtools/sps/models/formula.py
@@ -1,0 +1,53 @@
+from packtools.sps.utils import xml_utils
+
+class Formula:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+
+    @property
+    def disp_formula_nodes(self):
+        return self.xmltree.xpath('.//disp-formula')
+
+
+    def get_equation(self, node):
+        mnl_namespace = {'mnl': "http://www.w3.org/1998/Math/MathML"}
+        math_node_xpath = 'mnl:math'
+        tex_math_xpath = 'tex-math'
+        graphic_xpath = 'graphic'
+
+        if node.xpath(math_node_xpath, namespaces=mnl_namespace) or node.xpath(tex_math_xpath):
+            eq_node = node.xpath(math_node_xpath, namespaces=mnl_namespace) or node.xpath(tex_math_xpath)
+            eq_node_id = eq_node[0].get('id', '')          
+            eq = xml_utils.node_text_without_xref(eq_node[0])
+            eq_dict = {'id': eq_node_id, 'equation': eq}
+            return eq_dict
+        elif node.xpath(graphic_xpath):
+            eq_node = node.xpath(graphic_xpath)[0]
+            eq_node_id = eq_node.get('id', '')
+            eq_graphic = eq_node.get('{http://www.w3.org/1999/xlink}href')
+            eq_dict = {'id': eq_node_id, 'graphic': eq_graphic}
+            return eq_dict
+        return 'Not found formulas'
+
+
+    @property
+    def extract_disp_formula(self):
+        node = self.disp_formula_nodes
+        formulas = {'formulas': []}
+        for disp_node in node:
+            disp_node_id = disp_node.get('id', '')
+            
+            try:
+                disp_node_label = disp_node.xpath('label')[0].text  
+            except IndexError:
+                disp_node_label = ''
+            equation = self.get_equation(node=disp_node)
+            
+            formula = {
+                'disp_formula_id': disp_node_id,
+                'disp_formula_label': disp_node_label,
+                'equations': equation
+            }
+            formulas['formulas'].append(formula)
+        return formulas

--- a/packtools/sps/models/tables.py
+++ b/packtools/sps/models/tables.py
@@ -1,0 +1,73 @@
+from packtools.sps.utils import xml_utils
+
+
+def get_node_without_subtag(node):
+    """
+        Função que retorna nó sem subtags. 
+    """
+    return "".join(node.xpath(".//text()"))
+
+
+class Table:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    
+    def extract_table(self, subtag):
+        table_node = self.xmltree.xpath('.//table-wrap-group') or self.xmltree.xpath('.//table-wrap')
+        extract_node_text = xml_utils.node_text_without_xref if subtag else get_node_without_subtag
+        
+        if table_node:
+            if self.xmltree.xpath('.//table-wrap-group'):
+                return self._extract_table_with_table_wrap_group(node=table_node, extract_node_text=extract_node_text)
+            else:
+                return self._extract_table_without_table_wrap_group(node=table_node, extract_node_text=extract_node_text)
+        else:
+            return 'No tables found.'
+
+
+    def _extract_table_with_table_wrap_group(self, node, extract_node_text):
+        tables = []
+
+        for table_node in node:
+            table_group_id = table_node.get('id', '')
+            table_group = {'table_group_id': table_group_id}
+            data = self._extract_table_without_table_wrap_group(node=table_node.xpath('.//table-wrap'), extract_node_text=extract_node_text)
+            table_group.update(data)
+            tables.append(table_group)
+        return tables
+
+
+    def _extract_table_without_table_wrap_group(self, node, extract_node_text):
+        tables = {'tables': []}
+        data_tables = ['label', 'title']
+
+        for table_node in node:
+            table_id = table_node.get('id', '')
+            data = {'id': table_id}
+            
+            for field in data_tables:
+                try:
+                    data[field]  = extract_node_text(table_node.xpath(f'.//{field}')[0])
+                except IndexError:
+                    data[field] = ''
+            
+            try:
+                data['table'] = xml_utils.node_text_without_xref(table_node.xpath('table')[0])
+            except IndexError:
+                data['table'] = ''
+            
+            foot = self.extract_table_wrap_foot(node=table_node, extract_node_text=extract_node_text)
+            
+            data.update(foot)
+            tables['tables'].append(data)
+        return tables
+
+
+    def extract_table_wrap_foot(self, node, extract_node_text):
+        try:
+            foot = extract_node_text(node.xpath('table-wrap-foot')[0])
+        except IndexError:
+            foot = ''
+        foot = {'wrap-foot': foot}
+        return foot

--- a/tests/sps/test_figure.py
+++ b/tests/sps/test_figure.py
@@ -1,0 +1,181 @@
+from unittest import TestCase
+from packtools.sps.utils import xml_utils
+
+
+from packtools.sps.models.figures import Figure
+
+from lxml import etree
+
+
+class FiguresTest(TestCase):
+    def test_extract_with_fig_group(self):
+        xml = ("""
+			<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="en">
+				<front>
+					<article-meta>
+                        <fig-group id="dogpix4">
+                            <caption><title>Figures 12-14 Bonnie Lassie</title>
+                            <p>Three perspectives on My Dog</p>
+                            </caption>
+                        <fig id="fg-12">
+                            <label>a.</label>
+                                <caption>
+                                    <title><p>View A: From the Front, Laughing</p></title>
+                                </caption>
+                                <graphic xlink:href="frontView.png"/>
+                            </fig>
+                        <fig id="fg-13">
+                            <label>b.</label>
+                            <caption>
+                                <title><p>View B: From the Side, Best Profile</p></title>
+                            </caption>
+                            <graphic xlink:href="sideView.png"/>
+                            </fig>
+                        <fig id="fg-14">
+                            <label>c.</label>
+                            <caption>
+                                <title><p>View C: In Motion, A Blur on Feet</p></title>
+                            </caption>
+                            <graphic xlink:href="motionView.png"/>
+                        </fig>
+                        </fig-group>
+					</article-meta>
+				</front>
+			</article>
+		""")
+        xml = etree.fromstring(xml)
+        extract = Figure(xml).extract_figures(subtag=False)
+        
+        expected_output = [
+            {
+			'fig_group_id': 'dogpix4', 
+			'fig_group_title': 'Figures 12-14 Bonnie Lassie', 
+			'figs': [
+				{
+				'id': 'fg-12', 
+                'title': 'View A: From the Front, Laughing',
+				'label': 'a.', 
+				'graphic': 'frontView.png'
+                }, 
+                {
+				'id': 'fg-13',
+                'title': 'View B: From the Side, Best Profile', 
+                'label': 'b.', 
+                'graphic': 'sideView.png'
+                }, 
+                {
+            	'id': 'fg-14',
+                'title': 'View C: In Motion, A Blur on Feet', 
+                'label': 'c.', 
+                'graphic': 'motionView.png'
+                }
+            ]
+            }
+        ]
+        
+        self.assertEqual(extract, expected_output)
+
+
+    def test_extract_with_fig_group_and_subtag(self):
+        xml = ("""
+			<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="en">
+				<front>
+					<article-meta>
+                        <fig-group id="dogpix4">
+                            <caption><title>Figures 12-14 Bonnie Lassie</title>
+                            <p>Three perspectives on My Dog</p>
+                            </caption>
+                        <fig id="fg-12">
+                            <label>a.</label>
+                                <caption>
+                                    <title><p>View A: From the Front, Laughing</p></title>
+                                </caption>
+                                <graphic xlink:href="frontView.png"/>
+                            </fig>
+                        <fig id="fg-13">
+                            <label>b.</label>
+                            <caption>
+                                <title><p>View B: From the Side, Best Profile</p></title>
+                            </caption>
+                            <graphic xlink:href="sideView.png"/>
+                            </fig>
+                        <fig id="fg-14">
+                            <label>c.</label>
+                            <caption>
+                                <title><p>View C: In <italic>Motion</italic>, A Blur on Feet</p></title>
+                            </caption>
+                            <graphic xlink:href="motionView.png"/>
+                        </fig>
+                        </fig-group>
+					</article-meta>
+				</front>
+			</article>
+		""")
+        xml = etree.fromstring(xml)
+        extract = Figure(xml).extract_figures(subtag=True)
+        
+        expected_output = [
+            {
+			'fig_group_id': 'dogpix4', 
+			'fig_group_title': 'Figures 12-14 Bonnie Lassie', 
+			'figs': [
+				{
+				'id': 'fg-12', 
+                'title': '<p>View A: From the Front, Laughing</p>',
+				'label': 'a.', 
+				'graphic': 'frontView.png'
+                }, 
+                {
+				'id': 'fg-13',
+                'title': '<p>View B: From the Side, Best Profile</p>', 
+                'label': 'b.', 
+                'graphic': 'sideView.png'
+                }, 
+                {
+            	'id': 'fg-14',
+                'title': '<p>View C: In <italic>Motion</italic>, A Blur on Feet</p>', 
+                'label': 'c.', 
+                'graphic': 'motionView.png'
+                }
+            ]
+            }
+        ]
+        
+        self.assertEqual(extract, expected_output)
+
+
+    def test_extract_without_fig_group(self):
+        xml= xml_utils.get_xml_tree('tests/samples/0034-8910-rsp-48-2-0206.xml')
+        extract = Figure(xml).extract_figures(subtag=False)
+
+        expect_output = {
+            'figs': [
+            {
+            'id': 'f01', 
+            'label': 'Figure 1', 
+            'title': 'Graphical representation of the characteristic and information curves of the items selected.', 
+            'graphic': '0034-8910-rsp-48-2-0206-gf01'
+            }, 
+            {
+            'id': 'f02', 
+            'label': 'Figure 2', 
+            'title': 'Total Information curve (10 items).', 
+            'graphic': '0034-8910-rsp-48-2-0206-gf02'
+            }, 
+            {
+            'id': 'f03', 
+            'label': 
+            'Figure 3', 
+            'title': 'Graphical representation of the items and HIV/AIDS knowledge scores.', 
+            'graphic': '0034-8910-rsp-48-2-0206-gf03'
+            }, 
+            {
+            'id': 'f04', 
+            'label': 'Figure 4', 
+            'title': 'Items characteristic curves with differential item functioning.', 
+            'graphic': '0034-8910-rsp-48-2-0206-gf04'
+            }
+            ]
+        }
+
+        self.assertEqual(extract, expect_output)

--- a/tests/sps/test_formula.py
+++ b/tests/sps/test_formula.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+from packtools.sps.utils import xml_utils
+
+
+from packtools.sps.models.formula import Formula
+from lxml import etree
+
+
+class FormulasTest(TestCase):
+    def test_formula(self):
+        xml = (r"""
+			<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="en">
+				<front>
+					<article-meta>
+                        <disp-formula id="e3">
+                            <mml:math id="m1" display="block">
+                                <mml:mrow>
+                                <mml:msub>
+                                    <mml:mi>q</mml:mi>
+                                    <mml:mi>c</mml:mi>
+                                </mml:msub>
+                                <mml:mo>=</mml:mo>
+                                <mml:mi>h</mml:mi>
+                                <mml:mrow>
+                                    <mml:mo>(</mml:mo>
+                                    <mml:mrow>
+                                    <mml:mi>T</mml:mi>
+                                    <mml:mo>−</mml:mo>
+                                    <mml:msub>
+                                        <mml:mi>T</mml:mi>
+                                        <mml:mn>0</mml:mn>
+                                    </mml:msub>
+                                    </mml:mrow>
+                                    <mml:mo>)</mml:mo>
+                                </mml:mrow>
+                                </mml:mrow>
+                            </mml:math>
+                            <label>(3)</label>
+                        </disp-formula>
+                        <disp-formula id="e10">
+                            <label>(1)</label>
+                            <tex-math id="tx1">
+                                \documentclass {article}
+                                \usepackage{wasysym}
+                                \usepackage[substack]{amsmath}
+                                \usepackage{amsfonts}
+                                \usepackage{amssymb}
+                                \usepackage{amsbsy}
+                                \usepackage[mathscr]{eucal}
+                                \usepackage{mathrsfs}
+                                \usepackage{pmc}
+                                \usepackage[Euler]{upgreek}
+                                \pagestyle{empty}
+                                \oddsidemargin -1.0in
+                                \begin{document}
+                                \[E_it=α_i+Z_it γ+W_it δ+C_it θ+∑_i^n EFind_i+∑_t^n EFtemp_t+ ε_it                                 \]
+                                \end{document}
+                            </tex-math>
+                        </disp-formula>
+                        <disp-formula id="e1">
+                            <graphic xlink:href="1234-5678-rctb-45-05-0110-e01.tif"/>
+                        </disp-formula>
+					</article-meta>
+				</front>
+			</article>
+		""")
+
+        xml = xml_utils.get_xml_tree(xml)
+        extract = Formula(xml).extract_disp_formula
+
+        expected_output = {
+            'formulas': [
+            {
+            'disp_formula_id': 'e3', 
+            'disp_formula_label': '(3)', 
+            'equation': {
+                'id': 'm1', 
+                'eq': '<mml:mrow xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:msub><mml:mi>q</mml:mi><mml:mi>c</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mi>h</mml:mi><mml:mrow><mml:mo>(</mml:mo><mml:mrow><mml:mi>T</mml:mi><mml:mo>−</mml:mo><mml:msub><mml:mi>T</mml:mi><mml:mn>0</mml:mn></mml:msub></mml:mrow><mml:mo>)</mml:mo></mml:mrow></mml:mrow>'}
+            }, 
+            {
+            'disp_formula_id': 'e10', 
+            'disp_formula_label': '(1)', 
+            'equation': {
+                'id': 'tx1', 
+                'eq': '\n                                \\documentclass {article}\n                                \\usepackage{wasysym}\n                                \\usepackage[substack]{amsmath}\n                                \\usepackage{amsfonts}\n                                \\usepackage{amssymb}\n                                \\usepackage{amsbsy}\n                                \\usepackage[mathscr]{eucal}\n                                \\usepackage{mathrsfs}\n                                \\usepackage{pmc}\n                                \\usepackage[Euler]{upgreek}\n                                \\pagestyle{empty}\n                                \\oddsidemargin -1.0in\n                                \\begin{document}\n                                \\[E_it=α_i+Z_it γ+W_it δ+C_it θ+∑_i^n EFind_i+∑_t^n EFtemp_t+ ε_it                                 \\]\n                                \\end{document}\n                            '}
+            }, 
+            {
+            'disp_formula_id': 'e1', 
+            'disp_formula_label': '', 
+            'equation': {
+                'id': '', 
+                'graphic': '1234-5678-rctb-45-05-0110-e01.tif'}
+            }
+            ]
+        }

--- a/tests/sps/test_table.py
+++ b/tests/sps/test_table.py
@@ -1,0 +1,203 @@
+from unittest import TestCase
+from packtools.sps.utils import xml_utils
+
+from lxml import etree
+
+from packtools.sps.models.tables import Table
+
+
+class TablesTest(TestCase):
+    def test_extract_tables_with_group(self):
+        xml = ("""
+            <article>
+                <front>
+                    <article-meta>
+                        <table-wrap-group id="t01">
+                            <table-wrap id="t01">
+                                <label>Table. </label>
+                                <caption>
+                                    <title>Proportion of correct HIV/AIDS knowledge responses as reported by the men who have sex with men, the difficulty and discrimination parameters for each item, estimated by Item Response Theory. Brazil, 2008-2009. (N = 3,746)</title>
+                                </caption>
+                                <table frame="hsides" rules="groups">
+                                    <colgroup width="25%">
+                                        <col width="60%"/>
+                                        <col width="10%"/>
+                                        <col width="10%"/>
+                                        <col width="10%"/>
+                                    </colgroup>
+                                    <thead>
+                                        <tr>
+                                            <th style="font-weight:normal" align="left">Item</th>
+                                            <th style="font-weight:normal">% Correct response</th>
+                                            <th style="font-weight:normal">Difficulty (<italic>b</italic>
+                                                <sub>
+                                                    <italic>i</italic>
+                                                </sub>)</th>
+                                            <th style="font-weight:normal">Discrimination (<italic>a</italic>
+                                                <sub>
+                                                    <italic>i</italic>
+                                                </sub>)</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>1. The risk of transmitting HIV is small if one follows the treatment correctly.</td>
+                                            <td align="center">35.5</td>
+                                            <td align="center">14.45</td>
+                                            <td align="center">0.04</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2. People are using less condoms because of AIDS treatment.</td>
+                                            <td align="center">34.5</td>
+                                            <td align="center">14.23</td>
+                                            <td align="center">0.04</td>
+                                        </tr>
+                                        <tr>
+                                            <td>3. A person can get the AIDS virus by using public toilets.</td>
+                                            <td align="center">78.1</td>
+                                            <td align="center">3.72</td>
+                                            <td align="center">0.95</td>
+                                        </tr>
+                                        <tr>
+                                            <td>4. A person can get the AIDS virus through insect bites.</td>
+                                            <td align="center">75.5</td>
+                                            <td align="center">3.70</td>
+                                            <td align="center">0.72</td>
+                                        </tr>
+                                        <tr>
+                                            <td>5. A person can become infected by sharing eating utensils, cups or food.</td>
+                                            <td align="center">85.7</td>
+                                            <td align="center">3.28</td>
+                                            <td align="center">1.01</td>
+                                        </tr>
+                                        <tr>
+                                            <td>6. The risk of HIV + mothers infecting their babies is small if she receives treatment in pregnancy and childbirth.</td>
+                                            <td align="center">75.8</td>
+                                            <td align="center">2.70</td>
+                                            <td align="center">0.32</td>
+                                        </tr>
+                                        <tr>
+                                            <td>7. The risk of HIV infection can be reduced if you have relations only with an uninfected partner.</td>
+                                            <td align="center">72.6</td>
+                                            <td align="center">2.03</td>
+                                            <td align="center">0.20</td>
+                                        </tr>
+                                        <tr>
+                                            <td>8. A healthy person can be infected with the AIDS virus.</td>
+                                            <td align="center">94.1</td>
+                                            <td align="center">1.61</td>
+                                            <td align="center">0.59</td>
+                                        </tr>
+                                        <tr>
+                                            <td>9. A person can get the virus from sharing a syringe or needle.</td>
+                                            <td align="center">96.9</td>
+                                            <td align="center">1.51</td>
+                                            <td align="center">0.78</td>
+                                        </tr>
+                                        <tr>
+                                            <td>10. Anyone can get the AIDS virus if condoms are not used.</td>
+                                            <td align="center">98.5</td>
+                                            <td align="center">1.27</td>
+                                            <td align="center">0.95</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <table-wrap-foot>
+                                    <p>
+                                        <italic>b</italic>
+                                        <sub>
+                                            <italic>i</italic>
+                                        </sub>: Difficulty parameter of each item; <italic>a</italic>
+                                        <sub>
+                                            <italic>i</italic>
+                                        </sub>: Discrimination parameter of each item</p>
+                                </table-wrap-foot>
+                            </table-wrap>
+                        </table-wrap-group>
+                    </article-meta>
+                </front>
+            </article>
+        """)
+
+        xml = xml_utils.get_xml_tree(xml)
+        extract = Table(xml).extract_table(subtag=False)
+        expected_output = [
+            {
+            'table_group_id': 't01', 
+            'tables': [
+                {
+                'id': 't01', 
+                'label': 'Table. ', 
+                'title': 'Proportion of correct HIV/AIDS knowledge responses as reported by the men who have sex with men, the difficulty and discrimination parameters for each item, estimated by Item Response Theory. Brazil, 2008-2009. (N = 3,746)', 
+                'table': '<colgroup width="25%"><col width="60%"/><col width="10%"/><col width="10%"/><col width="10%"/></colgroup><thead><tr><th style="font-weight:normal" align="left">Item</th><th style="font-weight:normal">% Correct response</th><th style="font-weight:normal">Difficulty (<italic>b</italic>\n                                                <sub><italic>i</italic></sub>)</th><th style="font-weight:normal">Discrimination (<italic>a</italic>\n                                                <sub><italic>i</italic></sub>)</th></tr></thead><tbody><tr><td>1. The risk of transmitting HIV is small if one follows the treatment correctly.</td><td align="center">35.5</td><td align="center">14.45</td><td align="center">0.04</td></tr><tr><td>2. People are using less condoms because of AIDS treatment.</td><td align="center">34.5</td><td align="center">14.23</td><td align="center">0.04</td></tr><tr><td>3. A person can get the AIDS virus by using public toilets.</td><td align="center">78.1</td><td align="center">3.72</td><td align="center">0.95</td></tr><tr><td>4. A person can get the AIDS virus through insect bites.</td><td align="center">75.5</td><td align="center">3.70</td><td align="center">0.72</td></tr><tr><td>5. A person can become infected by sharing eating utensils, cups or food.</td><td align="center">85.7</td><td align="center">3.28</td><td align="center">1.01</td></tr><tr><td>6. The risk of HIV + mothers infecting their babies is small if she receives treatment in pregnancy and childbirth.</td><td align="center">75.8</td><td align="center">2.70</td><td align="center">0.32</td></tr><tr><td>7. The risk of HIV infection can be reduced if you have relations only with an uninfected partner.</td><td align="center">72.6</td><td align="center">2.03</td><td align="center">0.20</td></tr><tr><td>8. A healthy person can be infected with the AIDS virus.</td><td align="center">94.1</td><td align="center">1.61</td><td align="center">0.59</td></tr><tr><td>9. A person can get the virus from sharing a syringe or needle.</td><td align="center">96.9</td><td align="center">1.51</td><td align="center">0.78</td></tr><tr><td>10. Anyone can get the AIDS virus if condoms are not used.</td><td align="center">98.5</td><td align="center">1.27</td><td align="center">0.95</td></tr></tbody>', 'wrap-foot': 'bi: Difficulty parameter of each item; ai: Discrimination parameter of each item'
+                }
+                ]
+            }
+        ]
+
+        self.assertEqual(extract, expected_output)
+
+    def test_extract_tables_without_group(self):
+        xml =("""
+            <article>
+                <front>
+                    <article-meta>
+                        <table-wrap id="t5">
+                            <label>Tabela 5</label>
+                            <caption>
+                                <title>Alíquota menor para prestadores</title>
+                            </caption>
+                            <table>
+                                <thead>
+                                <tr>
+                                    <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
+                                </tr>
+                                <tr>
+                                    <th>Receita Bruta em 12 Meses - em R$</th>
+                                    <th>Anexo I - Comércio</th>
+                                    <th>Anexo II Indústria</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td>De R$ 225.000,01 a RS 450.000,00</td>
+                                    <td>4,00%</td>
+                                    <td>4,50%</td>
+                                </tr>
+                                <tr>
+                                    <td>De R$ 450.000,01 a R$ 900.000,00</td>
+                                    <td>8,25%</td>
+                                    <td>8,00%</td>
+                                </tr>
+                                <tr>
+                                    <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
+                                    <td>11,25%</td>
+                                    <td>12,25%</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <table-wrap-foot>
+                                <fn id="TFN1">
+                                <p>A informação de alíquota do anexo II é significativa</p>
+                                </fn>
+                            </table-wrap-foot>
+                        </table-wrap>
+                    </article-meta>
+                </front>
+            </article>
+        """)
+        xml = xml_utils.get_xml_tree(xml)
+        extract = Table(xml).extract_table(subtag=False)
+
+        expected_output = {
+            'tables': [
+                {
+                'id': 't5', 
+                'label': 'Tabela 5', 
+                'title': 'Alíquota menor para prestadores', 
+                'table': '<thead><tr><th rowspan="3">Proposta de Novas Tabelas - 2016</th></tr><tr><th>Receita Bruta em 12 Meses - em R$</th><th>Anexo I - Comércio</th><th>Anexo II Indústria</th></tr></thead><tbody><tr><td>De R$ 225.000,01 a RS 450.000,00</td><td>4,00%</td><td>4,50%</td></tr><tr><td>De R$ 450.000,01 a R$ 900.000,00</td><td>8,25%</td><td>8,00%</td></tr><tr><td>De R$ 900.000,01 a R$ 1.800.000,00</td><td>11,25%</td><td>12,25%</td></tr></tbody>', 'wrap-foot': 'A informação de alíquota do anexo II é significativa'
+                }
+                ]
+            }
+
+        self.assertEqual(extract, expected_output)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona classes de extracao para figuras, tabelas e formulas.

#### Onde a revisão poderia começar?
Pelo Commit

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests/sps/test_table.py `
`python setup.py test -s tests/sps/test_figure.py `
`python setup.py test -s tests/sps/test_formula.py `

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A
#### Quais são tickets relevantes?
[#393](https://github.com/scieloorg/packtools/issues/393)

### Referências
[SciElo Docs "disp-formula"](https://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.6-branch/tagset/elemento-disp-formula.html)
[SicElo Docs "table"](https://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.6-branch/tagset/elemento-table.html)
[SciElo Docs "fig"](https://docs.scielo.org/projects/scielo-publishing-schema/pt_BR/1.6-branch/tagset/elemento-fig.html)

