### PR TITLE
Fix pid provider absent href and absent contrib type

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -61,7 +61,10 @@ class Authors:
             except KeyError:
                 pass
 
-            _author["contrib-type"] = node.attrib.get("contrib-type") or 'author'
+            if node.attrib.get("contrib-type"):
+                # criar contrib-type somente se existir e
+                # não atribuir valor default para que a validação seja fiel
+                _author["contrib-type"] = node.attrib.get("contrib-type")
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -61,7 +61,7 @@ class Authors:
             except KeyError:
                 pass
 
-            _author["contrib-type"] = node.attrib["contrib-type"]
+            _author["contrib-type"] = node.attrib.get("contrib-type") or 'author'
             _data.append(_author)
         return _data
 

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -359,7 +359,9 @@ class XMLWithPre:
 
     @property
     def links(self):
-        return [item["href"] for item in self.related_items]
+        # Ha casos de related-article sem href
+        # <related-article id="pr03" related-article-type="press-release" specific-use="processing-only"/>
+        return [item["href"] for item in self.related_items if item.get("href")]
 
     @property
     def article_ids(self):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o código para considerar que alguns atributos estão ausentes como contrib-type de contrib e href de related-article.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Usando as respectivas classes com XMLs nas situações indicadas.

https://www.scielo.br/j/rgo/a/xqJTxHGKRyW3yNHtdZnV7bw/?format=xml
```xml
<related-article id="pr03" related-article-type="press-release" specific-use="processing-only"/>
```

#### Algum cenário de contexto que queira dar?
Problema identificado ao executar provide pids para scielo.br

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

