### PR TITLE
Validate article lang

### DIFF
--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -7,7 +7,7 @@ class ArticleLangValidation:
         self.articles = ArticleAndSubArticles(self.xmltree).data
         self.main_article_type = ArticleAndSubArticles(self.xmltree).main_article_type
 
-    def validate_language(self, default_values):
+    def validate_language(self, language_codes):
         """
         Params
         ------
@@ -27,17 +27,17 @@ class ArticleLangValidation:
             'advice': 'XML research-article has en as language, expected ['en']'
         }
         """
-        if default_values:
+        if language_codes:
             for article in self.articles:
                 lang = article.get('lang')
                 item = {
                     'title': 'Article element lang attribute validation',
                     'xpath': './article/@xml:lang' if article.get('article_type') == self.main_article_type else './/sub-article/@xml:lang',
                     'validation_type': 'value in list',
-                    'response': 'OK' if lang in default_values else 'ERROR',
-                    'expected_value': default_values,
+                    'response': 'OK' if lang in language_codes else 'ERROR',
+                    'expected_value': language_codes,
                     'got_value': lang,
-                    'message': 'Got {}, expected {}'.format(lang, default_values),
-                    'advice': 'XML {} has {} as language, expected {}'.format(article.get('article_type'), lang, default_values)
+                    'message': 'Got {}, expected one item of this list: {}'.format(lang, " | ".join(language_codes)),
+                    'advice': 'XML {} has {} as language, expected one item of this list: {}'.format(article.get('article_type'), lang, " | ".join(language_codes))
                 }
                 yield item

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -1,38 +1,43 @@
-from packtools.sps.validation import exceptions
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
-from langcodes import tag_is_valid
 
 
-def validate_language(xml):
-    """
-    Params
-    ------
-    xml: ElementTree
+class ArticleLangValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.articles = ArticleAndSubArticles(self.xmltree).data
+        self.main_article_type = ArticleAndSubArticles(self.xmltree).main_article_type
 
-    Returns
-    -------
-        A tuple comprising the validation status and the errors list.
-    """
-    errors = []
+    def validate_language(self, default_values):
+        """
+        Params
+        ------
+        list: Default values to languages
 
-    art_and_subarts = ArticleAndSubArticles(xml)
-
-    for i in art_and_subarts.data:
-        _lang = i.get('lang')
-        _article_type = i.get('article_type')
-
-        if _lang is None:
-            _message = f'XML {_article_type} has no language.'
-            errors.append(exceptions.ValidationArticleAndSubArticlesUnavailableLanguage(
-                message=_message,
-                line=i.get('line_number'),
-            ))
-
-        elif not tag_is_valid(_lang):
-            _message = f'XML {_article_type} has an invalid language: {_lang}'
-            errors.append(exceptions.ValidationArticleAndSubArticlesHasInvalidLanguage(
-                message=_message,
-                line=i.get('line_number'),
-            ))
-   
-    return len(errors) == 0, errors
+        Returns
+        -------
+        list: dicts as:
+        {
+            'title': 'Article element lang attribute validation',
+            'xpath': './article/@xml:lang',
+            'validation_type': 'value in list',
+            'response': 'OK',
+            'expected_value': ['en'],
+            'got_value': 'en',
+            'message': 'Got en, expected ['en']',
+            'advice': 'XML research-article has en as language, expected ['en']'
+        }
+        """
+        if default_values:
+            for article in self.articles:
+                lang = article.get('lang')
+                item = {
+                    'title': 'Article element lang attribute validation',
+                    'xpath': './article/@xml:lang' if article.get('article_type') == self.main_article_type else './/sub-article/@xml:lang',
+                    'validation_type': 'value in list',
+                    'response': 'OK' if lang in default_values else 'ERROR',
+                    'expected_value': default_values,
+                    'got_value': lang,
+                    'message': 'Got {}, expected {}'.format(lang, default_values),
+                    'advice': 'XML {} has {} as language, expected {}'.format(article.get('article_type'), lang, default_values)
+                }
+                yield item

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -19,7 +19,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -29,8 +29,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': None,
-                'message': "Got None, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has None as language, expected ['pt', 'en', 'es']"
+                'message': "Got None, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has None as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -52,7 +52,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -62,8 +62,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has en as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -85,7 +85,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -95,8 +95,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'e',
-                'message': "Got e, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has e as language, expected ['pt', 'en', 'es']"
+                'message': "Got e, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has e as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -108,7 +108,7 @@ class ArticleAndSubarticlesTest(TestCase):
         xml_str = open('tests/samples/article-abstract-en-sub-articles-pt-es.xml').read()
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -118,8 +118,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has en as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -129,8 +129,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
-                'message': "Got pt, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+                'message': "Got pt, expected one item of this list: pt | en | es",
+                'advice': "XML translation has pt as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -140,8 +140,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'es',
-                'message': "Got es, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has es as language, expected ['pt', 'en', 'es']"
+                'message': "Got es, expected one item of this list: pt | en | es",
+                'advice': "XML translation has es as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -160,7 +160,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -170,8 +170,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has en as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -181,8 +181,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
-                'message': "Got pt, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+                'message': "Got pt, expected one item of this list: pt | en | es",
+                'advice': "XML translation has pt as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -192,8 +192,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'es',
-                'message': "Got es, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has es as language, expected ['pt', 'en', 'es']"
+                'message': "Got es, expected one item of this list: pt | en | es",
+                'advice': "XML translation has es as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -212,7 +212,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -222,8 +222,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has en as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -233,8 +233,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
-                'message': "Got pt, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+                'message': "Got pt, expected one item of this list: pt | en | es",
+                'advice': "XML translation has pt as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -244,8 +244,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': '',
-                'message': "Got , expected ['pt', 'en', 'es']",
-                'advice': "XML translation has  as language, expected ['pt', 'en', 'es']"
+                'message': "Got , expected one item of this list: pt | en | es",
+                'advice': "XML translation has  as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -265,7 +265,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -275,8 +275,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has en as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -286,8 +286,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': None,
-                'message': "Got None, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has None as language, expected ['pt', 'en', 'es']"
+                'message': "Got None, expected one item of this list: pt | en | es",
+                'advice': "XML translation has None as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -297,8 +297,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': '',
-                'message': "Got , expected ['pt', 'en', 'es']",
-                'advice': "XML translation has  as language, expected ['pt', 'en', 'es']"
+                'message': "Got , expected one item of this list: pt | en | es",
+                'advice': "XML translation has  as language, expected one item of this list: pt | en | es"
 
             }
         ]
@@ -317,7 +317,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -327,8 +327,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'portugol',
-                'message': "Got portugol, expected ['pt', 'en', 'es']",
-                'advice': "XML research-article has portugol as language, expected ['pt', 'en', 'es']"
+                'message': "Got portugol, expected one item of this list: pt | en | es",
+                'advice': "XML research-article has portugol as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -338,8 +338,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'OK',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
-                'message': "Got en, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has en as language, expected ['pt', 'en', 'es']"
+                'message': "Got en, expected one item of this list: pt | en | es",
+                'advice': "XML translation has en as language, expected one item of this list: pt | en | es"
 
             },
             {
@@ -349,8 +349,8 @@ class ArticleAndSubarticlesTest(TestCase):
                 'response': 'ERROR',
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'thisisaninvalidlanguagecode',
-                'message': "Got thisisaninvalidlanguagecode, expected ['pt', 'en', 'es']",
-                'advice': "XML translation has thisisaninvalidlanguagecode as language, expected ['pt', 'en', 'es']"
+                'message': "Got thisisaninvalidlanguagecode, expected one item of this list: pt | en | es",
+                'advice': "XML translation has thisisaninvalidlanguagecode as language, expected one item of this list: pt | en | es"
 
             }
         ]

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from packtools.sps.utils.xml_utils import get_xml_tree
-from packtools.sps.validation.article_and_subarticles import validate_language
+from packtools.sps.validation.article_and_subarticles import ArticleLangValidation
 
 
 class ArticleAndSubarticlesTest(TestCase):
@@ -19,15 +19,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, errors = validate_language(xml_tree)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
-        self.assertFalse(result)
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': None,
+                'message': "Got None, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has None as language, expected ['pt', 'en', 'es']"
 
-        self.assertListEqual(
-            ['XML research-article has no language.'],
-            [e.message for e in errors]
-        )
-
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_has_valid_language(self):
         xml_str = """
@@ -43,9 +52,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_has_invalid_language(self):
         xml_str = """
@@ -61,31 +85,69 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, errors = validate_language(xml_tree)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
-        # Assegura que um problema de idioma foi identificado
-        self.assertFalse(result)
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'e',
+                'message': "Got e, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has e as language, expected ['pt', 'en', 'es']"
 
-        # Assegura que a mensagem relacionada ao problema identicado é a esperada
-        self.assertListEqual(
-            ['XML research-article has an invalid language: e'],
-            [e.message for e in errors]
-        )
-
-        # Assegura que a linha em que o problema foi identicado é a esperada
-        self.assertListEqual(
-            [2],
-            [e.line for e in errors]
-        )
-
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_have_valid_languages(self):
-        data = open('tests/samples/article-abstract-en-sub-articles-pt-es.xml').read()
-        xml_tree = get_xml_tree(data)
+        xml_str = open('tests/samples/article-abstract-en-sub-articles-pt-es.xml').read()
+        xml_tree = get_xml_tree(xml_str)
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': "Got pt, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'es',
+                'message': "Got es, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has es as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_three_valid_languages(self):
         xml_str = """
@@ -98,9 +160,46 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        result, _ = validate_language(xml_tree)
-        self.assertTrue(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': "Got pt, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'es',
+                'message': "Got es, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has es as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_two_valid_languages_and_one_invalid(self):
         xml_str = """
@@ -112,21 +211,50 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
-        
-        self.assertFalse(result)
 
-        self.assertListEqual(
-            ['XML translation has an invalid language: '],
-            [e.message for e in errors]
-        )
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            [5],
-            [e.line for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'pt',
+                'message': "Got pt, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has pt as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': '',
+                'message': "Got , expected ['pt', 'en', 'es']",
+                'advice': "XML translation has  as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_one_valid_language_one_empty_and_one_invalid(self):
+        self.maxDiff = None
         xml_str = """
         <article article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
             <sub-article article-type="translation" id="s1">
@@ -136,20 +264,47 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
-        
-        self.assertFalse(result)
 
-        self.assertListEqual(
-            ['XML translation has no language.', 'XML translation has an invalid language: '],
-            [e.message for e in errors]
-        )
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            [3, 5],
-            [e.line for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has en as language, expected ['pt', 'en', 'es']"
 
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': None,
+                'message': "Got None, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has None as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': '',
+                'message': "Got , expected ['pt', 'en', 'es']",
+                'advice': "XML translation has  as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_article_and_subarticles_with_two_invalid_languages(self):
         xml_str = """
@@ -161,19 +316,44 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        result, errors = validate_language(xml_tree)
 
-        self.assertFalse(result)
+        obtained = ArticleLangValidation(xml_tree).validate_language(default_values=['pt', 'en', 'es'])
 
-        self.assertListEqual(
-            [
-                'XML research-article has an invalid language: portugol',
-                'XML translation has an invalid language: thisisaninvalidlanguagecode'
-            ],
-            [e.message for e in errors]
-        )
+        expected = [
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'portugol',
+                'message': "Got portugol, expected ['pt', 'en', 'es']",
+                'advice': "XML research-article has portugol as language, expected ['pt', 'en', 'es']"
 
-        self.assertListEqual(
-            [2, 5],
-            [e.line for e in errors]
-        )
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'en',
+                'message': "Got en, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has en as language, expected ['pt', 'en', 'es']"
+
+            },
+            {
+                'title': 'Article element lang attribute validation',
+                'xpath': './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['pt', 'en', 'es'],
+                'got_value': 'thisisaninvalidlanguagecode',
+                'message': "Got thisisaninvalidlanguagecode, expected ['pt', 'en', 'es']",
+                'advice': "XML translation has thisisaninvalidlanguagecode as language, expected ['pt', 'en', 'es']"
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função de validação para idiomas de documentos.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_and_subarticles.py
`
#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

