### PR TITLE
Adiciona em ArticleTitles o título do artigo padronizado, sem tags e sem espaços extras

### DIFF
--- a/packtools/sps/models/article_titles.py
+++ b/packtools/sps/models/article_titles.py
@@ -39,6 +39,7 @@ class ArticleTitles:
             return {
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
             }
 
     @property
@@ -53,6 +54,7 @@ class ArticleTitles:
             _title = {
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
             }
             _titles.append(_title)
         return _titles
@@ -67,6 +69,7 @@ class ArticleTitles:
             _title = {
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
             }
             _titles.append(_title)
         return _titles

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -24,6 +24,23 @@ def get_nodes_with_lang(xmltree, lang_xpath, node_xpath=None):
     return _items
 
 
+def node_plain_text(node, remove_extra_spaces=False):
+    """
+    Função que retorna texto de nó, sem subtags.
+
+    Entrada:
+    <node><italic>Duguetia leucotricha</italic> (Annonaceae)<xref>1</xref></node>
+
+    Saída:
+    Duguetia leucotricha (Annonaceae)
+    """
+    for xref in node.findall(".//xref"):
+        for child in xref.findall(".//*"):
+            child.text = ""
+        xref.text = ""
+    return " ".join([text.strip() for text in node.xpath(".//text()") if text.strip()])
+
+
 def node_text_without_xref(node):
     """
     Retorna text com subtags, exceto `xref`

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -24,21 +24,28 @@ def get_nodes_with_lang(xmltree, lang_xpath, node_xpath=None):
     return _items
 
 
-def node_plain_text(node, remove_extra_spaces=False):
+def node_plain_text(node):
     """
-    Função que retorna texto de nó, sem subtags.
+    Função que retorna texto de nó, sem subtags e com espaços padronizados
 
     Entrada:
-    <node><italic>Duguetia leucotricha</italic> (Annonaceae)<xref>1</xref></node>
+    ```xml
+    <node>
+        <italic>Duguetia leucotricha</italic> (Annonaceae)<xref>1</xref>
+    </node>
+    ```
 
     Saída:
     Duguetia leucotricha (Annonaceae)
     """
+    if node is None:
+        return
     for xref in node.findall(".//xref"):
         for child in xref.findall(".//*"):
             child.text = ""
         xref.text = ""
-    return " ".join([text.strip() for text in node.xpath(".//text()") if text.strip()])
+    text = "".join([text for text in node.xpath(".//text()") if text.strip()])
+    return " ".join(text.split())
 
 
 def node_text_without_xref(node):

--- a/tests/sps/models/test_article_titles.py
+++ b/tests/sps/models/test_article_titles.py
@@ -132,7 +132,9 @@ class ArticleTitlesTest(TestCase):
             )
         },
         ]
-        self.assertEqual(expected, self.article_titles.data)
+        for i, item in enumerate(self.article_titles.data):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 class SubArticleTitlesTest(TestCase):
@@ -179,6 +181,6 @@ class SubArticleTitlesTest(TestCase):
             )
         },
         ]
-        self.assertEqual(expected, self.article_titles.data)
-    
-
+        for i, item in enumerate(self.article_titles.data):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)

--- a/tests/sps/models/test_article_titles.py
+++ b/tests/sps/models/test_article_titles.py
@@ -121,7 +121,12 @@ class ArticleTitlesTest(TestCase):
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
                 "de Tasas de Interés: un Análisis de Duración y"
                 " Convexidad con el Modelo de Nelson y Siegel"
-            )
+            ),
+            "plain_text": (
+                "Inmunización de Flujos Financieros con Futuros "
+                "de Tasas de Interés: un Análisis de Duración y"
+                " Convexidad con el Modelo de Nelson y Siegel"
+            ),
         },
         {
             "lang": "en",
@@ -129,7 +134,12 @@ class ArticleTitlesTest(TestCase):
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
                 "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "
                 "THE NELSON & SIEGEL MODEL"
-            )
+            ),
+            "plain_text": (
+                ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
+                "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "
+                "THE NELSON & SIEGEL MODEL"
+            ),
         },
         ]
         for i, item in enumerate(self.article_titles.data):
@@ -170,7 +180,12 @@ class SubArticleTitlesTest(TestCase):
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
                 "de Tasas de Interés: un Análisis de Duración y"
                 " Convexidad con el Modelo de Nelson y Siegel"
-            )
+            ),
+            "plain_text": (
+                "Inmunización de Flujos Financieros con Futuros "
+                "de Tasas de Interés: un Análisis de Duración y"
+                " Convexidad con el Modelo de Nelson y Siegel"
+            ),
         },
         {
             "lang": "en",
@@ -178,7 +193,12 @@ class SubArticleTitlesTest(TestCase):
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
                 "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "
                 "THE NELSON & SIEGEL MODEL"
-            )
+            ),
+            "plain_text": (
+                ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
+                "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "
+                "THE NELSON & SIEGEL MODEL"
+            ),
         },
         ]
         for i, item in enumerate(self.article_titles.data):

--- a/tests/sps/utils/test_xml_utils.py
+++ b/tests/sps/utils/test_xml_utils.py
@@ -12,7 +12,9 @@ class XMLUtilsTest(unittest.TestCase):
         xml = etree.fromstring(
             "<root>"
             "<title>Texto 1    <italic>italico</italic> TExto 2"
-            "<xref><sup><bold>1</bold></sup></xref> Texto 3</title></root>"
+            "<xref><sup><bold>1</bold></sup></xref> "
+            "         "
+            "Texto 3</title></root>"
         )
         expected = "Texto 1 italico TExto 2 Texto 3"
         result = xml_utils.node_plain_text(xml.find(".//title"))

--- a/tests/sps/utils/test_xml_utils.py
+++ b/tests/sps/utils/test_xml_utils.py
@@ -6,7 +6,7 @@ from lxml import etree
 from packtools.sps.utils import xml_utils
 
 
-class NodePlainTextTest(unittest.TestCase):
+class XMLUtilsTest(unittest.TestCase):
 
     def test_node_plain_text(self):
         xml = etree.fromstring(
@@ -17,3 +17,15 @@ class NodePlainTextTest(unittest.TestCase):
         expected = "Texto 1 italico TExto 2 Texto 3"
         result = xml_utils.node_plain_text(xml.find(".//title"))
         self.assertEqual(expected, result)
+
+    def test_node_text_without_xref(self):
+        xml = etree.fromstring(
+            "<root>"
+            "<title>Texto 1    <italic>italico</italic> TExto 2"
+            "<xref><sup><bold>1</bold></sup></xref> Texto 3</title></root>"
+        )
+        expected = "Texto 1    <italic>italico</italic> TExto 2 Texto 3"
+        node = xml.find(".//title")
+        result = xml_utils.node_text_without_xref(node)
+        self.assertEqual(expected, result)
+

--- a/tests/sps/utils/test_xml_utils.py
+++ b/tests/sps/utils/test_xml_utils.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+import unittest
+
+from lxml import etree
+
+from packtools.sps.utils import xml_utils
+
+
+class NodePlainTextTest(unittest.TestCase):
+
+    def test_node_plain_text(self):
+        xml = etree.fromstring(
+            "<root>"
+            "<title>Texto 1    <italic>italico</italic> TExto 2"
+            "<xref><sup><bold>1</bold></sup></xref> Texto 3</title></root>"
+        )
+        expected = "Texto 1 italico TExto 2 Texto 3"
+        result = xml_utils.node_plain_text(xml.find(".//title"))
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona em ArticleTitles o título do artigo padronizado, sem tags e sem espaços extras

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?

Executando os comandos

```console
python -m unittest -v -k XMLU
python -m unittest -v -k article_titl
```

#### Algum cenário de contexto que queira dar?
Demanda para pid_provider conseguir comparar os artigos usando o título padronizado

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
