### PR TITLE
Corrige o link para a imagem da licença quando há  no link

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-permissions.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-permissions.xsl
@@ -59,6 +59,7 @@
         <xsl:variable name="icon_path"><xsl:value-of select="substring-after(@xlink:href,'creativecommons.org/licenses/')"/></xsl:variable>
         <xsl:variable name="icon"><xsl:choose>
             <xsl:when test="contains($icon_path,'/legalcode')"><xsl:value-of select="substring-before($icon_path,'/legalcode')"/></xsl:when>
+            <xsl:when test="contains($icon_path,'/deed')"><xsl:value-of select="substring-before($icon_path,'/deed')"/></xsl:when>
             <xsl:when test="contains($icon_path,'/deen')"><xsl:value-of select="substring-before($icon_path,'/deen')"/></xsl:when>
             <xsl:otherwise><xsl:value-of select="$icon_path"/></xsl:otherwise>
         </xsl:choose></xsl:variable><xsl:value-of select="$icon"/>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o link da imagem da licença de uso. 
Corrige o termo `deed` (estava `deen`) para ser extraído da URI de licença e formar o link para a imagem

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python packtools/htmlgenerator.py --css /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css --print_css /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css --js /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/dot_in_id/tabelas.xml
```

```console
python packtools/htmlgenerator.py --css /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone.css --print_css /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-bundle-print.css --js /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/catalogs/htmlgenerator/static/scielo-article-standalone-min.js --nonetwork --nochecks --loglevel DEBUG  tests/fixtures/htmlgenerator/dot_in_id/arquivo.xml

```
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#423

### Referências
n/a
