### PR TITLE
Validation report generator

### DIFF
--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -85,8 +85,8 @@ class AffiliationValidation:
             'response': 'OK' if country_code in country_codes_list else 'ERROR',
             'expected_value': self.country_codes_list,
             'got_value': country_code,
-            'message': _('Got {}, expected {}').format(country_code, country_codes_list),
-            'advice': None if country_code else _('provide a valid @country affiliation')
+            'message': _('Got {}, expected one item of this list: {}').format(country_code, country_codes_list),
+            'advice': None if country_code in country_codes_list else _('provide a valid @country affiliation')
         }
 
     def validate_state(self):

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -30,25 +30,40 @@ class ArticleLangValidation:
         }
         """
 
-        if language_codes:
-            for article in self.articles:
-                article_lang = article.get('lang')
-                article_type = article.get('article_type')
-                article_id = article.get('article_id')
+        language_codes_list = language_codes_list or self.language_codes_list
+        if not language_codes_list:
+            raise AffiliationValidationValidateLanguageCodeException("Function requires list of language codes")
+        for article in self.articles:
+            article_lang = article.get('lang')
+            article_type = article.get('article_type')
+            article_id = article.get('article_id')
+            validated = article_lang in language_codes_list
 
-                if article_id == 'main':
-                    msg = '<article article-type={} xml:lang={}>'.format(article_type, article_lang)
-                else:
-                    msg = '<sub-article article-type={} id={} xml:lang={}>'.format(article_type, article_id, article_lang)
+            if article_id == 'main':
+                msg = '<article article-type={} xml:lang={}>'.format(article_type, article_lang)
+            else:
+                msg = '<sub-article article-type={} id={} xml:lang={}>'.format(article_type, article_id, article_lang)
 
-                item = {
-                    'title': 'Article element lang attribute validation',
-                    'xpath': './article/@xml:lang' if article_id == 'main' else './/sub-article/@xml:lang',
-                    'validation_type': 'value in list',
-                    'response': 'OK' if article_lang in language_codes else 'ERROR',
-                    'expected_value': language_codes,
-                    'got_value': article_lang,
-                    'message': 'Got {} expected one item of this list: {}'.format(msg, " | ".join(language_codes)),
-                    'advice': '{} has {} as language, expected one item of this list: {}'.format(msg, article_lang, " | ".join(language_codes))
-                }
-                yield item
+            item = {
+                'title': 'Article element lang attribute validation',
+                'xpath': './article/@xml:lang' if article_id == 'main' else './/sub-article/@xml:lang',
+                'validation_type': 'value in list',
+                'response': 'OK' if validated else 'ERROR',
+                'expected_value': language_codes_list,
+                'got_value': article_lang,
+                'message': 'Got {} expected one item of this list: {}'.format(msg, " | ".join(language_codes_list)),
+                'advice': None if validated else '{} has {} as language, expected one item of this list: {}'.format(msg, article_lang, " | ".join(language_codes_list))
+            }
+            yield item
+
+    def validate(self, data):
+        """
+        Função que executa as validações da classe ArticleLangValidation.
+
+        Returns:
+            dict: Um dicionário contendo os resultados das validações realizadas.
+
+        """
+        return {
+            'article_lang_validation': self.validate_language(data['language_codes_list'])
+        }

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -1,12 +1,14 @@
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
+from packtools.sps.validation.exceptions import AffiliationValidationValidateLanguageCodeException
 
 
 class ArticleLangValidation:
-    def __init__(self, xmltree):
+    def __init__(self, xmltree, language_codes_list=None):
         self.xmltree = xmltree
         self.articles = ArticleAndSubArticles(self.xmltree).data
+        self.language_codes_list = language_codes_list
 
-    def validate_language(self, language_codes=None):
+    def validate_language(self, language_codes_list=None):
         """
         Params
         ------

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -67,7 +67,7 @@ class ArticleXrefValidation:
             item['expected_value'] = rid
             item['got_value'] = rid if validated else None
             item['message'] = _('Got {}, expected {}').format(item['got_value'], rid)
-            item['advice'] = 'For each xref[@rid="{}"] must have one corresponding element which @id="{}"'.format(rid, rid)
+            item['advice'] = None if validated else 'For each xref[@rid="{}"] must have one corresponding element which @id="{}"'.format(rid, rid)
             yield item
 
     def validate_id(self):
@@ -129,7 +129,7 @@ class ArticleXrefValidation:
             item['expected_value'] = id
             item['got_value'] = id if validated else None
             item['message'] = _('Got {}, expected {}').format(item['got_value'], id)
-            item['advice'] = 'For each @id="{}" must have one corresponding element which xref[@rid="{}"]'.format(id, id)
+            item['advice'] = None if validated else 'For each @id="{}" must have one corresponding element which xref[@rid="{}"]'.format(id, id)
             yield item
 
     def validate(self, data):

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -17,3 +17,7 @@ class ValidationArticleAndSubArticlesHasInvalidLanguage(ValidationArticleDataErr
 
 class AffiliationValidationValidateCountryCodeException(Exception):
     ...
+
+
+class AffiliationValidationValidateLanguageCodeException(Exception):
+    ...

--- a/packtools/validation_report_generator.py
+++ b/packtools/validation_report_generator.py
@@ -1,0 +1,56 @@
+import csv
+import argparse
+from packtools.sps.utils import xml_utils
+from packtools.sps.validation.aff import AffiliationsListValidation
+from packtools.sps.validation.article_and_subarticles import ArticleLangValidation
+from packtools.sps.validation.article_xref import ArticleXrefValidation
+
+
+def get_xml_tree(file_to_read):
+    with open(file_to_read, 'r') as file:
+        return xml_utils.get_xml_tree(file.read())
+
+
+def validate_xml_tree(xml_tree, validation_params):
+    data = AffiliationsListValidation(xml_tree).validate(validation_params)['affiliations_validation']
+
+    validators = [
+        ArticleLangValidation(xml_tree),
+        ArticleXrefValidation(xml_tree)
+    ]
+
+    for validator in validators:
+        for key in validator.validate(validation_params):
+            for item in validator.validate(validation_params)[key]:
+                data.append(item)
+
+    return data
+
+
+def write_to_csv(data, file_to_write):
+    headers = data[0].keys()
+    with open(file_to_write, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-r', dest='file_to_read', required=True, help='XML file path to validate')
+    parser.add_argument('-c', dest='country_list', required=False, help='Comma separated list of country codes for validation')
+    parser.add_argument('-l', dest='lang_list', required=False, help='Comma separated list of languages for validation')
+    parser.add_argument('-w', dest='file_to_write', required=True, help='CSV file path to receive the validation result')
+    args = parser.parse_args()
+
+    file_to_read = args.file_to_read
+    file_to_write = args.file_to_write
+    xml_tree = get_xml_tree(file_to_read)
+    validation_params = {
+            'country_codes_list': list(args.country_list.split(',')),
+            'language_codes_list': list(args.lang_list.split(','))
+        }
+
+    data = validate_xml_tree(xml_tree, validation_params)
+
+    write_to_csv(data, file_to_write)

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -85,7 +85,7 @@ class AffiliationValidationTest(TestCase):
                     'response': 'OK',
                     'expected_value': ['BR'],
                     'got_value': 'BR',
-                    'message': "Got BR, expected ['BR']",
+                    'message': "Got BR, expected one item of this list: ['BR']",
                     'advice': None
                 },
                 {
@@ -149,7 +149,7 @@ class AffiliationValidationTest(TestCase):
                     'response': 'OK',
                     'expected_value': ['BR'],
                     'got_value': 'BR',
-                    'message': "Got BR, expected ['BR']",
+                    'message': "Got BR, expected one item of this list: ['BR']",
                     'advice': None
                 },
                 {
@@ -318,7 +318,7 @@ class AffiliationValidationTest(TestCase):
                     'response': 'ERROR',
                     'expected_value': ['BR'],
                     'got_value': None,
-                    'message': "Got None, expected ['BR']",
+                    'message': "Got None, expected one item of this list: ['BR']",
                     'advice': 'provide a valid @country affiliation'
                 }
 
@@ -477,7 +477,7 @@ class AffiliationValidationTest(TestCase):
                     'response': 'OK',
                     'expected_value': ['BR'],
                     'got_value': 'BR',
-                    'message': "Got BR, expected ['BR']",
+                    'message': "Got BR, expected one item of this list: ['BR']",
                     'advice': None
                 },
                 {
@@ -541,7 +541,7 @@ class AffiliationValidationTest(TestCase):
                     'response': 'OK',
                     'expected_value': ['BR'],
                     'got_value': 'BR',
-                    'message': "Got BR, expected ['BR']",
+                    'message': "Got BR, expected one item of this list: ['BR']",
                     'advice': None
                 },
                 {

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -20,7 +20,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -54,7 +54,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -65,7 +65,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             }
         ]
@@ -87,7 +87,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -111,7 +111,7 @@ class ArticleAndSubarticlesTest(TestCase):
         data = open('tests/samples/article-abstract-en-sub-articles-pt-es.xml').read()
         xml_tree = get_xml_tree(data)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -122,7 +122,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -133,7 +133,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
                 'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -144,7 +144,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'es',
                 'message': 'Got <sub-article article-type=translation id=s2 xml:lang=es> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s2 xml:lang=es> has es as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             }
         ]
@@ -163,7 +163,7 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -174,7 +174,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -185,7 +185,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
                 'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -196,7 +196,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'es',
                 'message': 'Got <sub-article article-type=translation id=s2 xml:lang=es> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s2 xml:lang=es> has es as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             }
         ]
@@ -215,7 +215,7 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -226,7 +226,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -237,7 +237,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'pt',
                 'message': 'Got <sub-article article-type=translation id=s1 xml:lang=pt> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s1 xml:lang=pt> has pt as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -267,7 +267,7 @@ class ArticleAndSubarticlesTest(TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -278,7 +278,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <article article-type=research-article xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<article article-type=research-article xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {
@@ -320,7 +320,7 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes=['pt', 'en', 'es'])
+        obtained = ArticleLangValidation(xml_tree).validate_language(language_codes_list=['pt', 'en', 'es'])
 
         expected = [
             {
@@ -342,7 +342,7 @@ class ArticleAndSubarticlesTest(TestCase):
                 'expected_value': ['pt', 'en', 'es'],
                 'got_value': 'en',
                 'message': 'Got <sub-article article-type=translation id=s1 xml:lang=en> expected one item of this list: pt | en | es',
-                'advice': "<sub-article article-type=translation id=s1 xml:lang=en> has en as language, expected one item of this list: pt | en | es"
+                'advice': None
 
             },
             {

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -41,7 +41,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'aff1',
                 'got_value': 'aff1',
                 'message': 'Got aff1, expected aff1',
-                'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
+                'advice': None
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -51,7 +51,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'fig1',
                 'got_value': 'fig1',
                 'message': 'Got fig1, expected fig1',
-                'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
+                'advice': None
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -61,7 +61,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'table1',
                 'got_value': 'table1',
                 'message': 'Got table1, expected table1',
-                'advice': 'For each xref[@rid="table1"] must have one corresponding element which @id="table1"'
+                'advice': None
             }
         ]
         for i, item in enumerate(self.article_xref.validate_rid()):
@@ -99,7 +99,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'aff1',
                 'got_value': 'aff1',
                 'message': 'Got aff1, expected aff1',
-                'advice': 'For each xref[@rid="aff1"] must have one corresponding element which @id="aff1"'
+                'advice': None
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -109,7 +109,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'fig1',
                 'got_value': 'fig1',
                 'message': 'Got fig1, expected fig1',
-                'advice': 'For each xref[@rid="fig1"] must have one corresponding element which @id="fig1"'
+                'advice': None
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -160,7 +160,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'aff1',
                 'got_value': 'aff1',
                 'message': 'Got aff1, expected aff1',
-                'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
+                'advice': None
             },
             {
                 'title': 'element id attribute validation',
@@ -170,7 +170,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'fig1',
                 'got_value': 'fig1',
                 'message': 'Got fig1, expected fig1',
-                'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
+                'advice': None
             },
             {
                 'title': 'element id attribute validation',
@@ -180,7 +180,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'table1',
                 'got_value': 'table1',
                 'message': 'Got table1, expected table1',
-                'advice': 'For each @id="table1" must have one corresponding element which xref[@rid="table1"]'
+                'advice': None
             }
         ]
 
@@ -221,7 +221,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'aff1',
                 'got_value': 'aff1',
                 'message': 'Got aff1, expected aff1',
-                'advice': 'For each @id="aff1" must have one corresponding element which xref[@rid="aff1"]'
+                'advice': None
             },
             {
                 'title': 'element id attribute validation',
@@ -231,7 +231,7 @@ class ArticleXrefValidationTest(TestCase):
                 'expected_value': 'fig1',
                 'got_value': 'fig1',
                 'message': 'Got fig1, expected fig1',
-                'advice': 'For each @id="fig1" must have one corresponding element which xref[@rid="fig1"]'
+                'advice': None
             },
             {
                 'title': 'element id attribute validation',


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona procedimento para a geração de um arquivo CSV com as validações realizadas.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Pela linha de comando, por exemplo:
`python3 validation_report_generator.py -r 'entrada.xml' -c "BR" -l "pt,en,es" -w 'saida.csv'`

#### Algum cenário de contexto que queira dar?
O arquivo resultante pode ser visualizado [aqui](https://docs.google.com/spreadsheets/d/1VRM8S4Si7-_kAHoBwuJmW7cNa0Z4nHweAbn57yHzrb4/edit?usp=sharing).

O arquivo utilizado como exemplo pode ser visualizado na seguinte pasta do repositório:
`tests/samples/article-abstract-en-sub-articles-pt-es.xml`

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

