### PR TITLE
Corrige a obtenção de rid de aff em autor que pode ser ausente

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -42,8 +42,9 @@ class Authors:
                 _content_type = role.get('content-type')
                 _author['role'].append({"text": _role, "content-type": _content_type})
 
-            _author['rid'] = node.find('./xref').attrib['rid']
+            for xref in node.xpath("xref"):
+                if xref.get("ref-type") == "aff":
+                    _author['rid'] = xref.get("rid")
             _author['contrib-type'] = node.attrib['contrib-type']
-            
             _data.append(_author)
         return _data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ charset-normalizer<3.0
 aiohttp==3.8.3
 python-magic==0.4.27
 tox==4.3.1
+langcodes==3.3.0
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data

--- a/tests/sps/test_article_authors.py
+++ b/tests/sps/test_article_authors.py
@@ -23,6 +23,39 @@ from unittest import TestCase, skip
 from lxml import etree
 
 
+class AuthorsWithoutXrefTest(TestCase):
+
+    def setUp(self):
+        xml = ("""
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                </contrib>
+                </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """)
+        xmltree = etree.fromstring(xml)
+        self.authors = Authors(xmltree)
+
+    def test_contribs(self):
+        expected = [
+            {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
+             "prefix": "Prof", "suffix": "Nieto", "contrib-type": "author"},
+        ]
+        result = self.authors.contribs
+        self.assertDictEqual(expected[0], result[0])
+
+
 class AuthorsTest(TestCase):
 
     def setUp(self):

--- a/tests/sps/test_article_authors.py
+++ b/tests/sps/test_article_authors.py
@@ -48,12 +48,8 @@ class AuthorsWithoutXrefTest(TestCase):
         self.authors = Authors(xmltree)
 
     def test_contribs(self):
-        expected = [
-            {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
-             "prefix": "Prof", "suffix": "Nieto", "contrib-type": "author"},
-        ]
         result = self.authors.contribs
-        self.assertDictEqual(expected[0], result[0])
+        self.assertIsNone(result[0].get("rid"))
 
 
 class AuthorsTest(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a obtenção de rid de aff em autor que pode ser ausente

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o teste automatizado com o comando:
```console
python -m unittest -v -k Witho
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
