### PR TITLE
Corrige o método `Authors.contribs_with_affs` para evitar exceção `KeyError: 'aff_rids'`

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -61,7 +61,7 @@ class Authors:
             except KeyError:
                 pass
 
-            _author["contrib-type"] = node.attrib["contrib-type"]
+            _author["contrib-type"] = node.attrib.get("contrib-type") or 'author'
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -18,15 +18,11 @@ class Authors:
         for node in self.xmltree.xpath(".//front//contrib"):
             _author = {}
             for tag in ("surname", "prefix", "suffix"):
-                xpath = f".//{tag}"
-                try:
-                    _author[tag] = node.xpath(xpath)[0].text
-                except IndexError:
-                    pass
-            try:
-                _author["given_names"] = node.xpath(".//given-names")[0].text
-            except IndexError:
-                pass
+                data = node.findtext(f".//{tag}")
+                if data:
+                    _author[tag] = data
+            _author["given_names"] = node.findtext(".//given-names")
+
             try:
                 _author["orcid"] = node.xpath("contrib-id[@contrib-id-type='orcid']")[
                     0
@@ -34,13 +30,13 @@ class Authors:
             except IndexError:
                 pass
 
-            if node.xpath(".//role"):
-                _author["role"] = []
-
+            _author["role"] = []
             for role in node.xpath(".//role"):
-                _role = role.text
-                _content_type = role.get("content-type")
-                _author["role"].append({"text": _role, "content-type": _content_type})
+                _author["role"].append({
+                    "text": role.text,
+                    "content-type": role.get("content-type")})
+            if not _author["role"]:
+                _author.pop("role")
 
             for xref in node.findall('.//xref'):
                 rid = xref.get("rid")
@@ -56,15 +52,8 @@ class Authors:
                 _author.setdefault("rid-aff", [])
                 _author["rid-aff"].append(rid)
 
-            try:
-                _author["aff_rids"] = _author["rid-aff"]
-            except KeyError:
-                pass
-
-            if node.attrib.get("contrib-type"):
-                # criar contrib-type somente se existir e
-                # não atribuir valor default para que a validação seja fiel
-                _author["contrib-type"] = node.attrib.get("contrib-type")
+            _author["aff_rids"] = _author.get("rid-aff")
+            _author["contrib-type"] = node.attrib.get("contrib-type")
             _data.append(_author)
         return _data
 

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -74,7 +74,7 @@ class Authors:
         affs_by_id = affs.affiliation_by_id
 
         for item in self.contribs:
-            for rid in item["aff_rids"]:
+            for rid in item.get("aff_rids") or []:
                 item.setdefault("affs", [])
                 item["affs"].append(affs_by_id.get(rid))
             yield item


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o método `Authors.contribs_with_affs` para evitar exceção `KeyError: 'aff_rids'`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instancie a classe usando um XML sem `xref`, por exemplo:

```xml
<contrib xmlns:xlink="http://www.w3.org/1999/xlink" contrib-type="author">
<name>
<surname>Portela-Lindoso</surname>
<given-names>Ana Ang&#233;lica Bulc&#227;o</given-names>
</name>
</contrib>
```
e use o método `contribs_with_affs`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
```
[2023-09-22 11:43:44,668: ERROR/ForkPoolWorker-4] Task publication.tasks.task_publish_article[fc96120e-4419-46ee-91ad-5e4b795790de] raised unexpected: KeyError('aff_rids')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/publication/tasks.py", line 203, in task_publish_article
    publish_article(user, website, scielo_article)
  File "/app/publication/db/document.py", line 41, in publish_article
    publication.publish(
  File "/app/publication/db/document.py", line 105, in publish
    for item in article_getter.get_authors():
  File "/app/publication/utils/document.py", line 40, in get_authors
    for item in Authors(self.xmltree).contribs_with_affs:
  File "/usr/local/lib/python3.9/site-packages/packtools/sps/models/article_authors.py", line 77, in contribs_with_affs
    for rid in item["aff_rids"]:
KeyError: 'aff_rids'
```

#### Quais são tickets relevantes?
n/a

### Referências
n/a
