### PR TITLE
Corrige nome de classe de exceção

### DIFF
--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -67,7 +67,7 @@ class ArticleXrefValidation:
             item['expected_value'] = rid
             item['got_value'] = rid if validated else None
             item['message'] = _('Got {}, expected {}').format(item['got_value'], rid)
-            item['advice'] = None if validated else 'For each xref[@rid="{}"] must have one corresponding element which @id="{}"'.format(rid, rid)
+            item['advice'] = None if validated else 'For each xref[@rid="{}"] must have at least one corresponding element which @id="{}"'.format(rid, rid)
             yield item
 
     def validate_id(self):
@@ -129,7 +129,7 @@ class ArticleXrefValidation:
             item['expected_value'] = id
             item['got_value'] = id if validated else None
             item['message'] = _('Got {}, expected {}').format(item['got_value'], id)
-            item['advice'] = None if validated else 'For each @id="{}" must have one corresponding element which xref[@rid="{}"]'.format(id, id)
+            item['advice'] = None if validated else 'For each @id="{}" must have at least one corresponding element which xref[@rid="{}"]'.format(id, id)
             yield item
 
     def validate(self, data):

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -15,7 +15,7 @@ class ValidationArticleAndSubArticlesHasInvalidLanguage(ValidationArticleDataErr
     ...
 
 
-class ValidationArticleAndSubArticlesCountryCodeException(Exception):
+class AffiliationValidationValidateCountryCodeException(Exception):
     ...
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige nome de classe de exceão que impacta nos testes

#### Onde a revisão poderia começar?
Por _commit_

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/*`

#### Algum cenário de contexto que queira dar?
Após a correção do nome os testes não estão quebrando:

```
python3 -m unittest -v tests/sps/validation/*
tests/sps/validation/__pycache__ (unittest.loader._FailedTest) ... ERROR
test_affiliation_without_original (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_affiliations_without_city (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_affiliations_without_country (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_affiliations_without_country_code (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_affiliations_without_orgname (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_affiliations_without_state (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_validate (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_validate_affiliations_list (tests.sps.validation.test_aff.AffiliationValidationTest) ... ok
test_article_and_subarticles_article_type_is_not_valid (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_article_type_is_valid (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_article_type_vs_subject_similarity (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_dtd_version (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_have_valid_languages (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_specific_use (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_there_is_no_subject_there_should_be_no_subject (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_there_is_subject_there_should_be_no_subject (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_with_one_valid_language_one_empty_and_one_invalid (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_with_three_valid_languages (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_with_two_invalid_languages (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_with_two_valid_languages_and_one_invalid (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_and_subarticles_without_specific_use (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_has_doi (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_has_invalid_language (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_has_no_doi (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_has_no_language_attribute (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_article_has_valid_language (tests.sps.validation.test_article_and_subarticles.ArticleAndSubarticlesTest) ... ok
test_success_orcid (tests.sps.validation.test_article_authors.ArticleAuthorsValidationOrcidTest) ... ok
test_validation_format_orcid (tests.sps.validation.test_article_authors.ArticleAuthorsValidationOrcidTest) ... ok
test_without_orcid (tests.sps.validation.test_article_authors.ArticleAuthorsValidationOrcidTest) ... ok
test_role_and_content_type_empty (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_role_no_text_with_content_type (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_role_without_content_type (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_success_role (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_without_role (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_wrong_role_and_content_type (tests.sps.validation.test_article_authors.ArticleAuthorsValidationTest) ... ok
test_validate_license_3_expected_1_obtained_not_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_validate_license_3_expected_1_obtained_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_validate_license_3_expected_3_obtained_not_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_validate_license_3_expected_3_obtained_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_validate_license_code_not_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_validate_license_code_ok (tests.sps.validation.test_article_license.ArticleLicenseValidationTest) ... ok
test_article_are_similar_articles_results_false (tests.sps.validation.test_article.ArticleTest) ... ok
test_article_are_similar_articles_results_true (tests.sps.validation.test_article.ArticleTest) ... ok
test_validade_article_title_is_different_from_section_titles_returns_error (tests.sps.validation.test_article_toc_sections.ArticleTocSectionsTest) ... ok
test_validade_article_title_is_different_from_section_titles_returns_ok (tests.sps.validation.test_article_toc_sections.ArticleTocSectionsTest) ... ok
test_validate_article_toc_sections_returns_error (tests.sps.validation.test_article_toc_sections.ArticleTocSectionsTest) ... ok
test_validate_article_toc_sections_returns_error_journal_has_no_section (tests.sps.validation.test_article_toc_sections.ArticleTocSectionsTest) ... ok
test_validate_article_toc_sections_returns_ok (tests.sps.validation.test_article_toc_sections.ArticleTocSectionsTest) ... ok
test_validate_ids_matches (tests.sps.validation.test_article_xref.ArticleXrefValidationTest) ... ok
test_validate_ids_no_matches (tests.sps.validation.test_article_xref.ArticleXrefValidationTest) ... ok
test_validate_rids_matches (tests.sps.validation.test_article_xref.ArticleXrefValidationTest) ... ok
test_validate_rids_no_matches (tests.sps.validation.test_article_xref.ArticleXrefValidationTest) ... ok
test_is_complete_a_correct_date (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_day (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_day_number (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_month (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_month_number (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_year (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_invalid_year_number (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_missing_day (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_missing_month (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_complete_a_date_with_missing_year (tests.sps.validation.test_dates.IsCompleteDateTest) ... ok
test_is_sorted_a_complete_date_list (tests.sps.validation.test_dates.IsSortedHistoryDateTest) ... ok
test_is_sorted_a_date_list_without_one_date_required (tests.sps.validation.test_dates.IsSortedHistoryDateTest) ... ok
test_is_sorted_a_incomplete_date_list (tests.sps.validation.test_dates.IsSortedHistoryDateTest) ... ok
test_is_sorted_a_sorted_date_list (tests.sps.validation.test_dates.IsSortedHistoryDateTest) ... ok
test_is_sorted_a_unsorted_date_list (tests.sps.validation.test_dates.IsSortedHistoryDateTest) ... ok
test_erratum_has_compatible_errata_and_document (tests.sps.validation.test_erratum.ErratumTest) ... ok
test_erratum_has_not_compatibile_errata_and_document (tests.sps.validation.test_erratum.ErratumTest) ... ok
test_issue_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_issue_no_issue (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_issue_no_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_suppl_implicit (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_suppl_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_suppl_no_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_volume_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_volume_no_matches (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_volume_no_volume (tests.sps.validation.test_front_articlemeta_issue.IssueTest) ... ok
test_acronym_match (tests.sps.validation.test_journal_meta.AcronymTest) ... ok
test_acronym_no_match (tests.sps.validation.test_journal_meta.AcronymTest) ... ok
test_issn_epub_match (tests.sps.validation.test_journal_meta.ISSNTest) ... ok
test_issn_epub_no_match (tests.sps.validation.test_journal_meta.ISSNTest) ... ok
test_issn_ppub_match (tests.sps.validation.test_journal_meta.ISSNTest) ... ok
test_issn_ppub_no_match (tests.sps.validation.test_journal_meta.ISSNTest) ... ok
test_journal_meta_match (tests.sps.validation.test_journal_meta.JournalMetaValidationTest) ... ok
test_more_than_one_publisher_match (tests.sps.validation.test_journal_meta.PublisherTest) ... ok
test_more_than_one_publisher_no_match (tests.sps.validation.test_journal_meta.PublisherTest) ... ok
test_one_publisher_match (tests.sps.validation.test_journal_meta.PublisherTest) ... ok
test_one_publisher_no_match (tests.sps.validation.test_journal_meta.PublisherTest) ... ok
test_abbreviated_journal_title_match (tests.sps.validation.test_journal_meta.TitleTest) ... ok
test_abbreviated_journal_title_no_match (tests.sps.validation.test_journal_meta.TitleTest) ... ok
test_journal_title_match (tests.sps.validation.test_journal_meta.TitleTest) ... ok
test_journal_title_no_match (tests.sps.validation.test_journal_meta.TitleTest) ... ok
test_are_article_and_journal_data_compatible_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_article_and_journal_data_compatible_true (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_acronyms_compatible_acronym_different_raises_error (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_acronyms_compatible_true (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_false_empty_issn_list_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_false_two_different_issn_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_missing_issn_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_one_different_issn_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_true_identical_issns (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_issns_compatible_with_one_xml_issn_and_one_empty_issn_is_true (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_titles_compatible_missing_title_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_titles_compatible_title_different_raises_exception (tests.sps.validation.test_journal.JournalTest) ... ok
test_are_journal_titles_compatible_true (tests.sps.validation.test_journal.JournalTest) ... ok

======================================================================
ERROR: tests/sps/validation/__pycache__ (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests/sps/validation/__pycache__
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
ModuleNotFoundError: No module named 'tests/sps/validation/__pycache__'


----------------------------------------------------------------------
Ran 107 tests in 0.013s

FAILED (errors=1)
```


### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

