### PR TITLE
Crossmark

### DIFF
--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1530,7 +1530,6 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
         crossmark_el.append(crossmark_domain_exclusive_el)
 
 
-def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree):
 def create_update_element(rel_article):
     update_el = ET.Element("update")
     href = rel_article.get("href")
@@ -1547,6 +1546,7 @@ def create_update_element(rel_article):
     return update_el
 
 
+def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data):
     """
     Adiciona o elemento 'update' ao XML Crossref se houver um DOI de atualização.
 
@@ -1569,13 +1569,14 @@ def create_update_element(rel_article):
             <journal_article language="en" publication_type="correction" reference_distribution_opts="any">
                 <crossmark>
                     <updates>
-                        <update type="correction" label="Correction">10.1590/1519-6984.263364</update>
+                        <update type="correction">10.1590/1519-6984.263364</update>
                     </updates>
                 </crossmark>
             </journal_article>
         </journal>
     </body>
     """
+
     # Obter informações necessárias do XML SciELO
     update_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
     update_doi = [item.get('href') for item in related_articles.RelatedItems(xml_tree).related_articles]

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from lxml import etree as ET
 
+from packtools.sps.formats.values import crossmark_pub_types
+
 from packtools.sps.models import (
     journal_meta,
     dates,

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1428,6 +1428,49 @@ def xml_crossref_crossmark_pipe(xml_crossref):
     xml_crossref.find('./body/journal/journal_article').append(crossmark)
 
 
+def xml_crossref_crossmark_policy_pipe(xml_crossref, data):
+    """
+        Adiciona o elemento 'crossmark_policy' ao xml_crossref.
+
+        Parameters
+        ----------
+        xml_crossref : lxml.etree._Element
+            Elemento XML no padrão CrossRef em construção
+
+        data : dict
+            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+                data = {
+                    "crossmark_policy": "10.5555/crossmark_policy"
+                }
+
+        Returns
+        -------
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doi_batch ...>
+            <body>
+                <journal>
+                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
+                        <crossmark>
+                            <crossmark_policy>10.5555/crossmark_policy</crossmark_policy>
+                        </crossmark>
+                    </journal_article>
+                </journal>
+            </body>
+        </doi_batch>
+    """
+    # TODO crossmark policy é usada para indicar a política CrossMark associada ao artigo.
+    #  A política CrossMark define como as atualizações, correções e informações sobre
+    #  o artigo serão tratadas e comunicadas aos leitores.
+    #  O valor atribuído à tag <crossmark_policy> pode variar, mas geralmente é uma URL que direciona para uma página
+    #  ou documento que descreve detalhadamente a política CrossMark aplicada ao artigo.
+    policy_value = data.get("crossmark_policy")
+    if policy_value:
+        policy_el = ET.Element("crossmark_policy")
+        policy_el.text = policy_value
+
+        xml_crossref.find('./body/journal/journal_article/crossmark').append(policy_el)
+
+
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     Adiciona o elemento 'item_number' ao xml_crossref.

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1531,6 +1531,22 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
 
 
 def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree):
+def create_update_element(rel_article):
+    update_el = ET.Element("update")
+    href = rel_article.get("href")
+    tp = crossmark_pub_types.get(rel_article.get("related-article-type"))
+    date = rel_article.get("date")
+
+    if href:
+        update_el.text = href
+    if tp:
+        update_el.set("type", tp)
+    if date:
+        update_el.set("date", date)
+
+    return update_el
+
+
     """
     Adiciona o elemento 'update' ao XML Crossref se houver um DOI de atualização.
 

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1450,41 +1450,29 @@ def xml_crossref_crossmark_policy_pipe(xml_crossref, data):
 
 def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
     """
-        Adiciona o elemento 'crossmark_domains' ao xml_crossref.
+    Adiciona o elemento 'crossmark_domains' ao XML Crossref.
 
-        Parameters
-        ----------
-        xml_crossref : lxml.etree._Element
-            Elemento XML no padrão CrossRef em construção
+    Parameters
+    ----------
+    xml_crossref : lxml.etree._Element
+        Elemento XML no padrão CrossRef em construção
 
-        data : dict
-            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
-                data = {
-                    "crossmark_domains": ["psychoceramics.labs.crossref.org"],
-                    "crossmark_domain_exclusive": "false"
-                }
+    data : dict
+        Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+            data = {
+                "crossmark_domains": ["psychoceramics.labs.crossref.org"],
+                "crossmark_domain_exclusive": "false"
+            }
 
-        Returns
-        -------
-        <?xml version="1.0" encoding="UTF-8"?>
-        <doi_batch ...>
-            <body>
-                <journal>
-                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
-                        <crossmark>
-                            <crossmark_domains>
-                                <crossmark_domain>
-                                    <domain>psychoceramics.labs.crossref.org</domain>
-                                </crossmark_domain>
-                            </crossmark_domains>
-                            <crossmark_domain_exclusive>false</crossmark_domain_exclusive>
-                        </crossmark>
-                    </journal_article>
-                </journal>
-            </body>
-        </doi_batch>
+    Returns
+    -------
+    None
     """
     crossmark_domains = data.get("crossmark_domains")
+    crossmark_domain_exclusive = data.get("crossmark_domain_exclusive")
+
+    crossmark_el = xml_crossref.find('./body/journal/journal_article/crossmark')
+
     if crossmark_domains:
         crossmark_domains_el = ET.Element("crossmark_domains")
         for crossmark_domain_value in crossmark_domains:
@@ -1493,15 +1481,12 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
             domain_el.text = crossmark_domain_value
             crossmark_domain_el.append(domain_el)
             crossmark_domains_el.append(crossmark_domain_el)
+        crossmark_el.append(crossmark_domains_el)
 
-        xml_crossref.find('./body/journal/journal_article/crossmark').append(crossmark_domains_el)
-
-    crossmark_domain_exclusive = data.get("crossmark_domain_exclusive")
     if crossmark_domain_exclusive:
         crossmark_domain_exclusive_el = ET.Element("crossmark_domain_exclusive")
         crossmark_domain_exclusive_el.text = crossmark_domain_exclusive
-
-        xml_crossref.find('./body/journal/journal_article/crossmark').append(crossmark_domain_exclusive_el)
+        crossmark_el.append(crossmark_domain_exclusive_el)
 
 
 def xml_crossref_crossmark_updates_pipe(xml_crossref, data):

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1489,63 +1489,35 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
         crossmark_el.append(crossmark_domain_exclusive_el)
 
 
-def xml_crossref_crossmark_updates_pipe(xml_crossref, data):
+def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree):
     """
-        Adiciona o elemento 'updates' ao xml_crossref.
+    Adiciona o elemento 'update' ao XML Crossref se houver um DOI de atualização.
 
-        Parameters
-        ----------
-        xml_crossref : lxml.etree._Element
-            Elemento XML no padrão CrossRef em construção
+    Parameters
+    ----------
+    xml_crossref : lxml.etree._Element
+        Elemento XML no padrão CrossRef em construção
 
-        data : dict
-            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
-                data = {
-                    "updates": [
-                        {"type": "retraction", "label": "Retraction", "date": "2009-09-14", "text": "10.5555/12345678"},
-                        {"type": "clarification", "label": "Clarification", "date": "2012-12-29", "text": "10.5555/666655554444"}
-                    ]
-                }
+    xml_tree : lxml.etree._Element
+        Elemento XML no padrão SciELO com os dados sobre atualizações
 
-        Returns
-        -------
-        <?xml version="1.0" encoding="UTF-8"?>
-        <doi_batch ...>
-            <body>
-                <journal>
-                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
-                        <crossmark>
-                            <updates>
-                                <update type="retraction" label="Retraction" date="2009-09-14">10.5555/12345678</update>
-                                <update type="clarification" label="Clarification" date="2012-12-29">10.5555/666655554444</update>
-                            </updates>
-                        </crossmark>
-                    </journal_article>
-                </journal>
-            </body>
-        </doi_batch>
+    Returns
+    -------
+    None
     """
-    updates = data.get("updates")
-    if updates:
-        updates_el = ET.Element("updates")
-        for update in updates:
-            tx = update.get("text")
-            if tx:
-                update_el = ET.Element("update")
-                update_el.text = tx
-                tp = update.get("type")
-                if tp:
-                    update_el.set("type", tp)
-                lb = update.get("label")
-                if lb:
-                    update_el.set("label", lb)
-                dt = update.get("date")
-                if dt:
-                    update_el.set("date", dt)
-                updates_el.append(update_el)
+    # Obter informações necessárias do XML SciELO
+    update_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
+    update_doi = [item.get('href') for item in related_articles.RelatedItems(xml_tree).related_articles][0]
 
-    xml_crossref.find('./body/journal/journal_article/crossmark').append(updates_el)
+    if update_doi:
+        update_el = ET.Element("update")
+        update_el.text = update_doi
+        update_el.set("type", update_type)
+        update_el.set("label", update_type.capitalize())
 
+        # Verificar se já existe um elemento 'updates' no XML Crossref
+        crossmark_el = xml_crossref.find('./body/journal/journal_article/crossmark')
+        updates_el = crossmark_el.find('updates')
 
 def xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, data):
     """

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1401,6 +1401,33 @@ def xml_crossref_pid_pipe(xml_crossref, xml_tree):
     xml_crossref.find('./body/journal/journal_article').append(publisher_item)
 
 
+def xml_crossref_crossmark_pipe(xml_crossref):
+    """
+       Adiciona o elemento 'crossmark' ao xml_crossref.
+
+       Parameters
+       ----------
+       xml_crossref : lxml.etree._Element
+           Elemento XML no padrão CrossRef em construção
+
+       Returns
+       -------
+       <?xml version="1.0" encoding="UTF-8"?>
+       <doi_batch ...>
+          <body>
+             <journal>
+                <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
+                   <crossmark/>
+                </journal_article>
+             </journal>
+          </body>
+       </doi_batch>
+       """
+    crossmark = ET.Element("crossmark")
+
+    xml_crossref.find('./body/journal/journal_article').append(crossmark)
+
+
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     Adiciona o elemento 'item_number' ao xml_crossref.

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1578,24 +1578,25 @@ def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data):
     """
 
     # Obter informações necessárias do XML SciELO
-    update_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
-    update_doi = [item.get('href') for item in related_articles.RelatedItems(xml_tree).related_articles]
+    rel_articles = [item for item in related_articles.RelatedItems(xml_tree).related_articles]
+    rel_articles_from_data = data.get("related-articles")
 
-    if update_doi:
-        update_el = ET.Element("update")
-        update_el.text = update_doi[0]
-        update_el.set("type", update_type)
-        update_el.set("label", update_type.capitalize())
+    if rel_articles_from_data:
+        rel_articles.extend(rel_articles_from_data)
 
-        # Verificar se já existe um elemento 'updates' no XML Crossref
-        crossmark_el = xml_crossref.find('./body/journal/journal_article/crossmark')
-        updates_el = crossmark_el.find('updates')
+    for rel_article in rel_articles:
+        if rel_article:
+            update_el = create_update_element(rel_article)
 
-        if updates_el is None:
-            updates_el = ET.Element("updates")
-            crossmark_el.append(updates_el)
+            # Verificar se já existe um elemento 'updates' no XML Crossref
+            crossmark_el = xml_crossref.find('./body/journal/journal_article/crossmark')
+            updates_el = crossmark_el.find('updates')
 
-        updates_el.append(update_el)
+            if updates_el is None:
+                updates_el = ET.Element("updates")
+                crossmark_el.append(updates_el)
+
+            updates_el.append(update_el)
 
 
 def xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, xml_tree, data):

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1471,6 +1471,62 @@ def xml_crossref_crossmark_policy_pipe(xml_crossref, data):
         xml_crossref.find('./body/journal/journal_article/crossmark').append(policy_el)
 
 
+def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
+    """
+        Adiciona o elemento 'crossmark_domains' ao xml_crossref.
+
+        Parameters
+        ----------
+        xml_crossref : lxml.etree._Element
+            Elemento XML no padrão CrossRef em construção
+
+        data : dict
+            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+                data = {
+                    "crossmark_domains": ["psychoceramics.labs.crossref.org"],
+                    "crossmark_domain_exclusive": "false"
+                }
+
+        Returns
+        -------
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doi_batch ...>
+            <body>
+                <journal>
+                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
+                        <crossmark>
+                            <crossmark_domains>
+                                <crossmark_domain>
+                                    <domain>psychoceramics.labs.crossref.org</domain>
+                                </crossmark_domain>
+                            </crossmark_domains>
+                            <crossmark_domain_exclusive>false</crossmark_domain_exclusive>
+                        </crossmark>
+                    </journal_article>
+                </journal>
+            </body>
+        </doi_batch>
+    """
+    crossmark_domains = data.get("crossmark_domains")
+    if crossmark_domains:
+        crossmark_domains_el = ET.Element("crossmark_domains")
+        for crossmark_domain_value in crossmark_domains:
+            crossmark_domain_el = ET.Element("crossmark_domain")
+            domain_el = ET.Element("domain")
+            domain_el.text = crossmark_domain_value
+            crossmark_domain_el.append(domain_el)
+            crossmark_domains_el.append(crossmark_domain_el)
+
+        xml_crossref.find('./body/journal/journal_article/crossmark').append(crossmark_domains_el)
+
+    crossmark_domain_exclusive = data.get("crossmark_domain_exclusive")
+    if crossmark_domain_exclusive:
+        crossmark_domain_exclusive_el = ET.Element("crossmark_domain_exclusive")
+        crossmark_domain_exclusive_el.text = crossmark_domain_exclusive
+
+        xml_crossref.find('./body/journal/journal_article/crossmark').append(crossmark_domain_exclusive_el)
+
+
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     Adiciona o elemento 'item_number' ao xml_crossref.

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -19,6 +19,7 @@ from packtools.sps.models import (
     article_titles,
     article_doi_with_lang,
     article_citations,
+    related_articles,
 )
 
 SUPPLBEG_REGEX = re.compile(r'^0 ')
@@ -1403,29 +1404,20 @@ def xml_crossref_pid_pipe(xml_crossref, xml_tree):
 
 def xml_crossref_crossmark_pipe(xml_crossref):
     """
-       Adiciona o elemento 'crossmark' ao xml_crossref.
+    Adiciona o elemento 'crossmark' ao XML Crossref.
 
-       Parameters
-       ----------
-       xml_crossref : lxml.etree._Element
-           Elemento XML no padrão CrossRef em construção
+    Parameters
+    ----------
+    xml_crossref : lxml.etree._Element
+        Elemento XML no padrão CrossRef em construção
 
-       Returns
-       -------
-       <?xml version="1.0" encoding="UTF-8"?>
-       <doi_batch ...>
-          <body>
-             <journal>
-                <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
-                   <crossmark/>
-                </journal_article>
-             </journal>
-          </body>
-       </doi_batch>
-       """
+    Returns
+    -------
+    None
+    """
     crossmark = ET.Element("crossmark")
-
-    xml_crossref.find('./body/journal/journal_article').append(crossmark)
+    article_el = xml_crossref.find('./body/journal/journal_article')
+    article_el.append(crossmark)
 
 
 def xml_crossref_crossmark_policy_pipe(xml_crossref, data):

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1422,45 +1422,30 @@ def xml_crossref_crossmark_pipe(xml_crossref):
 
 def xml_crossref_crossmark_policy_pipe(xml_crossref, data):
     """
-        Adiciona o elemento 'crossmark_policy' ao xml_crossref.
+    Adiciona o elemento 'crossmark_policy' ao XML Crossref.
 
-        Parameters
-        ----------
-        xml_crossref : lxml.etree._Element
-            Elemento XML no padrão CrossRef em construção
+    Parameters
+    ----------
+    xml_crossref : lxml.etree._Element
+        Elemento XML no padrão CrossRef em construção
 
-        data : dict
-            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
-                data = {
-                    "crossmark_policy": "10.5555/crossmark_policy"
-                }
+    data : dict
+        Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+            data = {
+                "crossmark_policy": "10.5555/crossmark_policy"
+            }
 
-        Returns
-        -------
-        <?xml version="1.0" encoding="UTF-8"?>
-        <doi_batch ...>
-            <body>
-                <journal>
-                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
-                        <crossmark>
-                            <crossmark_policy>10.5555/crossmark_policy</crossmark_policy>
-                        </crossmark>
-                    </journal_article>
-                </journal>
-            </body>
-        </doi_batch>
+    Returns
+    -------
+    None
     """
-    # TODO crossmark policy é usada para indicar a política CrossMark associada ao artigo.
-    #  A política CrossMark define como as atualizações, correções e informações sobre
-    #  o artigo serão tratadas e comunicadas aos leitores.
-    #  O valor atribuído à tag <crossmark_policy> pode variar, mas geralmente é uma URL que direciona para uma página
-    #  ou documento que descreve detalhadamente a política CrossMark aplicada ao artigo.
     policy_value = data.get("crossmark_policy")
+
     if policy_value:
+        crossmark_el = xml_crossref.find('./body/journal/journal_article/crossmark')
         policy_el = ET.Element("crossmark_policy")
         policy_el.text = policy_value
-
-        xml_crossref.find('./body/journal/journal_article/crossmark').append(policy_el)
+        crossmark_el.append(policy_el)
 
 
 def xml_crossref_crossmark_domains_pipe(xml_crossref, data):

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1414,6 +1414,16 @@ def xml_crossref_crossmark_pipe(xml_crossref):
     Returns
     -------
     None
+
+    XML Crossref example
+    --------------------
+    <body>
+        <journal>
+            <journal_article language="en" publication_type="research-article" reference_distribution_opts="any">
+                <crossmark/>
+            </journal_article>
+        </journal>
+    </body>
     """
     crossmark = ET.Element("crossmark")
     article_el = xml_crossref.find('./body/journal/journal_article')
@@ -1438,6 +1448,18 @@ def xml_crossref_crossmark_policy_pipe(xml_crossref, data):
     Returns
     -------
     None
+
+    XML Crossref example
+    --------------------
+    <body>
+        <journal>
+            <journal_article language="en" publication_type="research-article" reference_distribution_opts="any">
+                <crossmark>
+                    <crossmark_policy>10.5555/crossmark_policy</crossmark_policy>
+                </crossmark>
+            </journal_article>
+        </journal>
+    </body>
     """
     policy_value = data.get("crossmark_policy")
 
@@ -1467,6 +1489,23 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
     Returns
     -------
     None
+
+    XML Crossref example
+    --------------------
+    <body>
+        <journal>
+            <journal_article language="en" publication_type="research-article" reference_distribution_opts="any">
+                <crossmark>
+                    <crossmark_domains>
+                        <crossmark_domain>
+                            <domain>psychoceramics.labs.crossref.org</domain>
+                        </crossmark_domain>
+                    </crossmark_domains>
+                    <crossmark_domain_exclusive>false</crossmark_domain_exclusive>
+                </crossmark>
+            </journal_article>
+        </journal>
+    </body>
     """
     crossmark_domains = data.get("crossmark_domains")
     crossmark_domain_exclusive = data.get("crossmark_domain_exclusive")
@@ -1504,14 +1543,28 @@ def xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree):
     Returns
     -------
     None
+
+    XML Crossref example
+    --------------------
+    <body>
+        <journal>
+            <journal_article language="en" publication_type="correction" reference_distribution_opts="any">
+                <crossmark>
+                    <updates>
+                        <update type="correction" label="Correction">10.1590/1519-6984.263364</update>
+                    </updates>
+                </crossmark>
+            </journal_article>
+        </journal>
+    </body>
     """
     # Obter informações necessárias do XML SciELO
     update_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
-    update_doi = [item.get('href') for item in related_articles.RelatedItems(xml_tree).related_articles][0]
+    update_doi = [item.get('href') for item in related_articles.RelatedItems(xml_tree).related_articles]
 
     if update_doi:
         update_el = ET.Element("update")
-        update_el.text = update_doi
+        update_el.text = update_doi[0]
         update_el.set("type", update_type)
         update_el.set("label", update_type.capitalize())
 
@@ -1555,6 +1608,22 @@ def xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, xml_tree, data):
     Returns
     -------
     None
+
+    XML Crossref example
+    --------------------
+    <body>
+        <journal>
+            <journal_article language="en" publication_type="research-article" reference_distribution_opts="any">
+                <crossmark>
+                    <custom_metadata>
+                        <assertion name="received" label="Received" group_name="publication_history" group_label="Publication History" order="0">2022-04-23</assertion>
+                        <assertion name="accepted" label="Accepted" group_name="publication_history" group_label="Publication History" order="1">2022-08-17</assertion>
+                        <assertion name="remorse" label="Level of Remorse" group_name="publication_notes" group_label="Publication Notes">90%</assertion>
+                    </custom_metadata>
+                </crossmark>
+            </journal_article>
+        </journal>
+    </body>
     """
     history = dates.ArticleDates(xml_tree).history_dates_dict
 

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1527,6 +1527,64 @@ def xml_crossref_crossmark_domains_pipe(xml_crossref, data):
         xml_crossref.find('./body/journal/journal_article/crossmark').append(crossmark_domain_exclusive_el)
 
 
+def xml_crossref_crossmark_updates_pipe(xml_crossref, data):
+    """
+        Adiciona o elemento 'updates' ao xml_crossref.
+
+        Parameters
+        ----------
+        xml_crossref : lxml.etree._Element
+            Elemento XML no padrão CrossRef em construção
+
+        data : dict
+            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+                data = {
+                    "updates": [
+                        {"type": "retraction", "label": "Retraction", "date": "2009-09-14", "text": "10.5555/12345678"},
+                        {"type": "clarification", "label": "Clarification", "date": "2012-12-29", "text": "10.5555/666655554444"}
+                    ]
+                }
+
+        Returns
+        -------
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doi_batch ...>
+            <body>
+                <journal>
+                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
+                        <crossmark>
+                            <updates>
+                                <update type="retraction" label="Retraction" date="2009-09-14">10.5555/12345678</update>
+                                <update type="clarification" label="Clarification" date="2012-12-29">10.5555/666655554444</update>
+                            </updates>
+                        </crossmark>
+                    </journal_article>
+                </journal>
+            </body>
+        </doi_batch>
+    """
+    updates = data.get("updates")
+    if updates:
+        updates_el = ET.Element("updates")
+        for update in updates:
+            tx = update.get("text")
+            if tx:
+                update_el = ET.Element("update")
+                update_el.text = tx
+                tp = update.get("type")
+                if tp:
+                    update_el.set("type", tp)
+                lb = update.get("label")
+                if lb:
+                    update_el.set("label", lb)
+                dt = update.get("date")
+                if dt:
+                    update_el.set("date", dt)
+                updates_el.append(update_el)
+
+    xml_crossref.find('./body/journal/journal_article/crossmark').append(updates_el)
+
+
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     Adiciona o elemento 'item_number' ao xml_crossref.

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -1585,6 +1585,71 @@ def xml_crossref_crossmark_updates_pipe(xml_crossref, data):
     xml_crossref.find('./body/journal/journal_article/crossmark').append(updates_el)
 
 
+def xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, data):
+    """
+        Adiciona o elemento 'custom_metadata' ao xml_crossref.
+
+        Parameters
+        ----------
+        xml_crossref : lxml.etree._Element
+            Elemento XML no padrão CrossRef em construção
+
+        data : dict
+            Dicionário com dados suplementares para a criação do xml_crossref como, por exemplo:
+                data = {
+                    "assertions": [
+                        {
+                        "name": "remorse",
+                        "label": "Level of Remorse",
+                        "group_name": "publication_notes",
+                        "group_label": "Publication Notes",
+                        "text": "90%"
+                        }
+                    ]
+                }
+
+        Returns
+        -------
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doi_batch ...>
+            <body>
+                <journal>
+                    <journal_article language="pt" publication_type="research-article" reference_distribution_opts="any">
+                        <crossmark>
+                            <custom_metadata>
+                                <assertion name="remorse" label="Level of Remorse" group_name="publication_notes" group_label="Publication Notes">90%</assertion>
+                            </custom_metadata>
+                        </crossmark>
+                    </journal_article>
+                </journal>
+            </body>
+        </doi_batch>
+    """
+    assertions = data.get("assertions")
+    if assertions:
+        custom_metadata_el = ET.Element("custom_metadata")
+        for assertion in assertions:
+            tx = assertion.get("text")
+            if tx:
+                assertion_el = ET.Element("assertion")
+                assertion_el.text = tx
+                nm = assertion.get("name")
+                if nm:
+                    assertion_el.set("name", nm)
+                lb = assertion.get("label")
+                if lb:
+                    assertion_el.set("label", lb)
+                gn = assertion.get("group_name")
+                if gn:
+                    assertion_el.set("group_name", gn)
+                gl = assertion.get("group_label")
+                if gl:
+                    assertion_el.set("group_label", gl)
+                custom_metadata_el.append(assertion_el)
+
+    xml_crossref.find('./body/journal/journal_article/crossmark').append(custom_metadata_el)
+
+
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     Adiciona o elemento 'item_number' ao xml_crossref.

--- a/packtools/sps/formats/values.py
+++ b/packtools/sps/formats/values.py
@@ -1,18 +1,18 @@
 # As correlações abaixo precisam de validação
 
 crossmark_pub_types = {
-"addendum": "addendum",
-"commentary": "clarification",
-"commentary-article": "clarification",
-"companion": "addendum",
-"corrected-article": "correction",
-"correction-forward": "correction",
-"in-this-issue": "clarification",
-"letter": "addendum",
-"partial-retraction": "partial-retraction",
-"retracted-article": "retraction",
-"retraction-forward": "retraction"
-}
+    "addendum": "addendum",
+    "commentary": "clarification",
+    "commentary-article": "clarification",
+    "companion": "addendum",
+    "corrected-article": "correction",
+    "correction-forward": "correction",
+    "in-this-issue": "clarification",
+    "letter": "addendum",
+    "partial-retraction": "partial-retraction",
+    "retracted-article": "retraction",
+    "retraction-forward": "retraction"
+    }
 
 
 # https://jats.nlm.nih.gov/publishing/tag-library/1.0/

--- a/packtools/sps/formats/values.py
+++ b/packtools/sps/formats/values.py
@@ -1,0 +1,48 @@
+# As correlações abaixo precisam de validação
+
+crossmark_pub_types = {
+"addendum": "addendum",
+"commentary": "clarification",
+"commentary-article": "clarification",
+"companion": "addendum",
+"corrected-article": "correction",
+"correction-forward": "correction",
+"in-this-issue": "clarification",
+"letter": "addendum",
+"partial-retraction": "partial-retraction",
+"retracted-article": "retraction",
+"retraction-forward": "retraction"
+}
+
+
+# https://jats.nlm.nih.gov/publishing/tag-library/1.0/
+
+# Attribute Values to <related-article> element:
+# - addendum: Additional material for an article, which was generated too late to be added to the main text
+# - commentary: Used in an article to name its associated commentary or editorial
+# - commentary-article: Used in a commentary or editorial to name the article on which this one is commenting
+# - companion: Used in an article to name a companion (related or sibling) article
+# - corrected-article: Used in a correction to name the article being corrected. Sometimes called “erratum”.
+# - correction-forward: Used in an article to name (point forward to) its associated correction (rarely used)
+# - in-this-issue: Names a related article in the same journal issue
+# - letter: Names a letter to the publication or a reply to such a letter
+# - partial-retraction: Retraction or disavowal of part(s) of previously published material
+# - retracted-article: Used in a retraction to name the article being retracted
+# - retraction-forward: Used in an article to name (forward) its associated retraction (rare)
+
+
+# https://data.crossref.org/schemas/common5.3.1.xsd
+
+# Attribute Values to <update type>
+# addendum
+# clarification
+# correction
+# corrigendum
+# erratum
+# expression_of_concern
+# new_edition
+# new_version
+# partial_retraction
+# removal
+# retraction
+# withdrawal

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2218,7 +2218,9 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+        data = {}
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -2264,7 +2266,9 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+        data = {}
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -2321,7 +2325,14 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+        data = {
+                    "related-articles": [
+                        {"related-article-type": "letter", "href": "10.1590/YYYY-YYYYY.YYYYYY", "date": "1900-01-01"},
+                        {"related-article-type": "retracted-article", "href": "10.1590/XXXX-XXXX.XXXXXX", "date": "1900-01-01"},
+                    ]
+                }
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2274,7 +2274,7 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
-    def test_xml_crossref_crossmark_updates_correction_exists_updates_pipe(self):
+    def test_xml_crossref_crossmark_updates_correction_with_complementary_data_pipe(self):
         xml_tree = ET.fromstring(
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1" '
@@ -2299,11 +2299,7 @@ class PipelineCrossref(TestCase):
             '<body>'
             '<journal>'
             '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
-            '<crossmark>'
-            '<updates>'
-            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
-            '</updates>'
-            '</crossmark>'
+            '<crossmark/>'
             '</journal_article>'
             '</journal>'
             '</body>'
@@ -2316,8 +2312,9 @@ class PipelineCrossref(TestCase):
             '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
             '<crossmark>'
             '<updates>'
-            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
-            '<update type="correction" label="Correction">10.1590/1519-6984.263364</update>'
+            '<update type="correction">10.1590/1519-6984.263364</update>'
+            '<update type="addendum" date="1900-01-01">10.1590/YYYY-YYYYY.YYYYYY</update>'
+            '<update type="retraction" date="1900-01-01">10.1590/XXXX-XXXX.XXXXXX</update>'
             '</updates>'
             '</crossmark>'
             '</journal_article>'
@@ -2376,7 +2373,7 @@ class PipelineCrossref(TestCase):
             '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
             '<crossmark>'
             '<updates>'
-            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
+            '<update type="correction">10.1590/1519-6984.ER263364</update>'
             '</updates>'
             '</crossmark>'
             '</journal_article>'
@@ -2384,7 +2381,13 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+        data = {}
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2455,6 +2455,54 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_custom_metadata_without_history_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">8sdNTpgmHMDpVKXZ4b4tn8G</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100401</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbAO263364_EN</article-id>'
+            '<article-id pub-id-type="other">00401</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.263364</article-id>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {}
+
+        crossref.xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, xml_tree, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
     def test_xml_pipe_line_crossref(self):
         xmltree = xml_utils.get_xml_tree('tests/samples/scielo_format_example.xml')
         data = {

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2224,6 +2224,52 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_updates_article_without_related_article_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" '
+            'specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">5chbLYfpJfJVdGRbTD6krTQ</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100903</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbER263364</article-id>'
+            '<article-id pub-id-type="other">00903</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.ER263364</article-id>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
     def test_xml_crossref_crossmark_updates_correction_exists_updates_pipe(self):
         xml_tree = ET.fromstring(
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2389,6 +2389,50 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_updates_research_article_without_updates_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" '
+            'specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">5chbLYfpJfJVdGRbTD6krTQ</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100903</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbER263364</article-id>'
+            '<article-id pub-id-type="other">00903</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.ER263364</article-id>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {}
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree, data)
+
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
         self.assertIn(expected, obtained)

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2100,6 +2100,34 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_pipe(self):
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any" />'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        xml_crossref_crossmark_pipe(xml_crossref)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
     def test_xml_pipe_line_crossref(self):
         xmltree = xml_utils.get_xml_tree('tests/samples/scielo_format_example.xml')
         data = {

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2334,6 +2334,34 @@ class PipelineCrossref(TestCase):
         self.assertIn(expected, obtained)
 
     def test_xml_crossref_crossmark_custom_metadata_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">8sdNTpgmHMDpVKXZ4b4tn8G</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100401</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbAO263364_EN</article-id>'
+            '<article-id pub-id-type="other">00401</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.263364</article-id>'
+            '<history>'
+            '<date date-type="received">'
+            '<day>23</day>'
+            '<month>04</month>'
+            '<year>2022</year>'
+            '</date>'
+            '<date date-type="accepted">'
+            '<day>17</day>'
+            '<month>08</month>'
+            '<year>2022</year>'
+            '</date>'
+            '</history>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
         xml_crossref = ET.fromstring(
             '<doi_batch>'
             '<head/>'
@@ -2353,6 +2381,8 @@ class PipelineCrossref(TestCase):
             '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
             '<crossmark>'
             '<custom_metadata>'
+            '<assertion name="received" label="Received" group_name="publication_history" group_label="Publication History" order="0">2022-04-23</assertion>'
+            '<assertion name="accepted" label="Accepted" group_name="publication_history" group_label="Publication History" order="1">2022-08-17</assertion>'
             '<assertion name="remorse" label="Level of Remorse" group_name="publication_notes" group_label="Publication Notes">90%</assertion>'
             '</custom_metadata>'
             '</crossmark>'
@@ -2373,7 +2403,7 @@ class PipelineCrossref(TestCase):
             ]
         }
 
-        crossref.xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, data)
+        crossref.xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, xml_tree, data)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2167,6 +2167,48 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_updates_pipe(self):
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<updates>'
+            '<update type="retraction" label="Retraction" date="2009-09-14">10.5555/12345678</update>'
+            '<update type="clarification" label="Clarification" date="2012-12-29">10.5555/666655554444</update>'
+            '</updates>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {
+            "updates": [
+                {"type": "retraction", "label": "Retraction", "date": "2009-09-14", "text": "10.5555/12345678"},
+                {"type": "clarification", "label": "Clarification", "date": "2012-12-29", "text": "10.5555/666655554444"}
+            ]
+        }
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2172,7 +2172,58 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
-    def test_xml_crossref_crossmark_updates_pipe(self):
+    def test_xml_crossref_crossmark_updates_correction_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1" '
+            'specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">5chbLYfpJfJVdGRbTD6krTQ</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100903</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbER263364</article-id>'
+            '<article-id pub-id-type="other">00903</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.ER263364</article-id>'
+            '<related-article ext-link-type="doi" id="ra1" journal-id="Brazilian Journal of Biology" page="1" '
+            'related-article-type="corrected-article" vol="82" xlink:href="10.1590/1519-6984.263364"/> '
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<updates>'
+            '<update type="correction" label="Correction">10.1590/1519-6984.263364</update>'
+            '</updates>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
         xml_crossref = ET.fromstring(
             '<doi_batch>'
             '<head/>'

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2224,6 +2224,63 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_updates_correction_exists_updates_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1" '
+            'specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">5chbLYfpJfJVdGRbTD6krTQ</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100903</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbER263364</article-id>'
+            '<article-id pub-id-type="other">00903</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.ER263364</article-id>'
+            '<related-article ext-link-type="doi" id="ra1" journal-id="Brazilian Journal of Biology" page="1" '
+            'related-article-type="corrected-article" vol="82" xlink:href="10.1590/1519-6984.263364"/> '
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<updates>'
+            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
+            '</updates>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<updates>'
+            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
+            '<update type="correction" label="Correction">10.1590/1519-6984.263364</update>'
+            '</updates>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
         xml_crossref = ET.fromstring(
             '<doi_batch>'
             '<head/>'

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -4,41 +4,7 @@ from unittest.mock import patch
 from lxml import etree as ET
 
 from packtools.sps.utils import xml_utils
-from packtools.sps.formats.crossref import (
-    pipeline_crossref,
-    setupdoibatch_pipe,
-    xml_crossref_head_pipe,
-    xml_crossref_doibatchid_pipe,
-    xml_crossref_timestamp_pipe,
-    xml_crossref_depositor_pipe,
-    xml_crossref_registrant_pipe,
-    xml_crossref_body_pipe,
-    xml_crossref_journal_pipe,
-    xml_crossref_journalmetadata_pipe,
-    xml_crossref_journaltitle_pipe,
-    xml_crossref_abbreviatedjournaltitle_pipe,
-    xml_crossref_issn_pipe,
-    xml_crossref_journalissue_pipe,
-    xml_crossref_pubdate_pipe,
-    xml_crossref_journalvolume_pipe,
-    xml_crossref_volume_pipe,
-    xml_crossref_issue_pipe,
-    xml_crossref_journalarticle_pipe,
-    xml_crossref_articlecontributors_pipe,
-    xml_crossref_articleabstract_pipe,
-    xml_crossref_articlepubdate_pipe,
-    xml_crossref_pages_pipe,
-    xml_crossref_pid_pipe,
-    xml_crossref_elocation_pipe,
-    xml_crossref_permissions_pipe,
-    xml_crossref_articletitles_pipe,
-    xml_crossref_programrelateditem_pipe,
-    xml_crossref_doidata_pipe,
-    xml_crossref_doi_pipe,
-    xml_crossref_resource_pipe,
-    xml_crossref_collection_pipe,
-    xml_crossref_articlecitations_pipe,
-)
+from packtools.sps.formats.crossref import *
 
 
 class PipelineCrossref(TestCase):

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2125,6 +2125,48 @@ class PipelineCrossref(TestCase):
         }
 
         xml_crossref_crossmark_policy_pipe(xml_crossref, data)
+    def test_xml_crossref_crossmark_domains_pipe(self):
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<crossmark_domains>'
+            '<crossmark_domain>'
+            '<domain>psychoceramics.labs.crossref.org</domain>'
+            '</crossmark_domain>'
+            '</crossmark_domains>'
+            '<crossmark_domain_exclusive>false</crossmark_domain_exclusive>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {
+            "crossmark_domains": ["psychoceramics.labs.crossref.org"],
+            "crossmark_domain_exclusive": "false"
+        }
+
+        crossref.xml_crossref_crossmark_domains_pipe(xml_crossref, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2226,10 +2226,10 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
-    def test_xml_crossref_crossmark_updates_article_without_related_article_pipe(self):
+    def test_xml_crossref_crossmark_updates_correction_without_updates_pipe(self):
         xml_tree = ET.fromstring(
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1" '
             'specific-use="sps-1.9" xml:lang="en">'
             '<front>'
             '<article-meta>'
@@ -2248,7 +2248,7 @@ class PipelineCrossref(TestCase):
             '<head/>'
             '<body>'
             '<journal>'
-            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
             '<crossmark/>'
             '</journal_article>'
             '</journal>'
@@ -2259,7 +2259,7 @@ class PipelineCrossref(TestCase):
         expected = (
             '<body>'
             '<journal>'
-            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
             '<crossmark/>'
             '</journal_article>'
             '</journal>'

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2209,6 +2209,47 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_custom_metadata_pipe(self):
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<custom_metadata>'
+            '<assertion name="remorse" label="Level of Remorse" group_name="publication_notes" group_label="Publication Notes">90%</assertion>'
+            '</custom_metadata>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {
+            "assertions": [
+                {
+                    "name": "remorse",
+                    "label": "Level of Remorse",
+                    "group_name": "publication_notes",
+                    "group_label": "Publication Notes",
+                    "text": "90%"
+                }
+            ]
+        }
+
+        crossref.xml_crossref_crossmark_custom_metadata_pipe(xml_crossref, data)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2094,6 +2094,42 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_policy_pipe(self):
+        xml_crossref = ET.fromstring(
+            '<doi_batch>'
+            '<head/>'
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark/>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+            '</doi_batch>'
+        )
+
+        expected = (
+            '<body>'
+            '<journal>'
+            '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
+            '<crossmark>'
+            '<crossmark_policy>10.5555/crossmark_policy</crossmark_policy>'
+            '</crossmark>'
+            '</journal_article>'
+            '</journal>'
+            '</body>'
+        )
+
+        data = {
+            "crossmark_policy": "10.5555/crossmark_policy"
+        }
+
+        xml_crossref_crossmark_policy_pipe(xml_crossref, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
     def test_xml_pipe_line_crossref(self):
         xmltree = xml_utils.get_xml_tree('tests/samples/scielo_format_example.xml')
         data = {

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2281,6 +2281,25 @@ class PipelineCrossref(TestCase):
 
         self.assertIn(expected, obtained)
 
+    def test_xml_crossref_crossmark_updates_research_article_pipe(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<article-id specific-use="scielo-v3" pub-id-type="publisher-id">8sdNTpgmHMDpVKXZ4b4tn8G</article-id>'
+            '<article-id specific-use="scielo-v2" pub-id-type="publisher-id">S1519-69842024000100401</article-id>'
+            '<article-id pub-id-type="publisher-id">bjbAO263364_EN</article-id>'
+            '<article-id pub-id-type="other">00401</article-id>'
+            '<article-id pub-id-type="doi">10.1590/1519-6984.263364</article-id>'
+            '<related-article ext-link-type="doi" id="ra1" '
+            'related-article-type="corrected-article" xlink:href="10.1590/1519-6984.ER263364"/> '
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
         xml_crossref = ET.fromstring(
             '<doi_batch>'
             '<head/>'
@@ -2300,8 +2319,7 @@ class PipelineCrossref(TestCase):
             '<journal_article language="en" publication_type="research-article" reference_distribution_opts="any">'
             '<crossmark>'
             '<updates>'
-            '<update type="retraction" label="Retraction" date="2009-09-14">10.5555/12345678</update>'
-            '<update type="clarification" label="Clarification" date="2012-12-29">10.5555/666655554444</update>'
+            '<update type="research-article" label="Research-article">10.1590/1519-6984.ER263364</update>'
             '</updates>'
             '</crossmark>'
             '</journal_article>'
@@ -2309,14 +2327,7 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        data = {
-            "updates": [
-                {"type": "retraction", "label": "Retraction", "date": "2009-09-14", "text": "10.5555/12345678"},
-                {"type": "clarification", "label": "Clarification", "date": "2012-12-29", "text": "10.5555/666655554444"}
-            ]
-        }
-
-        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, data)
+        crossref.xml_crossref_crossmark_updates_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from lxml import etree as ET
 
 from packtools.sps.utils import xml_utils
-from packtools.sps.formats.crossref import *
+from packtools.sps.formats import crossref
 
 
 class PipelineCrossref(TestCase):
@@ -19,7 +19,7 @@ class PipelineCrossref(TestCase):
             'http://www.crossref.org/schemas/crossref4.4.0.xsd"/>'
         )
 
-        result = setupdoibatch_pipe()
+        result = crossref.setupdoibatch_pipe()
         obtained = ET.tostring(result, encoding="utf-8").decode("utf-8")
 
         self.assertEqual(expected, obtained)
@@ -37,7 +37,7 @@ class PipelineCrossref(TestCase):
             """
         )
 
-        xml_crossref_head_pipe(xml_crossref)
+        crossref.xml_crossref_head_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('head'))
 
@@ -58,7 +58,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_doibatchid_pipe(xml_crossref)
+        crossref.xml_crossref_doibatchid_pipe(xml_crossref)
 
         self.obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -79,7 +79,7 @@ class PipelineCrossref(TestCase):
             '</head>'
             '</doi_batch>'
         )
-        xml_crossref_timestamp_pipe(xml_crossref)
+        crossref.xml_crossref_timestamp_pipe(xml_crossref)
 
         self.obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -107,7 +107,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_depositor_pipe(xml_crossref, data)
+        crossref.xml_crossref_depositor_pipe(xml_crossref, data)
 
         self.obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -130,15 +130,15 @@ class PipelineCrossref(TestCase):
             '</head>'
             '</doi_batch>'
         )
-        xml_crossref_registrant_pipe(xml_crossref, data)
+        crossref.xml_crossref_registrant_pipe(xml_crossref, data)
 
         self.obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
         self.assertIn(expected, self.obtained)
 
     def test_xml_body_pipe(self):
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('body'))
 
@@ -151,7 +151,7 @@ class PipelineCrossref(TestCase):
             '</body>'
             '</doi_batch>'
         )
-        xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('./body/journal'))
 
@@ -167,7 +167,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_journalmetadata_pipe(xml_crossref)
+        crossref.xml_crossref_journalmetadata_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('./body/journal/journal_metadata'))
 
@@ -208,7 +208,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_journaltitle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_journaltitle_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -249,7 +249,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_abbreviatedjournaltitle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_abbreviatedjournaltitle_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -290,7 +290,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_issn_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_issn_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -306,7 +306,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_journalissue_pipe(xml_crossref)
+        crossref.xml_crossref_journalissue_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('./body/journal/journal_issue'))
 
@@ -352,7 +352,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_pubdate_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_pubdate_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -370,7 +370,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_journalvolume_pipe(xml_crossref)
+        crossref.xml_crossref_journalvolume_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('./body/journal/journal_issue/journal_volume'))
 
@@ -418,7 +418,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_volume_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_volume_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -469,7 +469,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_issue_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_issue_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -509,7 +509,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -617,7 +617,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -750,7 +750,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -892,7 +892,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1136,7 +1136,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1245,12 +1245,12 @@ class PipelineCrossref(TestCase):
         #     '</body>'
         #     '</doi_batch>'
         # )
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_articleabstract_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articleabstract_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1312,12 +1312,12 @@ class PipelineCrossref(TestCase):
         #     '</doi_batch>'
         # )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_articlepubdate_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlepubdate_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1367,7 +1367,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_pages_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_pages_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1415,7 +1415,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_pid_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_pid_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1473,7 +1473,7 @@ class PipelineCrossref(TestCase):
             '</doi_batch>'
         )
 
-        xml_crossref_elocation_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_elocation_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1548,12 +1548,12 @@ class PipelineCrossref(TestCase):
         #     '</doi_batch>'
         # )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_permissions_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_permissions_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1622,12 +1622,12 @@ class PipelineCrossref(TestCase):
         #     '</doi_batch>'
         # )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_articletitles_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articletitles_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1686,12 +1686,12 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_programrelateditem_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_programrelateditem_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1728,12 +1728,12 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_doidata_pipe(xml_crossref)
+        crossref.xml_crossref_doidata_pipe(xml_crossref)
 
         self.assertIsNotNone(xml_crossref.find('.//doi_data'))
 
@@ -1783,13 +1783,13 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
-        xml_crossref_doidata_pipe(xml_crossref)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_doidata_pipe(xml_crossref)
 
-        xml_crossref_doi_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_doi_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1833,13 +1833,13 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
-        xml_crossref_doidata_pipe(xml_crossref)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_doidata_pipe(xml_crossref)
 
-        xml_crossref_resource_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_resource_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -1891,13 +1891,13 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
-        xml_crossref_doidata_pipe(xml_crossref)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_doidata_pipe(xml_crossref)
 
-        xml_crossref_collection_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_collection_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -2055,12 +2055,12 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref = setupdoibatch_pipe()
-        xml_crossref_body_pipe(xml_crossref)
-        xml_crossref_journal_pipe(xml_crossref)
-        xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
+        xml_crossref = crossref.setupdoibatch_pipe()
+        crossref.xml_crossref_body_pipe(xml_crossref)
+        crossref.xml_crossref_journal_pipe(xml_crossref)
+        crossref.xml_crossref_journalarticle_pipe(xml_crossref, xml_tree)
 
-        xml_crossref_articlecitations_pipe(xml_crossref, xml_tree)
+        crossref.xml_crossref_articlecitations_pipe(xml_crossref, xml_tree)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -2088,7 +2088,7 @@ class PipelineCrossref(TestCase):
             '</body>'
         )
 
-        xml_crossref_crossmark_pipe(xml_crossref)
+        crossref.xml_crossref_crossmark_pipe(xml_crossref)
 
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
@@ -2124,7 +2124,12 @@ class PipelineCrossref(TestCase):
             "crossmark_policy": "10.5555/crossmark_policy"
         }
 
-        xml_crossref_crossmark_policy_pipe(xml_crossref, data)
+        crossref.xml_crossref_crossmark_policy_pipe(xml_crossref, data)
+
+        obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
+
+        self.assertIn(expected, obtained)
+
     def test_xml_crossref_crossmark_domains_pipe(self):
         xml_crossref = ET.fromstring(
             '<doi_batch>'
@@ -2262,7 +2267,7 @@ class PipelineCrossref(TestCase):
             "depositor_email_address": "name@domain.com",
             "registrant": "registrant"
         }
-        xml_crossref = pipeline_crossref(xmltree, data)
+        xml_crossref = crossref.pipeline_crossref(xmltree, data)
         obtained = ET.tostring(xml_crossref, encoding="utf-8").decode("utf-8")
 
         xml_crossref_expected = xml_utils.get_xml_tree('tests/samples/crossref_format_example.xml')

--- a/tests/sps/formats/test_crossref.py
+++ b/tests/sps/formats/test_crossref.py
@@ -2210,7 +2210,7 @@ class PipelineCrossref(TestCase):
             '<journal_article language="en" publication_type="correction" reference_distribution_opts="any">'
             '<crossmark>'
             '<updates>'
-            '<update type="correction" label="Correction">10.1590/1519-6984.263364</update>'
+            '<update type="correction">10.1590/1519-6984.263364</update>'
             '</updates>'
             '</crossmark>'
             '</journal_article>'


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a tag `<crossmark>` ao procedimento de conversão de um `XML JATS` para o formato `XML CrossRef`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
A partir da avaliação dos testes, que podem ser executados com o seguinte comando:
`python3 -m unittest -v tests/sps/formats/test_crossref.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA. 

#### Quais são tickets relevantes?
NA.

### Referências
[https://www.crossref.org/documentation/crossmark/](https://www.crossref.org/documentation/crossmark/)

