### PR TITLE
Página do artigo - apresentação de contrib/bio

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/html-modals-contribs.xsl
@@ -119,6 +119,9 @@
     </xsl:template>
     
     <xsl:template match="contrib" mode="modal-contrib">
+        <!--
+            ((contrib-id)*, (anonymous | collab | collab-alternatives | name | name-alternatives | string-name)*, (degrees)*, (address | aff | aff-alternatives | author-comment | bio | email | ext-link | on-behalf-of | role | uri | xref)*)
+        -->
         <div class="tutors">
             <xsl:apply-templates select="." mode="modal-contrib-type"/>
             <strong><xsl:apply-templates select="anonymous|name|collab|on-behalf-of"/></strong>
@@ -126,7 +129,7 @@
                 <xsl:apply-templates select="xref[@ref-type='corresp']" />
             </xsl:if>
             <br/>
-            <xsl:apply-templates select="role"/>
+            <xsl:apply-templates select="role | bio"/>
             <xsl:apply-templates select="xref" mode="modal-contrib"/>
             <xsl:apply-templates select="author-notes"/>
             <xsl:if test="contrib-id">


### PR DESCRIPTION
#### O que esse PR faz?
Página do Artigo - Adiciona apresentação de contrib/bio

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Executando htmlgenerator para o pacote mencionado em https://github.com/scieloorg/opac/issues/2856

```console
python packtools/htmlgenerator.py --nonetwork --nochecks --loglevel DEBUG path_do_xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="710" alt="Captura de Tela 2023-12-04 às 15 30 49" src="https://github.com/scieloorg/packtools/assets/505143/b8ff0205-4cbe-45d4-822f-12f96ebefbcb">

<img width="508" alt="Captura de Tela 2023-12-04 às 15 28 44" src="https://github.com/scieloorg/packtools/assets/505143/7f2492d1-9e0f-4cf4-8050-40349b03ab46">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2856

### Referências
https://jats.nlm.nih.gov/publishing/tag-library/1.3/element/bio.html
