### PR TITLE
Article id other validation

### DIFF
--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -472,7 +472,7 @@ class ArticleIdValidation:
         dict, such as:
             {
                 'title': 'Article id other validation',
-                'xpath': './/article-id/@pub-id-type="other"',
+                'xpath': './/article-id[@pub-id-type="other"]',
                 'validation_type': 'format',
                 'response': 'OK',
                 'expected_value': '123',

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -1,4 +1,5 @@
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
+from packtools.sps.models.article_ids import ArticleIds
 from packtools.sps.validation.exceptions import (
     ValidationArticleAndSubArticlesLanguageCodeException,
     ValidationArticleAndSubArticlesSpecificUseException,
@@ -444,4 +445,51 @@ class ArticleSubjectsValidation:
         }
 
 
+class ArticleIdValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.other_id = ArticleIds(self.xmltree).other
 
+    def validate_article_id_other(self):
+        """
+        Check whether an article that shouldn't have a subject actually doesn't.
+
+        XML input
+        ---------
+        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+        article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+                <article-meta>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+                    <article-id pub-id-type="other">123</article-id>
+                </article-meta>
+            </front>
+        </article>
+
+        Returns
+        -------
+        dict, such as:
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id/@pub-id-type="other"',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '123',
+                'got_value': '123',
+                'message': 'Got 123 expected 123',
+                'advice': None
+            }
+        """
+        is_valid = self.other_id.isnumeric() and len(self.other_id) <= 5
+        expected_value = self.other_id if is_valid else 'A numeric value with up to five digits'
+        return {
+            'title': 'Article id other validation',
+            'xpath': './/article-id/@pub-id-type="other"',
+            'validation_type': 'format',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': expected_value,
+            'got_value': self.other_id,
+            'message': 'Got {} expected {}'.format(self.other_id, expected_value[0].lower() + expected_value[1:]),
+            'advice': None if is_valid else 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+        }

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -485,7 +485,7 @@ class ArticleIdValidation:
         expected_value = self.other_id if is_valid else 'A numeric value with up to five digits'
         return {
             'title': 'Article id other validation',
-            'xpath': './/article-id/@pub-id-type="other"',
+            'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',
             'response': 'OK' if is_valid else 'ERROR',
             'expected_value': expected_value,

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -5,7 +5,8 @@ from packtools.sps.validation.article_and_subarticles import (
     ArticleLangValidation,
     ArticleAttribsValidation,
     ArticleTypeValidation,
-    ArticleSubjectsValidation
+    ArticleSubjectsValidation,
+    ArticleIdValidation
 )
 
 
@@ -670,3 +671,90 @@ class ArticleAndSubarticlesTest(TestCase):
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
+
+    def test_article_and_subarticles_validate_article_id_other_is_ok(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            <article-id pub-id-type="other">123</article-id>
+            </article-meta>
+            </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+
+        expected = {
+            'title': 'Article id other validation',
+            'xpath': './/article-id/@pub-id-type="other"',
+            'validation_type': 'format',
+            'response': 'OK',
+            'expected_value': '123',
+            'got_value': '123',
+            'message': 'Got 123 expected 123',
+            'advice': None
+            }
+        self.assertDictEqual(expected, obtained)
+
+    def test_article_and_subarticles_validate_article_id_other_non_numeric_digit(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            <article-id pub-id-type="other">x23</article-id>
+            </article-meta>
+            </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+
+        expected = {
+            'title': 'Article id other validation',
+            'xpath': './/article-id/@pub-id-type="other"',
+            'validation_type': 'format',
+            'response': 'ERROR',
+            'expected_value': 'A numeric value with up to five digits',
+            'got_value': 'x23',
+            'message': 'Got x23 expected a numeric value with up to five digits',
+            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+            }
+        self.assertDictEqual(expected, obtained)
+
+    def test_article_and_subarticles_validate_article_id_other_with_more_than_five_digits(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            <article-id pub-id-type="other">123456</article-id>
+            </article-meta>
+            </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+
+        expected = {
+            'title': 'Article id other validation',
+            'xpath': './/article-id/@pub-id-type="other"',
+            'validation_type': 'format',
+            'response': 'ERROR',
+            'expected_value': 'A numeric value with up to five digits',
+            'got_value': '123456',
+            'message': 'Got 123456 expected a numeric value with up to five digits',
+            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+            }
+        self.assertDictEqual(expected, obtained)

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -691,7 +691,7 @@ class ArticleAndSubarticlesTest(TestCase):
 
         expected = {
             'title': 'Article id other validation',
-            'xpath': './/article-id/@pub-id-type="other"',
+            'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',
             'response': 'OK',
             'expected_value': '123',
@@ -720,7 +720,7 @@ class ArticleAndSubarticlesTest(TestCase):
 
         expected = {
             'title': 'Article id other validation',
-            'xpath': './/article-id/@pub-id-type="other"',
+            'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',
             'response': 'ERROR',
             'expected_value': 'A numeric value with up to five digits',
@@ -749,7 +749,7 @@ class ArticleAndSubarticlesTest(TestCase):
 
         expected = {
             'title': 'Article id other validation',
-            'xpath': './/article-id/@pub-id-type="other"',
+            'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',
             'response': 'ERROR',
             'expected_value': 'A numeric value with up to five digits',


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona classe de validação para `article-id-other.`

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_and_subarticles.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

