### PR TITLE
Modificado article abstract para extrair texto com ou sem subtags

### DIFF
--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -1,3 +1,5 @@
+from packtools.sps.utils import xml_utils
+
 """
 <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
 article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
@@ -71,86 +73,116 @@ article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lan
 """
 
 
-class Abstract:
+def extract_subtag_text(node, subtag):
+    function_tag = (
+        xml_utils.node_text_without_xref
+        if subtag
+        else xml_utils.get_node_without_subtag
+    )
+    return function_tag(node)
 
+
+class Abstract:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    def get_values_dict_without_tags(self, attrib, lang):
+    def get_values_dict_without_title(self, attrib, lang, subtag):
         values = []
         for node in self.xmltree.xpath(f"{attrib}//sec"):
-            values.append(node.xpath("./p")[0].text)
+            values.append(extract_subtag_text(node.xpath("./p")[0], subtag=subtag))
         out = {lang: " ".join(values)}
         return out
 
-    def get_values_dict_with_tags(self, attrib):
+    def get_values_dict_with_title(self, attrib, subtag):
         out = dict()
         for node in self.xmltree.xpath(f"{attrib}//sec"):
-            out[node.xpath("./title")[0].text] = node.xpath("./p")[0].text
+            out[node.xpath("./title")[0].text] = extract_subtag_text(
+                node.xpath("p")[0], subtag=subtag
+            )
 
         return out
 
-    @property
-    def main_abstract_without_tags(self):
+    def main_abstract_without_title(self, subtag):
         lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
+        return self.get_values_dict_without_title(
+            attrib=".//front//article-meta//abstract", lang=lang, subtag=subtag
+        )
 
-        return self.get_values_dict_without_tags('.//front//article-meta//abstract', lang)
-
-    @property
-    def main_abstract_with_tags(self):
+    def main_abstract_with_title(self, subtag):
         try:
             out = {
-                'lang': self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang"),
-                'title': self.xmltree.xpath(".//front//article-meta//abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//front//article-meta//abstract')
+                "lang": self.xmltree.find(".").get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                "title": self.xmltree.xpath(".//front//article-meta//abstract//title")[0].text,
+                "sections": self.get_values_dict_with_title(
+                    attrib=".//front//article-meta//abstract", subtag=subtag
+                ),
             }
             return out
         except AttributeError:
             pass
 
-    @property
-    def sub_article_abstract_with_tags(self):
+    def sub_article_abstract_with_title(self, subtag):
         try:
             out = {
-                'lang': self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang"),
-                'title': self.xmltree.xpath(".//sub-article//front-stub//abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//sub-article//front-stub//abstract')
+                "lang": self.xmltree.find(".//sub-article").get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                "title": self.xmltree.xpath(
+                    ".//sub-article//front-stub//abstract//title"
+                )[0].text,
+                "sections": self.get_values_dict_with_title(
+                    attrib=".//sub-article//front-stub//abstract", subtag=subtag
+                ),
             }
             return out
         except AttributeError:
             pass
 
-    @property
-    def sub_article_abstract_without_tags(self):
-        lang = self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang")
+    def sub_article_abstract_without_title(self, subtag):
+        lang = self.xmltree.find(".//sub-article").get(
+            "{http://www.w3.org/XML/1998/namespace}lang"
+        )
 
-        return self.get_values_dict_without_tags('.//sub-article//front-stub//abstract', lang)
+        return self.get_values_dict_without_title(
+            attrib=".//sub-article//front-stub//abstract", lang=lang, subtag=subtag
+        )
 
-    @property
-    def trans_abstract_with_tags(self):
+    def trans_abstract_with_title(self, subtag):
         try:
             out = {
-                'lang': self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang"),
-                'title': self.xmltree.xpath(".//front//article-meta//trans-abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//front//article-meta//trans-abstract')
+                "lang": self.xmltree.find(".//trans-abstract").get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                "title": self.xmltree.xpath(
+                    ".//front//article-meta//trans-abstract//title")[0].text,
+                "sections": self.get_values_dict_with_title(
+                    attrib=".//front//article-meta//trans-abstract", subtag=subtag
+                ),
             }
             return out
         except AttributeError:
             pass
 
-    @property
-    def trans_abstract_without_tags(self):
-        lang = self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang")
+    def trans_abstract_without_title(self, subtag):
+        lang = self.xmltree.find(".//trans-abstract").get(
+            "{http://www.w3.org/XML/1998/namespace}lang"
+        )
 
-        return self.get_values_dict_without_tags('.//front//article-meta//trans-abstract', lang)
+        return self.get_values_dict_without_title(
+            attrib=".//front//article-meta//trans-abstract", lang=lang, subtag=subtag
+        )
 
-    @property
-    def abstracts_with_tags(self):
-        return [self.main_abstract_with_tags, self.trans_abstract_with_tags, self.sub_article_abstract_with_tags]
+    def abstracts_with_title(self, subtag):
+        return [
+            self.main_abstract_with_title(subtag=subtag),
+            self.trans_abstract_with_title(subtag=subtag),
+            self.sub_article_abstract_with_title(subtag=subtag),
+        ]
 
-    @property
-    def abstracts_without_tags(self):
-        out = self.main_abstract_without_tags
-        out.update(self.trans_abstract_without_tags)
-        out.update(self.sub_article_abstract_without_tags)
+    def abstracts_without_title(self, subtag):
+        out = self.main_abstract_without_title(subtag=subtag)
+        out.update(self.trans_abstract_without_title(subtag=subtag))
+        out.update(self.sub_article_abstract_without_title(subtag=subtag))
         return out

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -274,3 +274,26 @@ def match_pubdate(node, pubdate_xpaths):
         pubdate = node.find(xpath)
         if pubdate is not None:
             return pubdate
+
+
+def get_node_without_subtag(node):
+    """
+    Returns a node without subtags.
+
+    Parameters:
+    - node: The node to be processed.
+
+    Returns:
+    A string containing the text within the node, without the subtags.
+
+    Example:
+    >>> from lxml import etree
+    >>> xml = "<p>Text <italic>with subtag</italic> inside the node</p>"
+    >>> root = etree.fromstring(xml)
+    >>> node = root.find("tag")
+    >>> get_node_without_subtag(node)
+    'Text with subtag inside the ndoe'
+    """
+    return "".join(node.xpath(".//text()"))
+
+

--- a/tests/sps/test_article_abstract.py
+++ b/tests/sps/test_article_abstract.py
@@ -3,14 +3,14 @@ from unittest import TestCase
 from lxml import etree as ET
 
 from packtools.sps.models.article_abstract import Abstract
+from packtools.sps.utils import xml_utils
 
 
 class AbstractTest(TestCase):
     maxDiff = None
 
-    def test_main_abstract_with_tags(self):
-        xml = (
-            """
+    def test_main_abstract_with_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -38,10 +38,9 @@ class AbstractTest(TestCase):
             </front>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).main_abstract_with_tags
-
+        obtained = Abstract(data).main_abstract_with_title(subtag=False)
+        # import ipdb; ipdb.set_trace()
         expected = {
             "lang": "en",
             "title": "Abstract",
@@ -49,15 +48,14 @@ class AbstractTest(TestCase):
                 "Objective:": "objective",
                 "Method:": "method",
                 "Results:": "results",
-                "Conclusion:": "conclusion"
-            }
+                "Conclusion:": "conclusion",
+            },
         }
 
         self.assertEqual(obtained, expected)
 
-    def test_main_abstract_without_tags(self):
-        xml = (
-            """
+    def test_main_abstract_without_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -85,17 +83,15 @@ class AbstractTest(TestCase):
             </front>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).main_abstract_without_tags
+        obtained = Abstract(data).main_abstract_without_title(subtag=False)
 
-        expected = {'en': 'objective method results conclusion'}
+        expected = {"en": "objective method results conclusion"}
 
         self.assertEqual(obtained, expected)
 
-    def test_sub_article_abstract_with_tags(self):
-        xml = (
-            """
+    def test_sub_article_abstract_with_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
                 <sub-article article-type="translation" id="s1" xml:lang="pt">
@@ -124,9 +120,8 @@ class AbstractTest(TestCase):
                 </sub-article>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).sub_article_abstract_with_tags
+        obtained = Abstract(data).sub_article_abstract_with_title(subtag=False)
 
         expected = {
             "lang": "pt",
@@ -135,15 +130,14 @@ class AbstractTest(TestCase):
                 "Objetivo:": "objetivo",
                 "Método:": "metodo",
                 "Resultados:": "resultados",
-                "Conclusão:": "conclusão"
-            }
+                "Conclusão:": "conclusão",
+            },
         }
 
         self.assertEqual(obtained, expected)
 
-    def test_sub_article_abstract_without_tags(self):
-        xml = (
-            """
+    def test_sub_article_abstract_without_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
                 <sub-article article-type="translation" id="s1" xml:lang="pt">
@@ -172,17 +166,15 @@ class AbstractTest(TestCase):
                 </sub-article>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).sub_article_abstract_without_tags
+        obtained = Abstract(data).sub_article_abstract_without_title(subtag=False)
 
-        expected = {'pt': 'objetivo metodo resultados conclusão'}
+        expected = {"pt": "objetivo metodo resultados conclusão"}
 
         self.assertEqual(obtained, expected)
 
-    def test_trans_abstract_with_tags(self):
-        xml = (
-            """
+    def test_trans_abstract_with_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -210,9 +202,8 @@ class AbstractTest(TestCase):
             </front>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_with_tags
+        obtained = Abstract(data).trans_abstract_with_title(subtag=False)
 
         expected = {
             "lang": "es",
@@ -221,15 +212,14 @@ class AbstractTest(TestCase):
                 "Objetivo:": "objetivo",
                 "Método:": "metodo",
                 "Resultados:": "resultados",
-                "Conclusión:": "conclusion"
-            }
+                "Conclusión:": "conclusion",
+            },
         }
 
         self.assertEqual(obtained, expected)
 
-    def test_trans_abstract_without_tags(self):
-        xml = (
-            """
+    def test_trans_abstract_without_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -257,17 +247,15 @@ class AbstractTest(TestCase):
             </front>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_without_tags
+        obtained = Abstract(data).trans_abstract_without_title(subtag=False)
 
-        expected = {'es': 'objetivo metodo resultados conclusion'}
+        expected = {"es": "objetivo metodo resultados conclusion"}
 
         self.assertEqual(obtained, expected)
 
-    def test_abstracts_with_tags(self):
-        xml = (
-            """
+    def test_abstracts_with_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -338,9 +326,8 @@ class AbstractTest(TestCase):
                 </sub-article>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).abstracts_with_tags
+        obtained = Abstract(data).abstracts_with_title(subtag=True)
 
         expected = [
             {
@@ -350,8 +337,8 @@ class AbstractTest(TestCase):
                     "Objective:": "objective",
                     "Method:": "method",
                     "Results:": "results",
-                    "Conclusion:": "conclusion"
-                }
+                    "Conclusion:": "conclusion",
+                },
             },
             {
                 "lang": "es",
@@ -360,8 +347,8 @@ class AbstractTest(TestCase):
                     "Objetivo:": "objetivo",
                     "Método:": "metodo",
                     "Resultados:": "resultados",
-                    "Conclusión:": "conclusion"
-                }
+                    "Conclusión:": "conclusion",
+                },
             },
             {
                 "lang": "pt",
@@ -370,17 +357,15 @@ class AbstractTest(TestCase):
                     "Objetivo:": "objetivo",
                     "Método:": "metodo",
                     "Resultados:": "resultados",
-                    "Conclusão:": "conclusão"
-                }
-            }
-
+                    "Conclusão:": "conclusão",
+                },
+            },
         ]
 
         self.assertEqual(obtained, expected)
 
-    def test_abstracts_without_tags(self):
-        xml = (
-            """
+    def test_abstracts_without_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -451,21 +436,19 @@ class AbstractTest(TestCase):
                 </sub-article>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).abstracts_without_tags
+        obtained = Abstract(data).abstracts_without_title(subtag=False)
 
         expected = {
-            'en': 'objective method results conclusion',
-            'pt': 'objetivo metodo resultados conclusão',
-            'es': 'objetivo metodo resultados conclusion'
+            "en": "objective method results conclusion",
+            "pt": "objetivo metodo resultados conclusão",
+            "es": "objetivo metodo resultados conclusion",
         }
 
         self.assertEqual(obtained, expected)
 
-    def test_without_trans_abstract_with_tags(self):
-        xml = (
-            """
+    def test_without_trans_abstract_with_title(self):
+        xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
@@ -474,10 +457,91 @@ class AbstractTest(TestCase):
             </front>
             </article>
             """
-        )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_with_tags
+        obtained = Abstract(data).trans_abstract_with_title(subtag=False)
 
         expected = None
+
+        self.assertEqual(obtained, expected)
+
+    def test_main_abstract_with_title_and_without_subtags(self):
+        xml = """
+        <article>
+            <front>
+                <article-meta>
+                    <abstract>
+                <title>Abstract</title>
+                <sec>
+                    <title>Background and objectives:</title>
+                    <p>Pain is one of the most common reason for seeking medical care. This study
+                        aimed to analyze patients with chronic pain in Maricá, Rio de Janeiro State,
+                        Brazil.</p>
+                </sec>
+                <sec>
+                    <title>Methods:</title>
+                    <p>A transversal retrospective study with 200 patients, who were treated in
+                        ambulatory care in a public hospital from June 2014 to December 2015. The
+                        variables considered were: pain intensity, type of pain, anatomical
+                        location, diagnosis and treatment. The data were statistically analyzed, the
+                        Fisher's exact test was applied, and the probability <italic>p</italic> was
+                        significant when &#x2264;0.05.</p>
+                </sec>
+            </abstract>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml = ET.fromstring(xml)
+        obtained = Abstract(xmltree=xml).main_abstract_with_title(subtag=False)
+
+        expected = {
+            "lang": None,
+            "title": "Abstract",
+            "sections": {
+                "Background and objectives:": "Pain is one of the most common reason for seeking medical care. This study\n                        aimed to analyze patients with chronic pain in Maricá, Rio de Janeiro State,\n                        Brazil.",
+                "Methods:": "A transversal retrospective study with 200 patients, who were treated in\n                        ambulatory care in a public hospital from June 2014 to December 2015. The\n                        variables considered were: pain intensity, type of pain, anatomical\n                        location, diagnosis and treatment. The data were statistically analyzed, the\n                        Fisher's exact test was applied, and the probability p was\n                        significant when ≤0.05.",
+            },
+        }
+
+        self.assertEqual(obtained, expected)
+
+    def test_main_abstract_with_title_and_subtags(self):
+        xml = """
+        <article>
+            <front>
+                <article-meta>
+                    <abstract>
+                <title>Abstract</title>
+                <sec>
+                    <title>Background and objectives:</title>
+                    <p>Pain is one of the most common reason for seeking medical care. This study
+                        aimed to analyze patients with chronic pain <italic>in</italic> Maricá, Rio de Janeiro State,
+                        Brazil.</p>
+                </sec>
+                <sec>
+                    <title>Methods:</title>
+                    <p>A transversal retrospective study with 200 patients, who were treated in
+                        ambulatory care in a public hospital from June 2014 to December 2015. The
+                        variables considered were: pain intensity, type of pain, anatomical
+                        location, diagnosis and treatment. The data were statistically analyzed, the
+                        Fisher's exact test was applied, and the probability <italic>p</italic> was
+                        significant when &#x2264;0.05.</p>
+                </sec>
+            </abstract>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml = ET.fromstring(xml)
+        obtained = Abstract(xmltree=xml).main_abstract_with_title(subtag=True)
+
+        expected = {
+            "lang": None,
+            "title": "Abstract",
+            "sections": {
+                "Background and objectives:": "Pain is one of the most common reason for seeking medical care. This study\n                        aimed to analyze patients with chronic pain <italic>in</italic> Maricá, Rio de Janeiro State,\n                        Brazil.",
+                "Methods:": "A transversal retrospective study with 200 patients, who were treated in\n                        ambulatory care in a public hospital from June 2014 to December 2015. The\n                        variables considered were: pain intensity, type of pain, anatomical\n                        location, diagnosis and treatment. The data were statistically analyzed, the\n                        Fisher's exact test was applied, and the probability <italic>p</italic> was\n                        significant when ≤0.05.",
+            },
+        }
 
         self.assertEqual(obtained, expected)


### PR DESCRIPTION
#### O que esse PR faz?
Modifica métodos da classe Abstract para extrair textos das tags com ou sem subtags.

#### Onde a revisão poderia começar?
A partir do commit https://github.com/scieloorg/packtools/commit/3b66fdf0e6fd466e96e67aa2a4eb31fbc45fd6f9

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests/sps/test_article_abstract.py `

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![Captura de tela de 2023-05-24 22-39-56](https://github.com/scieloorg/packtools/assets/82840278/22620678-0b40-4c1d-896b-11c3cbb071f0)


#### Quais são tickets relevantes?
[#384](https://github.com/scieloorg/packtools/issues/384)

### Referências
N/A

