### PR TITLE
Pid provider article date

### DIFF
--- a/tests/sps/models/test_dates.py
+++ b/tests/sps/models/test_dates.py
@@ -115,7 +115,6 @@ class ArticleDatesArticleFrom1_8Test(TestCase):
         self.assertEqual("20", self.xml_dates.article_date["day"])
 
 
-
 class ArticleDatesArticleBefore1_8Test(TestCase):
 
     def setUp(self):
@@ -136,3 +135,25 @@ class ArticleDatesArticleBefore1_8Test(TestCase):
 
     def test_article_date_day(self):
         self.assertEqual("20", self.xml_dates.article_date["day"])
+
+
+class ArticleDatesArticleBefore1_8EpubIncompleteTest(TestCase):
+
+    def setUp(self):
+        pub_dates = ("""
+            <pub-date pub-type="epub"><year>2023</year><month>02</month></pub-date>
+        """)
+        self.xmltree = etree.fromstring(_get_xml(pub_dates))
+        self.xml_dates = ArticleDates(self.xmltree)
+
+    def test_article_date_is_none(self):
+        self.assertIsNone(self.xml_dates.article_date)
+
+    def test_collection_date_year(self):
+        self.assertEqual("2023", self.xml_dates.collection_date["year"])
+
+    def test_collection_date_month(self):
+        self.assertEqual("02", self.xml_dates.collection_date["month"])
+
+    def test_collection_date_day(self):
+        self.assertIsNone(self.xml_dates.collection_date.get("day"))


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a identificação de `<date pub-type="epub"/>` como sendo data do tipo collection por não ser completa.
Na versão SPS 1.8 era possível epub representar data de fascículo e também de artigo, dependendo se era completa ou incompleta.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python3 -m unittest -v tests/sps/models/test_dates.py
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt-br/1.7-branch/tagset/elemento-pub-date.html
https://www.scielo.br/j/abo/a/xwsWKQNn8K7LpbNyXqydyzd/?format=xml

