### PR TITLE
Corrige a classe Abstract que facilita o acesso aos resumos do XML SciELO

### DIFF
--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -229,7 +229,7 @@ class Abstract:
             yield item
 
     @property
-    def sub_article_abstract_with_tags(self):
+    def _sub_article_abstract_with_tags(self):
         try:
             out = {
                 'lang': self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang"),
@@ -241,7 +241,7 @@ class Abstract:
             pass
 
     @property
-    def sub_article_abstract_without_tags(self):
+    def _sub_article_abstract_without_tags(self):
         abstracts = {}
         for sub_article in self.xmltree.xpath(".//sub-article"):
             lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
@@ -266,7 +266,7 @@ class Abstract:
             yield item
 
     @property
-    def trans_abstract_with_tags(self):
+    def _trans_abstract_with_tags(self):
         try:
             out = {
                 'lang': self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang"),
@@ -278,7 +278,7 @@ class Abstract:
             pass
 
     @property
-    def trans_abstract_without_tags(self):
+    def _trans_abstract_without_tags(self):
         abstracts = {}
         for trans_abstract_node in self.xmltree.xpath(".//trans-abstract"):
             lang = trans_abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
@@ -299,17 +299,11 @@ class Abstract:
 
     @property
     def abstracts_with_tags(self):
-        return [self.main_abstract_with_tags, self.trans_abstract_with_tags, self.sub_article_abstract_with_tags]
+        return [self.main_abstract_with_tags, self._trans_abstract_with_tags, self._sub_article_abstract_with_tags]
 
     @property
     def abstracts_without_tags(self):
         out = self.main_abstract_without_tags
-        try:
-            out.update(self.trans_abstract_without_tags)
-        except TypeError:
-            pass
-        try:
-            out.update(self.sub_article_abstract_without_tags)
-        except TypeError:
-            pass
+        out.update(self._trans_abstract_without_tags)
+        out.update(self._sub_article_abstract_without_tags)
         return out

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -150,7 +150,7 @@ class Abstract:
             # abstract/p
             node_p = abstract_node.find("p")
             if node_p is not None:
-                out["p"] = node_text(node_p)
+                out["p"] = node_text(node_p).strip()
         return out
 
     def _format_abstract(self, abstract_node, style=None):
@@ -171,7 +171,7 @@ class Abstract:
             texts = []
             for node_p in abstract_node.xpath(".//p"):
                 p_text = get_node_without_subtag(node_p)
-                texts.append(p_text)
+                texts.append(p_text.strip())
             return " ".join(texts)
 
     @property
@@ -210,12 +210,15 @@ class Abstract:
 
     @property
     def sub_article_abstract_without_tags(self):
-        lang = self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang")
-        p_text = self._format_abstract(
-            abstract_node=self.xmltree.find(".//sub-article//front-stub//abstract"),
-            style="only_p"
-        )
-        return {lang: p_text}
+        abstracts = {}
+        for sub_article in self.xmltree.xpath(".//sub-article"):
+            lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
+            p_text = self._format_abstract(
+                abstract_node=sub_article.find(".//front-stub//abstract"),
+                style="only_p"
+            )
+            abstracts[lang] = p_text
+        return abstracts
 
     @property
     def trans_abstract_with_tags(self):
@@ -231,12 +234,15 @@ class Abstract:
 
     @property
     def trans_abstract_without_tags(self):
-        lang = self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang")
-        p_text = self._format_abstract(
-            abstract_node=self.xmltree.find(".//front//article-meta//trans-abstract"),
-            style="only_p"
-        )
-        return {lang: p_text}
+        abstracts = {}
+        for trans_abstract_node in self.xmltree.xpath(".//trans-abstract"):
+            lang = trans_abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
+            p_text = self._format_abstract(
+                abstract_node=trans_abstract_node,
+                style="only_p"
+            )
+            abstracts[lang] = p_text
+        return abstracts
 
     @property
     def abstracts_with_tags(self):

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -77,24 +77,6 @@ class Abstract:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    def _get_section_paragraphs(self, attrib, lang):
-        """
-        Retorna os parágrafos das seções dos resumos
-
-        Returns
-        -------
-        dict : {lang: todos os abstract/sec/p concatenados por espaço}
-        """
-        values = []
-        for node in self.xmltree.xpath(f"{attrib}//sec"):
-            node_p = node.find("p")
-            if node_p is None:
-                continue
-            values.append(get_node_without_subtag(node_p))
-        if values:
-            return {lang: " ".join(values)}
-        return {}
-
     def _get_section_titles_and_paragraphs(self, attrib):
         """
         Retorna os títulos pareados com os textos das seções do resumo
@@ -196,7 +178,11 @@ class Abstract:
     def main_abstract_without_tags(self):
         lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
 
-        return self._get_section_paragraphs('.//front//article-meta//abstract', lang)
+        p_text = self._format_abstract(
+            abstract_node=self.xmltree.find(".//abstract"),
+            style="only_p"
+        )
+        return {lang: p_text}
 
     @property
     def main_abstract_with_tags(self):
@@ -224,12 +210,12 @@ class Abstract:
 
     @property
     def sub_article_abstract_without_tags(self):
-        try:
-            lang = self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang")
-
-            return self._get_section_paragraphs('.//sub-article//front-stub//abstract', lang)
-        except AttributeError:
-            pass
+        lang = self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang")
+        p_text = self._format_abstract(
+            abstract_node=self.xmltree.find(".//sub-article//front-stub//abstract"),
+            style="only_p"
+        )
+        return {lang: p_text}
 
     @property
     def trans_abstract_with_tags(self):
@@ -245,12 +231,12 @@ class Abstract:
 
     @property
     def trans_abstract_without_tags(self):
-        try:
-            lang = self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang")
-
-            return self._get_section_paragraphs('.//front//article-meta//trans-abstract', lang)
-        except AttributeError:
-            pass
+        lang = self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang")
+        p_text = self._format_abstract(
+            abstract_node=self.xmltree.find(".//front//article-meta//trans-abstract"),
+            style="only_p"
+        )
+        return {lang: p_text}
 
     @property
     def abstracts_with_tags(self):

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -154,17 +154,13 @@ class Abstract:
         return out
 
     def _format_abstract(self, abstract_node, style=None):
-        if not style:
-            # xml
+        if style == "xml":
+            # formato xml
             return node_text(abstract_node)
-
-        if style == "structured":
-            # retorna abstract em formato de dicionário
-            return self._get_structured_abstract(abstract_node)
 
         if style == "inline":
             # retorna o conteúdo do nó abstract como str
-            return get_node_without_subtag(abstract_node)
+            return get_node_without_subtag(abstract_node, remove_extra_spaces=True)
 
         if style == "only_p":
             # retorna somente o conteúdo dos nós abstract//p como str
@@ -173,6 +169,27 @@ class Abstract:
                 p_text = get_node_without_subtag(node_p)
                 texts.append(p_text.strip())
             return " ".join(texts)
+
+        # retorna abstract em formato de dicionário
+        return self._get_structured_abstract(abstract_node)
+
+    def get_main_abstract(self, style=None):
+        """
+        Retorna o resumo principal no formato indicado.
+        Formato padrão: inline
+
+        """
+        lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
+        abstract = self._format_abstract(
+            abstract_node=self.xmltree.find(".//abstract"),
+            style=style,
+        )
+        if not style:
+            abstract["lang"] = lang
+        return {
+            "lang": lang,
+            "abstract": abstract,
+        }
 
     @property
     def main_abstract_without_tags(self):

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -76,7 +76,7 @@ class Abstract:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    def get_values_dict_without_tags(self, attrib, lang):
+    def _get_section_paragraphs(self, attrib, lang):
         values = []
         try:
             for node in self.xmltree.xpath(f"{attrib}//sec"):
@@ -91,7 +91,7 @@ class Abstract:
         out = {lang: " ".join(values)}
         return out
 
-    def get_values_dict_with_tags(self, attrib):
+    def _get_section_titles_and_paragraphs(self, attrib):
         out = dict()
         for node in self.xmltree.xpath(f"{attrib}//sec"):
             out[node.xpath("./title")[0].text] = node.xpath("./p")[0].text
@@ -102,7 +102,7 @@ class Abstract:
     def main_abstract_without_tags(self):
         lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
 
-        return self.get_values_dict_without_tags('.//front//article-meta//abstract', lang)
+        return self._get_section_paragraphs('.//front//article-meta//abstract', lang)
 
     @property
     def main_abstract_with_tags(self):
@@ -110,7 +110,7 @@ class Abstract:
             out = {
                 'lang': self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang"),
                 'title': self.xmltree.xpath(".//front//article-meta//abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//front//article-meta//abstract')
+                'sections': self._get_section_titles_and_paragraphs('.//front//article-meta//abstract')
             }
             return out
         except IndexError:
@@ -122,7 +122,7 @@ class Abstract:
             out = {
                 'lang': self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang"),
                 'title': self.xmltree.xpath(".//sub-article//front-stub//abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//sub-article//front-stub//abstract')
+                'sections': self._get_section_titles_and_paragraphs('.//sub-article//front-stub//abstract')
             }
             return out
         except AttributeError:
@@ -133,7 +133,7 @@ class Abstract:
         try:
             lang = self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang")
 
-            return self.get_values_dict_without_tags('.//sub-article//front-stub//abstract', lang)
+            return self._get_section_paragraphs('.//sub-article//front-stub//abstract', lang)
         except AttributeError:
             pass
 
@@ -143,7 +143,7 @@ class Abstract:
             out = {
                 'lang': self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang"),
                 'title': self.xmltree.xpath(".//front//article-meta//trans-abstract//title")[0].text,
-                'sections': self.get_values_dict_with_tags('.//front//article-meta//trans-abstract')
+                'sections': self._get_section_titles_and_paragraphs('.//front//article-meta//trans-abstract')
             }
             return out
         except AttributeError:
@@ -154,7 +154,7 @@ class Abstract:
         try:
             lang = self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang")
 
-            return self.get_values_dict_without_tags('.//front//article-meta//trans-abstract', lang)
+            return self._get_section_paragraphs('.//front//article-meta//trans-abstract', lang)
         except AttributeError:
             pass
 

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -297,6 +297,15 @@ class Abstract:
         yield from self._get_trans_abstracts(style=style)
         yield from self._get_sub_article_abstracts(style=style)
 
+    def get_abstracts_by_lang(self, style=None):
+        """
+        Retorna dicionário cuja chave é idioma e valor o resumo no formato dado por style
+        """
+        d = {}
+        for item in self.get_abstracts(style=style):
+            d[item["lang"]] = item["abstract"]
+        return d
+
     @property
     def abstracts_with_tags(self):
         return [self.main_abstract_with_tags, self._trans_abstract_with_tags, self._sub_article_abstract_with_tags]

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -78,6 +78,10 @@ class Abstract:
         self.xmltree = xmltree
 
     def _get_section_titles_and_paragraphs(self, attrib):
+        # TODO identificar quem usa este método e eliminar o uso e o método
+        # pois não parecer fazer sentido ter como chaves de dicionário o título de seção do resumo 
+        # além disso, dict não tem como característica
+        # manter os itens ordenados, sendo assim o mais adequado é usar list
         """
         Retorna os títulos pareados com os textos das seções do resumo
 
@@ -193,6 +197,12 @@ class Abstract:
 
     @property
     def main_abstract_without_tags(self):
+        # TODO adaptar o código usuário deste método para no lugar deste
+        # usar get_main_abstract(style="only_p")
+        # pois com este nome parece que retorna o resumo principal
+        # sem "tags", ou seja, todos os textos conteúdo de todos os elementos (title, p, sec, etc),
+        # mas o que faz é retornar um dicionário cuja chave é o idioma
+        # do resumo principal e o valor é o conteúdo concatenados somente dos elementos p
         lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
 
         p_text = self._format_abstract(
@@ -203,6 +213,12 @@ class Abstract:
 
     @property
     def main_abstract_with_tags(self):
+        # TODO adaptar o código usuário deste método para no lugar deste
+        # usar get_main_abstract(style=None)
+        # pois com este nome parece que retorna o resumo principal com "tags",
+        # ou seja, parece que retorna o próprio xml do abstract,
+        # mas o que faz é retornar um dicionário cuja chave é o idioma
+        # do resumo principal e o valor é o resumo estruturado em dicionário
         try:
             out = {
                 'lang': self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang"),
@@ -230,6 +246,13 @@ class Abstract:
 
     @property
     def _sub_article_abstract_with_tags(self):
+        # TODO adaptar o código usuário deste método para no lugar deste
+        # usar _get_sub_article_abstracts(style=None)
+        # pois com este nome parece que retorna os resumos com "tags",
+        # ou seja, parece que retorna o próprio xml do abstract,
+        # mas o que faz é retornar um dicionário representando o resumo em
+        # formato estruturado
+        # além disso, este código não considera que sub-article ocorra mais de 1 vez
         try:
             out = {
                 'lang': self.xmltree.find(".//sub-article").get("{http://www.w3.org/XML/1998/namespace}lang"),
@@ -255,6 +278,13 @@ class Abstract:
 
     @property
     def _trans_abstract_with_tags(self):
+        # TODO adaptar o código usuário deste método para no lugar deste
+        # usar _get_trans_abstracts(style=None)
+        # pois com este nome parece que retorna os resumos com "tags",
+        # ou seja, parece que retorna o próprio xml do abstract,
+        # mas o que faz é retornar um dicionário representando o resumo em
+        # formato estruturado
+        # além disso, este código não considera que trans-abstract ocorra mais de 1 vez
         try:
             out = {
                 'lang': self.xmltree.find(".//trans-abstract").get("{http://www.w3.org/XML/1998/namespace}lang"),
@@ -284,6 +314,12 @@ class Abstract:
 
     @property
     def abstracts_with_tags(self):
+        # TODO adaptar o código usuário deste método para no lugar deste
+        # usar get_abstracts(style=None)
+        # pois com este nome parece que retorna os resumos com "tags",
+        # ou seja, parece que retorna o próprio xml do abstract,
+        # mas o que faz é retornar um dicionário representando o resumo em
+        # formato estruturado
         return [self.main_abstract_with_tags, self._trans_abstract_with_tags, self._sub_article_abstract_with_tags]
 
     @property

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -240,18 +240,6 @@ class Abstract:
         except AttributeError:
             pass
 
-    @property
-    def _sub_article_abstract_without_tags(self):
-        abstracts = {}
-        for sub_article in self.xmltree.xpath(".//sub-article"):
-            lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
-            p_text = self._format_abstract(
-                abstract_node=sub_article.find(".//front-stub//abstract"),
-                style="only_p"
-            )
-            abstracts[lang] = p_text
-        return abstracts
-
     def _get_trans_abstracts(self, style=None):
         """
         Retorna gerador de resumos trans-abstract
@@ -277,18 +265,6 @@ class Abstract:
         except AttributeError:
             pass
 
-    @property
-    def _trans_abstract_without_tags(self):
-        abstracts = {}
-        for trans_abstract_node in self.xmltree.xpath(".//trans-abstract"):
-            lang = trans_abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
-            p_text = self._format_abstract(
-                abstract_node=trans_abstract_node,
-                style="only_p"
-            )
-            abstracts[lang] = p_text
-        return abstracts
-
     def get_abstracts(self, style=None):
         """
         Retorna gerador de resumos
@@ -312,7 +288,4 @@ class Abstract:
 
     @property
     def abstracts_without_tags(self):
-        out = self.main_abstract_without_tags
-        out.update(self._trans_abstract_without_tags)
-        out.update(self._sub_article_abstract_without_tags)
-        return out
+        return self.get_abstracts_by_lang(style="only_p")

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -213,6 +213,21 @@ class Abstract:
         except IndexError:
             pass
 
+    def _get_sub_article_abstracts(self, style=None):
+        """
+        Retorna gerador de resumos em sub-article
+        """
+        for sub_article in self.xmltree.xpath(".//sub-article"):
+            item = {}
+            item["lang"] = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
+            item["abstract"] = self._format_abstract(
+                abstract_node=sub_article.find(".//front-stub//abstract"),
+                style=style
+            )
+            if not style:
+                item["abstract"]["lang"] = item["lang"]
+            yield item
+
     @property
     def sub_article_abstract_with_tags(self):
         try:
@@ -237,6 +252,19 @@ class Abstract:
             abstracts[lang] = p_text
         return abstracts
 
+    def _get_trans_abstracts(self, style=None):
+        """
+        Retorna gerador de resumos trans-abstract
+        """
+        for trans_abstract in self.xmltree.xpath(".//trans-abstract"):
+            item = {}
+            item["lang"] = trans_abstract.get("{http://www.w3.org/XML/1998/namespace}lang")
+            item["abstract"] = self._format_abstract(
+                abstract_node=trans_abstract,
+                style=style
+            )
+            yield item
+
     @property
     def trans_abstract_with_tags(self):
         try:
@@ -260,6 +288,14 @@ class Abstract:
             )
             abstracts[lang] = p_text
         return abstracts
+
+    def get_abstracts(self, style=None):
+        """
+        Retorna gerador de resumos
+        """
+        yield self.get_main_abstract(style=style)
+        yield from self._get_trans_abstracts(style=style)
+        yield from self._get_sub_article_abstracts(style=style)
 
     @property
     def abstracts_with_tags(self):

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -141,26 +141,11 @@ def node_text(node):
     return "".join(items)
 
 
-def node_text_without_tags(node, exception_list=None):
+def get_node_without_subtag(node):
     """
-    Retorna todos os node.text, excluindo a subtags
-    Para <title>Text <bold>text</bold> Text</title>, retorna
-    Text text Text
+        Função que retorna nó sem subtags. 
     """
-    exception_list = exception_list or []
-    items = [node.text or ""]
-    for child in node.getchildren():
-        if child in exception_list:
-            items.append(
-                etree.tostring(child, encoding="utf-8").decode("utf-8")
-            )
-        else:
-            items.append(
-                child.text
-            )
-        if child.tail:
-            items.append(child.tail)
-    return "".join(items)
+    return "".join(node.xpath(".//text()"))
 
 
 def get_year_month_day(node):

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -141,6 +141,28 @@ def node_text(node):
     return "".join(items)
 
 
+def node_text_without_tags(node, exception_list=None):
+    """
+    Retorna todos os node.text, excluindo a subtags
+    Para <title>Text <bold>text</bold> Text</title>, retorna
+    Text text Text
+    """
+    exception_list = exception_list or []
+    items = [node.text or ""]
+    for child in node.getchildren():
+        if child in exception_list:
+            items.append(
+                etree.tostring(child, encoding="utf-8").decode("utf-8")
+            )
+        else:
+            items.append(
+                child.text
+            )
+        if child.tail:
+            items.append(child.tail)
+    return "".join(items)
+
+
 def get_year_month_day(node):
     """
     Retorna os valores respectivos dos elementos "year", "month", "day".

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -141,10 +141,12 @@ def node_text(node):
     return "".join(items)
 
 
-def get_node_without_subtag(node):
+def get_node_without_subtag(node, remove_extra_spaces=False):
     """
         Função que retorna nó sem subtags. 
     """
+    if remove_extra_spaces:
+        return " ".join([text.strip()for text in node.xpath(".//text()") if text.strip()])
     return "".join(node.xpath(".//text()"))
 
 

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -116,11 +116,6 @@ class SubArticleAbstractTest(TestCase):
 
         self.assertEqual(obtained, expected)
 
-    def test_sub_article_abstract_without_tags(self):
-        obtained = self.abstract._sub_article_abstract_without_tags
-        expected = {'pt': 'objetivo metodo resultados conclusão'}
-        self.assertEqual(obtained, expected)
-
 
 class ArticleTransAbstractTest(TestCase):
     maxDiff = None
@@ -172,13 +167,6 @@ class ArticleTransAbstractTest(TestCase):
                 "Conclusión:": "conclusion"
             }
         }
-
-        self.assertEqual(obtained, expected)
-
-    def test_trans_abstract_without_tags(self):
-        obtained = self.abstract._trans_abstract_without_tags
-
-        expected = {'es': 'objetivo metodo resultados conclusion'}
 
         self.assertEqual(obtained, expected)
 
@@ -427,22 +415,6 @@ class AbstractWithSectionsTest(TestCase):
         expected = {
             "en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
         result = self.abstract.main_abstract_without_tags
-        self.assertDictEqual(expected, result)
-
-    def test__sub_article_abstract_without_tags(self):
-        expected = {
-            "es": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. Ensayo Clínico Aleatorizado ... World Health Organization Quality of Life Assessment (WHOQOL-BREF) y el módulo Old(WHOQOL-OLD) 1semana, 2meses y 1año después del alta.",
-            "de": "Randomisierte klinische Studie... Modul Alt (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung. Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.",
-        }
-        result = self.abstract._sub_article_abstract_without_tags
-        self.assertDictEqual(expected, result)
-
-    def test__trans_abstract_without_tags(self):
-        expected = {
-            "pt": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). Ensaio Clínico Randomizado... Módulo Old (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta.",
-            "fr": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC. Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.",
-        }
-        result = self.abstract._trans_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):
@@ -743,22 +715,6 @@ class AbstractWithoutSectionsTest(TestCase):
     def test__main_abstract_without_tags(self):
         expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
         result = self.abstract.main_abstract_without_tags
-        self.assertDictEqual(expected, result)
-
-    def test__sub_article_abstract_without_tags(self):
-        expected = {
-            "es": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 ensayos clínicos controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
-            "it": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 studi clinici controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
-        }
-        result = self.abstract._sub_article_abstract_without_tags
-        self.assertDictEqual(expected, result)
-
-    def test__trans_abstract_without_tags(self):
-        expected = {
-            "pt": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 estudos clínicos controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
-            "fr": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 essais cliniques contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
-        }
-        result = self.abstract._trans_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -443,10 +443,107 @@ class AbstractWithSectionsTest(TestCase):
             "fr": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC. Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.",
         }
         result = self.abstract.trans_abstract_without_tags
-        print("")
-        print(result["fr"])
-        print(expected["fr"])
+        self.assertDictEqual(expected, result)
 
+    def test_get_main_abstract_default_style(self):
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            "abstract": {
+                "lang": "en",
+                "title": "Abstract",
+                "sections": [{
+                    "title": "Objective",
+                    "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.",
+                },
+                {
+                    "title": "Design",
+                    "p": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+
+                }],
+            }
+        }
+        result = self.abstract.get_main_abstract()
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_inline(self):
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Design Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+        }
+        result = self.abstract.get_main_abstract(style="inline")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_xml(self):
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            "abstract": """<title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>""",
+        }
+        result = self.abstract.get_main_abstract(style="xml")
+        self.assertEqual(expected["lang"], result["lang"])
+        self.assertIn("<title>Abstract</title>", result["abstract"])
+        self.assertIn("<italic>clinical trials</italic>", result["abstract"])
+        self.assertIn("<title>Objective</title>", result["abstract"])
+        self.assertIn("<title>Design</title>", result["abstract"])
+        self.assertIn("<p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>", result["abstract"])
+
+    def test_get_main_abstract_only_p(self):
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
 
 
@@ -521,4 +618,44 @@ class AbstractWithoutSectionsTest(TestCase):
             "fr": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 essais cliniques contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
         }
         result = self.abstract.trans_abstract_without_tags
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_default_style(self):
+        expected = {
+            "lang": "en",
+            "abstract": {
+                "lang": "en",
+                "title": "Abstract",
+                "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            }
+        }
+        result = self.abstract.get_main_abstract()
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_inline(self):
+        expected = {
+            "lang": "en",
+            "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+        }
+        result = self.abstract.get_main_abstract(style="inline")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_xml(self):
+        expected = {
+            "lang": "en",
+            "abstract": """<title>Abstract</title>
+                <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>""",
+        }
+        result = self.abstract.get_main_abstract(style="xml")
+        self.assertEqual(expected["lang"], result["lang"])
+        self.assertIn("<title>Abstract</title>", result["abstract"])
+        self.assertIn("<italic>clinical trials</italic>", result["abstract"])
+        self.assertIn("<p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>", result["abstract"])
+
+    def test_get_main_abstract_only_p(self):
+        expected = {
+            "lang": "en",
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -333,6 +333,7 @@ class ArticleAbstractsTest(TestCase):
 
         self.assertEqual(obtained, expected)
 
+
 class AbstractWithSectionsTest(TestCase):
 
     def setUp(self):
@@ -385,6 +386,29 @@ class AbstractWithSectionsTest(TestCase):
             """)
         self.abstract = Abstract(xmltree)
 
+    def test__get_section_paragraphs(self):
+        expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
+        result = self.abstract._get_section_paragraphs(
+            ".//front//abstract", "en",
+        )
+        self.assertDictEqual(expected, result)
+
+    def test__get_section_titles_and_paragraphs(self):
+        expected = {
+            "Objective": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.",
+            "Design": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+        }
+        result = self.abstract._get_section_titles_and_paragraphs(
+            ".//front//abstract",
+        )
+        self.assertDictEqual(expected, result)
+
+    def test__main_abstract_without_tags(self):
+        expected = {
+            "en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
+        result = self.abstract.main_abstract_without_tags
+        self.assertDictEqual(expected, result)
+
 
 class AbstractWithoutSectionsTest(TestCase):
 
@@ -430,3 +454,22 @@ class AbstractWithoutSectionsTest(TestCase):
         </article>
         """)
         self.abstract = Abstract(xmltree)
+
+    def test__get_section_paragraphs(self):
+        expected = {}
+        result = self.abstract._get_section_paragraphs(
+            ".//front//abstract", "en",
+        )
+        self.assertDictEqual(expected, result)
+
+    def test__get_section_titles_and_paragraphs(self):
+        expected = {}
+        result = self.abstract._get_section_titles_and_paragraphs(
+            ".//front//abstract",
+        )
+        self.assertDictEqual(expected, result)
+
+    def test__main_abstract_without_tags(self):
+        expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
+        result = self.abstract.main_abstract_without_tags
+        self.assertDictEqual(expected, result)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -101,7 +101,7 @@ class SubArticleAbstractTest(TestCase):
         self.abstract = Abstract(xmltree)
 
     def test_sub_article_abstract_with_tags(self):
-        obtained = self.abstract.sub_article_abstract_with_tags
+        obtained = self.abstract._sub_article_abstract_with_tags
 
         expected = {
             "lang": "pt",
@@ -117,7 +117,7 @@ class SubArticleAbstractTest(TestCase):
         self.assertEqual(obtained, expected)
 
     def test_sub_article_abstract_without_tags(self):
-        obtained = self.abstract.sub_article_abstract_without_tags
+        obtained = self.abstract._sub_article_abstract_without_tags
         expected = {'pt': 'objetivo metodo resultados conclusão'}
         self.assertEqual(obtained, expected)
 
@@ -160,7 +160,7 @@ class ArticleTransAbstractTest(TestCase):
         self.abstract = Abstract(xmltree)
 
     def test_trans_abstract_with_tags(self):
-        obtained = self.abstract.trans_abstract_with_tags
+        obtained = self.abstract._trans_abstract_with_tags
 
         expected = {
             "lang": "es",
@@ -176,7 +176,7 @@ class ArticleTransAbstractTest(TestCase):
         self.assertEqual(obtained, expected)
 
     def test_trans_abstract_without_tags(self):
-        obtained = self.abstract.trans_abstract_without_tags
+        obtained = self.abstract._trans_abstract_without_tags
 
         expected = {'es': 'objetivo metodo resultados conclusion'}
 
@@ -327,7 +327,7 @@ class ArticleAbstractsTest(TestCase):
             """
         )
         data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_with_tags
+        obtained = Abstract(data)._trans_abstract_with_tags
 
         expected = None
 
@@ -434,7 +434,7 @@ class AbstractWithSectionsTest(TestCase):
             "es": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. Ensayo Clínico Aleatorizado ... World Health Organization Quality of Life Assessment (WHOQOL-BREF) y el módulo Old(WHOQOL-OLD) 1semana, 2meses y 1año después del alta.",
             "de": "Randomisierte klinische Studie... Modul Alt (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung. Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.",
         }
-        result = self.abstract.sub_article_abstract_without_tags
+        result = self.abstract._sub_article_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test__trans_abstract_without_tags(self):
@@ -442,7 +442,7 @@ class AbstractWithSectionsTest(TestCase):
             "pt": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). Ensaio Clínico Randomizado... Módulo Old (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta.",
             "fr": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC. Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.",
         }
-        result = self.abstract.trans_abstract_without_tags
+        result = self.abstract._trans_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):
@@ -750,7 +750,7 @@ class AbstractWithoutSectionsTest(TestCase):
             "es": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 ensayos clínicos controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
             "it": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 studi clinici controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
         }
-        result = self.abstract.sub_article_abstract_without_tags
+        result = self.abstract._sub_article_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test__trans_abstract_without_tags(self):
@@ -758,7 +758,7 @@ class AbstractWithoutSectionsTest(TestCase):
             "pt": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 estudos clínicos controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
             "fr": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 essais cliniques contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
         }
-        result = self.abstract.trans_abstract_without_tags
+        result = self.abstract._trans_abstract_without_tags
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -437,6 +437,18 @@ class AbstractWithSectionsTest(TestCase):
         result = self.abstract.sub_article_abstract_without_tags
         self.assertDictEqual(expected, result)
 
+    def test__trans_abstract_without_tags(self):
+        expected = {
+            "pt": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). Ensaio Clínico Randomizado... Módulo Old (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta.",
+            "fr": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC. Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.",
+        }
+        result = self.abstract.trans_abstract_without_tags
+        print("")
+        print(result["fr"])
+        print(expected["fr"])
+
+        self.assertDictEqual(expected, result)
+
 
 class AbstractWithoutSectionsTest(TestCase):
 
@@ -501,4 +513,12 @@ class AbstractWithoutSectionsTest(TestCase):
             "it": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 studi clinici controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
         }
         result = self.abstract.sub_article_abstract_without_tags
+        self.assertDictEqual(expected, result)
+
+    def test__trans_abstract_without_tags(self):
+        expected = {
+            "pt": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 estudos clínicos controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
+            "fr": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 essais cliniques contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
+        }
+        result = self.abstract.trans_abstract_without_tags
         self.assertDictEqual(expected, result)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -8,7 +8,7 @@ from packtools.sps.models.article_abstract import Abstract
 class AbstractTest(TestCase):
     maxDiff = None
 
-    def test_main_abstract_with_tags(self):
+    def setUp(self):
         xml = (
             """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
@@ -39,9 +39,11 @@ class AbstractTest(TestCase):
             </article>
             """
         )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).main_abstract_with_tags
+        xmltree = ET.fromstring(xml)
+        self.abstract = Abstract(xmltree)
 
+    def test_main_abstract_with_tags(self):
+        obtained = self.abstract.main_abstract_with_tags
         expected = {
             "lang": "en",
             "title": "Abstract",
@@ -52,48 +54,18 @@ class AbstractTest(TestCase):
                 "Conclusion:": "conclusion"
             }
         }
-
         self.assertEqual(obtained, expected)
 
     def test_main_abstract_without_tags(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-            <abstract>
-                <title>Abstract</title>
-                    <sec>
-                    <title>Objective:</title>
-                        <p>objective</p>
-                    </sec>
-                    <sec>
-                    <title>Method:</title>
-                        <p>method</p>
-                    </sec>
-                    <sec>
-                    <title>Results:</title>
-                        <p>results</p>
-                    </sec>
-                    <sec>
-                    <title>Conclusion:</title>
-                        <p>conclusion</p>
-                    </sec>
-            </abstract>
-            </article-meta>
-            </front>
-            </article>
-            """
-        )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).main_abstract_without_tags
-
+        obtained = self.abstract.main_abstract_without_tags
         expected = {'en': 'objective method results conclusion'}
-
         self.assertEqual(obtained, expected)
 
-    def test_sub_article_abstract_with_tags(self):
+
+class SubArticleAbstractTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
         xml = (
             """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
@@ -125,8 +97,11 @@ class AbstractTest(TestCase):
             </article>
             """
         )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).sub_article_abstract_with_tags
+        xmltree = ET.fromstring(xml)
+        self.abstract = Abstract(xmltree)
+
+    def test_sub_article_abstract_with_tags(self):
+        obtained = self.abstract.sub_article_abstract_with_tags
 
         expected = {
             "lang": "pt",
@@ -142,45 +117,15 @@ class AbstractTest(TestCase):
         self.assertEqual(obtained, expected)
 
     def test_sub_article_abstract_without_tags(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-                <sub-article article-type="translation" id="s1" xml:lang="pt">
-                    <front-stub>
-                        <article-id pub-id-type="doi">10.1590/1980-220X-REEUSP-2021-0569pt</article-id>
-                        <abstract>
-                            <title>RESUMO</title>
-                            <sec>
-                                <title>Objetivo:</title>
-                                <p>objetivo</p>
-                            </sec>
-                            <sec>
-                                <title>Método:</title>
-                                <p>metodo</p>
-                            </sec>
-                            <sec>
-                                <title>Resultados:</title>
-                                <p>resultados</p>
-                            </sec>
-                            <sec>
-                                <title>Conclusão:</title>
-                                <p>conclusão</p>
-                            </sec>
-                        </abstract>
-                    </front-stub>
-                </sub-article>
-            </article>
-            """
-        )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).sub_article_abstract_without_tags
-
+        obtained = self.abstract.sub_article_abstract_without_tags
         expected = {'pt': 'objetivo metodo resultados conclusão'}
-
         self.assertEqual(obtained, expected)
 
-    def test_trans_abstract_with_tags(self):
+
+class ArticleTransAbstractTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
         xml = (
             """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -211,8 +156,11 @@ class AbstractTest(TestCase):
             </article>
             """
         )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_with_tags
+        xmltree = ET.fromstring(xml)
+        self.abstract = Abstract(xmltree)
+
+    def test_trans_abstract_with_tags(self):
+        obtained = self.abstract.trans_abstract_with_tags
 
         expected = {
             "lang": "es",
@@ -228,44 +176,17 @@ class AbstractTest(TestCase):
         self.assertEqual(obtained, expected)
 
     def test_trans_abstract_without_tags(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-            <trans-abstract xml:lang="es">
-            <title>RESUMEN</title>
-            <sec>
-            <title>Objetivo:</title>
-            <p>objetivo</p>
-            </sec>
-            <sec>
-            <title>Método:</title>
-            <p>metodo</p>
-            </sec>
-            <sec>
-            <title>Resultados:</title>
-            <p>resultados</p>
-            </sec>
-            <sec>
-            <title>Conclusión:</title>
-            <p>conclusion</p>
-            </sec>
-            </trans-abstract>
-            </article-meta>
-            </front>
-            </article>
-            """
-        )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).trans_abstract_without_tags
+        obtained = self.abstract.trans_abstract_without_tags
 
         expected = {'es': 'objetivo metodo resultados conclusion'}
 
         self.assertEqual(obtained, expected)
 
-    def test_abstracts_with_tags(self):
+
+class ArticleAbstractsTest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
         xml = (
             """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
@@ -339,8 +260,11 @@ class AbstractTest(TestCase):
             </article>
             """
         )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).abstracts_with_tags
+        xmltree = ET.fromstring(xml)
+        self.abstract = Abstract(xmltree)
+
+    def test_abstracts_with_tags(self):
+        obtained = self.abstract.abstracts_with_tags
 
         expected = [
             {
@@ -379,81 +303,8 @@ class AbstractTest(TestCase):
         self.assertEqual(obtained, expected)
 
     def test_abstracts_without_tags(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-                <abstract>
-                    <title>Abstract</title>
-                        <sec>
-                        <title>Objective:</title>
-                            <p>objective</p>
-                        </sec>
-                        <sec>
-                        <title>Method:</title>
-                            <p>method</p>
-                        </sec>
-                        <sec>
-                        <title>Results:</title>
-                            <p>results</p>
-                        </sec>
-                        <sec>
-                        <title>Conclusion:</title>
-                            <p>conclusion</p>
-                        </sec>
-                </abstract>
-                    <trans-abstract xml:lang="es">
-                    <title>RESUMEN</title>
-                    <sec>
-                    <title>Objetivo:</title>
-                        <p>objetivo</p>
-                    </sec>
-                    <sec>
-                    <title>Método:</title>
-                        <p>metodo</p>
-                    </sec>
-                    <sec>
-                    <title>Resultados:</title>
-                        <p>resultados</p>
-                    </sec>
-                    <sec>
-                    <title>Conclusión:</title>
-                        <p>conclusion</p>
-                    </sec>
-                </trans-abstract>
-            </article-meta>
-            </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                    <front-stub>
-                        <article-id pub-id-type="doi">10.1590/1980-220X-REEUSP-2021-0569pt</article-id>
-                        <abstract>
-                            <title>RESUMO</title>
-                            <sec>
-                                <title>Objetivo:</title>
-                                <p>objetivo</p>
-                            </sec>
-                            <sec>
-                                <title>Método:</title>
-                                <p>metodo</p>
-                            </sec>
-                            <sec>
-                                <title>Resultados:</title>
-                                <p>resultados</p>
-                            </sec>
-                            <sec>
-                                <title>Conclusão:</title>
-                                <p>conclusão</p>
-                            </sec>
-                        </abstract>
-                    </front-stub>
-                </sub-article>
-            </article>
-            """
-        )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data).abstracts_without_tags
+
+        obtained = self.abstract.abstracts_without_tags
 
         expected = {
             'en': 'objective method results conclusion',

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -332,3 +332,101 @@ class ArticleAbstractsTest(TestCase):
         expected = None
 
         self.assertEqual(obtained, expected)
+
+class AbstractWithSectionsTest(TestCase):
+
+    def setUp(self):
+        xmltree = ET.fromstring(
+            """
+            <article 
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <abstract>
+                <title>Abstract</title>
+                <sec>
+                    <title>Objective</title>
+                    <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+                </sec>
+                <sec>
+                    <title>Design</title>
+                    <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+                </sec>
+            </abstract>
+            <trans-abstract xml:lang="pt">
+                <title>Resumo</title>
+                <sec>
+                  <title>Objetivo: </title>
+                  <p>avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). </p>
+                </sec>
+                <sec>
+                  <title>Método: </title>
+                  <p>Ensaio Clínico Randomizado... Módulo <italic>Old</italic> (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta. </p>
+                </sec>
+            </trans-abstract>
+            </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="es">
+                <front-stub>
+                    <abstract>
+                        <title>Resumen</title>
+                        <sec>
+                          <title>Objetivo: </title>
+                          <p>evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. </p>
+                        </sec>
+                        <sec>
+                          <title>Método: </title>
+                          <p>Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. </p>
+                        </sec>
+                      </abstract>
+                </front-stub>
+            </sub-article>
+            </article>
+            """)
+        self.abstract = Abstract(xmltree)
+
+
+class AbstractWithoutSectionsTest(TestCase):
+
+    def setUp(self):
+        xmltree = ET.fromstring(
+            """
+            <article 
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <abstract>
+                <title>Abstract</title>
+                <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+            </abstract>
+            <trans-abstract xml:lang="pt">
+                <title>Resumo</title>
+                <p>Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).</p>
+            </trans-abstract>
+            <trans-abstract xml:lang="fr">
+                <title>Resumo</title>
+                <p>Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).</p>
+            </trans-abstract>
+            </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="es">
+                <front-stub>
+                    <abstract>
+                        <title>Resumen</title>
+                        <p>
+                          Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).</p>
+                      </abstract>
+                </front-stub>
+            </sub-article>
+            <sub-article article-type="translation" xml:lang="it">
+                <front-stub>
+                    <abstract>
+                        <title>Resumen</title>
+                        <p>
+                          Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
+                      </abstract>
+                </front-stub>
+            </sub-article>
+        </article>
+        """)
+        self.abstract = Abstract(xmltree)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -365,6 +365,18 @@ class AbstractWithSectionsTest(TestCase):
                   <p>Ensaio Clínico Randomizado... Módulo <italic>Old</italic> (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta. </p>
                 </sec>
             </trans-abstract>
+
+            <trans-abstract xml:lang="fr">
+                <title>Resumo</title>
+                <sec>
+                  <title>Objetivo: </title>
+                  <p>évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC.</p>
+                </sec>
+                <sec>
+                  <title>Método: </title>
+                  <p>Essai clinique randomisé... Module <italic>Old</italic> (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.</p>
+                </sec>
+            </trans-abstract>
             </article-meta>
             </front>
             <sub-article article-type="translation" xml:lang="es">
@@ -382,16 +394,24 @@ class AbstractWithSectionsTest(TestCase):
                       </abstract>
                 </front-stub>
             </sub-article>
+            <sub-article article-type="translation" xml:lang="de">
+                <front-stub>
+                    <abstract>
+                        <title>Resumen</title>
+                        <sec>
+                          <title>Objetivo: </title>
+                          <p>Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung.</p>
+                        </sec>
+                        <sec>
+                          <title>Método: </title>
+                          <p>Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.</p>
+                        </sec>
+                      </abstract>
+                </front-stub>
+            </sub-article>
             </article>
             """)
         self.abstract = Abstract(xmltree)
-
-    def test__get_section_paragraphs(self):
-        expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
-        result = self.abstract._get_section_paragraphs(
-            ".//front//abstract", "en",
-        )
-        self.assertDictEqual(expected, result)
 
     def test__get_section_titles_and_paragraphs(self):
         expected = {
@@ -407,6 +427,14 @@ class AbstractWithSectionsTest(TestCase):
         expected = {
             "en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
         result = self.abstract.main_abstract_without_tags
+        self.assertDictEqual(expected, result)
+
+    def test__sub_article_abstract_without_tags(self):
+        expected = {
+            "es": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. Ensayo Clínico Aleatorizado ... World Health Organization Quality of Life Assessment (WHOQOL-BREF) y el módulo Old(WHOQOL-OLD) 1semana, 2meses y 1año después del alta.",
+            "de": "Randomisierte klinische Studie... Modul Alt (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung. Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.",
+        }
+        result = self.abstract.sub_article_abstract_without_tags
         self.assertDictEqual(expected, result)
 
 
@@ -455,13 +483,6 @@ class AbstractWithoutSectionsTest(TestCase):
         """)
         self.abstract = Abstract(xmltree)
 
-    def test__get_section_paragraphs(self):
-        expected = {}
-        result = self.abstract._get_section_paragraphs(
-            ".//front//abstract", "en",
-        )
-        self.assertDictEqual(expected, result)
-
     def test__get_section_titles_and_paragraphs(self):
         expected = {}
         result = self.abstract._get_section_titles_and_paragraphs(
@@ -472,4 +493,12 @@ class AbstractWithoutSectionsTest(TestCase):
     def test__main_abstract_without_tags(self):
         expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
         result = self.abstract.main_abstract_without_tags
+        self.assertDictEqual(expected, result)
+
+    def test__sub_article_abstract_without_tags(self):
+        expected = {
+            "es": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 ensayos clínicos controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
+            "it": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 studi clinici controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
+        }
+        result = self.abstract.sub_article_abstract_without_tags
         self.assertDictEqual(expected, result)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -367,13 +367,13 @@ class AbstractWithSectionsTest(TestCase):
             </trans-abstract>
 
             <trans-abstract xml:lang="fr">
-                <title>Resumo</title>
+                <title>Résumé</title>
                 <sec>
-                  <title>Objetivo: </title>
+                  <title>Objectif: </title>
                   <p>évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC.</p>
                 </sec>
                 <sec>
-                  <title>Método: </title>
+                  <title>Méthode: </title>
                   <p>Essai clinique randomisé... Module <italic>Old</italic> (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.</p>
                 </sec>
             </trans-abstract>
@@ -397,13 +397,13 @@ class AbstractWithSectionsTest(TestCase):
             <sub-article article-type="translation" xml:lang="de">
                 <front-stub>
                     <abstract>
-                        <title>Resumen</title>
+                        <title>Zusammenfassung</title>
                         <sec>
-                          <title>Objetivo: </title>
+                          <title>Ziel: </title>
                           <p>Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung.</p>
                         </sec>
                         <sec>
-                          <title>Método: </title>
+                          <title>Methode: </title>
                           <p>Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.</p>
                         </sec>
                       </abstract>
@@ -546,6 +546,147 @@ class AbstractWithSectionsTest(TestCase):
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
 
+    def test__get_sub_article_abstracts(self):
+        """
+        <sub-article article-type="translation" xml:lang="es">
+            <front-stub>
+                <abstract>
+                    <title>Resumen</title>
+                    <sec>
+                      <title>Objetivo: </title>
+                      <p>evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. </p>
+                    </sec>
+                    <sec>
+                      <title>Método: </title>
+                      <p>Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. </p>
+                    </sec>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        <sub-article article-type="translation" xml:lang="de">
+            <front-stub>
+                <abstract>
+                    <title>Zusammenfassung</title>
+                    <sec>
+                      <title>Ziel: </title>
+                      <p>Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung.</p>
+                    </sec>
+                    <sec>
+                      <title>Methode: </title>
+                      <p>Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.</p>
+                    </sec>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        """
+        expected = (
+            {
+                "lang": "es",
+                "abstract": {
+                    "lang": "es",
+                    "title": "Resumen",
+                    "sections": [
+                        {
+                            "title": "Objetivo: ",
+                            "p": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. "
+                        },
+                        {
+                            "title": "Método: ",
+                            "p": "Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. "
+                        },
+                    ]
+                }
+            },
+            {
+                "lang": "de",
+                "abstract": {
+                    "lang": "de",
+                    "title": "Zusammenfassung",
+                    "sections": [
+                        {
+                            "title": "Ziel: ",
+                            "p": "Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung."
+                        },
+                        {
+                            "title": "Methode: ",
+                            "p": "Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben."
+                        },
+                    ]
+                }
+            },
+        )
+        result = self.abstract._get_sub_article_abstracts()
+        for res, exp in zip(result, expected):
+            with self.subTest(res["lang"]):
+                self.assertDictEqual(exp, res)
+
+    def test__get_trans_abstracts(self):
+        """
+        <trans-abstract xml:lang="pt">
+            <title>Resumo</title>
+            <sec>
+              <title>Objetivo: </title>
+              <p>avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). </p>
+            </sec>
+            <sec>
+              <title>Método: </title>
+              <p>Ensaio Clínico Randomizado... Módulo <italic>Old</italic> (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta. </p>
+            </sec>
+        </trans-abstract>
+
+        <trans-abstract xml:lang="fr">
+            <title>Résumé</title>
+            <sec>
+              <title>Objectif: </title>
+              <p>évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC.</p>
+            </sec>
+            <sec>
+              <title>Méthode: </title>
+              <p>Essai clinique randomisé... Module <italic>Old</italic> (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie.</p>
+            </sec>
+        </trans-abstract>
+        """
+        expected = (
+            {
+                "lang": "pt",
+                "abstract": {
+                    "lang": "pt",
+                    "title": "Resumo",
+                    "sections": [
+                        {
+                            "title": "Objetivo: ",
+                            "p": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). "
+                        },
+                        {
+                            "title": "Método: ",
+                            "p": "Ensaio Clínico Randomizado... Módulo <italic>Old</italic> (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta. "
+                        },
+                    ]
+                }
+            },
+            {
+                "lang": "fr",
+                "abstract": {
+                    "lang": "fr",
+                    "title": "Résumé",
+                    "sections": [
+                        {
+                            "title": "Objectif: ",
+                            "p": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC."
+                        },
+                        {
+                            "title": "Méthode: ",
+                            "p": "Essai clinique randomisé... Module <italic>Old</italic> (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie."
+                        },
+                    ]
+                }
+            },
+        )
+        result = self.abstract._get_trans_abstracts()
+        for res, exp in zip(result, expected):
+            with self.subTest(exp["lang"]):
+                self.assertDictEqual(exp, res)
+
 
 class AbstractWithoutSectionsTest(TestCase):
 
@@ -565,7 +706,7 @@ class AbstractWithoutSectionsTest(TestCase):
                 <p>Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).</p>
             </trans-abstract>
             <trans-abstract xml:lang="fr">
-                <title>Resumo</title>
+                <title>Résumé</title>
                 <p>Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).</p>
             </trans-abstract>
             </article-meta>
@@ -582,7 +723,7 @@ class AbstractWithoutSectionsTest(TestCase):
             <sub-article article-type="translation" xml:lang="it">
                 <front-stub>
                     <abstract>
-                        <title>Resumen</title>
+                        <title>Riepilogo</title>
                         <p>
                           Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
                       </abstract>
@@ -659,3 +800,81 @@ class AbstractWithoutSectionsTest(TestCase):
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
+
+    def test__get_sub_article_abstracts(self):
+        """
+        <sub-article article-type="translation" xml:lang="es">
+            <front-stub>
+                <abstract>
+                    <title>Resumen</title>
+                    <p>
+                      Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).</p>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        <sub-article article-type="translation" xml:lang="it">
+            <front-stub>
+                <abstract>
+                    <title>Riepilogo</title>
+                    <p>
+                      Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        """
+        expected = (
+            {
+                "lang": "es",
+                "abstract": {
+                    "lang": "es",
+                    "title": "Resumen",
+                    "p": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
+                }
+            },
+            {
+                "lang": "it",
+                "abstract": {
+                    "lang": "it",
+                    "title": "Riepilogo",
+                    "p": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
+                }
+            },
+        )
+        result = self.abstract._get_sub_article_abstracts()
+        for res, exp in zip(result, expected):
+            with self.subTest(res["lang"]):
+                self.assertDictEqual(exp, res)
+
+    def test__get_trans_abstracts(self):
+        """
+        <trans-abstract xml:lang="pt">
+            <title>Resumo</title>
+            <p>Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).</p>
+        </trans-abstract>
+        <trans-abstract xml:lang="fr">
+            <title>Résumé</title>
+            <p>Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).</p>
+        </trans-abstract>
+        """
+        expected = (
+            {
+                "lang": "pt",
+                "abstract": {
+                    "lang": "pt",
+                    "title": "Resumo",
+                    "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
+                }
+            },
+            {
+                "lang": "fr",
+                "abstract": {
+                    "lang": "fr",
+                    "title": "Résumé",
+                    "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
+                }
+            },
+        )
+        result = self.abstract._get_trans_abstracts()
+        for res, exp in zip(result, expected):
+            with self.subTest(exp["lang"]):
+                self.assertDictEqual(exp, res)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a classe Abstract que facilita o acesso aos resumos do XML SciELO.

A implementação anterior tinha alguns problemas:
- exigia que os resumos sempre tem `sec`;
- considera que sub-article e trans-abstract ocorrem mais de 1 vez;
- os nomes dos métodos não refletem o que fazem e não há comentários que facilitem a compreensão;
- uso de dicionário quando é melhor usar lista de dicionário;

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando os testes automatizados
```console
python -m unittest -v -k  article_abstr
```
Ou instanciando a class Abstract (packtools.sps.models.article_abstract)

#### Algum cenário de contexto que queira dar?
Para manter a compatibilidade com os usuários da classe, alguns métodos não foram eliminados.
É necessário refatorar os códigos usuários e, então, eliminar os métodos sem uso.

### Screenshots
n/a

#### Quais são tickets relevantes?
#384

### Referências
n/a
