### PR TITLE
Faz com que Authors retorne as afiliações junto aos dados de autores

### DIFF
--- a/packtools/sps/models/aff.py
+++ b/packtools/sps/models/aff.py
@@ -140,7 +140,7 @@ class Affiliation:
     @property
     def affiliation_list(self):
         """
-        Retorna lista de afiliações dos autores principais
+        Retorna lista de afiliações
 
         Returns
         -------
@@ -163,7 +163,7 @@ class Affiliation:
         loc_types = ["state", "city"]
         inst_types = ["orgname", "orgdiv1", "orgdiv2", "original"]
 
-        for aff_node in self._xmltree.xpath(".//article-meta//aff"):
+        for aff_node in self._xmltree.xpath(".//aff"):
 
             affiliation_id = aff_node.get("id")
 
@@ -177,10 +177,10 @@ class Affiliation:
 
             address = {}
             for loc_type in loc_types:
-                address[loc_type] = aff_node.findtext(f"addr-line/{field}")
+                address[loc_type] = aff_node.findtext(f"addr-line/{loc_type}")
                 if not address[loc_type]:
                     address[loc_type] = aff_node.findtext(
-                        f'addr-line/named-content[@content-type="{field}"]'
+                        f'addr-line/named-content[@content-type="{loc_type}"]'
                     )
             address["country_name"] = aff_node.findtext("country")
 
@@ -197,4 +197,33 @@ class Affiliation:
             item.update(institution)
             item.update(address)
             data.append(item)
+        return data
+
+    @property
+    def affiliation_by_id(self):
+        """
+        Retorna as afiliações indexadas pelo seu id
+
+        Returns
+        -------
+        dict of dict, which key is id
+        {"aff1":
+            {
+                "id": affiliation_id or None,
+                "label": label or None,
+                "orgname": orgname or None,
+                "orgdiv1": orgdiv1 or None,
+                "orgdiv2": orgdiv2 or None,
+                "original": original or None,
+                "city": city or None,
+                "state": state or None,
+                "country_name": country_name or None,
+                "country_code": country_code or None,
+                "email": email or None,
+            }
+        }
+        """
+        data = {}
+        for item in self.affiliation_list:
+            data[item["id"]] = item
         return data

--- a/packtools/sps/models/aff.py
+++ b/packtools/sps/models/aff.py
@@ -4,7 +4,7 @@ from packtools.sps.utils import xml_utils
 
 def get_node_without_subtag(node):
     """
-        Função que retorna nó sem subtags. 
+    Função que retorna nó sem subtags.
     """
     return "".join(node.xpath(".//text()"))
 
@@ -27,7 +27,7 @@ class AffiliationExtractor:
 
     def extract_affiliation_data(self, nodes, subtag):
         data = []
-        address_aff = ['state', 'city']
+        address_aff = ["state", "city"]
         institution_aff = ["orgname", "orgdiv1", "orgdiv2", "original"]
 
         # Define se a extração vai ocorrer com subtags ou sem.
@@ -39,56 +39,62 @@ class AffiliationExtractor:
                 affiliation_id = aff_node.get('id')
 
                 try:
-                    label = aff_node.xpath('label')[0].text
+                    label = aff_node.xpath("label")[0].text
                 except IndexError:
                     label = None
 
                 institution = {}
                 for inst in institution_aff:
                     try:
-                        institution[inst] = aff_text(aff_node.xpath(f'institution[@content-type="{inst}"]')[0])
+                        institution[inst] = aff_text(
+                            aff_node.xpath(f'institution[@content-type="{inst}"]')[0]
+                        )
                     except IndexError:
-                        institution[inst] = ''
+                        institution[inst] = ""
 
                 address = {}
                 for field in address_aff:
                     try:
                         address[field] = aff_text(
-                            aff_node.xpath(f'addr-line/named-content[@content-type="{field}"]')[0])
+                            aff_node.xpath(
+                                f'addr-line/named-content[@content-type="{field}"]'
+                            )[0]
+                        )
                     except IndexError:
-                        pass
+                        address[field] = ""
 
-                city = address['city']
-                state = address['state']
+                city = address["city"]
+                state = address["state"]
 
                 try:
-                    country_node = aff_node.xpath('country')[0]
+                    country_node = aff_node.xpath("country")[0]
                     country = aff_text(country_node)
-                    country_code = country_node.get('country', '')
+                    country_code = country_node.get("country", "")
                 except IndexError:
-                    country = ''
-                    country_code = ''
+                    country = ""
+                    country_code = ""
 
                 try:
-                    email = aff_node.xpath('email')[0].text
+                    email = aff_node.xpath("email")[0].text
                 except IndexError:
-                    email = ''
+                    email = ""
 
-                data.append({
-                    'id': affiliation_id,
-                    'label': label,
-                    'institution': [institution],
-                    'city': city,
-                    'state': state,
-                    'country': [
-                        {
-                            'code': country_code,
-                            'name': country,
-                        }
-                    ],
-                    'email': email,
-                })
-
+                data.append(
+                    {
+                        "id": affiliation_id,
+                        "label": label,
+                        "institution": [institution],
+                        "city": city,
+                        "state": state,
+                        "country": [
+                            {
+                                "code": country_code,
+                                "name": country,
+                            }
+                        ],
+                        "email": email,
+                    }
+                )
         return data
 
     def get_affiliation_dict(self, subtag):
@@ -105,19 +111,19 @@ class AffiliationExtractor:
         contrib_group_node = self.extract_contrib_group
 
         try:
-            if article_meta_node[0].xpath('aff'):
+            if article_meta_node[0].xpath("aff"):
                 list_nodes.append(article_meta_node[0])
         except IndexError:
             pass
 
         try:
-            if front_stub_node[0].xpath('aff'):
+            if front_stub_node[0].xpath("aff"):
                 list_nodes.append(front_stub_node[0])
         except IndexError:
             pass
 
         try:
-            if contrib_group_node[0].xpath('aff'):
+            if contrib_group_node[0].xpath("aff"):
                 list_nodes.append(contrib_group_node[0])
         except IndexError:
             pass

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -1,3 +1,6 @@
+from packtools.sps.models.aff import Affiliation
+
+
 class Authors:
     def __init__(self, xmltree):
         self.xmltree = xmltree
@@ -44,3 +47,14 @@ class Authors:
             _author['contrib-type'] = node.attrib['contrib-type']
             _data.append(_author)
         return _data
+
+    @property
+    def contribs_with_affs(self):
+        affs = Affiliation(self.xmltree)
+        affs_by_id = affs.affiliation_by_id
+
+        for item in self.contribs:
+            for rid in item["aff_rids"]:
+                item.setdefault("affs", [])
+                item["affs"].append(affs_by_id.get(rid))
+            yield item

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -44,6 +44,7 @@ class Authors:
 
             _author['rid'] = [xref.get('rid') for xref in node.findall('.//xref')]
             _author['rid-aff'] = [xref.get('rid') for xref in node.findall('.//xref[@ref-type="aff"]')]
+            _author['aff_rids'] = _author['rid-aff']
             _author['contrib-type'] = node.attrib['contrib-type']
             _data.append(_author)
         return _data

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -42,10 +42,26 @@ class Authors:
                 _content_type = role.get("content-type")
                 _author["role"].append({"text": _role, "content-type": _content_type})
 
-            _author['rid'] = [xref.get('rid') for xref in node.findall('.//xref')]
-            _author['rid-aff'] = [xref.get('rid') for xref in node.findall('.//xref[@ref-type="aff"]')]
-            _author['aff_rids'] = _author['rid-aff']
-            _author['contrib-type'] = node.attrib['contrib-type']
+            for xref in node.findall('.//xref'):
+                rid = xref.get("rid")
+
+                if not rid:
+                    continue
+                _author.setdefault("rid", [])
+                _author["rid"].append(rid)
+
+                reftype = xref.get("ref-type")
+                if not reftype == "aff":
+                    continue
+                _author.setdefault("rid-aff", [])
+                _author["rid-aff"].append(rid)
+
+            try:
+                _author["aff_rids"] = _author["rid-aff"]
+            except KeyError:
+                pass
+
+            _author["contrib-type"] = node.attrib["contrib-type"]
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -1,5 +1,4 @@
 class Authors:
-
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
@@ -22,25 +21,23 @@ class Authors:
                 except IndexError:
                     pass
             try:
-                _author["given_names"] = (
-                    node.xpath(".//given-names")[0].text
-                )
+                _author["given_names"] = node.xpath(".//given-names")[0].text
             except IndexError:
                 pass
             try:
-                _author["orcid"] = (
-                    node.xpath("contrib-id[@contrib-id-type='orcid']")[0].text
-                )
+                _author["orcid"] = node.xpath("contrib-id[@contrib-id-type='orcid']")[
+                    0
+                ].text
             except IndexError:
                 pass
 
             if node.xpath(".//role"):
-                _author['role'] = []
+                _author["role"] = []
 
             for role in node.xpath(".//role"):
                 _role = role.text
-                _content_type = role.get('content-type')
-                _author['role'].append({"text": _role, "content-type": _content_type})
+                _content_type = role.get("content-type")
+                _author["role"].append({"text": _role, "content-type": _content_type})
 
             _author['rid'] = [xref.get('rid') for xref in node.findall('.//xref')]
             _author['rid-aff'] = [xref.get('rid') for xref in node.findall('.//xref[@ref-type="aff"]')]

--- a/tests/sps/models/test_aff.py
+++ b/tests/sps/models/test_aff.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from packtools.sps.models.aff import AffiliationExtractor
+from packtools.sps.models.aff import Affiliation
 
 from lxml import etree
 
@@ -675,3 +676,300 @@ class AffTest(TestCase):
             }
         }
         self.assertEqual(data, expected_output)
+
+
+class AffiliationTest(TestCase):
+    def test_extract_affiliation_list_only_from_article_meta(self):
+        xml = """
+        <article>
+            <front>
+                <article-meta>
+                    <aff id="aff1">
+                        <label>I</label>
+                        <institution content-type="orgname">Secretaria Municipal de Saúde de Belo Horizonte</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                    <aff id="aff2">
+                        <label>II</label>
+                        <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                        <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                </article-meta>
+                <front-stub>
+                <aff id="aff3">
+                    <label>III</label>
+                    <institution content-type="orgdiv2">Departamento de Ciências Sociais</institution>
+                    <institution content-type="orgdiv1">Escola Nacional de Saúde Pública Sergio Arouca</institution>
+                    <institution content-type="orgname">Fundação Oswaldo Cruz</institution>
+                    <addr-line>
+                        <named-content content-type="city">Rio de Janeiro</named-content>
+                        <named-content content-type="state">RJ</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil</institution>
+                </aff>
+            </front-stub>
+            <contrib-group>
+                <aff id="aff4">
+                    <label>IV</label>
+                    <institution content-type="orgdiv2">Departamento de Farmácia Social</institution>
+                    <institution content-type="orgdiv1">Faculdade de Farmácia</institution>
+                    <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                    <addr-line>
+                        <named-content content-type="city">Belo Horizonte</named-content>
+                        <named-content content-type="state">MG</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                </aff>
+                <aff id="aff5">
+                    <label>V</label>
+                    <institution content-type="orgdiv2">Departamento de Saúde Comunitária</institution>
+                    <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                    <institution content-type="orgname">Universidade Federal do Ceará</institution>
+                    <addr-line>
+                        <named-content content-type="city">Fortaleza</named-content>
+                        <named-content content-type="state">CE</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil</institution>
+                </aff>
+            </contrib-group>
+            </front>
+        </article>
+        """
+
+        xml = etree.fromstring(xml)
+        data = Affiliation(xml).affiliation_list
+
+        expected_output = [
+            {
+                "id": "aff1",
+                "label": "I",
+                "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                "orgdiv1": None,
+                "orgdiv2": None,
+                "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+            {
+                "id": "aff2",
+                "label": "II",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "orgname": "Universidade Federal de Minas Gerais",
+                "orgdiv1": "Faculdade de Medicina",
+                "orgdiv2": None,
+                "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                "email": None,
+            },
+            {
+                "id": "aff3",
+                "label": "III",
+                "orgname": "Fundação Oswaldo Cruz",
+                "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
+                "orgdiv2": "Departamento de Ciências Sociais",
+                "original": "Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil",
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+            {
+                "id": "aff4",
+                "label": "IV",
+                "orgname": "Universidade Federal de Minas Gerais",
+                "orgdiv1": "Faculdade de Farmácia",
+                "orgdiv2": "Departamento de Farmácia Social",
+                "original": "Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+            {
+                "id": "aff5",
+                "label": "V",
+                "orgname": "Universidade Federal do Ceará",
+                "orgdiv1": "Faculdade de Medicina",
+                "orgdiv2": "Departamento de Saúde Comunitária",
+                "original": "Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil",
+                "city": "Fortaleza",
+                "state": "CE",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+        ]
+
+        self.assertEqual(5, len(data))
+        for i, item in enumerate(data):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected_output[i])
+
+    def test_extract_affiliation_by_id_only_from_article_meta(self):
+        xml = """
+        <article>
+            <front>
+                <article-meta>
+                    <aff id="aff1">
+                        <label>I</label>
+                        <institution content-type="orgname">Secretaria Municipal de Saúde de Belo Horizonte</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                    <aff id="aff2">
+                        <label>II</label>
+                        <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                        <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                </article-meta>
+                <front-stub>
+                <aff id="aff3">
+                    <label>III</label>
+                    <institution content-type="orgdiv2">Departamento de Ciências Sociais</institution>
+                    <institution content-type="orgdiv1">Escola Nacional de Saúde Pública Sergio Arouca</institution>
+                    <institution content-type="orgname">Fundação Oswaldo Cruz</institution>
+                    <addr-line>
+                        <named-content content-type="city">Rio de Janeiro</named-content>
+                        <named-content content-type="state">RJ</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil</institution>
+                </aff>
+            </front-stub>
+            <contrib-group>
+                <aff id="aff4">
+                    <label>IV</label>
+                    <institution content-type="orgdiv2">Departamento de Farmácia Social</institution>
+                    <institution content-type="orgdiv1">Faculdade de Farmácia</institution>
+                    <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                    <addr-line>
+                        <named-content content-type="city">Belo Horizonte</named-content>
+                        <named-content content-type="state">MG</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                </aff>
+                <aff id="aff5">
+                    <label>V</label>
+                    <institution content-type="orgdiv2">Departamento de Saúde Comunitária</institution>
+                    <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                    <institution content-type="orgname">Universidade Federal do Ceará</institution>
+                    <addr-line>
+                        <named-content content-type="city">Fortaleza</named-content>
+                        <named-content content-type="state">CE</named-content>
+                    </addr-line>
+                    <country>Brasil</country>
+                    <institution content-type="original">Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil</institution>
+                </aff>
+            </contrib-group>
+            </front>
+        </article>
+        """
+
+        xml = etree.fromstring(xml)
+        data = Affiliation(xml).affiliation_by_id
+
+        expected_output = {
+        "aff1":
+            {
+                "id": "aff1",
+                "label": "I",
+                "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                "orgdiv1": None,
+                "orgdiv2": None,
+                "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+        "aff2": {
+                "id": "aff2",
+                "label": "II",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "orgname": "Universidade Federal de Minas Gerais",
+                "orgdiv1": "Faculdade de Medicina",
+                "orgdiv2": None,
+                "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                "email": None,
+            },
+        "aff3": {
+                "id": "aff3",
+                "label": "III",
+                "orgname": "Fundação Oswaldo Cruz",
+                "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
+                "orgdiv2": "Departamento de Ciências Sociais",
+                "original": "Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil",
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+        "aff4": {
+                "id": "aff4",
+                "label": "IV",
+                "orgname": "Universidade Federal de Minas Gerais",
+                "orgdiv1": "Faculdade de Farmácia",
+                "orgdiv2": "Departamento de Farmácia Social",
+                "original": "Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            },
+        "aff5": {
+                "id": "aff5",
+                "label": "V",
+                "orgname": "Universidade Federal do Ceará",
+                "orgdiv1": "Faculdade de Medicina",
+                "orgdiv2": "Departamento de Saúde Comunitária",
+                "original": "Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil",
+                "city": "Fortaleza",
+                "state": "CE",
+                "country_code": None,
+                "country_name": "Brasil",
+                "email": None,
+            }
+        }
+
+        self.assertEqual(5, len(data))
+        for k, item in data.items():
+            with self.subTest(k):
+                self.assertDictEqual(expected_output[k], item)

--- a/tests/sps/models/test_aff.py
+++ b/tests/sps/models/test_aff.py
@@ -7,7 +7,7 @@ from lxml import etree
 
 class AffTest(TestCase):
     def test_extract_affliation_article_meta_front_stub_contrib_group(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -75,123 +75,100 @@ class AffTest(TestCase):
             </contrib-group>
             </front>
         </article>
-        """)
+        """
 
         xml = etree.fromstring(xml)
-        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(subtag=False)
+        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(
+            subtag=False
+        )
 
         expected_output = [
             {
-                'id': 'aff1',
-                'label': 'I',
-                'institution': [
+                "id": "aff1",
+                "label": "I",
+                "institution": [
                     {
-                        'orgname': 'Secretaria Municipal de Saúde de Belo Horizonte',
-                        'orgdiv1': '',
-                        'orgdiv2': '',
-                        'original': 'Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil'
+                        "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                        "orgdiv1": "",
+                        "orgdiv2": "",
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff2',
-                'label': 'II',
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
+                "id": "aff2",
+                "label": "II",
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "institution": [
                     {
-                        'code': '',
-                        'name': 'Brasil'
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "",
+                        "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'institution': [
-                    {
-                        'orgname': 'Universidade Federal de Minas Gerais',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': '',
-                        'original': 'Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
-                    }
-                ],
-                'email': ''
+                "email": "",
             },
             {
-                'id': 'aff3',
-                'label': 'III',
-                'institution': [
+                "id": "aff3",
+                "label": "III",
+                "institution": [
                     {
-                        'orgname': 'Fundação Oswaldo Cruz',
-                        'orgdiv1': 'Escola Nacional de Saúde Pública Sergio Arouca',
-                        'orgdiv2': 'Departamento de Ciências Sociais',
-                        'original': 'Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil'
+                        "orgname": "Fundação Oswaldo Cruz",
+                        "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
+                        "orgdiv2": "Departamento de Ciências Sociais",
+                        "original": "Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil",
                     }
                 ],
-                'city': 'Rio de Janeiro',
-                'state': 'RJ',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff4',
-                'label': 'IV',
-                'institution': [
+                "id": "aff4",
+                "label": "IV",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal de Minas Gerais',
-                        'orgdiv1': 'Faculdade de Farmácia',
-                        'orgdiv2': 'Departamento de Farmácia Social',
-                        'original': 'Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Farmácia",
+                        "orgdiv2": "Departamento de Farmácia Social",
+                        "original": "Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff5',
-                'label': 'V',
-                'institution': [
+                "id": "aff5",
+                "label": "V",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal do Ceará',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': 'Departamento de Saúde Comunitária',
-                        'original': 'Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil'
+                        "orgname": "Universidade Federal do Ceará",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "Departamento de Saúde Comunitária",
+                        "original": "Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil",
                     }
                 ],
-                'city': 'Fortaleza',
-                'state': 'CE',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
-            }
+                "city": "Fortaleza",
+                "state": "CE",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
+            },
         ]
 
         self.assertEqual(data, expected_output)
 
     def test_extract_affiliation_with_subtag(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -259,123 +236,100 @@ class AffTest(TestCase):
             </contrib-group>
             </front>
         </article>
-        """)
+        """
 
         xml = etree.fromstring(xml)
-        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(subtag=True)
+        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(
+            subtag=True
+        )
 
         expected_output = [
             {
-                'id': 'aff1',
-                'label': 'I',
-                'institution': [
+                "id": "aff1",
+                "label": "I",
+                "institution": [
                     {
-                        'orgname': 'Secretaria <italic>Municipal</italic> de Saúde de Belo Horizonte',
-                        'orgdiv1': '',
-                        'orgdiv2': '',
-                        'original': 'Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil'
+                        "orgname": "Secretaria <italic>Municipal</italic> de Saúde de Belo Horizonte",
+                        "orgdiv1": "",
+                        "orgdiv2": "",
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': '<bold>Belo Horizonte</bold>',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "<bold>Belo Horizonte</bold>",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff2',
-                'label': 'II',
-                'institution': [
+                "id": "aff2",
+                "label": "II",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal de Minas Gerais',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': '',
-                        'original': 'Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "",
+                        "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': '<italic>Belo Horizonte</italic>',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "<italic>Belo Horizonte</italic>",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff3',
-                'label': 'III',
-                'institution': [
+                "id": "aff3",
+                "label": "III",
+                "institution": [
                     {
-                        'orgname': 'Fundação Oswaldo Cruz',
-                        'orgdiv1': 'Escola Nacional de Saúde Pública Sergio Arouca',
-                        'orgdiv2': '<italic>Departamento de Ciências Sociais</italic>',
-                        'original': 'Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil'
+                        "orgname": "Fundação Oswaldo Cruz",
+                        "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
+                        "orgdiv2": "<italic>Departamento de Ciências Sociais</italic>",
+                        "original": "Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil",
                     }
                 ],
-                'city': 'Rio de Janeiro',
-                'state': 'RJ',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff4',
-                'label': 'IV',
-                'institution': [
+                "id": "aff4",
+                "label": "IV",
+                "institution": [
                     {
-                        'orgname': '<bold>Universidade Federal de Minas Gerais</bold>',
-                        'orgdiv1': 'Faculdade de Farmácia',
-                        'orgdiv2': 'Departamento de Farmácia Social',
-                        'original': 'Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
+                        "orgname": "<bold>Universidade Federal de Minas Gerais</bold>",
+                        "orgdiv1": "Faculdade de Farmácia",
+                        "orgdiv2": "Departamento de Farmácia Social",
+                        "original": "Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff5',
-                'label': 'V',
-                'institution': [
+                "id": "aff5",
+                "label": "V",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal do Ceará',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': 'Departamento de Saúde Comunitária',
-                        'original': 'Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil'
+                        "orgname": "Universidade Federal do Ceará",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "Departamento de Saúde Comunitária",
+                        "original": "Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil",
                     }
                 ],
-                'city': '<italic>Fortaleza</italic>',
-                'state': 'CE',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
-            }
+                "city": "<italic>Fortaleza</italic>",
+                "state": "CE",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
+            },
         ]
 
         self.assertEqual(data, expected_output)
 
     def test_extract_affiliation_without_subtag(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -443,119 +397,95 @@ class AffTest(TestCase):
             </contrib-group>
             </front>
         </article>
-        """)
+        """
 
         xml = etree.fromstring(xml)
-        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(subtag=False)
+        data = AffiliationExtractor(xml).get_affiliation_data_from_multiple_tags(
+            subtag=False
+        )
 
         expected_output = [
             {
-                'id': 'aff1',
-                'label': 'I',
-                'institution': [
+                "id": "aff1",
+                "label": "I",
+                "institution": [
                     {
-                        'orgname': 'Secretaria Municipal de Saúde de Belo Horizonte',
-                        'orgdiv1': '',
-                        'orgdiv2': '',
-                        'original': 'Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil'
+                        "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                        "orgdiv1": "",
+                        "orgdiv2": "",
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff2',
-                'label': 'II',
-                'institution': [
+                "id": "aff2",
+                "label": "II",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal de Minas Gerais',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': '',
-                        'original': 'Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "",
+                        "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff3',
-                'label': 'III',
-                'institution': [
+                "id": "aff3",
+                "label": "III",
+                "institution": [
                     {
-                        'orgname': 'Fundação Oswaldo Cruz',
-                        'orgdiv1': 'Escola Nacional de Saúde Pública Sergio Arouca',
-                        'orgdiv2': 'Departamento de Ciências Sociais',
-                        'original': 'Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil'
+                        "orgname": "Fundação Oswaldo Cruz",
+                        "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
+                        "orgdiv2": "Departamento de Ciências Sociais",
+                        "original": "Departamento de Ciências Sociais. Escola Nacional de Saúde Pública Sergio Arouca. Fundação Oswaldo Cruz. Rio de Janeiro, RJ, Brasil",
                     }
                 ],
-                'city': 'Rio de Janeiro',
-                'state': 'RJ',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Rio de Janeiro",
+                "state": "RJ",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff4',
-                'label': 'IV',
-                'institution': [
+                "id": "aff4",
+                "label": "IV",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal de Minas Gerais',
-                        'orgdiv1': 'Faculdade de Farmácia',
-                        'orgdiv2': 'Departamento de Farmácia Social',
-                        'original': 'Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil'
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Farmácia",
+                        "orgdiv2": "Departamento de Farmácia Social",
+                        "original": "Departamento de Farmácia Social. Faculdade de Farmácia. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
                     }
                 ],
-                'city': 'Belo Horizonte',
-                'state': 'MG',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
+                "city": "Belo Horizonte",
+                "state": "MG",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
             },
             {
-                'id': 'aff5',
-                'label': 'V',
-                'institution': [
+                "id": "aff5",
+                "label": "V",
+                "institution": [
                     {
-                        'orgname': 'Universidade Federal do Ceará',
-                        'orgdiv1': 'Faculdade de Medicina',
-                        'orgdiv2': 'Departamento de Saúde Comunitária',
-                        'original': 'Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil'
+                        "orgname": "Universidade Federal do Ceará",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": "Departamento de Saúde Comunitária",
+                        "original": "Departamento de Saúde Comunitária. Faculdade de Medicina. Universidade Federal do Ceará. Fortaleza, CE, Brasil",
                     }
                 ],
-                'city': 'Fortaleza',
-                'state': 'CE',
-                'country': [
-                    {
-                        'code': '',
-                        'name': 'Brasil'
-                    }
-                ],
-                'email': ''
-            }
+                "city": "Fortaleza",
+                "state": "CE",
+                "country": [{"code": "", "name": "Brasil"}],
+                "email": "",
+            },
         ]
-
         self.assertEqual(data, expected_output)
 
     def test_get_affiliation_dict(self):
@@ -744,5 +674,4 @@ class AffTest(TestCase):
                 'email': ''
             }
         }
-
         self.assertEqual(data, expected_output)

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -319,6 +319,7 @@ class AuthorsWithAffTest(TestCase):
                 "suffix": "Nieto",
                 "given_names": "FRANCISCO",
                 "rid": "aff2",
+                "rid-aff": ["aff1", "aff2"],
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
                 "affs": [
@@ -410,6 +411,7 @@ class AuthorsWithAffInContribGroupTest(TestCase):
                 "suffix": "Nieto",
                 "given_names": "FRANCISCO",
                 "rid": "aff2",
+                "rid-aff": ["aff1", "aff2"],
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
                 "affs": [

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -91,6 +91,8 @@ class AuthorsTest(TestCase):
                 "prefix": "Prof",
                 "suffix": "Nieto",
                 "rid": ["aff1", "aff2"],
+                "rid-aff": ["aff1", "aff2"],
+                "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
             },
             {
@@ -98,6 +100,8 @@ class AuthorsTest(TestCase):
                 "given_names": "Vanessa M.",
                 "orcid": "0000-0001-5518-4853",
                 "rid": ["aff1"],
+                "rid-aff": ["aff1"],
+                "aff_rids": ["aff1"],
                 "contrib-type": "author",
             },
         ]
@@ -122,7 +126,7 @@ class AuthorsTest(TestCase):
                     <suffix>Nieto</suffix>
                   </name>
                   <xref ref-type="aff" rid="aff1"/>
-                    <xref ref-type="aff" rid="aff1">a</xref>
+                    <xref ref-type="aff" rid="aff2">a</xref>
                     <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Role 1</role>
                     <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Role 2</role>
                     <role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Role 3</role>
@@ -173,7 +177,9 @@ class AuthorsTest(TestCase):
                         "content-type": "https://credit.niso.org/contributor-roles/writing-original-draft/",
                     },
                 ],
-                "rid": ["aff1"],
+                "rid": ["aff1", "aff2"],
+                "rid-aff": ["aff1", "aff2"],
+                "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
             },
             {
@@ -199,11 +205,14 @@ class AuthorsTest(TestCase):
                     },
                 ],
                 "rid": ["aff1"],
+                "rid-aff": ["aff1"],
+                "aff_rids": ["aff1"],
                 "contrib-type": "author",
             },
         ]
-
-        self.assertEqual(xmldata, expect_output)
+        for i, item in enumerate(xmldata):
+            with self.subTest(i):
+                self.assertDictEqual(expect_output[i], item)
 
     def test_role_wihtout_content_type(self):
         xml = """
@@ -257,6 +266,8 @@ class AuthorsTest(TestCase):
                     {"text": "Role 4", "content-type": None},
                 ],
                 "rid": ["aff1"],
+                "rid-aff": ["aff1"],
+                "aff_rids": ["aff1"],
                 "contrib-type": "author",
             },
             {
@@ -270,11 +281,15 @@ class AuthorsTest(TestCase):
                     {"text": "Writing – original draft", "content-type": None},
                 ],
                 "rid": ["aff1"],
+                "rid-aff": ["aff1"],
+                "aff_rids": ["aff1"],
                 "contrib-type": "author",
             },
         ]
 
-        self.assertEqual(xmldata, expected_output)
+        for i, item in enumerate(xmldata):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
 
 
 class AuthorsCollabTest(TestCase):
@@ -353,7 +368,7 @@ class AuthorsWithAffTest(TestCase):
                 "prefix": "Prof",
                 "suffix": "Nieto",
                 "given_names": "FRANCISCO",
-                "rid": "aff2",
+                "rid": ["aff1", "aff2"],
                 "rid-aff": ["aff1", "aff2"],
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
@@ -387,9 +402,9 @@ class AuthorsWithAffTest(TestCase):
                 ],
             }
         ]
-        for item in self.authors.contribs_with_affs:
+        for i, item in enumerate(self.authors.contribs_with_affs):
             with self.subTest(item):
-                self.assertDictEqual(expected[0], item)
+                self.assertDictEqual(expected[i], item)
 
 
 class AuthorsWithAffInContribGroupTest(TestCase):
@@ -445,7 +460,7 @@ class AuthorsWithAffInContribGroupTest(TestCase):
                 "prefix": "Prof",
                 "suffix": "Nieto",
                 "given_names": "FRANCISCO",
-                "rid": "aff2",
+                "rid": ["aff1", "aff2"],
                 "rid-aff": ["aff1", "aff2"],
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -15,18 +15,16 @@
 </article>
 """
 
-from packtools.sps.models.article_authors import (
-    Authors,
-)
 from unittest import TestCase, skip
 
 from lxml import etree
 
+from packtools.sps.models.article_authors import Authors
+
 
 class AuthorsWithoutXrefTest(TestCase):
-
     def setUp(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -43,7 +41,7 @@ class AuthorsWithoutXrefTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
 
@@ -53,9 +51,8 @@ class AuthorsWithoutXrefTest(TestCase):
 
 
 class AuthorsTest(TestCase):
-
     def setUp(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -82,10 +79,10 @@ class AuthorsTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
-        
+
     def test_contribs(self):
         expected = [
             {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
@@ -99,10 +96,10 @@ class AuthorsTest(TestCase):
         self.assertDictEqual(expected[1], result[1])
 
     def test_collab(self):
-        self.assertIsNone(self.authors.collab) 
-  
+        self.assertIsNone(self.authors.collab)
+
     def test_role_with_role_content_type(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -137,11 +134,11 @@ class AuthorsTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
 
         data = etree.fromstring(xml)
         xmldata = Authors(data).contribs
-        
+
         expect_output = [
             {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
              "prefix": "Prof", "suffix": "Nieto",
@@ -174,11 +171,11 @@ class AuthorsTest(TestCase):
              "contrib-type": "author",
              },
         ]
-        
+
         self.assertEqual(xmldata, expect_output)
 
     def test_role_wihtout_content_type(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -212,7 +209,7 @@ class AuthorsTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         data = etree.fromstring(xml)
         xmldata = Authors(data).contribs
 
@@ -226,15 +223,16 @@ class AuthorsTest(TestCase):
                     {'text': 'Role 4', 'content-type': None}],
                 "rid": ["aff1"],
                 "contrib-type": "author"
-
             },
             {
-                'surname': 'Higa', 'given_names': 'Vanessa M.', 'orcid': '0000-0001-5518-4853',
-                'role': [
-                    {'text': 'Conceptualization', 'content-type': None},
-                    {'text': 'Data curation', 'content-type': None},
-                    {'text': 'Formal Analysis', 'content-type': None},
-                    {'text': 'Writing – original draft', 'content-type': None}
+                "surname": "Higa",
+                "given_names": "Vanessa M.",
+                "orcid": "0000-0001-5518-4853",
+                "role": [
+                    {"text": "Conceptualization", "content-type": None},
+                    {"text": "Data curation", "content-type": None},
+                    {"text": "Formal Analysis", "content-type": None},
+                    {"text": "Writing – original draft", "content-type": None},
                 ],
                 "rid": ["aff1"],
                 "contrib-type": "author"
@@ -245,9 +243,8 @@ class AuthorsTest(TestCase):
 
 
 class AuthorsCollabTest(TestCase):
-
     def setUp(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -257,7 +254,7 @@ class AuthorsCollabTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
 
@@ -269,9 +266,8 @@ class AuthorsCollabTest(TestCase):
 
 
 class AuthorsWithAffTest(TestCase):
-
     def setUp(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -311,46 +307,48 @@ class AuthorsWithAffTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
 
     def test_contribs(self):
         expected = [
             {
-                'surname': 'VENEGAS-MARTÍNEZ',
-                'prefix': 'Prof',
-                'suffix': 'Nieto',
-                'given_names': 'FRANCISCO',
+                "surname": "VENEGAS-MARTÍNEZ",
+                "prefix": "Prof",
+                "suffix": "Nieto",
+                "given_names": "FRANCISCO",
                 "rid": "aff2",
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
-                "affs": [{
-                    "id": "aff1",
-                    "label": "I",
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "city": "Belo Horizonte",
-                    "state": "MG",
-                    "country_code": None,
-                    "country_name": "Brasil",
-                    "email": None,
-                },
-                {
-                    "id": "aff2",
-                    "label": "II",
-                    "city": "Belo Horizonte",
-                    "state": "MG",
-                    "country_code": None,
-                    "country_name": "Brasil",
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "email": None,
-                }],
+                "affs": [
+                    {
+                        "id": "aff1",
+                        "label": "I",
+                        "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                        "orgdiv1": None,
+                        "orgdiv2": None,
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "country_code": None,
+                        "country_name": "Brasil",
+                        "email": None,
+                    },
+                    {
+                        "id": "aff2",
+                        "label": "II",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "country_code": None,
+                        "country_name": "Brasil",
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": None,
+                        "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                        "email": None,
+                    },
+                ],
             }
         ]
         for item in self.authors.contribs_with_affs:
@@ -359,9 +357,8 @@ class AuthorsWithAffTest(TestCase):
 
 
 class AuthorsWithAffInContribGroupTest(TestCase):
-
     def setUp(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -401,46 +398,48 @@ class AuthorsWithAffInContribGroupTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         self.authors = Authors(xmltree)
 
     def test_contribs(self):
         expected = [
             {
-                'surname': 'VENEGAS-MARTÍNEZ',
-                'prefix': 'Prof',
-                'suffix': 'Nieto',
-                'given_names': 'FRANCISCO',
+                "surname": "VENEGAS-MARTÍNEZ",
+                "prefix": "Prof",
+                "suffix": "Nieto",
+                "given_names": "FRANCISCO",
                 "rid": "aff2",
                 "aff_rids": ["aff1", "aff2"],
                 "contrib-type": "author",
-                "affs": [{
-                    "id": "aff1",
-                    "label": "I",
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "city": "Belo Horizonte",
-                    "state": "MG",
-                    "country_code": None,
-                    "country_name": "Brasil",
-                    "email": None,
-                },
-                {
-                    "id": "aff2",
-                    "label": "II",
-                    "city": "Belo Horizonte",
-                    "state": "MG",
-                    "country_code": None,
-                    "country_name": "Brasil",
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "email": None,
-                }],
+                "affs": [
+                    {
+                        "id": "aff1",
+                        "label": "I",
+                        "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                        "orgdiv1": None,
+                        "orgdiv2": None,
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "country_code": None,
+                        "country_name": "Brasil",
+                        "email": None,
+                    },
+                    {
+                        "id": "aff2",
+                        "label": "II",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "country_code": None,
+                        "country_name": "Brasil",
+                        "orgname": "Universidade Federal de Minas Gerais",
+                        "orgdiv1": "Faculdade de Medicina",
+                        "orgdiv2": None,
+                        "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                        "email": None,
+                    },
+                ],
             }
         ]
         for item in self.authors.contribs_with_affs:

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -99,7 +99,7 @@ class AuthorsTest(TestCase):
         self.assertDictEqual(expected[1], result[1])
 
     def test_collab(self):
-    	self.assertIsNone(self.authors.collab) 
+        self.assertIsNone(self.authors.collab) 
   
     def test_role_with_role_content_type(self):
         xml = ("""
@@ -116,10 +116,10 @@ class AuthorsTest(TestCase):
                   </name>
                   <xref ref-type="aff" rid="aff1"/>
                     <xref ref-type="aff" rid="aff1">a</xref>
-					<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Role 1</role>
-					<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Role 2</role>
-					<role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Role 3</role>
-					<role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Role 4</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Role 1</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Role 2</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Role 3</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Role 4</role>
                 </contrib>
                 <contrib contrib-type="author">
                   <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
@@ -128,10 +128,10 @@ class AuthorsTest(TestCase):
                     <given-names>Vanessa M.</given-names>
                   </name>
                   <xref ref-type="aff" rid="aff1">a</xref>
-					<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
-					<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
-					<role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Formal Analysis</role>
-					<role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Writing &#x2013; original draft</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/formal-analysis/">Formal Analysis</role>
+                    <role content-type="https://credit.niso.org/contributor-roles/writing-original-draft/">Writing &#x2013; original draft</role>
                 </contrib>
               </contrib-group>
             </article-meta>
@@ -141,19 +141,19 @@ class AuthorsTest(TestCase):
 
         data = etree.fromstring(xml)
         xmldata = Authors(data).contribs
-		
+        
         expect_output = [
             {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
              "prefix": "Prof", "suffix": "Nieto",
              'role': [
-				{'text': 'Role 1',
-					'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-				{'text': 'Role 2',
-					'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
-				{'text': 'Role 3',
-					'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-				{'text': 'Role 4',
-					'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
+                {'text': 'Role 1',
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
+                {'text': 'Role 2',
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
+                {'text': 'Role 3',
+                    'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
+                {'text': 'Role 4',
+                    'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
                             ],
              "rid": ["aff1"],
              "contrib-type": "author",
@@ -266,3 +266,183 @@ class AuthorsCollabTest(TestCase):
 
     def test_collab(self):
         self.assertEqual("XXXX", self.authors.collab)
+
+
+class AuthorsWithAffTest(TestCase):
+
+    def setUp(self):
+        xml = ("""
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                          <name>
+                            <surname>VENEGAS-MARTÍNEZ</surname>
+                            <given-names>FRANCISCO</given-names>
+                            <prefix>Prof</prefix>
+                            <suffix>Nieto</suffix>
+                          </name>
+                          <xref ref-type="aff" rid="aff1"/>
+                          <xref ref-type="aff" rid="aff2"/>
+                        </contrib>
+                    </contrib-group>
+                    <aff id="aff1">
+                        <label>I</label>
+                        <institution content-type="orgname">Secretaria Municipal de Saúde de Belo Horizonte</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                    <aff id="aff2">
+                        <label>II</label>
+                        <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                        <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                        <addr-line>
+                            <named-content content-type="city">Belo Horizonte</named-content>
+                            <named-content content-type="state">MG</named-content>
+                        </addr-line>
+                        <country>Brasil</country>
+                        <institution content-type="original">Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                    </aff>
+                </article-meta>
+            </front>
+        </article>
+        """)
+        xmltree = etree.fromstring(xml)
+        self.authors = Authors(xmltree)
+
+    def test_contribs(self):
+        expected = [
+            {
+                'surname': 'VENEGAS-MARTÍNEZ',
+                'prefix': 'Prof',
+                'suffix': 'Nieto',
+                'given_names': 'FRANCISCO',
+                "rid": "aff2",
+                "aff_rids": ["aff1", "aff2"],
+                "contrib-type": "author",
+                "affs": [{
+                    "id": "aff1",
+                    "label": "I",
+                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                    "orgdiv1": None,
+                    "orgdiv2": None,
+                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                    "city": "Belo Horizonte",
+                    "state": "MG",
+                    "country_code": None,
+                    "country_name": "Brasil",
+                    "email": None,
+                },
+                {
+                    "id": "aff2",
+                    "label": "II",
+                    "city": "Belo Horizonte",
+                    "state": "MG",
+                    "country_code": None,
+                    "country_name": "Brasil",
+                    "orgname": "Universidade Federal de Minas Gerais",
+                    "orgdiv1": "Faculdade de Medicina",
+                    "orgdiv2": None,
+                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                    "email": None,
+                }],
+            }
+        ]
+        for item in self.authors.contribs_with_affs:
+            with self.subTest(item):
+                self.assertDictEqual(expected[0], item)
+
+
+class AuthorsWithAffInContribGroupTest(TestCase):
+
+    def setUp(self):
+        xml = ("""
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                          <name>
+                            <surname>VENEGAS-MARTÍNEZ</surname>
+                            <given-names>FRANCISCO</given-names>
+                            <prefix>Prof</prefix>
+                            <suffix>Nieto</suffix>
+                          </name>
+                          <xref ref-type="aff" rid="aff1"/>
+                          <xref ref-type="aff" rid="aff2"/>
+                        </contrib>
+                        <aff id="aff1">
+                            <label>I</label>
+                            <institution content-type="orgname">Secretaria Municipal de Saúde de Belo Horizonte</institution>
+                            <addr-line>
+                                <named-content content-type="city">Belo Horizonte</named-content>
+                                <named-content content-type="state">MG</named-content>
+                            </addr-line>
+                            <country>Brasil</country>
+                            <institution content-type="original">Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil</institution>
+                        </aff>
+                        <aff id="aff2">
+                            <label>II</label>
+                            <institution content-type="orgdiv1">Faculdade de Medicina</institution>
+                            <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                            <addr-line>
+                                <named-content content-type="city">Belo Horizonte</named-content>
+                                <named-content content-type="state">MG</named-content>
+                            </addr-line>
+                            <country>Brasil</country>
+                            <institution content-type="original">Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil</institution>
+                        </aff>
+                    </contrib-group>
+                </article-meta>
+            </front>
+        </article>
+        """)
+        xmltree = etree.fromstring(xml)
+        self.authors = Authors(xmltree)
+
+    def test_contribs(self):
+        expected = [
+            {
+                'surname': 'VENEGAS-MARTÍNEZ',
+                'prefix': 'Prof',
+                'suffix': 'Nieto',
+                'given_names': 'FRANCISCO',
+                "rid": "aff2",
+                "aff_rids": ["aff1", "aff2"],
+                "contrib-type": "author",
+                "affs": [{
+                    "id": "aff1",
+                    "label": "I",
+                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                    "orgdiv1": None,
+                    "orgdiv2": None,
+                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                    "city": "Belo Horizonte",
+                    "state": "MG",
+                    "country_code": None,
+                    "country_name": "Brasil",
+                    "email": None,
+                },
+                {
+                    "id": "aff2",
+                    "label": "II",
+                    "city": "Belo Horizonte",
+                    "state": "MG",
+                    "country_code": None,
+                    "country_name": "Brasil",
+                    "orgname": "Universidade Federal de Minas Gerais",
+                    "orgdiv1": "Faculdade de Medicina",
+                    "orgdiv2": None,
+                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
+                    "email": None,
+                }],
+            }
+        ]
+        for item in self.authors.contribs_with_affs:
+            with self.subTest(item):
+                self.assertDictEqual(expected[0], item)

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -85,11 +85,21 @@ class AuthorsTest(TestCase):
 
     def test_contribs(self):
         expected = [
-            {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
-             "prefix": "Prof", "suffix": "Nieto", "rid": ["aff1", "aff2"], "contrib-type": "author"},
-            {"surname": "Higa", "given_names": "Vanessa M.",
-             "orcid": "0000-0001-5518-4853", "rid": ["aff1"], "contrib-type": "author"
-             },
+            {
+                "surname": "VENEGAS-MARTÍNEZ",
+                "given_names": "FRANCISCO",
+                "prefix": "Prof",
+                "suffix": "Nieto",
+                "rid": ["aff1", "aff2"],
+                "contrib-type": "author",
+            },
+            {
+                "surname": "Higa",
+                "given_names": "Vanessa M.",
+                "orcid": "0000-0001-5518-4853",
+                "rid": ["aff1"],
+                "contrib-type": "author",
+            },
         ]
         result = self.authors.contribs
         self.assertDictEqual(expected[0], result[0])
@@ -140,36 +150,57 @@ class AuthorsTest(TestCase):
         xmldata = Authors(data).contribs
 
         expect_output = [
-            {"surname": "VENEGAS-MARTÍNEZ", "given_names": "FRANCISCO",
-             "prefix": "Prof", "suffix": "Nieto",
-             'role': [
-                {'text': 'Role 1',
-                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                {'text': 'Role 2',
-                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                {'text': 'Role 3',
-                    'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                {'text': 'Role 4',
-                    'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
-                            ],
-             "rid": ["aff1"],
-             "contrib-type": "author",
-                },
-            {"surname": "Higa", "given_names": "Vanessa M.",
-             "orcid": "0000-0001-5518-4853",
-                     'role': [
-                         {'text': 'Conceptualization',
-                  'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                         {'text': 'Data curation',
-                  'content-type': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                         {'text': 'Formal Analysis',
-                  'content-type': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                         {'text': 'Writing – original draft',
-                  'content-type': 'https://credit.niso.org/contributor-roles/writing-original-draft/'}
-                         ],
-             "rid": ["aff1"],
-             "contrib-type": "author",
-             },
+            {
+                "surname": "VENEGAS-MARTÍNEZ",
+                "given_names": "FRANCISCO",
+                "prefix": "Prof",
+                "suffix": "Nieto",
+                "role": [
+                    {
+                        "text": "Role 1",
+                        "content-type": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "text": "Role 2",
+                        "content-type": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "text": "Role 3",
+                        "content-type": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "text": "Role 4",
+                        "content-type": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                ],
+                "rid": ["aff1"],
+                "contrib-type": "author",
+            },
+            {
+                "surname": "Higa",
+                "given_names": "Vanessa M.",
+                "orcid": "0000-0001-5518-4853",
+                "role": [
+                    {
+                        "text": "Conceptualization",
+                        "content-type": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "text": "Data curation",
+                        "content-type": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "text": "Formal Analysis",
+                        "content-type": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "text": "Writing – original draft",
+                        "content-type": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                ],
+                "rid": ["aff1"],
+                "contrib-type": "author",
+            },
         ]
 
         self.assertEqual(xmldata, expect_output)
@@ -215,14 +246,18 @@ class AuthorsTest(TestCase):
 
         expected_output = [
             {
-                'surname': 'VENEGAS-MARTÍNEZ', 'prefix': 'Prof', 'suffix': 'Nieto', 'given_names': 'FRANCISCO',
-                'role': [
-                    {'text': 'Role 1', 'content-type': None},
-                    {'text': 'Role 2', 'content-type': None},
-                    {'text': 'Role 3', 'content-type': None},
-                    {'text': 'Role 4', 'content-type': None}],
+                "surname": "VENEGAS-MARTÍNEZ",
+                "prefix": "Prof",
+                "suffix": "Nieto",
+                "given_names": "FRANCISCO",
+                "role": [
+                    {"text": "Role 1", "content-type": None},
+                    {"text": "Role 2", "content-type": None},
+                    {"text": "Role 3", "content-type": None},
+                    {"text": "Role 4", "content-type": None},
+                ],
                 "rid": ["aff1"],
-                "contrib-type": "author"
+                "contrib-type": "author",
             },
             {
                 "surname": "Higa",
@@ -235,8 +270,8 @@ class AuthorsTest(TestCase):
                     {"text": "Writing – original draft", "content-type": None},
                 ],
                 "rid": ["aff1"],
-                "contrib-type": "author"
-            }
+                "contrib-type": "author",
+            },
         ]
 
         self.assertEqual(xmldata, expected_output)

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -37,32 +37,32 @@ class ArticleAuthorsValidationTest(TestCase):
 
     def test_without_role(self):
         xml = ("""
-		<article>
-			<front>
-				<article-meta>
-					<contrib-group>
-						<contrib contrib-type="author">
-							<name>
-								<surname>VENEGAS-MARTÍNEZ</surname>
-								<given-names>FRANCISCO</given-names>
-								<prefix>Prof</prefix>
-								<suffix>Nieto</suffix>
-							</name>
-							<xref ref-type="aff" rid="aff1"/>
-							</contrib>
-							<contrib contrib-type="author">
-							<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-							<name>
-								<surname>Higa</surname>
-								<given-names>Vanessa M.</given-names>
-							</name>
-							<xref ref-type="aff" rid="aff1">a</xref>
-						</contrib>
-					</contrib-group>
-				</article-meta>
-			</front>
-		</article>
-		""")
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                            <name>
+                                <surname>Higa</surname>
+                                <given-names>Vanessa M.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1">a</xref>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+        </article>
+        """)
 
         data = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
@@ -141,38 +141,43 @@ class ArticleAuthorsValidationTest(TestCase):
             }
         ]
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
 
     def test_role_and_content_type_empty(self):
         xml = ("""
-		<article>
-			<front>
-				<article-meta>
-					<contrib-group>
-						<contrib contrib-type="author">
-							<name>
-								<surname>VENEGAS-MARTÍNEZ</surname>
-								<given-names>FRANCISCO</given-names>
-								<prefix>Prof</prefix>
-								<suffix>Nieto</suffix>
-							</name>
-							<xref ref-type="aff" rid="aff1"/>
-							<role></role>
-							</contrib>
-							<contrib contrib-type="author">
-							<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-							<name>
-								<surname>Higa</surname>
-								<given-names>Vanessa M.</given-names>
-							</name>
-							<xref ref-type="aff" rid="aff1">a</xref>
-							<role></role>
-						</contrib>
-					</contrib-group>
-				</article-meta>
-			</front>
-		</article>
-		""")
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                            <role></role>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                            <name>
+                                <surname>Higa</surname>
+                                <given-names>Vanessa M.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1">a</xref>
+                            <role></role>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+        </article>
+        """)
 
         data = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
@@ -251,39 +256,45 @@ class ArticleAuthorsValidationTest(TestCase):
             },
         ]
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
+
 
     def test_role_without_content_type(self):
         xml = ("""
-			<article>
-				<front>
-					<article-meta>
-						<contrib-group>
-							<contrib contrib-type="author">
-								<name>
-									<surname>VENEGAS-MARTÍNEZ</surname>
-									<given-names>FRANCISCO</given-names>
-									<prefix>Prof</prefix>
-									<suffix>Nieto</suffix>
-								</name>
-								<xref ref-type="aff" rid="aff1"/>
-								<role>Data curation</role>
-								<role>Concepalization</role>
-								</contrib>
-								<contrib contrib-type="author">
-								<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-								<name>
-									<surname>Higa</surname>
-									<given-names>Vanessa M.</given-names>
-								</name>
-								<xref ref-type="aff" rid="aff1">a</xref>
-								<role>Formal analysis</role>
-							</contrib>
-						</contrib-group>
-					</article-meta>
-				</front>
-			</article>
-			""")
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>VENEGAS-MARTÍNEZ</surname>
+                                    <given-names>FRANCISCO</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1"/>
+                                <role>Data curation</role>
+                                <role>Concepalization</role>
+                                </contrib>
+                                <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                                <name>
+                                    <surname>Higa</surname>
+                                    <given-names>Vanessa M.</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">a</xref>
+                                <role>Formal analysis</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """)
 
         expected_output = [
             {
@@ -397,39 +408,45 @@ class ArticleAuthorsValidationTest(TestCase):
         messages = ArticleAuthorsValidation(
             xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
+
 
     def test_role_no_text_with_content_type(self):
         xml = ("""
-			<article>
-				<front>
-					<article-meta>
-						<contrib-group>
-							<contrib contrib-type="author">
-								<name>
-									<surname>VENEGAS-MARTÍNEZ</surname>
-									<given-names>FRANCISCO</given-names>
-									<prefix>Prof</prefix>
-									<suffix>Nieto</suffix>
-								</name>
-								<xref ref-type="aff" rid="aff1"/>
-								<role content-type="content-type="https://credit.niso.org/contributor-roles/data-curation/"></role>
-								<role content-type="https://credit.niso.org/contributor-roles/conceptualization/"></role>
-								</contrib>
-								<contrib contrib-type="author">
-								<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-								<name>
-									<surname>Higa</surname>
-									<given-names>Vanessa M.</given-names>
-								</name>
-								<xref ref-type="aff" rid="aff1">a</xref>
-								<role content-type="https://credit.niso.org/contributor-roles/formal-analysis/"></role>
-							</contrib>
-						</contrib-group>
-					</article-meta>
-				</front>
-			</article>
-			""")
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>VENEGAS-MARTÍNEZ</surname>
+                                    <given-names>FRANCISCO</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1"/>
+                                <role content-type="content-type="https://credit.niso.org/contributor-roles/data-curation/"></role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/"></role>
+                                </contrib>
+                                <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                                <name>
+                                    <surname>Higa</surname>
+                                    <given-names>Vanessa M.</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">a</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/formal-analysis/"></role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """)
 
         expected_output = [
             {
@@ -541,35 +558,35 @@ class ArticleAuthorsValidationTest(TestCase):
 
     def test_wrong_role_and_content_type(self):
         xml = ("""
-		<article>
-			<front>
-				<article-meta>
-					<contrib-group>
-						<contrib contrib-type="author">
-							<name>
-								<surname>VENEGAS-MARTÍNEZ</surname>
-								<given-names>FRANCISCO</given-names>
-								<prefix>Prof</prefix>
-								<suffix>Nieto</suffix>
-							</name>
-							<xref ref-type="aff" rid="aff1"/>
-							<role content-type="https://credit.niso.org/contributor-roles/data-curan/">Data curation</role>
-							<role content-type="https://credit.niso.org/contributor-roles/conceualizan/">Conceplization</role>
-							</contrib>
-							<contrib contrib-type="author">
-							<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-							<name>
-								<surname>Higa</surname>
-								<given-names>Vanessa M.</given-names>
-							</name>
-							<xref ref-type="aff" rid="aff1">a</xref>
-							<role content-type="https://credit.niso.org/contributor-roles/foal-analysis/">Formal analysis</role>
-						</contrib>
-					</contrib-group>
-				</article-meta>
-			</front>
-		</article>
-		""")
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                            <role content-type="https://credit.niso.org/contributor-roles/data-curan/">Data curation</role>
+                            <role content-type="https://credit.niso.org/contributor-roles/conceualizan/">Conceplization</role>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                            <name>
+                                <surname>Higa</surname>
+                                <given-names>Vanessa M.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1">a</xref>
+                            <role content-type="https://credit.niso.org/contributor-roles/foal-analysis/">Formal analysis</role>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+        </article>
+        """)
 
         expected_output = [
             {
@@ -683,39 +700,45 @@ class ArticleAuthorsValidationTest(TestCase):
         messages = ArticleAuthorsValidation(
             xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
+
 
     def test_success_role(self):
         xml = ("""
-		<article>
-			<front>
-				<article-meta>
-					<contrib-group>
-						<contrib contrib-type="author">
-							<name>
-								<surname>VENEGAS-MARTÍNEZ</surname>
-								<given-names>FRANCISCO</given-names>
-								<prefix>Prof</prefix>
-								<suffix>Nieto</suffix>
-							</name>
-							<xref ref-type="aff" rid="aff1"/>
-							<role content-type="https://credit.niso.org/contributor-roles/data-curation/">data curation</role>
-							<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
-							</contrib>
-							<contrib contrib-type="author">
-							<contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
-							<name>
-								<surname>Higa</surname>
-								<given-names>Vanessa M.</given-names>
-							</name>
-							<xref ref-type="aff" rid="aff1">a</xref>
-							<role content-type="https://credit.niso.org/contributor-roles/visualization/">Visualization</role>
-						</contrib>
-					</contrib-group>
-				</article-meta>
-			</front>
-		</article>
-		""")
+        <article>
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                            <role content-type="https://credit.niso.org/contributor-roles/data-curation/">data curation</role>
+                            <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0001-5518-4853</contrib-id>
+                            <name>
+                                <surname>Higa</surname>
+                                <given-names>Vanessa M.</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1">a</xref>
+                            <role content-type="https://credit.niso.org/contributor-roles/visualization/">Visualization</role>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+        </article>
+        """)
 
         expected_output = [
             {
@@ -737,7 +760,13 @@ class ArticleAuthorsValidationTest(TestCase):
         messages = ArticleAuthorsValidation(
             xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
+
 
 
 class ArticleAuthorsValidationOrcidTest(TestCase):
@@ -784,7 +813,11 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                     'prefix': 'Prof', 
                     'suffix': 'Nieto', 
                     'given_names': 'FRANCISCO', 
-                    'orcid': '0990-01-58-4853'
+                    'orcid': '0990-01-58-4853',
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 },
             },
             {
@@ -794,12 +827,20 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'author': {
                     'surname': 'Higa', 
                     'given_names': 'Vanessa M.', 
-                    'orcid': '00-0001-5518-4853'
+                    'orcid': '00-0001-5518-4853',
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 }
             }
         ]
-
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
 
     def test_without_orcid(self):
         xml = ("""
@@ -854,7 +895,12 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             }
         ]
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])
 
     def test_success_orcid(self):
         xml = ("""
@@ -912,4 +958,9 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             }
         ]
 
-        self.assertEqual(messages, expected_output)
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                print("")
+                print(item)
+                print(expected_output[i])
+                self.assertDictEqual(item, expected_output[i])

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -229,10 +229,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_role_and_content_type_empty(self):
         xml = """
@@ -401,10 +398,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_role_without_content_type(self):
         xml = """
@@ -637,10 +631,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_role_no_text_with_content_type(self):
         xml = """
@@ -1097,10 +1088,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_success_role(self):
         xml = """
@@ -1157,10 +1145,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
 
 class ArticleAuthorsValidationOrcidTest(TestCase):
@@ -1230,10 +1215,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
         ]
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_without_orcid(self):
         xml = """
@@ -1275,6 +1257,10 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                     "prefix": "Prof",
                     "suffix": "Nieto",
                     "given_names": "FRANCISCO",
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 },
             },
             {
@@ -1284,16 +1270,17 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 "author": {
                     "surname": "Higa",
                     "given_names": "Vanessa M.",
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 },
             },
         ]
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)
 
     def test_success_orcid(self):
         xml = """
@@ -1338,6 +1325,10 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                     "suffix": "Nieto",
                     "given_names": "FRANCISCO",
                     "orcid": "0990-0001-0058-4853",
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 },
             },
             {
@@ -1347,13 +1338,14 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                     "surname": "Higa",
                     "given_names": "Vanessa M.",
                     "orcid": "0000-3333-1238-6873",
+                    "rid": ["aff1"],
+                    "rid-aff": ["aff1"],
+                    "aff_rids": ["aff1"],
+                    "contrib-type": "author",
                 },
             },
         ]
 
         for i, item in enumerate(messages):
             with self.subTest(i):
-                print("")
-                print(item)
-                print(expected_output[i])
-                self.assertDictEqual(item, expected_output[i])
+                self.assertDictEqual(expected_output[i], item)

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -7,36 +7,65 @@ from packtools.sps.utils import xml_utils
 from packtools.sps.validation.article_authors import ArticleAuthorsValidation
 
 credit_terms_and_urls = [
-    {'term': 'Conceptualization',
-        'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-    {'term': 'Data curation',
-        'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-    {'term': 'Formal analysis',
-        'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-    {'term': 'Funding acquisition',
-        'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-    {'term': 'Investigation',
-        'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-    {'term': 'Methodology', 'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-    {'term': 'Project administration',
-        'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-    {'term': 'Resources', 'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-    {'term': 'Software', 'uri': 'https://credit.niso.org/contributor-roles/software/'},
-    {'term': 'Supervision', 'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-    {'term': 'Validation', 'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-    {'term': 'Visualization',
-        'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-    {'term': 'Writing – original draft',
-        'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-    {'term': 'Writing – review & editing',
-        'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
+    {
+        "term": "Conceptualization",
+        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+    },
+    {
+        "term": "Data curation",
+        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+    },
+    {
+        "term": "Formal analysis",
+        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+    },
+    {
+        "term": "Funding acquisition",
+        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+    },
+    {
+        "term": "Investigation",
+        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+    },
+    {
+        "term": "Methodology",
+        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+    },
+    {
+        "term": "Project administration",
+        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+    },
+    {
+        "term": "Resources",
+        "uri": "https://credit.niso.org/contributor-roles/resources/",
+    },
+    {"term": "Software", "uri": "https://credit.niso.org/contributor-roles/software/"},
+    {
+        "term": "Supervision",
+        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+    },
+    {
+        "term": "Validation",
+        "uri": "https://credit.niso.org/contributor-roles/validation/",
+    },
+    {
+        "term": "Visualization",
+        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+    },
+    {
+        "term": "Writing – original draft",
+        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+    },
+    {
+        "term": "Writing – review & editing",
+        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+    },
 ]
 
 
 class ArticleAuthorsValidationTest(TestCase):
-
     def test_without_role(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -62,83 +91,140 @@ class ArticleAuthorsValidationTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
 
         data = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
-            credit_terms_and_urls=credit_terms_and_urls)
+            credit_terms_and_urls=credit_terms_and_urls
+        )
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'No role found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ does not have a role. Please add a role according to the credit-taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No role found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ does not have a role. Please add a role according to the credit-taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'No role found',
-                'message': "The author Vanessa M. Higa does not have a role. Please add a role according to the credit-taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
-            }
+                "result": "error",
+                "error_type": "No role found",
+                "message": "The author Vanessa M. Higa does not have a role. Please add a role according to the credit-taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
+            },
         ]
 
         for i, item in enumerate(messages):
@@ -149,7 +235,7 @@ class ArticleAuthorsValidationTest(TestCase):
                 self.assertDictEqual(item, expected_output[i])
 
     def test_role_and_content_type_empty(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -177,82 +263,139 @@ class ArticleAuthorsValidationTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
 
         data = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
-            credit_terms_and_urls=credit_terms_and_urls)
+            credit_terms_and_urls=credit_terms_and_urls
+        )
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'Text and content-type not found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text and content-type attributes. Please add valid text and content-type attributes according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "Text and content-type not found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text and content-type attributes. Please add valid text and content-type attributes according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'Text and content-type not found',
-                'message': "The author Vanessa M. Higa has a role with no text and content-type attributes. Please add valid text and content-type attributes according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "Text and content-type not found",
+                "message": "The author Vanessa M. Higa has a role with no text and content-type attributes. Please add valid text and content-type attributes according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
         ]
 
@@ -263,9 +406,8 @@ class ArticleAuthorsValidationTest(TestCase):
                 print(expected_output[i])
                 self.assertDictEqual(item, expected_output[i])
 
-
     def test_role_without_content_type(self):
-        xml = ("""
+        xml = """
             <article>
                 <front>
                     <article-meta>
@@ -294,119 +436,204 @@ class ArticleAuthorsValidationTest(TestCase):
                     </article-meta>
                 </front>
             </article>
-            """)
+            """
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'No content-type found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role Data curation with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No content-type found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role Data curation with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'No content-type found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role Concepalization with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No content-type found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role Concepalization with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'No content-type found',
-                'message': "The author Vanessa M. Higa has a role Formal analysis with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No content-type found",
+                "message": "The author Vanessa M. Higa has a role Formal analysis with text but no content-type attribute. Please add a valid URI to the content-type attribute according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
         ]
 
         data = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(
-            xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
+        messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
+            credit_terms_and_urls=credit_terms_and_urls
+        )
 
         for i, item in enumerate(messages):
             with self.subTest(i):
@@ -415,9 +642,8 @@ class ArticleAuthorsValidationTest(TestCase):
                 print(expected_output[i])
                 self.assertDictEqual(item, expected_output[i])
 
-
     def test_role_no_text_with_content_type(self):
-        xml = ("""
+        xml = """
             <article>
                 <front>
                     <article-meta>
@@ -446,118 +672,202 @@ class ArticleAuthorsValidationTest(TestCase):
                     </article-meta>
                 </front>
             </article>
-            """)
+            """
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'No text found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No text found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'No text found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No text found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'No text found',
-                'message': "The author Vanessa M. Higa has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "No text found",
+                "message": "The author Vanessa M. Higa has a role with no text. Please add valid text to the role according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
         ]
 
     def test_wrong_role_and_content_type(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -586,119 +896,204 @@ class ArticleAuthorsValidationTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'Role and content-type not found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "Role and content-type not found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'Role and content-type not found',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "Role and content-type not found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
             {
-                'result': 'error',
-                'error_type': 'Role and content-type not found',
-                'message': "The author Vanessa M. Higa has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
-                'credit_terms_and_urls': [
-                    {'term': 'Conceptualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/conceptualization/'},
-                    {'term': 'Data curation',
-                     'uri': 'https://credit.niso.org/contributor-roles/data-curation/'},
-                    {'term': 'Formal analysis',
-                     'uri': 'https://credit.niso.org/contributor-roles/formal-analysis/'},
-                    {'term': 'Funding acquisition',
-                     'uri': 'https://credit.niso.org/contributor-roles/funding-acquisition/'},
-                    {'term': 'Investigation',
-                     'uri': 'https://credit.niso.org/contributor-roles/investigation/'},
-                    {'term': 'Methodology',
-                     'uri': 'https://credit.niso.org/contributor-roles/methodology/'},
-                    {'term': 'Project administration',
-                     'uri': 'https://credit.niso.org/contributor-roles/project-administration/'},
-                    {'term': 'Resources',
-                     'uri': 'https://credit.niso.org/contributor-roles/resources/'},
-                    {'term': 'Software',
-                     'uri': 'https://credit.niso.org/contributor-roles/software/'},
-                    {'term': 'Supervision',
-                     'uri': 'https://credit.niso.org/contributor-roles/supervision/'},
-                    {'term': 'Validation',
-                     'uri': 'https://credit.niso.org/contributor-roles/validation/'},
-                    {'term': 'Visualization',
-                     'uri': 'https://credit.niso.org/contributor-roles/visualization/'},
-                    {'term': 'Writing – original draft',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-original-draft/'},
-                    {'term': 'Writing – review & editing',
-                     'uri': 'https://credit.niso.org/contributor-roles/writing-review-editing/'}
-                ]
+                "result": "error",
+                "error_type": "Role and content-type not found",
+                "message": "The author Vanessa M. Higa has a role and content-type that are not found in the credit taxonomy. Please check the role and content-type attributes according to the credit taxonomy below.",
+                "credit_terms_and_urls": [
+                    {
+                        "term": "Conceptualization",
+                        "uri": "https://credit.niso.org/contributor-roles/conceptualization/",
+                    },
+                    {
+                        "term": "Data curation",
+                        "uri": "https://credit.niso.org/contributor-roles/data-curation/",
+                    },
+                    {
+                        "term": "Formal analysis",
+                        "uri": "https://credit.niso.org/contributor-roles/formal-analysis/",
+                    },
+                    {
+                        "term": "Funding acquisition",
+                        "uri": "https://credit.niso.org/contributor-roles/funding-acquisition/",
+                    },
+                    {
+                        "term": "Investigation",
+                        "uri": "https://credit.niso.org/contributor-roles/investigation/",
+                    },
+                    {
+                        "term": "Methodology",
+                        "uri": "https://credit.niso.org/contributor-roles/methodology/",
+                    },
+                    {
+                        "term": "Project administration",
+                        "uri": "https://credit.niso.org/contributor-roles/project-administration/",
+                    },
+                    {
+                        "term": "Resources",
+                        "uri": "https://credit.niso.org/contributor-roles/resources/",
+                    },
+                    {
+                        "term": "Software",
+                        "uri": "https://credit.niso.org/contributor-roles/software/",
+                    },
+                    {
+                        "term": "Supervision",
+                        "uri": "https://credit.niso.org/contributor-roles/supervision/",
+                    },
+                    {
+                        "term": "Validation",
+                        "uri": "https://credit.niso.org/contributor-roles/validation/",
+                    },
+                    {
+                        "term": "Visualization",
+                        "uri": "https://credit.niso.org/contributor-roles/visualization/",
+                    },
+                    {
+                        "term": "Writing – original draft",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-original-draft/",
+                    },
+                    {
+                        "term": "Writing – review & editing",
+                        "uri": "https://credit.niso.org/contributor-roles/writing-review-editing/",
+                    },
+                ],
             },
         ]
 
         data = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(
-            xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
+        messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
+            credit_terms_and_urls=credit_terms_and_urls
+        )
 
         for i, item in enumerate(messages):
             with self.subTest(i):
@@ -707,9 +1102,8 @@ class ArticleAuthorsValidationTest(TestCase):
                 print(expected_output[i])
                 self.assertDictEqual(item, expected_output[i])
 
-
     def test_success_role(self):
-        xml = ("""
+        xml = """
         <article>
             <front>
                 <article-meta>
@@ -738,27 +1132,28 @@ class ArticleAuthorsValidationTest(TestCase):
                 </article-meta>
             </front>
         </article>
-        """)
+        """
 
         expected_output = [
             {
-                'result': 'success',
+                "result": "success",
                 # Testa case-insensitive
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a valid role and content-type attribute for the role data curation."
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a valid role and content-type attribute for the role data curation.",
             },
             {
-                'result': 'success',
-                'message': "The author FRANCISCO VENEGAS-MARTÍNEZ has a valid role and content-type attribute for the role Conceptualization."
+                "result": "success",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a valid role and content-type attribute for the role Conceptualization.",
             },
             {
-                'result': 'success',
-                'message': "The author Vanessa M. Higa has a valid role and content-type attribute for the role Visualization."
-            }
+                "result": "success",
+                "message": "The author Vanessa M. Higa has a valid role and content-type attribute for the role Visualization.",
+            },
         ]
 
         data = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(
-            xmltree=data).validate_authors_role(credit_terms_and_urls=credit_terms_and_urls)
+        messages = ArticleAuthorsValidation(xmltree=data).validate_authors_role(
+            credit_terms_and_urls=credit_terms_and_urls
+        )
 
         for i, item in enumerate(messages):
             with self.subTest(i):
@@ -768,11 +1163,9 @@ class ArticleAuthorsValidationTest(TestCase):
                 self.assertDictEqual(item, expected_output[i])
 
 
-
 class ArticleAuthorsValidationOrcidTest(TestCase):
-
     def test_validation_format_orcid(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -799,21 +1192,21 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'Format invalid',
-                'message': 'The author FRANCISCO VENEGAS-MARTÍNEZ has an orcid in an invalid format. Please ensure that the ORCID is entered correctly, including the proper format (e.g., 0000-0002-1825-0097).',
-                'author': {
-                    'surname': 'VENEGAS-MARTÍNEZ', 
-                    'prefix': 'Prof', 
-                    'suffix': 'Nieto', 
-                    'given_names': 'FRANCISCO', 
-                    'orcid': '0990-01-58-4853',
+                "result": "error",
+                "error_type": "Format invalid",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has an orcid in an invalid format. Please ensure that the ORCID is entered correctly, including the proper format (e.g., 0000-0002-1825-0097).",
+                "author": {
+                    "surname": "VENEGAS-MARTÍNEZ",
+                    "prefix": "Prof",
+                    "suffix": "Nieto",
+                    "given_names": "FRANCISCO",
+                    "orcid": "0990-01-58-4853",
                     "rid": ["aff1"],
                     "rid-aff": ["aff1"],
                     "aff_rids": ["aff1"],
@@ -821,19 +1214,19 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 },
             },
             {
-                'result': 'error',
-                'error_type': 'Format invalid',
-                'message': 'The author Vanessa M. Higa has an orcid in an invalid format. Please ensure that the ORCID is entered correctly, including the proper format (e.g., 0000-0002-1825-0097).',
-                'author': {
-                    'surname': 'Higa', 
-                    'given_names': 'Vanessa M.', 
-                    'orcid': '00-0001-5518-4853',
+                "result": "error",
+                "error_type": "Format invalid",
+                "message": "The author Vanessa M. Higa has an orcid in an invalid format. Please ensure that the ORCID is entered correctly, including the proper format (e.g., 0000-0002-1825-0097).",
+                "author": {
+                    "surname": "Higa",
+                    "given_names": "Vanessa M.",
+                    "orcid": "00-0001-5518-4853",
                     "rid": ["aff1"],
                     "rid-aff": ["aff1"],
                     "aff_rids": ["aff1"],
                     "contrib-type": "author",
-                }
-            }
+                },
+            },
         ]
         for i, item in enumerate(messages):
             with self.subTest(i):
@@ -843,7 +1236,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 self.assertDictEqual(item, expected_output[i])
 
     def test_without_orcid(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -868,31 +1261,31 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
         xmltree = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
 
         expected_output = [
             {
-                'result': 'error',
-                'error_type': 'Orcid not found',
-                'message': 'The author FRANCISCO VENEGAS-MARTÍNEZ does not have an orcid. Please add a valid orcid.',
-                'author': {
-                    'surname': 'VENEGAS-MARTÍNEZ', 
-                    'prefix': 'Prof', 
-                    'suffix': 'Nieto', 
-                    'given_names': 'FRANCISCO', 
-                },            
+                "result": "error",
+                "error_type": "Orcid not found",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ does not have an orcid. Please add a valid orcid.",
+                "author": {
+                    "surname": "VENEGAS-MARTÍNEZ",
+                    "prefix": "Prof",
+                    "suffix": "Nieto",
+                    "given_names": "FRANCISCO",
+                },
             },
             {
-                'result': 'error',
-                'error_type': 'Orcid not found',
-                'message': 'The author Vanessa M. Higa does not have an orcid. Please add a valid orcid.',
-                'author': {
-                    'surname': 'Higa', 
-                    'given_names': 'Vanessa M.', 
-                },               
-            }
+                "result": "error",
+                "error_type": "Orcid not found",
+                "message": "The author Vanessa M. Higa does not have an orcid. Please add a valid orcid.",
+                "author": {
+                    "surname": "Higa",
+                    "given_names": "Vanessa M.",
+                },
+            },
         ]
 
         for i, item in enumerate(messages):
@@ -903,7 +1296,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 self.assertDictEqual(item, expected_output[i])
 
     def test_success_orcid(self):
-        xml = ("""
+        xml = """
         <article>
         <front>
             <article-meta>
@@ -930,32 +1323,32 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             </article-meta>
           </front>
         </article>
-        """)
+        """
 
         xmltree = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
 
         expected_output = [
             {
-                'result': 'success',
-                'message': 'The author FRANCISCO VENEGAS-MARTÍNEZ has a valid orcid.',
-                'author': {
-                    'surname': 'VENEGAS-MARTÍNEZ', 
-                    'prefix': 'Prof', 
-                    'suffix': 'Nieto', 
-                    'given_names': 'FRANCISCO', 
-                    'orcid': '0990-0001-0058-4853'
+                "result": "success",
+                "message": "The author FRANCISCO VENEGAS-MARTÍNEZ has a valid orcid.",
+                "author": {
+                    "surname": "VENEGAS-MARTÍNEZ",
+                    "prefix": "Prof",
+                    "suffix": "Nieto",
+                    "given_names": "FRANCISCO",
+                    "orcid": "0990-0001-0058-4853",
                 },
             },
             {
-                'result': 'success',
-                'message': 'The author Vanessa M. Higa has a valid orcid.',
-                'author': {
-                    'surname': 'Higa', 
-                    'given_names': 'Vanessa M.', 
-                    'orcid': '0000-3333-1238-6873'
-                },            
-            }
+                "result": "success",
+                "message": "The author Vanessa M. Higa has a valid orcid.",
+                "author": {
+                    "surname": "Higa",
+                    "given_names": "Vanessa M.",
+                    "orcid": "0000-3333-1238-6873",
+                },
+            },
         ]
 
         for i, item in enumerate(messages):


### PR DESCRIPTION
#### O que esse PR faz?
Faz com que Authors retorne as afiliações junto aos dados de autores

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando a classe Authors

#### Algum cenário de contexto que queira dar?
Já existe a classe AffiliationExtractor, mas o seu retorno me pareceu muito complexo, pois instituição é uma lista de dicionário de um item, e isso ocorre também com country.
Estas classes tem como objetivo simplificar o acesso ao conteúdo do XML.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

