### PR TITLE
Cria versão 2 da classe ArticleAssets para manipular os ativos digitais do XML

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -61,7 +61,7 @@ class Authors:
             except KeyError:
                 pass
 
-            _author["contrib-type"] = node.attrib["contrib-type"]
+            _author["contrib-type"] = node.attrib.get("contrib-type") or 'author'
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/v2/article_assets.py
+++ b/packtools/sps/models/v2/article_assets.py
@@ -1,0 +1,274 @@
+import os
+
+
+class AssetReplacementError(Exception):
+    ...
+
+
+class ArticleAssets:
+    ASSET_TAGS = (
+        "graphic",
+        "media",
+        "inline-graphic",
+        "supplementary-material",
+        "inline-supplementary-material",
+    )
+
+    ASSET_EXTENDED_TAGS = ASSET_TAGS + ("disp-formula",)
+
+    XPATH_FOR_IDENTIFYING_ASSETS = "|".join(
+        [".//" + at + "[@xlink:href]" for at in ASSET_TAGS]
+    )
+
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self._create_parent_map()
+        self._discover_assets()
+
+    def _create_parent_map(self):
+        self._parent_map = dict((c, p) for p in self.xmltree.iter() for c in p)
+
+    @property
+    def article_assets(self):
+        return self.article_assets_which_have_id + self.article_assets_which_have_no_id
+
+    @property
+    def article_assets_which_have_id(self):
+        return self._assets_which_have_id
+
+    @property
+    def article_assets_which_have_no_id(self):
+        return self._assets_which_have_no_id
+
+    def _discover_assets(self):
+        self._discover_assets_which_have_id()
+        self._discover_assets_which_have_no_id()
+
+    def _discover_assets_which_have_id(self):
+        self._assets_which_have_id = []
+        _visited_nodes = []
+
+        for node in self.xmltree.xpath(".//*[@id]"):
+            if node.tag == "sub-article":
+                continue
+
+            i = 0
+            for child_node in self._asset_nodes(node):
+                if child_node not in _visited_nodes:
+                    self._assets_which_have_id.append(
+                        Asset(
+                            node=child_node,
+                            parent_map=self._parent_map,
+                            parent_node_with_id=node,
+                            number=i,
+                        )
+                    )
+                    _visited_nodes.append(child_node)
+                    i += 1
+
+    def _discover_assets_which_have_no_id(self):
+        self._assets_which_have_no_id = []
+        _visited_nodes = []
+
+        nodes_which_have_id = [i.node for i in self._assets_which_have_id]
+
+        i = 0
+        for child_node in self._asset_nodes():
+            if child_node not in nodes_which_have_id:
+                if child_node not in _visited_nodes:
+                    self._assets_which_have_no_id.append(
+                        Asset(node=child_node, parent_map=self._parent_map, number=i)
+                    )
+                    _visited_nodes.append(child_node)
+                    i += 1
+
+    def _asset_nodes(self, node=None):
+        _assets = []
+
+        if node is None:
+            source = self.xmltree
+        else:
+            source = node
+
+        for node in source.xpath(
+            ArticleAssets.XPATH_FOR_IDENTIFYING_ASSETS,
+            namespaces={"xlink": "http://www.w3.org/1999/xlink"},
+        ):
+            _assets.append(node)
+
+        return _assets
+
+    def replace_names(self, from_to):
+        """
+        Replace names
+
+        Parameters
+        ----------
+        from_to : dict
+
+        Returns
+        -------
+        str list : not found names to replace
+        """
+        not_found = []
+        for asset in self.article_assets:
+            try:
+                asset.name = from_to[asset.name]
+            except KeyError as e:
+                not_found.append(asset.name)
+        return not_found
+
+
+class Asset:
+    def __init__(self, node, parent_map, parent_node_with_id=None, number=None):
+        self.node = node
+        self._parent_map = parent_map
+        self._parent_node_with_id = parent_node_with_id
+        self._number = number
+
+    @property
+    def id(self):
+        try:
+            return self.node.attrib["id"]
+        except KeyError:
+            ...
+
+        try:
+            return self._parent_node_with_id.get("id")
+        except (AttributeError, TypeError):
+            ...
+
+        return ""
+
+    @property
+    def name(self):
+        return self.node.attrib["{http://www.w3.org/1999/xlink}href"]
+
+    @name.setter
+    def name(self, value):
+        self.node.set("{http://www.w3.org/1999/xlink}href", value)
+
+    @property
+    def _content_type(self):
+        ct = self.node.get("content-type")
+        if ct:
+            return f"-{ct}"
+        return ""
+
+    @property
+    def tag(self):
+        if self._parent_node_with_id is not None:
+            return self._parent_node_with_id.tag
+
+        current_node = self._parent_map[self.node]
+        while current_node.tag not in ArticleAssets.ASSET_EXTENDED_TAGS:
+            try:
+                current_node = self._parent_map[current_node]
+            except KeyError:
+                return ""
+
+        return current_node.tag
+
+    @property
+    def _category_name_code(self):
+        """
+        -g: figure graphic
+        -i: inline graphic
+        -e: equation
+        -s: supplementary data file
+        """
+        if "disp-formula" in self.tag:
+            return "e"
+        if "supplementary" in self.tag or "app" in self.tag:
+            return "s"
+        if "inline" in self.tag:
+            return "i"
+        return "g"
+
+    @property
+    def _suffix(self):
+        return f"-{self._category_name_code}{self._id_str}{self._number_str}{self._content_type}"
+
+    @property
+    def _ext(self):
+        _, ext = os.path.splitext(self.name)
+        return ext
+
+    @property
+    def _lang(self):
+        """
+        Tenta obter lang de asset associado a sub-article, caso contrário, retorna string vazia.
+        Asset cujo lang é representado por uma string vazia possui nome canônico sem o idioma.
+        """
+        current_node = self._parent_map[self.node]
+        while current_node.tag != "sub-article":
+            try:
+                current_node = self._parent_map[current_node]
+            except KeyError:
+                return ""
+
+        return (
+            f"-{current_node.get('{http://www.w3.org/XML/1998/namespace}lang')}" or ""
+        )
+
+    def name_canonical(self, package_name):
+        return f"{package_name}{self._suffix}{self._lang}{self._ext}"
+
+    @property
+    def _id_str(self):
+        digits = [i for i in self.id if i.isdigit()]
+        if len(digits) > 0:
+            return "".join(digits).zfill(2)
+        return ""
+
+    @property
+    def _number_str(self):
+        """
+        Esta propriedade é utilizada em name_canonical quando o Asset não possui um nó próximo com ID, isto é, um _parent_node_with_id.
+        """
+        if self._id_str == "":
+            return f"-n{str(self._number).zfill(2)}"
+        return ""
+
+    @property
+    def type(self):
+        """
+        <alternatives>
+            <graphic xlink:href="original.tif"/>
+            <graphic xlink:href="padrao.png" specific-use="scielo-web"/>
+            <graphic xlink:href="mini.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+        </alternatives>
+
+        In the above case, this property returns 'original' for original.tif, 'optimised' for pattern.png and 'thumbnail' for mini.jpg'.
+        """
+        if "content-type" in self.node.attrib:
+            return "thumbnail"
+        elif "specific-use" in self.node.attrib:
+            return "optimised"
+        else:
+            return "original"
+
+
+class SupplementaryMaterials:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self._assets = ArticleAssets(xmltree)
+
+    @property
+    def items(self):
+        return [
+            item
+            for item in self._assets.article_assets
+            if item.node.tag
+            in ("supplementary-material", "inline-supplementary-material")
+        ]
+
+    @property
+    def data(self):
+        return [
+            {
+                "id": item.id,
+                "name": item.name,
+            }
+            for item in self.items
+        ]

--- a/packtools/sps/models/v2/article_assets.py
+++ b/packtools/sps/models/v2/article_assets.py
@@ -13,6 +13,14 @@ class ArticleAssets:
         "supplementary-material",
         "inline-supplementary-material",
     )
+    PARENTE_ASSET_TAGS = (
+        "fig",
+        "fig-group",
+        "table-wrap",
+        "supplementary-material",
+        "disp-formula",
+        "app",
+    )
 
     ASSET_EXTENDED_TAGS = ASSET_TAGS + ("disp-formula",)
 

--- a/packtools/sps/models/v2/article_assets.py
+++ b/packtools/sps/models/v2/article_assets.py
@@ -5,106 +5,38 @@ class AssetReplacementError(Exception):
     ...
 
 
+ASSET_TAGS = (
+    "graphic",
+    "media",
+    "inline-graphic",
+    "supplementary-material",
+    "inline-supplementary-material",
+)
+PARENTE_ASSET_TAGS = (
+    "fig",
+    "fig-group",
+    "table-wrap",
+    "supplementary-material",
+    "disp-formula",
+    "app",
+)
+
+ASSET_EXTENDED_TAGS = ASSET_TAGS + ("disp-formula",)
+
+PARENTE_ASSET_XPATH = " | ".join(PARENTE_ASSET_TAGS)
+XPATH_FOR_IDENTIFYING_ASSETS = "|".join(
+    [".//" + at + "[@xlink:href]" for at in ASSET_TAGS]
+)
+
+
 class ArticleAssets:
-    ASSET_TAGS = (
-        "graphic",
-        "media",
-        "inline-graphic",
-        "supplementary-material",
-        "inline-supplementary-material",
-    )
-    PARENTE_ASSET_TAGS = (
-        "fig",
-        "fig-group",
-        "table-wrap",
-        "supplementary-material",
-        "disp-formula",
-        "app",
-    )
-
-    ASSET_EXTENDED_TAGS = ASSET_TAGS + ("disp-formula",)
-
-    XPATH_FOR_IDENTIFYING_ASSETS = "|".join(
-        [".//" + at + "[@xlink:href]" for at in ASSET_TAGS]
-    )
 
     def __init__(self, xmltree):
         self.xmltree = xmltree
-        self._create_parent_map()
-        self._discover_assets()
-
-    def _create_parent_map(self):
-        self._parent_map = dict((c, p) for p in self.xmltree.iter() for c in p)
 
     @property
     def article_assets(self):
-        return self.article_assets_which_have_id + self.article_assets_which_have_no_id
-
-    @property
-    def article_assets_which_have_id(self):
-        return self._assets_which_have_id
-
-    @property
-    def article_assets_which_have_no_id(self):
-        return self._assets_which_have_no_id
-
-    def _discover_assets(self):
-        self._discover_assets_which_have_id()
-        self._discover_assets_which_have_no_id()
-
-    def _discover_assets_which_have_id(self):
-        self._assets_which_have_id = []
-        _visited_nodes = []
-
-        for node in self.xmltree.xpath(".//*[@id]"):
-            if node.tag == "sub-article":
-                continue
-
-            i = 0
-            for child_node in self._asset_nodes(node):
-                if child_node not in _visited_nodes:
-                    self._assets_which_have_id.append(
-                        Asset(
-                            node=child_node,
-                            parent_map=self._parent_map,
-                            parent_node_with_id=node,
-                            number=i,
-                        )
-                    )
-                    _visited_nodes.append(child_node)
-                    i += 1
-
-    def _discover_assets_which_have_no_id(self):
-        self._assets_which_have_no_id = []
-        _visited_nodes = []
-
-        nodes_which_have_id = [i.node for i in self._assets_which_have_id]
-
-        i = 0
-        for child_node in self._asset_nodes():
-            if child_node not in nodes_which_have_id:
-                if child_node not in _visited_nodes:
-                    self._assets_which_have_no_id.append(
-                        Asset(node=child_node, parent_map=self._parent_map, number=i)
-                    )
-                    _visited_nodes.append(child_node)
-                    i += 1
-
-    def _asset_nodes(self, node=None):
-        _assets = []
-
-        if node is None:
-            source = self.xmltree
-        else:
-            source = node
-
-        for node in source.xpath(
-            ArticleAssets.XPATH_FOR_IDENTIFYING_ASSETS,
-            namespaces={"xlink": "http://www.w3.org/1999/xlink"},
-        ):
-            _assets.append(node)
-
-        return _assets
+        pass
 
     def replace_names(self, from_to):
         """

--- a/tests/sps/models/test_article_assets.py
+++ b/tests/sps/models/test_article_assets.py
@@ -35,35 +35,34 @@ def generate_xmltree(snippet):
 
 
 def obtain_asset_dict(article_assets, package_name=None):
-  assets_dict = {}
+    assets_dict = {}
 
-  for asset in article_assets:
-    asset_metadata = {'name': asset.name, 'type': asset.type}
-    if package_name:
-      asset_metadata['name_canonical'] = asset.name_canonical(package_name)
+    for asset in article_assets:
+        asset_metadata = {"name": asset.name, "type": asset.type}
+        if package_name:
+            asset_metadata["name_canonical"] = asset.name_canonical(package_name)
 
-    a_id = asset.id
-    if a_id not in assets_dict:
-      assets_dict[a_id] = []
+        a_id = asset.id
+        if a_id not in assets_dict:
+            assets_dict[a_id] = []
 
-    assets_dict[a_id].append(asset_metadata)
+        assets_dict[a_id].append(asset_metadata)
 
-  return assets_dict
+    return assets_dict
 
 
 class ArticleAssetsTest(TestCase):
     def test_article_assets_with_one_figure(self):
-      data = open('tests/sps/fixtures/document3.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open("tests/sps/fixtures/document3.xml").read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {'': [{'name': 'document3-xdadaf.jpg', 'type': 'original'}]}
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {"": [{"name": "document3-xdadaf.jpg", "type": "original"}]}
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_one_figure_multiple_formats(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <fig id="f01">
             <label>Figura 1</label>
@@ -81,97 +80,224 @@ class ArticleAssetsTest(TestCase):
         </fig>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {'f01': [{'name': 'original.tif', 'type': 'original'}, {'name': 'ampliada.png', 'type': 'optimised'}, {'name': 'miniatura.jpg', 'type': 'thumbnail'}]}
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "original.tif", "type": "original"},
+                {"name": "ampliada.png", "type": "optimised"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ]
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_multiple_figures(self):
-      data = open('tests/sps/fixtures/document2.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open("tests/sps/fixtures/document2.xml").read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f01': [
-          {'name': 'https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/fd89fb6a2a0f973016f2de7ee2b64b51ca573999.jpg', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/0c10c88b56f3f9b4f4eccfe9ddbca3fd581aac1b.jpg', 'type': 'thumbnail'}
-        ],
-        'f02': [
-          {'name': 'https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/afd520e3ff23a23f2c973bbbaa26094e9e50f487.jpg', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/c2e5f2b77881866ef9820b03e99b3fedbb14cb69.jpg', 'type': 'thumbnail'}
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/fd89fb6a2a0f973016f2de7ee2b64b51ca573999.jpg",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/0c10c88b56f3f9b4f4eccfe9ddbca3fd581aac1b.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f02": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/afd520e3ff23a23f2c973bbbaa26094e9e50f487.jpg",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1414-431X/ywDM7t6mxHzCRWp7kGF9rXQ/c2e5f2b77881866ef9820b03e99b3fedbb14cb69.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_images_outside_figure_and_name_canonical(self):
-      # O XML é composto por:
-      #  um artigo principal em Inglês composto por 3 figuras (cada uma com original, otimizado e miniatura)
-      #  um subartigo em Espanhol com 3 figuras (cada uma com original, otimizado e miniatura)
-      #  um subartigo em Português com 3 figuras (cada uma com original, otimizado e miniatura)
-      # Há 27 assets sem ID
-      data = open('tests/fixtures/htmlgenerator/alternatives/imagens_fora_de_fig.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        # O XML é composto por:
+        #  um artigo principal em Inglês composto por 3 figuras (cada uma com original, otimizado e miniatura)
+        #  um subartigo em Espanhol com 3 figuras (cada uma com original, otimizado e miniatura)
+        #  um subartigo em Português com 3 figuras (cada uma com original, otimizado e miniatura)
+        # Há 27 assets sem ID
+        data = open(
+            "tests/fixtures/htmlgenerator/alternatives/imagens_fora_de_fig.xml"
+        ).read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
+        expected = {
+            "": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/8d6031a105ac49f92d2bac1dab55785ec62ed139.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n00.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n01.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n02-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/6c7e45494816692122f9467ee9b5ee7a88f86e01.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n03.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n04.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n05-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/7172c66d1c5fa56dc230efa7123dea014f21e62f.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n06.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n07.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n08-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/9a4a202884a687ad4858fc95fbf3be801e63215b.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n09-es.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n10-es.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n11-scielo-267x140-es.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/1fdbee345fae2065d9bd0fd0b4b09a4f77e99e90.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n12-es.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n13-es.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n14-scielo-267x140-es.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/aa495447d05a9156d0d15f5f95f8890ee1d55743.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n15-es.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n16-es.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n17-scielo-267x140-es.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/e971ae023bce641ced89dfbdc40d62be94c4c738.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n18-pt.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n19-pt.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n20-scielo-267x140-pt.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/30d718ea67b77dd98bcda9d3acba9cb296fcba9e.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n21-pt.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n22-pt.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n23-scielo-267x140-pt.jpg",
+                    "type": "thumbnail",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/b824ebf96bd03d51ee26edc6c3807c3092bf1901.tif",
+                    "name_canonical": "NOME-DO-PACOTE-g-n24-pt.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png",
+                    "name_canonical": "NOME-DO-PACOTE-g-n25-pt.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg",
+                    "name_canonical": "NOME-DO-PACOTE-g-n26-scielo-267x140-pt.jpg",
+                    "type": "thumbnail",
+                },
+            ]
+        }
+        obtained = obtain_asset_dict(
+            ArticleAssets(xmltree).article_assets, package_name="NOME-DO-PACOTE"
+        )
 
-        '': [
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/8d6031a105ac49f92d2bac1dab55785ec62ed139.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n01.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n02-scielo-267x140.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/6c7e45494816692122f9467ee9b5ee7a88f86e01.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n03.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n04.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n05-scielo-267x140.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/7172c66d1c5fa56dc230efa7123dea014f21e62f.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n06.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n07.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n08-scielo-267x140.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/9a4a202884a687ad4858fc95fbf3be801e63215b.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n09-es.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n10-es.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n11-scielo-267x140-es.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/1fdbee345fae2065d9bd0fd0b4b09a4f77e99e90.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n12-es.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n13-es.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n14-scielo-267x140-es.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/aa495447d05a9156d0d15f5f95f8890ee1d55743.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n15-es.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n16-es.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n17-scielo-267x140-es.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/e971ae023bce641ced89dfbdc40d62be94c4c738.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n18-pt.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d9b80494cba33a6e60786bdfc56a0c9c048125af.png', 'name_canonical': 'NOME-DO-PACOTE-g-n19-pt.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/352c2528e5e3489f3d2c9d4a958bccd776b2667d.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n20-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/30d718ea67b77dd98bcda9d3acba9cb296fcba9e.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n21-pt.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/c225686bbd2607bacabd946fcb55b30a10b9e5d2.png', 'name_canonical': 'NOME-DO-PACOTE-g-n22-pt.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/d414c6174f0a5069a63c1f4450df8011666a1e35.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n23-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/b824ebf96bd03d51ee26edc6c3807c3092bf1901.tif', 'name_canonical': 'NOME-DO-PACOTE-g-n24-pt.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0d201e31cd5186c2a53f178bfd0509401f2d1ca6.png', 'name_canonical': 'NOME-DO-PACOTE-g-n25-pt.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1518-8345/L34w8qg8ccfQxW79FZH3Bnh/0be8783d8e1eb3e4b98cf803ff71ce829a652a1b.jpg', 'name_canonical': 'NOME-DO-PACOTE-g-n26-scielo-267x140-pt.jpg', 'type': 'thumbnail'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
-
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_media(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <body>
           <p><media mimetype="video" mime-subtype="mp4" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
         </body>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {'': [{'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'}],}
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "": [{"name": "1234-5678-rctb-45-05-0110-m01.mp4", "type": "original"}],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-  
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_media_and_graphic(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <body>
           <p><media mimetype="video" mime-subtype="mp4" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
@@ -194,25 +320,24 @@ class ArticleAssetsTest(TestCase):
         </body>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        '': [
-          {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
-        ],
-        'f01': [
-          {'name': 'original.tif', 'type': 'original'},
-          {'name': 'ampliada.png', 'type': 'optimised'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "": [
+                {"name": "1234-5678-rctb-45-05-0110-m01.mp4", "type": "original"},
+            ],
+            "f01": [
+                {"name": "original.tif", "type": "original"},
+                {"name": "ampliada.png", "type": "optimised"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_inline_graphic_and_name_canonical(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <front>
           <article-meta>
@@ -226,20 +351,25 @@ class ArticleAssetsTest(TestCase):
         </body>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        '': [
-          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
+        expected = {
+            "": [
+                {
+                    "name": "1234-5678-rctb-45-05-0110-e04.tif",
+                    "type": "original",
+                    "name_canonical": "NOME-DO-PACOTE-g-n00.tif",
+                },
+            ]
+        }
+        obtained = obtain_asset_dict(
+            ArticleAssets(xmltree).article_assets, package_name="NOME-DO-PACOTE"
+        )
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_inline_graphic_and_others(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <front>
           <article-meta>
@@ -276,32 +406,65 @@ class ArticleAssetsTest(TestCase):
         </body>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f01': [
-          {'name': 'original.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g01.tif'},
-          {'name': 'ampliada.png', 'type': 'optimised', 'name_canonical': 'NOME-DO-PACOTE-g01.png'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail', 'name_canonical': 'NOME-DO-PACOTE-g01-scielo-20x20.jpg'},
-        ],
-        'f03': [
-          {'name': '1234-5678-rctb-45-05-0110-gf03.tiff', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g03.tiff'},
-          {'name': '1234-5678-rctb-45-05-0110-gf03.png', 'type': 'optimised', 'name_canonical': 'NOME-DO-PACOTE-g03.png'},
-          {'name': '1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg', 'type': 'thumbnail', 'name_canonical': 'NOME-DO-PACOTE-g03-scielo-267x140.jpg'},
-        ],
-        '': [
-          {'name': '1234-5678-rctb-45-05-0110-e04.tif', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n00.tif'},
-          {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original', 'name_canonical': 'NOME-DO-PACOTE-g-n01.mp4'},
-        ]
-      }
+        expected = {
+            "f01": [
+                {
+                    "name": "original.tif",
+                    "type": "original",
+                    "name_canonical": "NOME-DO-PACOTE-g01.tif",
+                },
+                {
+                    "name": "ampliada.png",
+                    "type": "optimised",
+                    "name_canonical": "NOME-DO-PACOTE-g01.png",
+                },
+                {
+                    "name": "miniatura.jpg",
+                    "type": "thumbnail",
+                    "name_canonical": "NOME-DO-PACOTE-g01-scielo-20x20.jpg",
+                },
+            ],
+            "f03": [
+                {
+                    "name": "1234-5678-rctb-45-05-0110-gf03.tiff",
+                    "type": "original",
+                    "name_canonical": "NOME-DO-PACOTE-g03.tiff",
+                },
+                {
+                    "name": "1234-5678-rctb-45-05-0110-gf03.png",
+                    "type": "optimised",
+                    "name_canonical": "NOME-DO-PACOTE-g03.png",
+                },
+                {
+                    "name": "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
+                    "type": "thumbnail",
+                    "name_canonical": "NOME-DO-PACOTE-g03-scielo-267x140.jpg",
+                },
+            ],
+            "": [
+                {
+                    "name": "1234-5678-rctb-45-05-0110-e04.tif",
+                    "type": "original",
+                    "name_canonical": "NOME-DO-PACOTE-g-n00.tif",
+                },
+                {
+                    "name": "1234-5678-rctb-45-05-0110-m01.mp4",
+                    "type": "original",
+                    "name_canonical": "NOME-DO-PACOTE-g-n01.mp4",
+                },
+            ],
+        }
 
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='NOME-DO-PACOTE')
+        obtained = obtain_asset_dict(
+            ArticleAssets(xmltree).article_assets, package_name="NOME-DO-PACOTE"
+        )
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_supplementary_material(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <body>
           <supplementary-material id="S1"
@@ -318,20 +481,19 @@ class ArticleAssetsTest(TestCase):
       </article>
       """
 
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'S1': [
-        {'name': '1471-2105-1-1-s1.pdf', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "S1": [
+                {"name": "1471-2105-1-1-s1.pdf", "type": "original"},
+            ]
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_supplementary_material_and_media_and_graphic(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink">
         <body>
           <supplementary-material id="S1"
@@ -365,69 +527,114 @@ class ArticleAssetsTest(TestCase):
       </article>
       """
 
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'S1': [
-          {'name': '1471-2105-1-1-s1.pdf', 'type': 'original'},
-        ],
-        '': [
-          {'name': '1234-5678-rctb-45-05-0110-m01.mp4', 'type': 'original'},
-        ],
-        'f01': [
-          {'name': 'original.tif', 'type': 'original'},
-          {'name': 'ampliada.png', 'type': 'optimised'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'},
-        ]
-      }
+        expected = {
+            "S1": [
+                {"name": "1471-2105-1-1-s1.pdf", "type": "original"},
+            ],
+            "": [
+                {"name": "1234-5678-rctb-45-05-0110-m01.mp4", "type": "original"},
+            ],
+            "f01": [
+                {"name": "original.tif", "type": "original"},
+                {"name": "ampliada.png", "type": "optimised"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ],
+        }
 
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_multiple_supplementary_material(self):
-      data = open('tests/sps/fixtures/document-with-supplementary-material.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open(
+            "tests/sps/fixtures/document-with-supplementary-material.xml"
+        ).read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f1': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/256bcf2e607f18b0bb3842a31332f6b48620cb09.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c00655410885461df4a98dd77860b81b2e5baa2c.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ebd30641f55d890debe55743b8e2946135c74140.jpg', 'type': 'thumbnail'},
-        ],
-        'f2': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b784533145d2f1557a7df00e05e5c6207fc57e2a.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b298055fb49aba04fa94a1287ed4c38c0680ccf7.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c0a10dd209a9da0ef40f92f070ee6c77b0ca220b.jpg', 'type': 'thumbnail'},
-        ],
-        'f3': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/14717caba8b886eddbbc9e1e4a8c579631730187.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b0b01286ff114d6eda85f9a5afb1217d164e32b5.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b03ad3e4bced80bf0a81dfe12fbe6e567982414b.jpg', 'type': 'thumbnail'},
-        ],
-        'f4': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/407a7771f32d6364ee6536278a011a2c05da3339.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c1ba665e5e0731d623095779a2d4099c808e776b.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/f1da586984d4176883f92f2fb28e9abea946b8d2.jpg', 'type': 'thumbnail'},
-        ],
-        'suppl01': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/e738857c8fb8bc085b766a812bbe73277c67d346.pdf', 'type': 'original'},
-        ],
-        'suppl02': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b72942b47698183bf992f1ad8cebdf61d346e0cf.xls', 'type': 'original'},
-        ],
-        'suppl03': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f1": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/256bcf2e607f18b0bb3842a31332f6b48620cb09.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c00655410885461df4a98dd77860b81b2e5baa2c.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ebd30641f55d890debe55743b8e2946135c74140.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f2": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b784533145d2f1557a7df00e05e5c6207fc57e2a.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b298055fb49aba04fa94a1287ed4c38c0680ccf7.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c0a10dd209a9da0ef40f92f070ee6c77b0ca220b.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f3": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/14717caba8b886eddbbc9e1e4a8c579631730187.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b0b01286ff114d6eda85f9a5afb1217d164e32b5.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b03ad3e4bced80bf0a81dfe12fbe6e567982414b.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f4": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/407a7771f32d6364ee6536278a011a2c05da3339.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c1ba665e5e0731d623095779a2d4099c808e776b.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/f1da586984d4176883f92f2fb28e9abea946b8d2.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "suppl01": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/e738857c8fb8bc085b766a812bbe73277c67d346.pdf",
+                    "type": "original",
+                },
+            ],
+            "suppl02": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b72942b47698183bf992f1ad8cebdf61d346e0cf.xls",
+                    "type": "original",
+                },
+            ],
+            "suppl03": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf",
+                    "type": "original",
+                },
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_fig_group_graphic(self):
-      snippet = """
+        snippet = """
       <fig-group id="f01">
         <fig xml:lang="pt">
           <label>Figura 1</label>
@@ -450,23 +657,18 @@ class ArticleAssetsTest(TestCase):
         <graphic xlink:href="original"/>
       </fig-group>
       """
-      xmltree = generate_xmltree(snippet)
+        xmltree = generate_xmltree(snippet)
 
-      expected = {
-        'f01': [
-          {'name': 'original', 'type': 'original'}
-        ],
-        'f02': [
-          {'name': 'figura2.jpg', 'type': 'original'}
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [{"name": "original", "type": "original"}],
+            "f02": [{"name": "figura2.jpg", "type": "original"}],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_fig_group_graphic_alternatives(self):
-      snippet = """
+        snippet = """
       <fig-group id="f01">
         <fig xml:lang="pt">
           <label>Figura 1</label>
@@ -493,25 +695,24 @@ class ArticleAssetsTest(TestCase):
         </alternatives>
       </fig-group>
       """
-      xmltree = generate_xmltree(snippet)
+        xmltree = generate_xmltree(snippet)
 
-      expected = {
-        'f01': [
-          {'name': 'original.tif', 'type': 'original'},
-          {'name': 'ampliada.png', 'type': 'optimised'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'},
-        ],
-        'f02': [
-          {'name': 'figura2.jpg', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "original.tif", "type": "original"},
+                {"name": "ampliada.png", "type": "optimised"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ],
+            "f02": [
+                {"name": "figura2.jpg", "type": "original"},
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_fig_group_graphic_before_attrib(self):
-      snippet = """
+        snippet = """
       <fig-group id="f01">
         <fig xml:lang="pt">
           <label>Figura 1</label>
@@ -534,23 +735,22 @@ class ArticleAssetsTest(TestCase):
         </fig>
       </fig-group>
       """
-      xmltree = generate_xmltree(snippet)
+        xmltree = generate_xmltree(snippet)
 
-      expected = {
-        'f01': [
-          {'name': 'original', 'type': 'original'},
-        ],
-        'f02': [
-          {'name': 'figura2.jpg', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "original", "type": "original"},
+            ],
+            "f02": [
+                {"name": "figura2.jpg", "type": "original"},
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_with_fig_group_graphic_alternatives_before_attrib(self):
-      snippet = """
+        snippet = """
       <fig-group id="f01">
         <fig xml:lang="pt">
           <label>Figura 1</label>
@@ -577,45 +777,50 @@ class ArticleAssetsTest(TestCase):
         </fig>
       </fig-group>
       """
-      xmltree = generate_xmltree(snippet)
+        xmltree = generate_xmltree(snippet)
 
-      expected = {
-        'f01': [
-          {'name': 'original.tif', 'type': 'original'},
-          {'name': 'ampliada.png', 'type': 'optimised'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'},
-        ],
-        'f02': [
-          {'name': 'figura2.jpg', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "original.tif", "type": "original"},
+                {"name": "ampliada.png", "type": "optimised"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ],
+            "f02": [
+                {"name": "figura2.jpg", "type": "original"},
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_optimised_default(self):
-      data = open('tests/sps/fixtures/2318-0889-tinf-33-e200068.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open("tests/sps/fixtures/2318-0889-tinf-33-e200068.xml").read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f01': [
-          {'name': '2318-0889-tinf-33-e200068-gf01.tif', 'type': 'original'},
-          {'name': '2318-0889-tinf-33-e200068-gf01.png', 'type': 'optimised'},
-          {'name': '2318-0889-tinf-33-e200068-gf01.thumbnail.jpg', 'type': 'thumbnail'}],
-        'f02': [
-          {'name': '2318-0889-tinf-33-e200068-gf02.tif', 'type': 'original'},
-          {'name': '2318-0889-tinf-33-e200068-gf02.png', 'type': 'optimised'},
-          {'name': '2318-0889-tinf-33-e200068-gf02.thumbnail.jpg', 'type': 'thumbnail'}
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "2318-0889-tinf-33-e200068-gf01.tif", "type": "original"},
+                {"name": "2318-0889-tinf-33-e200068-gf01.png", "type": "optimised"},
+                {
+                    "name": "2318-0889-tinf-33-e200068-gf01.thumbnail.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f02": [
+                {"name": "2318-0889-tinf-33-e200068-gf02.tif", "type": "original"},
+                {"name": "2318-0889-tinf-33-e200068-gf02.png", "type": "optimised"},
+                {
+                    "name": "2318-0889-tinf-33-e200068-gf02.thumbnail.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_article_assets_optimised_png_as_original(self):
-      snippet = """
+        snippet = """
       <fig-group id="f01">
         <fig xml:lang="pt">
           <label>Figura 1</label>
@@ -641,19 +846,20 @@ class ArticleAssetsTest(TestCase):
         </fig>
       </fig-group>
       """
-      xmltree = generate_xmltree(snippet)
+        xmltree = generate_xmltree(snippet)
 
-      expected = {
-        'f01': [
-          {'name': 'original.png', 'type': 'original'},
-          {'name': 'miniatura.jpg', 'type': 'thumbnail'}],
-        'f02': [
-          {'name': 'figura2.jpg', 'type': 'original'},
-        ]
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
+        expected = {
+            "f01": [
+                {"name": "original.png", "type": "original"},
+                {"name": "miniatura.jpg", "type": "thumbnail"},
+            ],
+            "f02": [
+                {"name": "figura2.jpg", "type": "original"},
+            ],
+        }
+        obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets)
 
-      self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained)
 
     def test_replace_names_not_found(self):
         snippet = """
@@ -694,10 +900,9 @@ class ArticleAssetsTest(TestCase):
         self.assertEqual(not_found, [])
 
         updated = article_assets.article_assets
-        self.assertEqual(updated[0].name, 'novo_original.png')
-        self.assertEqual(updated[1].name, 'novo_miniatura.jpg')
-        self.assertEqual(updated[2].name, 'novo_figura2.jpg')
-
+        self.assertEqual(updated[0].name, "novo_original.png")
+        self.assertEqual(updated[1].name, "novo_miniatura.jpg")
+        self.assertEqual(updated[2].name, "novo_figura2.jpg")
 
     def test_replace_names(self):
         snippet = """
@@ -738,54 +943,114 @@ class ArticleAssetsTest(TestCase):
         not_found = article_assets.replace_names(from_to)
 
         updated = article_assets.article_assets
-        self.assertEqual(updated[0].name, 'novo_original.png')
-        self.assertEqual(updated[1].name, 'novo_miniatura.jpg')
+        self.assertEqual(updated[0].name, "novo_original.png")
+        self.assertEqual(updated[1].name, "novo_miniatura.jpg")
         self.assertEqual(not_found, ["figura2.jpg"])
 
-
     def test_assets_canonical_name_without_subarticles(self):
-      data = open('tests/sps/fixtures/document-with-supplementary-material.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open(
+            "tests/sps/fixtures/document-with-supplementary-material.xml"
+        ).read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f1': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/256bcf2e607f18b0bb3842a31332f6b48620cb09.tif', 'name_canonical': '1676-0611-bn-2021-1306-g01.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c00655410885461df4a98dd77860b81b2e5baa2c.png', 'name_canonical': '1676-0611-bn-2021-1306-g01.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ebd30641f55d890debe55743b8e2946135c74140.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g01-scielo-267x140.jpg', 'type': 'thumbnail'},
-        ],
-        'f2': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b784533145d2f1557a7df00e05e5c6207fc57e2a.tif', 'name_canonical': '1676-0611-bn-2021-1306-g02.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b298055fb49aba04fa94a1287ed4c38c0680ccf7.png', 'name_canonical': '1676-0611-bn-2021-1306-g02.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c0a10dd209a9da0ef40f92f070ee6c77b0ca220b.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g02-scielo-267x140.jpg', 'type': 'thumbnail'},
-        ],
-        'f3': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/14717caba8b886eddbbc9e1e4a8c579631730187.tif', 'name_canonical': '1676-0611-bn-2021-1306-g03.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b0b01286ff114d6eda85f9a5afb1217d164e32b5.png', 'name_canonical': '1676-0611-bn-2021-1306-g03.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b03ad3e4bced80bf0a81dfe12fbe6e567982414b.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g03-scielo-267x140.jpg', 'type': 'thumbnail'},
-        ],
-        'f4': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/407a7771f32d6364ee6536278a011a2c05da3339.tif', 'name_canonical': '1676-0611-bn-2021-1306-g04.tif', 'type': 'original'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c1ba665e5e0731d623095779a2d4099c808e776b.png', 'name_canonical': '1676-0611-bn-2021-1306-g04.png', 'type': 'optimised'},
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/f1da586984d4176883f92f2fb28e9abea946b8d2.jpg', 'name_canonical': '1676-0611-bn-2021-1306-g04-scielo-267x140.jpg', 'type': 'thumbnail'},
-        ],
-        'suppl01': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/e738857c8fb8bc085b766a812bbe73277c67d346.pdf', 'name_canonical': '1676-0611-bn-2021-1306-s01.pdf', 'type': 'original'},
-        ],
-        'suppl02': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b72942b47698183bf992f1ad8cebdf61d346e0cf.xls', 'name_canonical': '1676-0611-bn-2021-1306-s02.xls', 'type': 'original'},
-        ],
-        'suppl03': [
-          {'name': 'https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf', 'name_canonical': '1676-0611-bn-2021-1306-s03.pdf', 'type': 'original'},
-        ]
-      }
-      aa = ArticleAssets(xmltree).article_assets
-      obtained = obtain_asset_dict(aa, package_name='1676-0611-bn-2021-1306')
+        expected = {
+            "f1": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/256bcf2e607f18b0bb3842a31332f6b48620cb09.tif",
+                    "name_canonical": "1676-0611-bn-2021-1306-g01.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c00655410885461df4a98dd77860b81b2e5baa2c.png",
+                    "name_canonical": "1676-0611-bn-2021-1306-g01.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ebd30641f55d890debe55743b8e2946135c74140.jpg",
+                    "name_canonical": "1676-0611-bn-2021-1306-g01-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f2": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b784533145d2f1557a7df00e05e5c6207fc57e2a.tif",
+                    "name_canonical": "1676-0611-bn-2021-1306-g02.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b298055fb49aba04fa94a1287ed4c38c0680ccf7.png",
+                    "name_canonical": "1676-0611-bn-2021-1306-g02.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c0a10dd209a9da0ef40f92f070ee6c77b0ca220b.jpg",
+                    "name_canonical": "1676-0611-bn-2021-1306-g02-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f3": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/14717caba8b886eddbbc9e1e4a8c579631730187.tif",
+                    "name_canonical": "1676-0611-bn-2021-1306-g03.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b0b01286ff114d6eda85f9a5afb1217d164e32b5.png",
+                    "name_canonical": "1676-0611-bn-2021-1306-g03.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b03ad3e4bced80bf0a81dfe12fbe6e567982414b.jpg",
+                    "name_canonical": "1676-0611-bn-2021-1306-g03-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "f4": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/407a7771f32d6364ee6536278a011a2c05da3339.tif",
+                    "name_canonical": "1676-0611-bn-2021-1306-g04.tif",
+                    "type": "original",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/c1ba665e5e0731d623095779a2d4099c808e776b.png",
+                    "name_canonical": "1676-0611-bn-2021-1306-g04.png",
+                    "type": "optimised",
+                },
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/f1da586984d4176883f92f2fb28e9abea946b8d2.jpg",
+                    "name_canonical": "1676-0611-bn-2021-1306-g04-scielo-267x140.jpg",
+                    "type": "thumbnail",
+                },
+            ],
+            "suppl01": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/e738857c8fb8bc085b766a812bbe73277c67d346.pdf",
+                    "name_canonical": "1676-0611-bn-2021-1306-s01.pdf",
+                    "type": "original",
+                },
+            ],
+            "suppl02": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/b72942b47698183bf992f1ad8cebdf61d346e0cf.xls",
+                    "name_canonical": "1676-0611-bn-2021-1306-s02.xls",
+                    "type": "original",
+                },
+            ],
+            "suppl03": [
+                {
+                    "name": "https://minio.scielo.br/documentstore/1676-0611/GJq3kzJLQw876pxRdSrhmQG/ffc50de0245a936540df9f98b7de123c8c597cbf.pdf",
+                    "name_canonical": "1676-0611-bn-2021-1306-s03.pdf",
+                    "type": "original",
+                },
+            ],
+        }
+        aa = ArticleAssets(xmltree).article_assets
+        obtained = obtain_asset_dict(aa, package_name="1676-0611-bn-2021-1306")
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_assets_category_name_code(self):
-      data = """
+        data = """
       <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="pt">
         <body>
           <sec sec-type="methods">
@@ -825,65 +1090,143 @@ class ArticleAssetsTest(TestCase):
         </sub-article>
       </article>
       """
-      xmltree = xml_utils.get_xml_tree(data)
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = [
-        # <graphic> com cujo parente possui id f01
-        ('g', 'f01', '0034-8910-rsp-48-2-0232-gf01'), 
-        # <supplementary-material> cujo parente possui id app01
-        ('s', 'app01', '0034-8910-rsp-48-2-0232-app01'),
-        # <display-formula> sem parente com id
-        ('e', '', '0034-8910-rsp-48-2-0232-ee01'),
-        # <display-formula> cujo parente com id é sub-article
-        ('e', '', '0034-8910-rsp-48-2-0232-ee01-en'),
-      ]
+        expected = [
+            # <graphic> com cujo parente possui id f01
+            ("g", "f01", "0034-8910-rsp-48-2-0232-gf01"),
+            # <supplementary-material> cujo parente possui id app01
+            ("s", "app01", "0034-8910-rsp-48-2-0232-app01"),
+            # <display-formula> sem parente com id
+            ("e", "", "0034-8910-rsp-48-2-0232-ee01"),
+            # <display-formula> cujo parente com id é sub-article
+            ("e", "", "0034-8910-rsp-48-2-0232-ee01-en"),
+        ]
 
-      aa = ArticleAssets(xmltree).article_assets
-      obtained = [(i._category_name_code, i.id, i.name) for i in aa]
-      
-      self.assertListEqual(expected, obtained)
+        aa = ArticleAssets(xmltree).article_assets
+        obtained = [(i._category_name_code, i.id, i.name) for i in aa]
 
+        self.assertListEqual(expected, obtained)
 
     def test_assets_canonical_name_with_subarticles_and_without_id(self):
-      data = open('tests/samples/0034-8910-rsp-48-2-0232.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open("tests/samples/0034-8910-rsp-48-2-0232.xml").read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        '': [
-          # <graphic> dentro de <disp-formula> sem id associado
-          {'name': '0034-8910-rsp-48-2-0232-ee01', 'name_canonical': '0034-8910-rsp-48-2-0232-e-n00', 'type': 'original'},
-          # <graphic> dentro de <disp-formula> sem id associado e em sub-article cujo lang é en
-          {'name': '0034-8910-rsp-48-2-0232-ee01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-e-n01-en', 'type': 'original'}
-        ],
-        # <graphic> dentro de <app> cujo id é app01 e em sub-article cujo lang é en
-        'app01': [{'name': '0034-8910-rsp-48-2-0232-app01', 'name_canonical': '0034-8910-rsp-48-2-0232-s01-en', 'type': 'original'}],
-        # <graphic> dentro de <fig> cujo id é f01
-        'f01': [{'name': '0034-8910-rsp-48-2-0232-gf01', 'name_canonical': '0034-8910-rsp-48-2-0232-g01', 'type': 'original'}],
-        # <graphic> dentro de <fig> cujo id é f01_en e em sub-article cujo lang é en
-        'f01_en': [{'name': '0034-8910-rsp-48-2-0232-gf01-en', 'name_canonical': '0034-8910-rsp-48-2-0232-g01-en', 'type': 'original'}],
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0232')
+        expected = {
+            "": [
+                # <graphic> dentro de <disp-formula> sem id associado
+                {
+                    "name": "0034-8910-rsp-48-2-0232-ee01",
+                    "name_canonical": "0034-8910-rsp-48-2-0232-e-n00",
+                    "type": "original",
+                },
+                # <graphic> dentro de <disp-formula> sem id associado e em sub-article cujo lang é en
+                {
+                    "name": "0034-8910-rsp-48-2-0232-ee01-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0232-e-n01-en",
+                    "type": "original",
+                },
+            ],
+            # <graphic> dentro de <app> cujo id é app01 e em sub-article cujo lang é en
+            "app01": [
+                {
+                    "name": "0034-8910-rsp-48-2-0232-app01",
+                    "name_canonical": "0034-8910-rsp-48-2-0232-s01-en",
+                    "type": "original",
+                }
+            ],
+            # <graphic> dentro de <fig> cujo id é f01
+            "f01": [
+                {
+                    "name": "0034-8910-rsp-48-2-0232-gf01",
+                    "name_canonical": "0034-8910-rsp-48-2-0232-g01",
+                    "type": "original",
+                }
+            ],
+            # <graphic> dentro de <fig> cujo id é f01_en e em sub-article cujo lang é en
+            "f01_en": [
+                {
+                    "name": "0034-8910-rsp-48-2-0232-gf01-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0232-g01-en",
+                    "type": "original",
+                }
+            ],
+        }
+        obtained = obtain_asset_dict(
+            ArticleAssets(xmltree).article_assets,
+            package_name="0034-8910-rsp-48-2-0232",
+        )
 
-      self.assertDictEqual(expected, obtained)
-
+        self.assertDictEqual(expected, obtained)
 
     def test_assets_canonical_name_with_subarticles_and_ids_with_lang(self):
-      data = open('tests/samples/0034-8910-rsp-48-2-0240.xml').read()
-      xmltree = xml_utils.get_xml_tree(data)
+        data = open("tests/samples/0034-8910-rsp-48-2-0240.xml").read()
+        xmltree = xml_utils.get_xml_tree(data)
 
-      expected = {
-        'f01': [{'name': '0034-8910-rsp-48-2-0240-gf01', 'name_canonical': '0034-8910-rsp-48-2-0240-g01', 'type': 'original'}],
-        'f02': [{'name': '0034-8910-rsp-48-2-0240-gf02', 'name_canonical': '0034-8910-rsp-48-2-0240-g02', 'type': 'original'}],
-        'f03': [{'name': '0034-8910-rsp-48-2-0240-gf03', 'name_canonical': '0034-8910-rsp-48-2-0240-g03', 'type': 'original'}],
-        'f04': [{'name': '0034-8910-rsp-48-2-0240-gf04', 'name_canonical': '0034-8910-rsp-48-2-0240-g04', 'type': 'original'}],
-        'f01_en': [{'name': '0034-8910-rsp-48-2-0240-gf01-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g01-en', 'type': 'original'}],
-        'f02_en': [{'name': '0034-8910-rsp-48-2-0240-gf02-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g02-en', 'type': 'original'}],
-        'f03_en': [{'name': '0034-8910-rsp-48-2-0240-gf03-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g03-en', 'type': 'original'}],
-        'f04_en': [{'name': '0034-8910-rsp-48-2-0240-gf04-en', 'name_canonical': '0034-8910-rsp-48-2-0240-g04-en', 'type': 'original'}],
-      }
-      obtained = obtain_asset_dict(ArticleAssets(xmltree).article_assets, package_name='0034-8910-rsp-48-2-0240')
+        expected = {
+            "f01": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf01",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g01",
+                    "type": "original",
+                }
+            ],
+            "f02": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf02",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g02",
+                    "type": "original",
+                }
+            ],
+            "f03": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf03",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g03",
+                    "type": "original",
+                }
+            ],
+            "f04": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf04",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g04",
+                    "type": "original",
+                }
+            ],
+            "f01_en": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf01-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g01-en",
+                    "type": "original",
+                }
+            ],
+            "f02_en": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf02-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g02-en",
+                    "type": "original",
+                }
+            ],
+            "f03_en": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf03-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g03-en",
+                    "type": "original",
+                }
+            ],
+            "f04_en": [
+                {
+                    "name": "0034-8910-rsp-48-2-0240-gf04-en",
+                    "name_canonical": "0034-8910-rsp-48-2-0240-g04-en",
+                    "type": "original",
+                }
+            ],
+        }
+        obtained = obtain_asset_dict(
+            ArticleAssets(xmltree).article_assets,
+            package_name="0034-8910-rsp-48-2-0240",
+        )
 
-      self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained)
 
 
 class SupplementaryMaterialsTest(TestCase):
@@ -891,9 +1234,7 @@ class SupplementaryMaterialsTest(TestCase):
         return xml_utils.get_xml_tree(xml)
 
     def test_inline_supplementary_material(self):
-        
-        data = (
-        """<article xmlns:xlink="http://www.w3.org/1999/xlink" >
+        data = """<article xmlns:xlink="http://www.w3.org/1999/xlink" >
 <back>
     <fn-group>
       <fn fn-type="supplementary-material">
@@ -905,11 +1246,13 @@ class SupplementaryMaterialsTest(TestCase):
     </fn-group></back></article>
 
         """
-        )
         xmltree = xml_utils.get_xml_tree(data)
 
         expected = [
-            ('', 'https://minio.scielo.br/documentstore/1678-4790/LgRcS7ZYYQ5wSDKw8wKytSp/818bf2b94169513756c9f4734c24d9bc774a3795.pdf'),
+            (
+                "",
+                "https://minio.scielo.br/documentstore/1678-4790/LgRcS7ZYYQ5wSDKw8wKytSp/818bf2b94169513756c9f4734c24d9bc774a3795.pdf",
+            ),
         ]
 
         for i, item in enumerate(SupplementaryMaterials(xmltree).items):
@@ -918,9 +1261,7 @@ class SupplementaryMaterialsTest(TestCase):
                 self.assertEqual(item.name, expected[i][1])
 
     def test_supplementary_material(self):
-        
-        data = (
-        """<article xmlns:xlink="http://www.w3.org/1999/xlink" >
+        data = """<article xmlns:xlink="http://www.w3.org/1999/xlink" >
 <back>
 <app-group>
 <app id="app01">
@@ -952,12 +1293,11 @@ obtida por Einstein em 1905
 </app-group></back></article>
 
         """
-        )
         xmltree = xml_utils.get_xml_tree(data)
 
         expected = [
-            ('suppl01', 'c834.pdf'),
-            ('suppl02', '0b97.pdf'),
+            ("suppl01", "c834.pdf"),
+            ("suppl02", "0b97.pdf"),
         ]
 
         for i, item in enumerate(SupplementaryMaterials(xmltree).items):

--- a/tests/sps/models/test_article_assets.py
+++ b/tests/sps/models/test_article_assets.py
@@ -1,11 +1,8 @@
 from unittest import TestCase
 
+from packtools.sps.models.article_assets import (ArticleAssets,
+                                                 SupplementaryMaterials)
 from packtools.sps.utils import xml_utils
-
-from packtools.sps.models.article_assets import (
-    ArticleAssets,
-    SupplementaryMaterials,
-)
 
 
 def generate_xmltree(snippet):

--- a/tests/sps/models/test_article_assets_v2.py
+++ b/tests/sps/models/test_article_assets_v2.py
@@ -1,0 +1,191 @@
+from unittest import TestCase
+
+from packtools.sps.models.v2.article_assets import ArticleAssets
+from packtools.sps.utils import xml_utils
+
+
+def get_xmltree(xml_assets, sub_xml_assets=None):
+
+    return xml_utils.get_xml_tree(
+        f"""<article  xmlns:xlink="http://www.w3.org/1999/xlink" >
+        <front>
+        </front>
+        <body>
+        {xml_assets or ''}
+        </body>
+        <back>
+        </back>
+        <sub-article xml:lang="en" id="sa01">
+            <body>
+            {sub_xml_assets or ''}
+            </body>
+        </sub-article>
+        </article>"""
+    )
+
+
+class ArticleAssetsFiggroupTest(TestCase):
+
+    def setUp(self):
+        xmltree = get_xmltree(
+            """<fig-group id="f1">
+            <fig xml:lang="pt">
+              <label>Figura 1</label>
+              <caption>
+                <title>Localização do Parque Estadual de Itapeva, Torres, Estado do Rio Grande do Sul, Brasil e áreas de coleta.</title>
+              </caption>
+            </fig>
+            <fig xml:lang="en">
+              <label>Figure 1</label>
+              <caption>
+                <title>Location of Parque Estadual de Itapeva, Torres, Rio Grande do Sul State, Brazil and collection areas.</title>
+              </caption>
+              <alternatives>
+                <graphic xlink:href="original.tif"/>
+                <graphic xlink:href="otimizado.png" specific-use="scielo-web"/>
+                <graphic xlink:href="mini.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+              </alternatives>
+            </fig>
+          </fig-group>"""
+        )
+        self.article_assets = ArticleAssets(xmltree)
+
+    def test_article_assets_items(self):
+        expected_items = [
+            {
+                'id': 'f1',
+                'is_supplementary_material': False,
+                'number': None,
+                'tag': 'fig-group',
+                'type': 'original',
+                'xlink_href': 'original.tif'
+            },
+            {
+                'id': 'f1',
+                'is_supplementary_material': False,
+                'number': None,
+                'tag': 'fig-group',
+                'type': 'optimised',
+                'xlink_href': 'otimizado.png'
+            },
+            {
+                'id': 'f1',
+                'is_supplementary_material': False,
+                'number': None,
+                'tag': 'fig-group',
+                'type': 'thumbnail',
+                'xlink_href': 'mini.jpg'
+            },
+        ]
+        items = list(self.article_assets.items)
+        for i, expected in enumerate(expected_items):
+            with self.subTest(i):
+                self.assertEqual(expected, items[i].data)
+
+    def test_article_assets_grouped_by_id(self):
+        expected_items = {
+            "f1": [
+                {
+                    'id': 'f1',
+                    'is_supplementary_material': False,
+                    'number': None,
+                    'tag': 'fig-group',
+                    'type': 'original',
+                        'xlink_href': 'original.tif'
+                },
+                {
+                    'id': 'f1',
+                    'is_supplementary_material': False,
+                    'number': None,
+                    'tag': 'fig-group',
+                    'type': 'optimised',
+                    'xlink_href': 'otimizado.png'
+                },
+                {
+                    'id': 'f1',
+                    'is_supplementary_material': False,
+                    'number': None,
+                    'tag': 'fig-group',
+                    'type': 'thumbnail',
+                    'xlink_href': 'mini.jpg'
+                },
+            ]
+        }
+        self.assertEqual(expected_items, self.article_assets.grouped_by_id)
+
+
+class ArticleAssetsTest(TestCase):
+
+    def setUp(self):
+        xmltree = get_xmltree("""
+            <fig id="f01">
+            <label>Figura 1</label>
+            <caption>
+                <title>Caption Figura 1</title>
+            </caption>
+            <disp-formula>
+              <alternatives>
+                  <graphic xlink:href="original.tif" />
+                  <graphic xlink:href="ampliada.png" specific-use="scielo-web" />
+                  <graphic xlink:href="miniatura.jpg" specific-use="scielo-web" content-type="scielo-20x20" />
+              </alternatives>
+            </disp-formula>
+            <attrib>Fonte: Dados originais da pesquisa</attrib>
+            </fig>
+            <fig id="f03">
+            <label>Fig. 3</label>
+            <caption>
+                <title>titulo da imagem</title>
+            </caption>
+            <alternatives>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.tiff"/>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.png" specific-use="scielo-web"/>
+                <graphic xlink:href="1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>
+            </alternatives>
+            </fig>
+            <p>We also used an ... based on the equation:<inline-graphic xlink:href="1234-5678-rctb-45-05-0110-e04.tif"/>.</p>
+            <p><media mimetype="video" mime-subtype="mp4" xlink:href="1234-5678-rctb-45-05-0110-m01.mp4"/></p>
+        """)
+        self.article_assets = ArticleAssets(xmltree)
+
+    def test_sps_pkg_name(self):
+        expected_items = [
+            {
+                "xlink_href": "original.tif",
+                "canonical_name": "NOME-DO-PACOTE-gf01.tif",
+            },
+            {
+                "xlink_href": "ampliada.png",
+                "canonical_name": "NOME-DO-PACOTE-gf01.png",
+            },
+            {
+                "xlink_href": "miniatura.jpg",
+                "canonical_name": "NOME-DO-PACOTE-gf01-scielo-20x20.jpg",
+            },
+            {
+                "xlink_href": "1234-5678-rctb-45-05-0110-gf03.tiff",
+                "canonical_name": "NOME-DO-PACOTE-gf03.tiff",
+            },
+            {
+                "xlink_href": "1234-5678-rctb-45-05-0110-gf03.png",
+                "canonical_name": "NOME-DO-PACOTE-gf03.png",
+            },
+            {
+                "xlink_href": "1234-5678-rctb-45-05-0110-gf03.thumbnail.jpg",
+                "canonical_name": "NOME-DO-PACOTE-gf03-scielo-267x140.jpg",
+            },
+            {
+                "xlink_href": "1234-5678-rctb-45-05-0110-e04.tif",
+                "canonical_name": "NOME-DO-PACOTE-g1.tif",
+            },
+            {
+                "xlink_href": "1234-5678-rctb-45-05-0110-m01.mp4",
+                "canonical_name": "NOME-DO-PACOTE-g2.mp4",
+            },
+        ]
+        items = list(self.article_assets.items)
+        for i, expected in enumerate(expected_items):
+            new_name = items[i].name_canonical("NOME-DO-PACOTE")
+            with self.subTest(i):
+                self.assertEqual(expected["xlink_href"], items[i].xlink_href)
+                self.assertEqual(expected["canonical_name"], new_name)


### PR DESCRIPTION
#### O que esse PR faz?
Cria versão 2 da classe ArticleAssets para manipular os ativos digitais do XML.
A anterior estava mais complexa e havia defeito ao gerar o nome de ativos digitais para o pacote SPS.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando a classe e fazendo uso.
Executando:
```console
python -m unittest -v -k test_article_assets_v2
```

#### Algum cenário de contexto que queira dar?
A classe anterior foi mantida, pois provavelmente estava em uso em Upload / upload
Esta nova classe será usada em Upload / migration

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
