### PR TITLE
Corrige retorno de XMLWithPre.pub_year

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -61,7 +61,7 @@ class Authors:
             except KeyError:
                 pass
 
-            _author["contrib-type"] = node.attrib["contrib-type"]
+            _author["contrib-type"] = node.attrib.get("contrib-type") or 'author'
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/article_ids.py
+++ b/packtools/sps/models/article_ids.py
@@ -62,18 +62,16 @@ class ArticleIds:
 
     @v2.setter
     def v2(self, value):
-        node = self._get_node(
-                './/article-id[@specific-use="scielo-v2"]'
-            )
-        if node is not None and node.text:
-            raise AttributeError(
-                "can't set attribute ArticleIds.v2. It is already set: %s" %
-                node.text
-            )
-        if not value:
+        value = value and value.strip()
+        if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute ArticleIds.v2. "
-                "Given value %s is not valid" % value)
+                "Expected value must have 23 characters. Got: %s" % value
+            )
+        try:
+            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v2"]')[0]
+        except IndexError:
+            node = None
         if node is None:
             node = etree.Element("article-id")
             node.set("pub-id-type", "publisher-id")
@@ -83,13 +81,17 @@ class ArticleIds:
 
     @v3.setter
     def v3(self, value):
-        if not value:
+        value = value and value.strip()
+        if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute ArticleIds.v3. "
-                "Given value %s is not valid" % value)
-        node = self._get_node(
-                './/article-id[@specific-use="scielo-v3"]'
+                "Expected value must have 23 characters. Got: %s" % value
             )
+        try:
+            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v3"]')[0]
+        except IndexError:
+            node = None
+
         if node is None:
             node = etree.Element("article-id")
             node.set("pub-id-type", "publisher-id")
@@ -100,14 +102,20 @@ class ArticleIds:
 
     @aop_pid.setter
     def aop_pid(self, value):
-        if not value:
+        value = value and value.strip()
+        if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute ArticleIds.aop_pid. "
-                "Given value %s is not valid" % value)
-        node = self._get_node(
+                "Expected value must have 23 characters. Got: %s" % value
+            )
+        try:
+            node = self.xmltree.xpath(
                 './/article-id[@specific-use="previous-pid" and '
                 '@pub-id-type="publisher-id"]'
-            )
+            )[0]
+        except IndexError:
+            node = None
+
         if node is None:
             node = etree.Element("article-id")
             node.set("pub-id-type", "publisher-id")

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -566,7 +566,10 @@ class XMLWithPre:
     def pub_year(self):
         if not hasattr(self, "_pub_year") or not self._pub_year:
             try:
-                self._pub_year = self.article_meta_issue.collection_date.get("year")
+                self._pub_year = (
+                    self.article_meta_issue.collection_date.get("year") or
+                    self.article_meta_issue.article_date.get("year")
+                )
             except AttributeError:
                 return None
         return self._pub_year

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -381,6 +381,7 @@ class XMLWithPre:
 
     @v2.setter
     def v2(self, value):
+        value = value and value.strip()
         if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute XMLWithPre.v2. "
@@ -400,6 +401,7 @@ class XMLWithPre:
 
     @v3.setter
     def v3(self, value):
+        value = value and value.strip()
         if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute XMLWithPre.v3. "
@@ -421,6 +423,7 @@ class XMLWithPre:
 
     @aop_pid.setter
     def aop_pid(self, value):
+        value = value and value.strip()
         if not value or len(value) != 23:
             raise ValueError(
                 "can't set attribute XMLWithPre.aop_pid. "


### PR DESCRIPTION
#### O que esse PR faz?
Corrige retorno de pub_year.
Também garante que os valores atribuídos para v2, v3 e aop_pid tem tamanho definido

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Instanciando ArticleDates com um XML  que possui somente `<pub-date pub-type="epub"/>`.

#### Algum cenário de contexto que queira dar?
Ajustes para uso no pid_provider. Impedimento de registro de artigo que possui somente "article date".

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

