### PR TITLE
Validate xref

### DIFF
--- a/packtools/sps/models/article_and_subarticles.py
+++ b/packtools/sps/models/article_and_subarticles.py
@@ -18,10 +18,21 @@ class ArticleAndSubArticles:
     def data(self):
         _data = []
         if self.main_article_type:
-            _data.append({"lang": self.main_lang, "article_type": self.main_article_type, "line_number": self.main_line_number})
+            _data.append({
+                "lang": self.main_lang,
+                "article_type": self.main_article_type,
+                "article_id": "main",
+                "line_number": self.main_line_number
+            })
 
         for sub_article in self.xmltree.xpath(".//sub-article"):
             lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
             article_type = sub_article.get('article-type')
-            _data.append({"lang": lang, "article_type": article_type, "line_number": sub_article.sourceline})
+            article_id = sub_article.get('id')
+            _data.append({
+                "lang": lang,
+                "article_type": article_type,
+                "article_id": article_id,
+                "line_number": sub_article.sourceline
+            })
         return _data

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -26,8 +26,8 @@ class ArticleXrefValidation:
             'xpath': './/xref[@rid]',
             'validation_type': 'match',
             'response': 'OK',
-            'expected_value': True,
-            'got_value': True,
+            'expected_value': aff1,
+            'got_value': aff1,
             'message': 'Got True, expected True',
             'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
             },
@@ -36,8 +36,8 @@ class ArticleXrefValidation:
             'xpath': './/xref[@rid]',
             'validation_type': 'match',
             'response': 'OK',
-            'expected_value': True,
-            'got_value': True,
+            'expected_value': fig1,
+            'got_value': fig1,
             'message': 'Got True, expected True',
             'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
             },
@@ -46,8 +46,8 @@ class ArticleXrefValidation:
             'xpath': './/xref[@rid]',
             'validation_type': 'match',
             'response': 'ERROR',
-            'expected_value': True,
-            'got_value': False,
+            'expected_value': table1,
+            'got_value': None,
             'message': 'Got False, expected True',
             'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
             }
@@ -89,8 +89,8 @@ class ArticleXrefValidation:
             'xpath': './/*[@id]',
             'validation_type': 'match',
             'response': 'OK',
-            'expected_value': True,
-            'got_value': True,
+            'expected_value': aff1,
+            'got_value': aff1,
             'message': 'Got True, expected True',
             'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
             },
@@ -99,8 +99,8 @@ class ArticleXrefValidation:
             'xpath': './/*[@id]',
             'validation_type': 'match',
             'response': 'OK',
-            'expected_value': True,
-            'got_value': True,
+            'expected_value': fig1,
+            'got_value': fig1,
             'message': 'Got True, expected True',
             'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
             },
@@ -109,8 +109,8 @@ class ArticleXrefValidation:
             'xpath': './/*[@id]',
             'validation_type': 'match',
             'response': 'ERROR',
-            'expected_value': True,
-            'got_value': False,
+            'expected_value': table1,
+            'got_value': None,
             'message': 'Got False, expected True',
             'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
             }

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -20,45 +20,42 @@ class ArticleXrefValidation:
         --------
         >>> validate_rid()
 
-        {
-            'validation':
-                [
-                    {
-                    'title': 'xref element rid attribute validation',
-                    'xpath': './/xref[@rid]',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': True,
-                    'got_value': True,
-                    'message': 'Got True, expected True',
-                    'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
-                    },
-                    {
-                    'title': 'xref element rid attribute validation',
-                    'xpath': './/xref[@rid]',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': True,
-                    'got_value': True,
-                    'message': 'Got True, expected True',
-                    'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
-                    },
-                    {
-                    'title': 'xref element rid attribute validation',
-                    'xpath': './/xref[@rid]',
-                    'validation_type': 'match',
-                    'response': 'ERROR',
-                    'expected_value': True,
-                    'got_value': False,
-                    'message': 'Got False, expected True',
-                    'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
-                    }
-                ]
-        }
+        [
+            {
+            'title': 'xref element rid attribute validation',
+            'xpath': './/xref[@rid]',
+            'validation_type': 'match',
+            'response': 'OK',
+            'expected_value': True,
+            'got_value': True,
+            'message': 'Got True, expected True',
+            'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
+            },
+            {
+            'title': 'xref element rid attribute validation',
+            'xpath': './/xref[@rid]',
+            'validation_type': 'match',
+            'response': 'OK',
+            'expected_value': True,
+            'got_value': True,
+            'message': 'Got True, expected True',
+            'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
+            },
+            {
+            'title': 'xref element rid attribute validation',
+            'xpath': './/xref[@rid]',
+            'validation_type': 'match',
+            'response': 'ERROR',
+            'expected_value': True,
+            'got_value': False,
+            'message': 'Got False, expected True',
+            'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
+            }
+        ]
+
         """
         rids = sorted(self.article_xref.all_xref_rids)
         ids = sorted(self.article_xref.all_ids)
-        resp = {'validation': []}
         for rid in rids:
             item = {
                 'title': _('xref element rid attribute validation'),
@@ -67,12 +64,11 @@ class ArticleXrefValidation:
             }
             validated = rid in ids
             item['response'] = 'OK' if validated else 'ERROR'
-            item['expected_value'] = True
-            item['got_value'] = validated
-            item['message'] = _('Got {}, expected True').format(validated)
+            item['expected_value'] = rid
+            item['got_value'] = rid if validated else None
+            item['message'] = _('Got {}, expected {}').format(item['got_value'], rid)
             item['advice'] = 'For each xref[@rid="{}"] must have one corresponding element which @id="{}"'.format(rid, rid)
-            resp['validation'].append(item)
-        return resp
+            yield item
 
     def validate_id(self):
         """
@@ -87,59 +83,54 @@ class ArticleXrefValidation:
         --------
         >>> validate_id()
 
-        {
-            'validation':
-                [
-                    {
-                    'title': 'xref element id attribute validation',
-                    'xpath': './/*[@id]',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': True,
-                    'got_value': True,
-                    'message': 'Got True, expected True',
-                    'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
-                    },
-                    {
-                    'title': 'xref element id attribute validation',
-                    'xpath': './/*[@id]',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': True,
-                    'got_value': True,
-                    'message': 'Got True, expected True',
-                    'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
-                    },
-                    {
-                    'title': 'xref element id attribute validation',
-                    'xpath': './/*[@id]',
-                    'validation_type': 'match',
-                    'response': 'ERROR',
-                    'expected_value': True,
-                    'got_value': False,
-                    'message': 'Got False, expected True',
-                    'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
-                    }
-                ]
-        }
+       [
+            {
+            'title': 'xref element id attribute validation',
+            'xpath': './/*[@id]',
+            'validation_type': 'match',
+            'response': 'OK',
+            'expected_value': True,
+            'got_value': True,
+            'message': 'Got True, expected True',
+            'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
+            },
+            {
+            'title': 'xref element id attribute validation',
+            'xpath': './/*[@id]',
+            'validation_type': 'match',
+            'response': 'OK',
+            'expected_value': True,
+            'got_value': True,
+            'message': 'Got True, expected True',
+            'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
+            },
+            {
+            'title': 'xref element id attribute validation',
+            'xpath': './/*[@id]',
+            'validation_type': 'match',
+            'response': 'ERROR',
+            'expected_value': True,
+            'got_value': False,
+            'message': 'Got False, expected True',
+            'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
+            }
+        ]
         """
         rids = sorted(self.article_xref.all_xref_rids)
         ids = sorted(self.article_xref.all_ids)
-        resp = {'validation': []}
         for id in ids:
             item = {
-                'title': _('xref element id attribute validation'),
+                'title': _('* element id attribute validation'),
                 'xpath': _('.//*[@id]'),
                 'validation_type': _('match')
             }
             validated = id in rids
             item['response'] = 'OK' if validated else 'ERROR'
-            item['expected_value'] = True
-            item['got_value'] = validated
-            item['message'] = _('Got {}, expected True').format(validated)
+            item['expected_value'] = id
+            item['got_value'] = id if validated else None
+            item['message'] = _('Got {}, expected {}').format(item['got_value'], id)
             item['advice'] = 'For each @id="{}" must have one corresponding element which xref[@rid="{}"]'.format(id, id)
-            resp['validation'].append(item)
-        return resp
+            yield item
 
     def validate(self, data):
         """

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -28,50 +28,50 @@ class ArticleXrefValidation:
                     'xpath': './/xref[@rid]',
                     'validation_type': 'match',
                     'response': 'OK',
-                    'expected_value': 'aff1',
-                    'got_value': 'aff1',
-                    'message': 'rid have the respective id',
-                    'advice': None
+                    'expected_value': True,
+                    'got_value': True,
+                    'message': 'Got True, expected True',
+                    'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
                     },
                     {
                     'title': 'xref element rid attribute validation',
                     'xpath': './/xref[@rid]',
                     'validation_type': 'match',
                     'response': 'OK',
-                    'expected_value': 'fig1',
-                    'got_value': 'fig1',
-                    'message': 'rid have the respective id',
-                    'advice': None
+                    'expected_value': True,
+                    'got_value': True,
+                    'message': 'Got True, expected True',
+                    'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
                     },
                     {
                     'title': 'xref element rid attribute validation',
                     'xpath': './/xref[@rid]',
                     'validation_type': 'match',
                     'response': 'ERROR',
-                    'expected_value': 'table1',
-                    'got_value': None,
-                    'message': 'rid does not have the respective id',
-                    'advice': 'add attribute id = table1 to the corresponding rid = table1'
+                    'expected_value': True,
+                    'got_value': False,
+                    'message': 'Got False, expected True',
+                    'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
                     }
                 ]
         }
         """
         rids = sorted(self.article_xref.all_xref_rids)
         ids = sorted(self.article_xref.all_ids)
-        resp = {_('validation'): []}
+        resp = {'validation': []}
         for rid in rids:
             item = {
-                _('title'): _('xref element rid attribute validation'),
-                _('xpath'): _('.//xref[@rid]'),
-                _('validation_type'): _('match'),
+                'title': _('xref element rid attribute validation'),
+                'xpath': _('.//xref[@rid]'),
+                'validation_type': _('match'),
             }
             validated = rid in ids
-            item[_('response')] = 'OK' if validated else 'ERROR'
-            item[_('expected_value')] = rid
-            item[_('got_value')] = rid if validated else None
-            item[_('message')] = _('rid have the respective id') if validated else _('rid does not have the respective id')
-            item[_('advice')] = None if validated else _(f'add attribute id = {rid} to the corresponding rid = {rid}')
-            resp[_('validation')].append(item)
+            item['response'] = 'OK' if validated else 'ERROR'
+            item['expected_value'] = True
+            item['got_value'] = validated
+            item['message'] = _('Got {}, expected True').format(validated)
+            item['advice'] = 'For each xref[@rid="{}"] must have one corresponding element which @id="{}"'.format(rid, rid)
+            resp['validation'].append(item)
         return resp
 
     def validate_id(self):
@@ -95,30 +95,30 @@ class ArticleXrefValidation:
                     'xpath': './/*[@id]',
                     'validation_type': 'match',
                     'response': 'OK',
-                    'expected_value': 'aff1',
-                    'got_value': 'aff1',
-                    'message': 'id have the respective rid',
-                    'advice': None
+                    'expected_value': True,
+                    'got_value': True,
+                    'message': 'Got True, expected True',
+                    'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
                     },
                     {
                     'title': 'xref element id attribute validation',
                     'xpath': './/*[@id]',
                     'validation_type': 'match',
                     'response': 'OK',
-                    'expected_value': 'fig1',
-                    'got_value': 'fig1',
-                    'message': 'id have the respective rid',
-                    'advice': None
+                    'expected_value': True,
+                    'got_value': True,
+                    'message': 'Got True, expected True',
+                    'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
                     },
                     {
                     'title': 'xref element id attribute validation',
                     'xpath': './/*[@id]',
                     'validation_type': 'match',
                     'response': 'ERROR',
-                    'expected_value': 'table1',
-                    'got_value': None,
-                    'message': 'id does not have the respective rid',
-                    'advice': 'add attribute rid = table1 to the corresponding id = table1'
+                    'expected_value': True,
+                    'got_value': False,
+                    'message': 'Got False, expected True',
+                    'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
                     }
                 ]
         }
@@ -128,17 +128,17 @@ class ArticleXrefValidation:
         resp = {'validation': []}
         for id in ids:
             item = {
-                _('title'): _('xref element id attribute validation'),
-                _('xpath'): _('.//*[@id]'),
-                _('validation_type'): _('match')
+                'title': _('xref element id attribute validation'),
+                'xpath': _('.//*[@id]'),
+                'validation_type': _('match')
             }
             validated = id in rids
-            item[_('response')] = 'OK' if validated else 'ERROR'
-            item[_('expected_value')] = id
-            item[_('got_value')] = id if validated else None
-            item[_('message')] = _('id have the respective rid') if validated else _('id does not have the respective rid')
-            item[_('advice')] = None if validated else _(f'add attribute rid = {id} to the corresponding id = {id}')
-            resp[_('validation')].append(item)
+            item['response'] = 'OK' if validated else 'ERROR'
+            item['expected_value'] = True
+            item['got_value'] = validated
+            item['message'] = _('Got {}, expected True').format(validated)
+            item['advice'] = 'For each @id="{}" must have one corresponding element which xref[@rid="{}"]'.format(id, id)
+            resp['validation'].append(item)
         return resp
 
     def validate(self, data):
@@ -150,10 +150,10 @@ class ArticleXrefValidation:
         
         """        
         xref_id_results = {
-            _('article_xref_id_validation'): self.validate_id()
+            'article_xref_id_validation': self.validate_id()
             }
         xref_rid_results = { 
-            _('article_xref_rid_validation'): self.validate_rid()
+            'article_xref_rid_validation': self.validate_rid()
             }
         
         xref_id_results.update(xref_rid_results)

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -28,7 +28,7 @@ class ArticleXrefValidation:
             'response': 'OK',
             'expected_value': aff1,
             'got_value': aff1,
-            'message': 'Got True, expected True',
+            'message': 'Got aff1, expected aff1',
             'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
             },
             {
@@ -38,7 +38,7 @@ class ArticleXrefValidation:
             'response': 'OK',
             'expected_value': fig1,
             'got_value': fig1,
-            'message': 'Got True, expected True',
+            'message': 'Got fig1, expected fig1',
             'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
             },
             {
@@ -48,7 +48,7 @@ class ArticleXrefValidation:
             'response': 'ERROR',
             'expected_value': table1,
             'got_value': None,
-            'message': 'Got False, expected True',
+            'message': 'Got None, expected table1',
             'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
             }
         ]
@@ -91,7 +91,7 @@ class ArticleXrefValidation:
             'response': 'OK',
             'expected_value': aff1,
             'got_value': aff1,
-            'message': 'Got True, expected True',
+            'message': 'Got aff1, expected aff1',
             'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
             },
             {
@@ -101,7 +101,7 @@ class ArticleXrefValidation:
             'response': 'OK',
             'expected_value': fig1,
             'got_value': fig1,
-            'message': 'Got True, expected True',
+            'message': 'Got fig1, expected fig1',
             'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
             },
             {
@@ -111,7 +111,7 @@ class ArticleXrefValidation:
             'response': 'ERROR',
             'expected_value': table1,
             'got_value': None,
-            'message': 'Got False, expected True',
+            'message': 'Got None, expected table1',
             'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
             }
         ]
@@ -120,7 +120,7 @@ class ArticleXrefValidation:
         ids = sorted(self.article_xref.all_ids)
         for id in ids:
             item = {
-                'title': _('* element id attribute validation'),
+                'title': _('element id attribute validation'),
                 'xpath': _('.//*[@id]'),
                 'validation_type': _('match')
             }

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -1,4 +1,5 @@
 from ..models.article_xref import ArticleXref
+from packtools.translator import _
 
 
 class ArticleXrefValidation:
@@ -23,46 +24,54 @@ class ArticleXrefValidation:
             'validation':
                 [
                     {
-                    'context': 'xref element rid attribute validation',
-                    'result': 'OK',
+                    'title': 'xref element rid attribute validation',
+                    'xpath': './/xref[@rid]',
+                    'validation_type': 'match',
+                    'response': 'OK',
                     'expected_value': 'aff1',
                     'got_value': 'aff1',
-                    'error_type': None,
-                    'message': 'rid have the respective id'
+                    'message': 'rid have the respective id',
+                    'advice': None
                     },
                     {
-                    'context': 'xref element rid attribute validation',
-                    'result': 'OK',
+                    'title': 'xref element rid attribute validation',
+                    'xpath': './/xref[@rid]',
+                    'validation_type': 'match',
+                    'response': 'OK',
                     'expected_value': 'fig1',
                     'got_value': 'fig1',
-                    'error_type': None,
-                    'message': 'rid have the respective id'
+                    'message': 'rid have the respective id',
+                    'advice': None
                     },
                     {
-                    'context': 'xref element rid attribute validation',
-                    'result': 'ERROR',
+                    'title': 'xref element rid attribute validation',
+                    'xpath': './/xref[@rid]',
+                    'validation_type': 'match',
+                    'response': 'ERROR',
                     'expected_value': 'table1',
                     'got_value': None,
-                    'error_type': 'no match',
-                    'message': 'rid does not have the respective id'
+                    'message': 'rid does not have the respective id',
+                    'advice': 'add attribute id = table1 to the corresponding rid = table1'
                     }
                 ]
         }
         """
         rids = sorted(self.article_xref.all_xref_rids)
         ids = sorted(self.article_xref.all_ids)
-        resp = {'validation': []}
+        resp = {_('validation'): []}
         for rid in rids:
             item = {
-                'context': 'xref element rid attribute validation'
+                _('title'): _('xref element rid attribute validation'),
+                _('xpath'): _('.//xref[@rid]'),
+                _('validation_type'): _('match'),
             }
             validated = rid in ids
-            item['result'] = 'OK' if validated else 'ERROR'
-            item['expected_value'] = rid
-            item['got_value'] = rid if validated else None
-            item['error_type'] = None if validated else 'no match'
-            item['message'] = 'rid have the respective id' if validated else 'rid does not have the respective id'
-            resp['validation'].append(item)
+            item[_('response')] = 'OK' if validated else 'ERROR'
+            item[_('expected_value')] = rid
+            item[_('got_value')] = rid if validated else None
+            item[_('message')] = _('rid have the respective id') if validated else _('rid does not have the respective id')
+            item[_('advice')] = None if validated else _(f'add attribute id = {rid} to the corresponding rid = {rid}')
+            resp[_('validation')].append(item)
         return resp
 
     def validate_id(self):
@@ -82,28 +91,34 @@ class ArticleXrefValidation:
             'validation':
                 [
                     {
-                    'context': 'xref element id attribute validation',
-                    'result': 'OK',
+                    'title': 'xref element id attribute validation',
+                    'xpath': './/*[@id]',
+                    'validation_type': 'match',
+                    'response': 'OK',
                     'expected_value': 'aff1',
                     'got_value': 'aff1',
-                    'error_type': None,
-                    'message': 'rid have the respective id'
+                    'message': 'id have the respective rid',
+                    'advice': None
                     },
                     {
-                    'context': 'xref element id attribute validation',
-                    'result': 'OK',
+                    'title': 'xref element id attribute validation',
+                    'xpath': './/*[@id]',
+                    'validation_type': 'match',
+                    'response': 'OK',
                     'expected_value': 'fig1',
                     'got_value': 'fig1',
-                    'error_type': None,
-                    'message': 'rid have the respective id'
+                    'message': 'id have the respective rid',
+                    'advice': None
                     },
                     {
-                    'context': 'xref element id attribute validation',
-                    'result': 'ERROR',
+                    'title': 'xref element id attribute validation',
+                    'xpath': './/*[@id]',
+                    'validation_type': 'match',
+                    'response': 'ERROR',
                     'expected_value': 'table1',
                     'got_value': None,
-                    'error_type': 'no match',
-                    'message': 'rid does not have the respective id'
+                    'message': 'id does not have the respective rid',
+                    'advice': 'add attribute rid = table1 to the corresponding id = table1'
                     }
                 ]
         }
@@ -113,24 +128,18 @@ class ArticleXrefValidation:
         resp = {'validation': []}
         for id in ids:
             item = {
-                'context': 'xref element id attribute validation'
+                _('title'): _('xref element id attribute validation'),
+                _('xpath'): _('.//*[@id]'),
+                _('validation_type'): _('match')
             }
             validated = id in rids
-            item['result'] = 'OK' if validated else 'ERROR'
-            item['expected_value'] = id
-            item['got_value'] = id if validated else None
-            item['error_type'] = None if validated else 'no match'
-            item['message'] = 'id have the respective rid' if validated else 'id does not have the respective rid'
-            resp['validation'].append(item)
+            item[_('response')] = 'OK' if validated else 'ERROR'
+            item[_('expected_value')] = id
+            item[_('got_value')] = id if validated else None
+            item[_('message')] = _('id have the respective rid') if validated else _('id does not have the respective rid')
+            item[_('advice')] = None if validated else _(f'add attribute rid = {id} to the corresponding id = {id}')
+            resp[_('validation')].append(item)
         return resp
-
-    @property
-    def ids_without_rids(self):
-        return self.article_xref.all_ids - self.article_xref.all_xref_rids
-
-    @property
-    def rids_without_ids(self):
-        return self.article_xref.all_xref_rids - self.article_xref.all_ids
 
     def validate(self, data):
         """
@@ -141,10 +150,10 @@ class ArticleXrefValidation:
         
         """        
         xref_id_results = {
-            'article_xref_id_validation': self.validate_id()
+            _('article_xref_id_validation'): self.validate_id()
             }
         xref_rid_results = { 
-            'article_xref_rid_validation': self.validate_rid()
+            _('article_xref_rid_validation'): self.validate_rid()
             }
         
         xref_id_results.update(xref_rid_results)

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -20,24 +20,49 @@ class ArticleXrefValidation:
         >>> validate_rid()
 
         {
-            'expected_value': ['aff1', 'fig1', 'table1'],
-            'obtained_value': ['aff1', 'fig1'],
-            'result': ['table1'],
-            'message': 'ERROR: the rids ['table1'] do not have the respective ids'
+            'validation':
+                [
+                    {
+                    'context': 'xref element rid attribute validation',
+                    'result': 'OK',
+                    'expected_value': 'aff1',
+                    'got_value': 'aff1',
+                    'error_type': None,
+                    'message': 'rid have the respective id'
+                    },
+                    {
+                    'context': 'xref element rid attribute validation',
+                    'result': 'OK',
+                    'expected_value': 'fig1',
+                    'got_value': 'fig1',
+                    'error_type': None,
+                    'message': 'rid have the respective id'
+                    },
+                    {
+                    'context': 'xref element rid attribute validation',
+                    'result': 'ERROR',
+                    'expected_value': 'table1',
+                    'got_value': None,
+                    'error_type': 'no match',
+                    'message': 'rid does not have the respective id'
+                    }
+                ]
         }
         """
-        diff = self.rids_without_ids
-        if diff == set():
-            message = "OK: all rids have the respective ids"
-        else:
-            message = f"ERROR: rids were found with the values {sorted(self.article_xref.all_xref_rids)}" \
-                  f" but there were no ids with the corresponding values"
-        resp = dict(
-            expected_value=sorted(self.article_xref.all_xref_rids),
-            obtained_value=sorted(self.article_xref.all_ids),
-            result=sorted(diff),
-            message=message
-        )
+        rids = sorted(self.article_xref.all_xref_rids)
+        ids = sorted(self.article_xref.all_ids)
+        resp = {'validation': []}
+        for rid in rids:
+            item = {
+                'context': 'xref element rid attribute validation'
+            }
+            validated = rid in ids
+            item['result'] = 'OK' if validated else 'ERROR'
+            item['expected_value'] = rid
+            item['got_value'] = rid if validated else None
+            item['error_type'] = None if validated else 'no match'
+            item['message'] = 'rid have the respective id' if validated else 'rid does not have the respective id'
+            resp['validation'].append(item)
         return resp
 
     def validate_id(self):
@@ -54,24 +79,49 @@ class ArticleXrefValidation:
         >>> validate_id()
 
         {
-            'obtained_value': ['aff1', 'fig1'],
-            'expected_value': ['aff1', 'fig1', 'table1'],
-            'diff': ['table1'],
-            'message': 'ERROR: the ids ['table1'] do not have the respective rids'
+            'validation':
+                [
+                    {
+                    'context': 'xref element id attribute validation',
+                    'result': 'OK',
+                    'expected_value': 'aff1',
+                    'got_value': 'aff1',
+                    'error_type': None,
+                    'message': 'rid have the respective id'
+                    },
+                    {
+                    'context': 'xref element id attribute validation',
+                    'result': 'OK',
+                    'expected_value': 'fig1',
+                    'got_value': 'fig1',
+                    'error_type': None,
+                    'message': 'rid have the respective id'
+                    },
+                    {
+                    'context': 'xref element id attribute validation',
+                    'result': 'ERROR',
+                    'expected_value': 'table1',
+                    'got_value': None,
+                    'error_type': 'no match',
+                    'message': 'rid does not have the respective id'
+                    }
+                ]
         }
         """
-        diff = self.ids_without_rids
-        if diff == set():
-            message = "OK: all ids have the respective rids"
-        else:
-            message = f"ERROR: ids were found with the values {sorted(self.article_xref.all_ids)}" \
-                  f" but there were no rids with the corresponding values"
-        resp = dict(
-            expected_value=sorted(self.article_xref.all_ids),
-            obtained_value=sorted(self.article_xref.all_xref_rids),
-            result=sorted(diff),
-            message=message
-        )
+        rids = sorted(self.article_xref.all_xref_rids)
+        ids = sorted(self.article_xref.all_ids)
+        resp = {'validation': []}
+        for id in ids:
+            item = {
+                'context': 'xref element id attribute validation'
+            }
+            validated = id in rids
+            item['result'] = 'OK' if validated else 'ERROR'
+            item['expected_value'] = id
+            item['got_value'] = id if validated else None
+            item['error_type'] = None if validated else 'no match'
+            item['message'] = 'id have the respective rid' if validated else 'id does not have the respective rid'
+            resp['validation'].append(item)
         return resp
 
     @property

--- a/packtools/translator.py
+++ b/packtools/translator.py
@@ -1,0 +1,5 @@
+def get_text(texto):
+    return texto
+
+
+_ = get_text

--- a/tests/sps/models/test_article_and_subarticles.py
+++ b/tests/sps/models/test_article_and_subarticles.py
@@ -44,3 +44,49 @@ class ArticleAndSubarticlesTest(TestCase):
         obtained = [d['article_type'] for d in ArticleAndSubArticles(xmltree).data]
 
         self.assertListEqual(expected, obtained)
+
+    def test_elements_order(self):
+        data = open('tests/samples/artigo-com-traducao-e-pareceres-traduzidos.xml').read()
+        xmltree = xml_utils.get_xml_tree(data)
+
+        expected = [
+            {
+                'article_id': 'main',
+                'article_type': 'research-article',
+                'lang': 'pt',
+                'line_number': 2
+            },
+            {
+                'article_id': 's2',
+                'article_type': 'reviewer-report',
+                'lang': 'pt',
+                'line_number': 93
+            },
+            {
+                'article_id': 's3',
+                'article_type': 'reviewer-report',
+                'lang': 'pt',
+                'line_number': 141
+            },
+            {
+                'article_id': 's1',
+                'article_type': 'translation',
+                'lang': 'en',
+                'line_number': 189
+            },
+            {
+                'article_id': 's5',
+                'article_type': 'reviewer-report',
+                'lang': 'en',
+                'line_number': 233
+            },
+            {
+                'article_id': 's6',
+                'article_type': 'reviewer-report',
+                'lang': 'en',
+                'line_number': 271
+            }
+        ]
+        obtained = [d for d in ArticleAndSubArticles(xmltree).data]
+
+        self.assertListEqual(expected, obtained)

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -1,11 +1,12 @@
 from unittest import TestCase
 
 from packtools.sps.utils.xml_utils import get_xml_tree
-from packtools.sps.validation.article_and_subarticles import validate_language
+from packtools.sps.validation.article_and_subarticles import ArticleLangValidation
 
 
 class ArticleAndSubarticlesTest(TestCase):
     def test_article_has_no_language_attribute(self):
+        self.maxDiff = None
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
             <front>
@@ -19,17 +20,27 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, errors = validate_language(xml_tree)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        self.assertFalse(result)
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': None,
+                'message': 'Got <article article-type=research-article xml:lang=None> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=None> has None as language, expected one item of this list: pt | en | es"
 
-        self.assertListEqual(
-            ['XML research-article has no language.'],
-            [e.message for e in errors]
-        )
-
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_has_valid_language(self):
+        self.maxDiff = None
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">
             <front>
@@ -43,9 +54,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_has_invalid_language(self):
         xml_str = """
@@ -61,33 +87,73 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, errors = validate_language(xml_tree)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        # Assegura que um problema de idioma foi identificado
-        self.assertFalse(result)
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'e',
+                'message': 'Got <article article-type=research-article xml:lang=e> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=e> has e as language, expected one item of this list: pt | en | es"
 
-        # Assegura que a mensagem relacionada ao problema identicado é a esperada
-        self.assertListEqual(
-            ['XML research-article has an invalid language: e'],
-            [e.message for e in errors]
-        )
-
-        # Assegura que a linha em que o problema foi identicado é a esperada
-        self.assertListEqual(
-            [2],
-            [e.line for e in errors]
-        )
-
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_have_valid_languages(self):
+        self.maxDiff = None
         data = open('tests/samples/article-abstract-en-sub-articles-pt-es.xml').read()
         xml_tree = get_xml_tree(data)
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'es',
+                'message': 'Got <sub-article article-type=translation id=s2 xml:lang=es> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s2 xml:lang=es> has es as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_three_valid_languages(self):
+        self.maxDiff = None
         xml_str = """
         <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
             <sub-article article-type="translation" id="s1" xml:lang="pt">
@@ -97,12 +163,49 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
 
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'es',
+                'message': 'Got <sub-article article-type=translation id=s2 xml:lang=es> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s2 xml:lang=es> has es as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_two_valid_languages_and_one_invalid(self):
+        self.maxDiff = None
         xml_str = """
         <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
             <sub-article article-type="translation" id="s1" xml:lang="pt">
@@ -112,21 +215,49 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
-        
-        self.assertFalse(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            ['XML translation has an invalid language: '],
-            [e.message for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
 
-        self.assertListEqual(
-            [5],
-            [e.line for e in errors]
-        )
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': '',
+                'message': 'Got <sub-article article-type=translation id=s2 xml:lang=> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s2 xml:lang=> has  as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_one_valid_language_one_empty_and_one_invalid(self):
+        self.maxDiff = None
         xml_str = """
         <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
             <sub-article article-type="translation" id="s1">
@@ -136,22 +267,49 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
-        
-        self.assertFalse(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            ['XML translation has no language.', 'XML translation has an invalid language: '],
-            [e.message for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
 
-        self.assertListEqual(
-            [3, 5],
-            [e.line for e in errors]
-        )
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': None,
+                'message': 'Got <sub-article article-type=translation id=s1 xml:lang=None> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s1 xml:lang=None> has None as language, expected one item of this list: pt | en | es"
 
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': '',
+                'message': 'Got <sub-article article-type=translation id=s2 xml:lang=> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s2 xml:lang=> has  as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_two_invalid_languages(self):
+        self.maxDiff = None
         xml_str = """
         <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="portugol" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
             <sub-article article-type="translation" id="s1" xml:lang="en">
@@ -161,19 +319,44 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
 
-        self.assertFalse(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            [
-                'XML research-article has an invalid language: portugol',
-                'XML translation has an invalid language: thisisaninvalidlanguagecode'
-            ],
-            [e.message for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'portugol',
+                'message': 'Got <article article-type=research-article xml:lang=portugol> expected one item of this list: pt | en | es',
+                'advice': "<article article-type=research-article xml:lang=portugol> has portugol as language, expected one item of this list: pt | en | es"
 
-        self.assertListEqual(
-            [2, 5],
-            [e.line for e in errors]
-        )
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': 'Got <sub-article article-type=translation id=s1 xml:lang=en> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s1 xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'thisisaninvalidlanguagecode',
+                'message': 'Got <sub-article article-type=translation id=s2 xml:lang=thisisaninvalidlanguagecode> expected one item of this list: pt | en | es',
+                'advice': "<sub-article article-type=translation id=s2 xml:lang=thisisaninvalidlanguagecode> has thisisaninvalidlanguagecode as language, expected one item of this list: pt | en | es"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -1,4 +1,6 @@
 from unittest import TestCase
+
+import self as self
 from lxml import etree
 
 from packtools.sps.validation.article_xref import ArticleXrefValidation
@@ -30,12 +32,36 @@ class ArticleXrefValidationTest(TestCase):
             """
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
-        expected = dict(
-            expected_value=['aff1', 'fig1', 'table1'],
-            obtained_value=['aff1', 'fig1', 'table1'],
-            result=[],
-            message="OK: all rids have the respective ids"
-        )
+
+        expected = {
+            'validation':
+                [
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'aff1',
+                        'got_value': 'aff1',
+                        'error_type': None,
+                        'message': 'rid have the respective id'
+                    },
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'fig1',
+                        'got_value': 'fig1',
+                        'error_type': None,
+                        'message': 'rid have the respective id'
+                    },
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'table1',
+                        'got_value': 'table1',
+                        'error_type': None,
+                        'message': 'rid have the respective id'
+                    }
+                ]
+        }
         obtained = self.article_xref.validate_rid()
         self.assertDictEqual(expected, obtained)
 
@@ -60,14 +86,36 @@ class ArticleXrefValidationTest(TestCase):
             """
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
-        expected = dict(
-            expected_value=['aff1', 'fig1', 'table1'],
-            obtained_value=['aff1', 'fig1'],
-            result=['table1'],
-            message="ERROR: rids were found with the values "
-                f"{self.article_xref.validate_rid()['expected_value']} but there were "
-                "no ids with the corresponding values"
-        )
+
+        expected = {
+            'validation':
+                [
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'aff1',
+                        'got_value': 'aff1',
+                        'error_type': None,
+                        'message': 'rid have the respective id'
+                    },
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'fig1',
+                        'got_value': 'fig1',
+                        'error_type': None,
+                        'message': 'rid have the respective id'
+                    },
+                    {
+                        'context': 'xref element rid attribute validation',
+                        'result': 'ERROR',
+                        'expected_value': 'table1',
+                        'got_value': None,
+                        'error_type': 'no match',
+                        'message': 'rid does not have the respective id'
+                    }
+                ]
+        }
         obtained = self.article_xref.validate_rid()
         self.assertDictEqual(expected, obtained)
 
@@ -95,16 +143,41 @@ class ArticleXrefValidationTest(TestCase):
             """
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
-        expected = dict(
-            obtained_value=['aff1', 'fig1', 'table1'],
-            expected_value=['aff1', 'fig1', 'table1'],
-            result=[],
-            message="OK: all ids have the respective rids"
-        )
+
+        expected = {
+            'validation':
+                [
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'aff1',
+                        'got_value': 'aff1',
+                        'error_type': None,
+                        'message': 'id have the respective rid'
+                    },
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'fig1',
+                        'got_value': 'fig1',
+                        'error_type': None,
+                        'message': 'id have the respective rid'
+                    },
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'table1',
+                        'got_value': 'table1',
+                        'error_type': None,
+                        'message': 'id have the respective rid'
+                    }
+                ]
+        }
         obtained = self.article_xref.validate_id()
         self.assertDictEqual(expected, obtained)
 
     def test_validate_ids_no_matches(self):
+        self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
             <article>
@@ -127,13 +200,35 @@ class ArticleXrefValidationTest(TestCase):
             """
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
-        expected = dict(
-            obtained_value=['aff1', 'fig1'],
-            expected_value=['aff1', 'fig1', 'table1'],
-            result=['table1'],
-            message="ERROR: ids were found with the values "
-                f"{self.article_xref.validate_id()['expected_value']} but there were "
-                "no rids with the corresponding values"
-        )
+
+        expected = {
+            'validation':
+                [
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'aff1',
+                        'got_value': 'aff1',
+                        'error_type': None,
+                        'message': 'id have the respective rid'
+                    },
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'OK',
+                        'expected_value': 'fig1',
+                        'got_value': 'fig1',
+                        'error_type': None,
+                        'message': 'id have the respective rid'
+                    },
+                    {
+                        'context': 'xref element id attribute validation',
+                        'result': 'ERROR',
+                        'expected_value': 'table1',
+                        'got_value': None,
+                        'error_type': 'no match',
+                        'message': 'id does not have the respective rid'
+                    }
+                ]
+        }
         obtained = self.article_xref.validate_id()
         self.assertDictEqual(expected, obtained)

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -37,28 +37,34 @@ class ArticleXrefValidationTest(TestCase):
             'validation':
                 [
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'aff1',
                         'got_value': 'aff1',
-                        'error_type': None,
-                        'message': 'rid have the respective id'
+                        'message': 'rid have the respective id',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'fig1',
                         'got_value': 'fig1',
-                        'error_type': None,
-                        'message': 'rid have the respective id'
+                        'message': 'rid have the respective id',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'table1',
                         'got_value': 'table1',
-                        'error_type': None,
-                        'message': 'rid have the respective id'
+                        'message': 'rid have the respective id',
+                        'advice': None
                     }
                 ]
         }
@@ -91,28 +97,34 @@ class ArticleXrefValidationTest(TestCase):
             'validation':
                 [
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'aff1',
                         'got_value': 'aff1',
-                        'error_type': None,
-                        'message': 'rid have the respective id'
+                        'message': 'rid have the respective id',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'fig1',
                         'got_value': 'fig1',
-                        'error_type': None,
-                        'message': 'rid have the respective id'
+                        'message': 'rid have the respective id',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element rid attribute validation',
-                        'result': 'ERROR',
+                        'title': 'xref element rid attribute validation',
+                        'xpath': './/xref[@rid]',
+                        'validation_type': 'match',
+                        'response': 'ERROR',
                         'expected_value': 'table1',
                         'got_value': None,
-                        'error_type': 'no match',
-                        'message': 'rid does not have the respective id'
+                        'message': 'rid does not have the respective id',
+                        'advice': 'add attribute id = table1 to the corresponding rid = table1'
                     }
                 ]
         }
@@ -148,28 +160,34 @@ class ArticleXrefValidationTest(TestCase):
             'validation':
                 [
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'aff1',
                         'got_value': 'aff1',
-                        'error_type': None,
-                        'message': 'id have the respective rid'
+                        'message': 'id have the respective rid',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'fig1',
                         'got_value': 'fig1',
-                        'error_type': None,
-                        'message': 'id have the respective rid'
+                        'message': 'id have the respective rid',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'table1',
                         'got_value': 'table1',
-                        'error_type': None,
-                        'message': 'id have the respective rid'
+                        'message': 'id have the respective rid',
+                        'advice': None
                     }
                 ]
         }
@@ -177,7 +195,6 @@ class ArticleXrefValidationTest(TestCase):
         self.assertDictEqual(expected, obtained)
 
     def test_validate_ids_no_matches(self):
-        self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
             <article>
@@ -205,28 +222,34 @@ class ArticleXrefValidationTest(TestCase):
             'validation':
                 [
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'aff1',
                         'got_value': 'aff1',
-                        'error_type': None,
-                        'message': 'id have the respective rid'
+                        'message': 'id have the respective rid',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'OK',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'OK',
                         'expected_value': 'fig1',
                         'got_value': 'fig1',
-                        'error_type': None,
-                        'message': 'id have the respective rid'
+                        'message': 'id have the respective rid',
+                        'advice': None
                     },
                     {
-                        'context': 'xref element id attribute validation',
-                        'result': 'ERROR',
+                        'title': 'xref element id attribute validation',
+                        'xpath': './/*[@id]',
+                        'validation_type': 'match',
+                        'response': 'ERROR',
                         'expected_value': 'table1',
                         'got_value': None,
-                        'error_type': 'no match',
-                        'message': 'id does not have the respective rid'
+                        'message': 'id does not have the respective rid',
+                        'advice': 'add attribute rid = table1 to the corresponding id = table1'
                     }
                 ]
         }

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -33,43 +33,41 @@ class ArticleXrefValidationTest(TestCase):
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
 
-        expected = {
-            'validation':
-                [
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
-                    },
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
-                    },
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
-                    }
-                ]
-        }
-        obtained = self.article_xref.validate_rid()
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'aff1',
+                'got_value': 'aff1',
+                'message': 'Got aff1, expected aff1',
+                'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
+            },
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'fig1',
+                'got_value': 'fig1',
+                'message': 'Got fig1, expected fig1',
+                'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
+            },
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'table1',
+                'got_value': 'table1',
+                'message': 'Got table1, expected table1',
+                'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
+            }
+        ]
+        for i, item in enumerate(self.article_xref.validate_rid()):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_rids_no_matches(self):
         self.xmltree = etree.fromstring(
@@ -93,43 +91,41 @@ class ArticleXrefValidationTest(TestCase):
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
 
-        expected = {
-            'validation':
-                [
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
-                    },
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
-                    },
-                    {
-                        'title': 'xref element rid attribute validation',
-                        'xpath': './/xref[@rid]',
-                        'validation_type': 'match',
-                        'response': 'ERROR',
-                        'expected_value': True,
-                        'got_value': False,
-                        'message': 'Got False, expected True',
-                        'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
-                    }
-                ]
-        }
-        obtained = self.article_xref.validate_rid()
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'aff1',
+                'got_value': 'aff1',
+                'message': 'Got aff1, expected aff1',
+                'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
+            },
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'fig1',
+                'got_value': 'fig1',
+                'message': 'Got fig1, expected fig1',
+                'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
+            },
+            {
+                'title': 'xref element rid attribute validation',
+                'xpath': './/xref[@rid]',
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'table1',
+                'got_value': None,
+                'message': 'Got None, expected table1',
+                'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
+            }
+        ]
+        for i, item in enumerate(self.article_xref.validate_rid()):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_ids_matches(self):
         self.xmltree = etree.fromstring(
@@ -156,43 +152,42 @@ class ArticleXrefValidationTest(TestCase):
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
 
-        expected = {
-            'validation':
-                [
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
-                    },
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
-                    },
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
-                    }
-                ]
-        }
-        obtained = self.article_xref.validate_id()
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'aff1',
+                'got_value': 'aff1',
+                'message': 'Got aff1, expected aff1',
+                'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
+            },
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'fig1',
+                'got_value': 'fig1',
+                'message': 'Got fig1, expected fig1',
+                'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
+            },
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'table1',
+                'got_value': 'table1',
+                'message': 'Got table1, expected table1',
+                'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
+            }
+        ]
+
+        for i, item in enumerate(self.article_xref.validate_id()):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_ids_no_matches(self):
         self.xmltree = etree.fromstring(
@@ -218,40 +213,39 @@ class ArticleXrefValidationTest(TestCase):
         )
         self.article_xref = ArticleXrefValidation(self.xmltree)
 
-        expected = {
-            'validation':
-                [
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
-                    },
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'OK',
-                        'expected_value': True,
-                        'got_value': True,
-                        'message': 'Got True, expected True',
-                        'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
-                    },
-                    {
-                        'title': 'xref element id attribute validation',
-                        'xpath': './/*[@id]',
-                        'validation_type': 'match',
-                        'response': 'ERROR',
-                        'expected_value': True,
-                        'got_value': False,
-                        'message': 'Got False, expected True',
-                        'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
-                    }
-                ]
-        }
-        obtained = self.article_xref.validate_id()
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'aff1',
+                'got_value': 'aff1',
+                'message': 'Got aff1, expected aff1',
+                'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
+            },
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'fig1',
+                'got_value': 'fig1',
+                'message': 'Got fig1, expected fig1',
+                'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
+            },
+            {
+                'title': '* element id attribute validation',
+                'xpath': './/*[@id]',
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'table1',
+                'got_value': None,
+                'message': 'Got None, expected table1',
+                'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
+            }
+        ]
+
+        for i, item in enumerate(self.article_xref.validate_id()):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-import self as self
 from lxml import etree
 
 from packtools.sps.validation.article_xref import ArticleXrefValidation
@@ -154,7 +153,7 @@ class ArticleXrefValidationTest(TestCase):
 
         expected = [
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'OK',
@@ -164,7 +163,7 @@ class ArticleXrefValidationTest(TestCase):
                 'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
             },
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'OK',
@@ -174,7 +173,7 @@ class ArticleXrefValidationTest(TestCase):
                 'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
             },
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'OK',
@@ -215,7 +214,7 @@ class ArticleXrefValidationTest(TestCase):
 
         expected = [
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'OK',
@@ -225,7 +224,7 @@ class ArticleXrefValidationTest(TestCase):
                 'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
             },
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'OK',
@@ -235,7 +234,7 @@ class ArticleXrefValidationTest(TestCase):
                 'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
             },
             {
-                'title': '* element id attribute validation',
+                'title': 'element id attribute validation',
                 'xpath': './/*[@id]',
                 'validation_type': 'match',
                 'response': 'ERROR',

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -41,30 +41,30 @@ class ArticleXrefValidationTest(TestCase):
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'aff1',
-                        'got_value': 'aff1',
-                        'message': 'rid have the respective id',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
                     },
                     {
                         'title': 'xref element rid attribute validation',
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'fig1',
-                        'got_value': 'fig1',
-                        'message': 'rid have the respective id',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
                     },
                     {
                         'title': 'xref element rid attribute validation',
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'table1',
-                        'got_value': 'table1',
-                        'message': 'rid have the respective id',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
                     }
                 ]
         }
@@ -101,30 +101,30 @@ class ArticleXrefValidationTest(TestCase):
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'aff1',
-                        'got_value': 'aff1',
-                        'message': 'rid have the respective id',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
                     },
                     {
                         'title': 'xref element rid attribute validation',
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'fig1',
-                        'got_value': 'fig1',
-                        'message': 'rid have the respective id',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
                     },
                     {
                         'title': 'xref element rid attribute validation',
                         'xpath': './/xref[@rid]',
                         'validation_type': 'match',
                         'response': 'ERROR',
-                        'expected_value': 'table1',
-                        'got_value': None,
-                        'message': 'rid does not have the respective id',
-                        'advice': 'add attribute id = table1 to the corresponding rid = table1'
+                        'expected_value': True,
+                        'got_value': False,
+                        'message': 'Got False, expected True',
+                        'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
                     }
                 ]
         }
@@ -164,30 +164,30 @@ class ArticleXrefValidationTest(TestCase):
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'aff1',
-                        'got_value': 'aff1',
-                        'message': 'id have the respective rid',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
                     },
                     {
                         'title': 'xref element id attribute validation',
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'fig1',
-                        'got_value': 'fig1',
-                        'message': 'id have the respective rid',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
                     },
                     {
                         'title': 'xref element id attribute validation',
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'table1',
-                        'got_value': 'table1',
-                        'message': 'id have the respective rid',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
                     }
                 ]
         }
@@ -226,30 +226,30 @@ class ArticleXrefValidationTest(TestCase):
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'aff1',
-                        'got_value': 'aff1',
-                        'message': 'id have the respective rid',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
                     },
                     {
                         'title': 'xref element id attribute validation',
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'OK',
-                        'expected_value': 'fig1',
-                        'got_value': 'fig1',
-                        'message': 'id have the respective rid',
-                        'advice': None
+                        'expected_value': True,
+                        'got_value': True,
+                        'message': 'Got True, expected True',
+                        'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
                     },
                     {
                         'title': 'xref element id attribute validation',
                         'xpath': './/*[@id]',
                         'validation_type': 'match',
                         'response': 'ERROR',
-                        'expected_value': 'table1',
-                        'got_value': None,
-                        'message': 'id does not have the respective rid',
-                        'advice': 'add attribute rid = table1 to the corresponding id = table1'
+                        'expected_value': True,
+                        'got_value': False,
+                        'message': 'Got False, expected True',
+                        'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
                     }
                 ]
         }


### PR DESCRIPTION
#### O que esse PR faz?
Refatora o procedimento de validação para o elemento `xref`, atributos `rid` e `id`, para adequação do retorno em um formato padronizado.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Avaliando os testes propostos:
`python3 -m unittest -v tests/sps/validation/test_article_xref.py`

#### Algum cenário de contexto que queira dar?
O objetivo principal deste PR é o entendimento comum sobre um formato padronizado de retorno das funções de validação.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

