### PR TITLE
Data availability validation

### DIFF
--- a/packtools/sps/models/article_data_availability.py
+++ b/packtools/sps/models/article_data_availability.py
@@ -1,0 +1,35 @@
+"""
+<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+    <back>
+        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+            <label>Data availability statement</label>
+            <p>Data will be available upon request.</p>
+        </sec>
+        <fn-group>
+            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                <label>Data Availability Statement</label>
+                <p>The data and code used to generate plots and perform statistical analyses have been
+                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+            </fn>
+        </fn-group>
+    </back>
+</article>
+"""
+
+
+class DataAvailability:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def specific_use(self):
+        xpath_query = './back//*[self::sec[@sec-type="data-availability"] | self::fn[@fn-type="data-availability"]]'
+        return [
+            {
+                'tag': node.tag,
+                'specific_use': node.get('specific-use')
+            }
+            for node in self.xmltree.xpath(xpath_query)
+        ]

--- a/packtools/sps/models/article_data_availability.py
+++ b/packtools/sps/models/article_data_availability.py
@@ -25,7 +25,7 @@ class DataAvailability:
 
     @property
     def specific_use(self):
-        xpath_query = './back//*[self::sec[@sec-type="data-availability"] | self::fn[@fn-type="data-availability"]]'
+        xpath_query = './/back//*[self::sec[@sec-type="data-availability"] | self::fn[@fn-type="data-availability"]]'
         return [
             {
                 'tag': node.tag,

--- a/packtools/sps/validation/article_data_availability.py
+++ b/packtools/sps/validation/article_data_availability.py
@@ -44,8 +44,8 @@ class DataAvailabilityValidation:
             [
                 {
                     'title': 'Data availability validation',
-                    'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                    'validation_type': 'exist, value in list',
+                    'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                    'validation_type': 'value in list',
                     'response': 'OK',
                     'expected_value': ["data-available", "data-available-upon-request"],
                     'got_value': 'data-available-upon-request',

--- a/packtools/sps/validation/article_data_availability.py
+++ b/packtools/sps/validation/article_data_availability.py
@@ -1,0 +1,72 @@
+from packtools.sps.models.article_data_availability import DataAvailability
+from packtools.sps.validation.exceptions import ValidationDataAvailabilityException
+
+
+class DataAvailabilityValidation:
+    def __init__(self, xmltree, specific_use_list=None):
+        self.xmltree = xmltree
+        self.data_availability = DataAvailability(self.xmltree)
+        self.specific_use_list = specific_use_list
+
+    def validate_data_availability(self, specific_use_list=None):
+        """
+        Check whether the data availability statement matches the options provided in a standard list.
+
+        XML input
+        ---------
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+            <back>
+                <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                    <label>Data availability statement</label>
+                    <p>Data will be available upon request.</p>
+                </sec>
+                <fn-group>
+                    <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                        <label>Data Availability Statement</label>
+                        <p>The data and code used to generate plots and perform statistical analyses have been
+                        uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                        xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                        w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                    </fn>
+                </fn-group>
+            </back>
+        </article>
+
+        Params
+        ------
+        specific_use_list : list, such as:
+            ["data-available", "data-available-upon-request"]
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'Data availability validation',
+                    'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                    'validation_type': 'exist, value in list',
+                    'response': 'OK',
+                    'expected_value': ["data-available", "data-available-upon-request"],
+                    'got_value': 'data-available-upon-request',
+                    'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
+                    'advice': None
+                }, ...
+            ]
+        """
+        specific_use_list = specific_use_list or self.specific_use_list
+        if not specific_use_list:
+            raise ValidationDataAvailabilityException("Function requires list of specific use")
+        for specific_use in self.data_availability.specific_use:
+            is_valid = specific_use['specific_use'] in specific_use_list
+
+            yield {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': specific_use_list,
+                'got_value': specific_use['specific_use'],
+                'message': 'Got {} expected one item of this list: {}'.format(specific_use['specific_use'], " | ".join(specific_use_list)),
+                'advice': None if is_valid else 'Provide a data availability statement from the following list: {}'.format(" | ".join(specific_use_list))
+            }

--- a/packtools/sps/validation/article_data_availability.py
+++ b/packtools/sps/validation/article_data_availability.py
@@ -56,17 +56,11 @@ class DataAvailabilityValidation:
         """
         specific_use_list = specific_use_list or self.specific_use_list
         if not specific_use_list:
-            raise ValidationDataAvailabilityException("Function requires list of specific use")
-        for specific_use in self.data_availability.specific_use:
-            is_valid = specific_use['specific_use'] in specific_use_list
+            raise ValidationDataAvailabilityException("Function requires a list of specific use.")
 
-            yield {
-                'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': specific_use_list,
-                'got_value': specific_use['specific_use'],
-                'message': 'Got {} expected one item of this list: {}'.format(specific_use['specific_use'], " | ".join(specific_use_list)),
-                'advice': None if is_valid else 'Provide a data availability statement from the following list: {}'.format(" | ".join(specific_use_list))
-            }
+        if not self.data_availability.specific_use:
+            yield self._create_response(None, specific_use_list)
+        else:
+            for specific_use in self.data_availability.specific_use:
+                yield self._create_response(specific_use, specific_use_list)
+

--- a/packtools/sps/validation/article_data_availability.py
+++ b/packtools/sps/validation/article_data_availability.py
@@ -64,3 +64,20 @@ class DataAvailabilityValidation:
             for specific_use in self.data_availability.specific_use:
                 yield self._create_response(specific_use, specific_use_list)
 
+    def _create_response(self, specific_use, specific_use_list):
+        got_value = specific_use['specific_use'] if specific_use else None
+        is_valid = got_value in specific_use_list
+        response_status = 'OK' if is_valid else 'ERROR'
+        message = f"Got {got_value} expected one item of this list: {' | '.join(specific_use_list)}"
+        advice = None if is_valid else f"Provide a data availability statement from the following list: {' | '.join(specific_use_list)}"
+
+        return {
+            'title': 'Data availability validation',
+            'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+            'validation_type': 'value in list',
+            'response': response_status,
+            'expected_value': specific_use_list,
+            'got_value': got_value,
+            'message': message,
+            'advice': advice
+        }

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -41,3 +41,7 @@ class ValidationArticleAndSubArticlesSubjectsException(Exception):
 
 class ValidationRelatedArticleException(Exception):
     ...
+
+
+class ValidationDataAvailabilityException(Exception):
+    ...

--- a/tests/sps/models/test_article_data_availability.py
+++ b/tests/sps/models/test_article_data_availability.py
@@ -1,0 +1,116 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.models.article_data_availability import DataAvailability
+
+
+class DataAvailabilityTest(unittest.TestCase):
+
+    def test_specific_use_sec_and_fn(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                            <label>Data availability statement</label>
+                            <p>Data will be available upon request.</p>
+                        </sec>
+                        <fn-group>
+                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                <label>Data Availability Statement</label>
+                                <p>The data and code used to generate plots and perform statistical analyses have been
+                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                            </fn>
+                        </fn-group>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'tag': 'sec',
+                'specific_use': 'data-available-upon-request'
+            },
+            {
+                'tag': 'fn',
+                'specific_use': 'data-available'
+            }
+        ]
+        obtained = DataAvailability(xmltree).specific_use
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_specific_use_sec(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                            <label>Data availability statement</label>
+                            <p>Data will be available upon request.</p>
+                        </sec>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'tag': 'sec',
+                'specific_use': 'data-available-upon-request'
+            }
+        ]
+        obtained = DataAvailability(xmltree).specific_use
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_specific_use_fn(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <fn-group>
+                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                <label>Data Availability Statement</label>
+                                <p>The data and code used to generate plots and perform statistical analyses have been
+                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                            </fn>
+                        </fn-group>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'tag': 'fn',
+                'specific_use': 'data-available'
+            }
+        ]
+        obtained = DataAvailability(xmltree).specific_use
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_specific_use_not_found(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = []
+        obtained = DataAvailability(xmltree).specific_use
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -6,15 +6,11 @@ from packtools.sps.validation.article_data_availability import DataAvailabilityV
 
 class DataAvailabilityTest(unittest.TestCase):
 
-    def test_validate_data_availability_with_sec_with_fn_ok(self):
+    def test_validate_data_availability_fn_ok(self):
         self.maxDiff = None
         xml = """
                 <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
                     <back>
-                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
-                            <label>Data availability statement</label>
-                            <p>Data will be available upon request.</p>
-                        </sec>
                         <fn-group>
                             <fn fn-type="data-availability" specific-use="data-available" id="fn1">
                                 <label>Data Availability Statement</label>
@@ -29,16 +25,6 @@ class DataAvailabilityTest(unittest.TestCase):
             """
         xmltree = etree.fromstring(xml)
         expected = [
-            {
-                'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
-                'response': 'OK',
-                'expected_value': ["data-available", "data-available-upon-request"],
-                'got_value': 'data-available-upon-request',
-                'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
-                'advice': None
-            },
             {
                 'title': 'Data availability validation',
                 'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
@@ -57,7 +43,7 @@ class DataAvailabilityTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_data_availability_with_sec_with_fn_not_ok(self):
+    def test_validate_data_availability_sec_ok(self):
         self.maxDiff = None
         xml = """
                 <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
@@ -66,6 +52,34 @@ class DataAvailabilityTest(unittest.TestCase):
                             <label>Data availability statement</label>
                             <p>Data will be available upon request.</p>
                         </sec>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available-upon-request',
+                'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_data_availability_fn_not_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
                         <fn-group>
                             <fn fn-type="data-availability" specific-use="data-available" id="fn1">
                                 <label>Data Availability Statement</label>
@@ -80,16 +94,6 @@ class DataAvailabilityTest(unittest.TestCase):
             """
         xmltree = etree.fromstring(xml)
         expected = [
-            {
-                'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
-                'response': 'ERROR',
-                'expected_value': ["data-not-available", "uninformed"],
-                'got_value': 'data-available-upon-request',
-                'message': 'Got data-available-upon-request expected one item of this list: data-not-available | uninformed',
-                'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
-            },
             {
                 'title': 'Data availability validation',
                 'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
@@ -108,7 +112,7 @@ class DataAvailabilityTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_data_availability_with_sec_without_fn_ok(self):
+    def test_validate_data_availability_sec_not_ok(self):
         self.maxDiff = None
         xml = """
                 <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
@@ -126,58 +130,21 @@ class DataAvailabilityTest(unittest.TestCase):
                 'title': 'Data availability validation',
                 'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
                 'validation_type': 'exist, value in list',
-                'response': 'OK',
-                'expected_value': ["data-available", "data-available-upon-request"],
+                'response': 'ERROR',
+                'expected_value': ["data-not-available", "uninformed"],
                 'got_value': 'data-available-upon-request',
-                'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
-                'advice': None
+                'message': 'Got data-available-upon-request expected one item of this list: data-not-available | uninformed',
+                'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
             }
         ]
         obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
+            ["data-not-available", "uninformed"]
         )
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_data_availability_without_sec_with_fn_ok(self):
-        self.maxDiff = None
-        xml = """
-                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
-                    <back>
-                        <fn-group>
-                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
-                                <label>Data Availability Statement</label>
-                                <p>The data and code used to generate plots and perform statistical analyses have been
-                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
-                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
-                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
-                            </fn>
-                        </fn-group>
-                    </back>
-                </article>
-            """
-        xmltree = etree.fromstring(xml)
-        expected = [
-            {
-                'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
-                'response': 'OK',
-                'expected_value': ["data-available", "data-available-upon-request"],
-                'got_value': 'data-available',
-                'message': 'Got data-available expected one item of this list: data-available | data-available-upon-request',
-                'advice': None
-            }
-        ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_data_availability_without_sec_without_fn_ok(self):
+    def test_validate_data_availability_without_data_availability(self):
         self.maxDiff = None
         xml = """
                 <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -161,6 +161,45 @@ class DataAvailabilityTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_data_availability_subarticle_fn_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <sub-article article-type="translation" id="TRen" xml:lang="en">
+                        <back>
+                            <fn-group>
+                                <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                    <label>Data Availability Statement</label>
+                                    <p>The data and code used to generate plots and perform statistical analyses have been
+                                    uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                    xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                    w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                                </fn>
+                            </fn-group>
+                        </back>
+                    </sub-article>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available',
+                'message': 'Got data-available expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -1,0 +1,199 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.article_data_availability import DataAvailabilityValidation
+
+
+class DataAvailabilityTest(unittest.TestCase):
+
+    def test_validate_data_availability_with_sec_with_fn_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                            <label>Data availability statement</label>
+                            <p>Data will be available upon request.</p>
+                        </sec>
+                        <fn-group>
+                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                <label>Data Availability Statement</label>
+                                <p>The data and code used to generate plots and perform statistical analyses have been
+                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                            </fn>
+                        </fn-group>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available-upon-request',
+                'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            },
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available',
+                'message': 'Got data-available expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_data_availability_with_sec_with_fn_not_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                            <label>Data availability statement</label>
+                            <p>Data will be available upon request.</p>
+                        </sec>
+                        <fn-group>
+                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                <label>Data Availability Statement</label>
+                                <p>The data and code used to generate plots and perform statistical analyses have been
+                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                            </fn>
+                        </fn-group>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'ERROR',
+                'expected_value': ["data-not-available", "uninformed"],
+                'got_value': 'data-available-upon-request',
+                'message': 'Got data-available-upon-request expected one item of this list: data-not-available | uninformed',
+                'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
+            },
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'ERROR',
+                'expected_value': ["data-not-available", "uninformed"],
+                'got_value': 'data-available',
+                'message': 'Got data-available expected one item of this list: data-not-available | uninformed',
+                'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-not-available", "uninformed"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_data_availability_with_sec_without_fn_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <sec sec-type="data-availability" specific-use="data-available-upon-request">
+                            <label>Data availability statement</label>
+                            <p>Data will be available upon request.</p>
+                        </sec>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available-upon-request',
+                'message': 'Got data-available-upon-request expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_data_availability_without_sec_with_fn_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                        <fn-group>
+                            <fn fn-type="data-availability" specific-use="data-available" id="fn1">
+                                <label>Data Availability Statement</label>
+                                <p>The data and code used to generate plots and perform statistical analyses have been
+                                uploaded to the Open Science Framework archive: <ext-link ext-link-type="uri"
+                                xlink:href="https://osf.io/jw6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e">https://osf.io/j
+                                w6vg/?view_only=0335a15b6db3477f93d0ae636cdf3b4e</ext-link>.</p>
+                            </fn>
+                        </fn-group>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'exist, value in list',
+                'response': 'OK',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': 'data-available',
+                'message': 'Got data-available expected one item of this list: data-available | data-available-upon-request',
+                'advice': None
+            }
+        ]
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_data_availability_without_sec_without_fn_ok(self):
+        self.maxDiff = None
+        xml = """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <back>
+                    </back>
+                </article>
+            """
+        xmltree = etree.fromstring(xml)
+        expected = []
+        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]
+        )
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -36,8 +36,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -68,8 +68,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -105,8 +105,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-not-available", "uninformed"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-not-available", "uninformed"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -137,8 +137,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-not-available", "uninformed"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-not-available", "uninformed"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -165,8 +165,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': 'Provide a data availability statement from the following list: data-available | data-available-upon-request'
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -204,8 +204,8 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"])]
+        obtained = list(DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"]))
 
         for i, item in enumerate(obtained):
             with self.subTest(i):

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -38,7 +38,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-available", "data-available-upon-request"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_data_availability_sec_ok(self):
         self.maxDiff = None
@@ -67,7 +70,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-available", "data-available-upon-request"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_data_availability_fn_not_ok(self):
         self.maxDiff = None
@@ -101,7 +107,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-not-available", "uninformed"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_data_availability_sec_not_ok(self):
         self.maxDiff = None
@@ -130,7 +139,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-not-available", "uninformed"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_data_availability_without_data_availability(self):
         self.maxDiff = None
@@ -155,7 +167,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-available", "data-available-upon-request"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_data_availability_subarticle_fn_ok(self):
         self.maxDiff = None
@@ -191,7 +206,10 @@ class DataAvailabilityTest(unittest.TestCase):
         ]
         obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
             ["data-available", "data-available-upon-request"])]
-        self.assertEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 if __name__ == '__main__':

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -27,8 +27,8 @@ class DataAvailabilityTest(unittest.TestCase):
         expected = [
             {
                 'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
                 'response': 'OK',
                 'expected_value': ["data-available", "data-available-upon-request"],
                 'got_value': 'data-available',
@@ -36,12 +36,9 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"])]
+        self.assertEqual(expected, obtained)
 
     def test_validate_data_availability_sec_ok(self):
         self.maxDiff = None
@@ -59,8 +56,8 @@ class DataAvailabilityTest(unittest.TestCase):
         expected = [
             {
                 'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
                 'response': 'OK',
                 'expected_value': ["data-available", "data-available-upon-request"],
                 'got_value': 'data-available-upon-request',
@@ -68,12 +65,9 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"])]
+        self.assertEqual(expected, obtained)
 
     def test_validate_data_availability_fn_not_ok(self):
         self.maxDiff = None
@@ -96,8 +90,8 @@ class DataAvailabilityTest(unittest.TestCase):
         expected = [
             {
                 'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
                 'response': 'ERROR',
                 'expected_value': ["data-not-available", "uninformed"],
                 'got_value': 'data-available',
@@ -105,12 +99,9 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
             }
         ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-not-available", "uninformed"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-not-available", "uninformed"])]
+        self.assertEqual(expected, obtained)
 
     def test_validate_data_availability_sec_not_ok(self):
         self.maxDiff = None
@@ -128,8 +119,8 @@ class DataAvailabilityTest(unittest.TestCase):
         expected = [
             {
                 'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
                 'response': 'ERROR',
                 'expected_value': ["data-not-available", "uninformed"],
                 'got_value': 'data-available-upon-request',
@@ -137,12 +128,9 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': 'Provide a data availability statement from the following list: data-not-available | uninformed'
             }
         ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-not-available", "uninformed"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-not-available", "uninformed"])]
+        self.assertEqual(expected, obtained)
 
     def test_validate_data_availability_without_data_availability(self):
         self.maxDiff = None
@@ -153,13 +141,21 @@ class DataAvailabilityTest(unittest.TestCase):
                 </article>
             """
         xmltree = etree.fromstring(xml)
-        expected = []
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        expected = [
+            {
+                'title': 'Data availability validation',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ["data-available", "data-available-upon-request"],
+                'got_value': None,
+                'message': 'Got None expected one item of this list: data-available | data-available-upon-request',
+                'advice': 'Provide a data availability statement from the following list: data-available | data-available-upon-request'
+            }
+        ]
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"])]
+        self.assertEqual(expected, obtained)
 
     def test_validate_data_availability_subarticle_fn_ok(self):
         self.maxDiff = None
@@ -184,8 +180,8 @@ class DataAvailabilityTest(unittest.TestCase):
         expected = [
             {
                 'title': 'Data availability validation',
-                'xpath': './back//fn[@fn-type="data-availability"]/@specific-use ./back//sec[@sec-type="data-availability"]/@specific-use',
-                'validation_type': 'exist, value in list',
+                'xpath': './/back//fn[@fn-type="data-availability"]/@specific-use .//back//sec[@sec-type="data-availability"]/@specific-use',
+                'validation_type': 'value in list',
                 'response': 'OK',
                 'expected_value': ["data-available", "data-available-upon-request"],
                 'got_value': 'data-available',
@@ -193,12 +189,9 @@ class DataAvailabilityTest(unittest.TestCase):
                 'advice': None
             }
         ]
-        obtained = DataAvailabilityValidation(xmltree).validate_data_availability(
-            ["data-available", "data-available-upon-request"]
-        )
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = [item for item in DataAvailabilityValidation(xmltree).validate_data_availability(
+            ["data-available", "data-available-upon-request"])]
+        self.assertEqual(expected, obtained)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona procedimento de validação para declaração de disponibilidade de dados.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_data_availability.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
https://wp.scielo.org/wp-content/uploads/dados.pdf
