### PR TITLE
Doi registered

### DIFF
--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -186,13 +186,56 @@ class ArticleDoiValidation:
             }
         ]
 
+    def validate_doi_registered(self, callable_get_validate=None):
+        """
+        Checks whether a DOI is registered as valid.
+
+        XML input
+        ---------
+        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            <article-id pub-id-type="doi">10.1590/1518-8345.2927.3231</article-id>
+            <article-id pub-id-type="other">00303</article-id>
+            </front>
+        </article>
+
+        Params
+
+        ------
+        callable_get_validation : function
+            A function that will be passed as an argument.
+            This function must have the signature 'def callable_get_validate(doi_name):' and returns True if the doi_name is valid or False otherwise
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'Article DOI element is registered',
+                    'xpath': './article-id[@pub-id-type="doi"]',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': 10.1590/1518-8345.2927.3231,
+                    'got_value': 10.1590/1518-8345.2927.3231,
+                    'message': 'Got 10.1590/1518-8345.2927.3231 expected 10.1590/1518-8345.2927.3231',
+                    'advice': None
+                }
+            ]
+        """
+        callable_get_validate = callable_get_validate or _callable_extern_validate_default
+        is_valid = callable_get_validate(self.doi)
         return {
-            'title': 'Article DOI element is unique',
+            'title': 'Article DOI element is registered',
             'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist/verification',
-            'response': 'OK' if validated else 'ERROR',
-            'expected_value': 'Unique DOI values',
-            'got_value': 'DOIs identified: {}'.format(" | ".join(list(dois.keys()))),
-            'message': 'Got DOIs and frequencies {}'.format(" | ".join([str((doi, freq)) for doi, freq in dois.items()])),
-            'advice': None if validated else 'Consider replacing the following DOIs that are not unique: {}'.format(" | ".join(diff))
+            'validation_type': 'exist',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': self.doi if is_valid else 'An article DOI registered',
+            'got_value': self.doi,
+            'message': 'Got {} expected {}'.format(self.doi, self.doi if is_valid else 'An article DOI registered'),
+            'advice': None if is_valid else 'DOI not registered or validator not found, provide a registered DOI or '
+                                            'check validator'
         }

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -185,7 +185,7 @@ class ArticleDoiValidation:
                 'validation_type': 'exist/verification',
                 'response': 'OK' if validated else 'ERROR',
                 'expected_value': 'Unique DOI values',
-                'got_value': 'DOIs identified: {}'.format(" | ".join(list(dois.keys()))),
+                'got_value': list(dois.keys()),
                 'message': 'Got DOIs and frequencies {}'.format(
                     " | ".join([str((doi, freq)) for doi, freq in dois.items()])),
                 'advice': None if validated else 'Consider replacing the following DOIs that are not unique: {}'.format(

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -335,17 +335,32 @@ class ArticleDoiValidation:
                                                                  'provide a value for {} element that matches the record '
                                                                  'for DOI.'.format(validation[0])
                         }
+                # Valida o tamanho das listas de autores
+                if not authors_is_valid:
+                    if len(expected_authors) > len(obtained_authors):
+                        diff = expected_authors[len(obtained_authors):]
+                        item_description = 'not found'
+                        action = ('Complete', 'in')
+                    else:
+                        diff = obtained_authors[len(expected_authors):]
+                        item_description = 'surplus'
+                        action = ('Remove', 'from')
+
+                    diff_str = ' | '.join(diff)
+                    message = f'The following items are {item_description} in the XML: {diff_str}'
+                    advice = f'{action[0]} the following items {action[1]} the XML: {diff_str}'
+                    yield {
+                        'title': 'Article DOI is registered (lang: {}, element: authors)'.format(lang),
                         'xpath': './article-id[@pub-id-type="doi"]',
                         'validation_type': 'exist',
-                        'response': 'OK' if validation[1] else 'ERROR',
-                        'expected_value': validation[2],
-                        'got_value': validation[3],
-                        'message': 'Got {} expected {}'.format(validation[3], validation[2]),
-                        'advice': None if validation[1] else 'DOI not registered or validator not found, '
-                                                             'provide a value for {} element that matches the record '
-                                                             'for DOI.'.format(validation[0])
+                        'response': 'ERROR',
+                        'expected_value': expected_authors,
+                        'got_value': obtained_authors,
+                        'message': message,
+                        'advice': advice
                     }
             else:
+                # Resposta para o caso de não haver identificação do DOI
                 yield {
                         'title': 'Article DOI is registered',
                         'xpath': './article-id[@pub-id-type="doi"]',

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -84,8 +84,8 @@ class ArticleDoiValidation:
 
         Returns
         -------
-        dict
-            Such as:
+        list of dict
+            A list of dictionaries, such as:
             [
                 {
                     'title': 'Sub-article translation DOI element',

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -1,9 +1,11 @@
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
+from packtools.sps.models.article_authors import Authors
+from packtools.sps.models.article_titles import ArticleTitles
 
 
 def _callable_extern_validate_default(doi):
-    return False
+    return 'Validate not found'
 
 
 class ArticleDoiValidation:
@@ -12,6 +14,8 @@ class ArticleDoiValidation:
         self.articles = ArticleAndSubArticles(self.xmltree)
         self.doi = DoiWithLang(self.xmltree).main_doi
         self.dois = DoiWithLang(self.xmltree).data
+        self.authors = Authors(self.xmltree).contribs
+        self.titles = ArticleTitles(self.xmltree).article_title_dict
 
     def validate_main_article_doi_exists(self):
         """

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -56,7 +56,7 @@ class ArticleDoiValidation:
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK' if self.doi else 'ERROR',
-                'expected_value': self.doi if self.doi else 'article DOI',
+                'expected_value': self.doi or 'article DOI',
                 'got_value': self.doi,
                 'message': 'Got {} expected {}'.format(self.doi, self.doi if self.doi else 'a DOI'),
                 'advice': None if self.doi else 'Provide a valid DOI for the {}'.format(self.articles.main_article_type)

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -119,8 +119,11 @@ class ArticleDoiValidation:
                     'expected_value': doi if doi else 'sub-article DOI',
                     'got_value': doi,
                     'message': 'Got {} expected {}'.format(doi, doi if doi else 'sub-article DOI'),
-                    'advice': None if doi else 'Provide a valid DOI for the sub-article translation ({}) which '
-                                               'language is {}'.format(article_id, lang)
+                    'advice': None if doi else 'Provide a valid DOI for the sub-article represented by the following'
+                                               ' tag: <sub-article article-type="translation" id="{}" xml:lang="{}">'.format(
+                        article_id,
+                        lang
+                    )
                 }
 
     def validate_all_dois_are_unique(self):

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -100,8 +100,6 @@ class ArticleDoiValidation:
             ]
         """
 
-        result = []
-
         doi_map = {d['lang']: d['value'] for d in self.dois}
 
         for sub_article in self.articles.data:
@@ -109,20 +107,17 @@ class ArticleDoiValidation:
                 lang = sub_article['lang']
                 article_id = sub_article['article_id']
                 doi = doi_map.get(lang)
-                result.append(
-                    {
-                        'title': 'Sub-article translation DOI element',
-                        'xpath': './sub-article[@article-type="translation"]',
-                        'validation_type': 'exist',
-                        'response': 'OK' if doi else 'ERROR',
-                        'expected_value': doi if doi else 'sub-article DOI',
-                        'got_value': doi,
-                        'message': 'Got {} expected {}'.format(doi, doi if doi else 'sub-article DOI'),
-                        'advice': None if doi else 'Provide a valid DOI for the sub-article translation ({}) which '
-                                                   'language is {}'.format(article_id, lang)
-                    }
-                )
-        return result
+                yield {
+                    'title': 'Sub-article translation DOI element',
+                    'xpath': './sub-article[@article-type="translation"]',
+                    'validation_type': 'exist',
+                    'response': 'OK' if doi else 'ERROR',
+                    'expected_value': doi if doi else 'sub-article DOI',
+                    'got_value': doi,
+                    'message': 'Got {} expected {}'.format(doi, doi if doi else 'sub-article DOI'),
+                    'advice': None if doi else 'Provide a valid DOI for the sub-article translation ({}) which '
+                                               'language is {}'.format(article_id, lang)
+                }
 
     def validate_all_dois_are_unique(self):
         """

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -369,5 +369,5 @@ class ArticleDoiValidation:
                         'expected_value': 'Data registered to the DOI {}'.format(doi.get('value')),
                         'got_value': None,
                         'message': 'Got None expected data registered to the DOI {}'.format(doi.get('value')),
-                        'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
+                        'advice': 'Consult again after DOI has been registered'
                     }

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -308,25 +308,13 @@ class ArticleDoiValidation:
                 obtained_doi = doi.get('value')
                 obtained_title = self.titles.get(lang)
                 obtained_authors = list(f"{author.get('surname')}, {author.get('given_names')}" for author in self.authors)
+                # valores esperados
                 expected_doi = expected.get(lang).get('doi')
                 expected_title = expected.get(lang).get('title')
                 expected_authors = expected.get('authors') or []
-
+                # validações
                 doi_is_valid = obtained_doi == expected_doi
                 title_is_valid = obtained_title == expected_title
-
-                validations.append(('doi', doi_is_valid, expected_doi, obtained_doi))
-                validations.append(('title', title_is_valid, expected_title, obtained_title))
-
-                for author in sorted(list(set(expected_authors).intersection(set(obtained_authors)))):
-                    validations.append(('author', True, author, author))
-
-                for author in sorted(list(set(expected_authors).difference(set(obtained_authors)))):
-                    validations.append(('author', False, author, None))
-
-                for author in sorted(list(set(obtained_authors).difference(set(expected_authors)))):
-                    validations.append(('author', False, None, author))
-
                 for validation in validations:
                     yield {
                         'title': 'Article DOI is registered (lang: {}, element: {})'.format(lang, validation[0]),

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -144,18 +144,20 @@ class ArticleDoiValidation:
 
         Returns
         -------
-        dict
-            Such as:
-            {
-                'title': 'Article DOI element is unique',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist/verification',
-                'response': 'OK',
-                'expected_value': 'Unique DOI values',
-                'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
-                'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
-                'advice': None
-            }
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'Article DOI element is unique',
+                    'xpath': './article-id[@pub-id-type="doi"]',
+                    'validation_type': 'exist/verification',
+                    'response': 'OK',
+                    'expected_value': 'Unique DOI values',
+                    'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
+                    'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
+                    'advice': None
+                }
+            ]
         """
         validated = True
         dois = {}
@@ -168,6 +170,21 @@ class ArticleDoiValidation:
 
         if not validated:
             diff = [doi for doi, freq in dois.items() if freq > 1]
+
+        return [
+            {
+                'title': 'Article DOI element is unique',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist/verification',
+                'response': 'OK' if validated else 'ERROR',
+                'expected_value': 'Unique DOI values',
+                'got_value': 'DOIs identified: {}'.format(" | ".join(list(dois.keys()))),
+                'message': 'Got DOIs and frequencies {}'.format(
+                    " | ".join([str((doi, freq)) for doi, freq in dois.items()])),
+                'advice': None if validated else 'Consider replacing the following DOIs that are not unique: {}'.format(
+                    " | ".join(diff))
+            }
+        ]
 
         return {
             'title': 'Article DOI element is unique',

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -315,6 +315,13 @@ class ArticleDoiValidation:
                 # validações
                 doi_is_valid = obtained_doi == expected_doi
                 title_is_valid = obtained_title == expected_title
+                authors_is_valid = len(obtained_authors) == len(expected_authors)
+                # agrega as validações
+                validations.append(('doi', doi_is_valid, obtained_doi, expected_doi))
+                validations.append(('title', title_is_valid, obtained_title, expected_title))
+                for author in zip(obtained_authors, expected_authors):
+                    validations.append(('author', author[0] == author[1], author[0], author[1]))
+                # gera os resultados das validações
                 for validation in validations:
                     yield {
                         'title': 'Article DOI is registered (lang: {}, element: {})'.format(lang, validation[0]),

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -193,7 +193,7 @@ class ArticleDoiValidation:
             }
         ]
 
-    def validate_doi_registered(self, callable_get_validate=None):
+    def validate_doi_registered(self, callable_get_data=None):
         """
         Checks whether a DOI is registered as valid.
 

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -31,29 +31,33 @@ class ArticleDoiValidation:
 
         Returns
         -------
-        dict
-            Such as:
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'Article DOI element',
+                    'xpath': './article-id[@pub-id-type="doi"]',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': 'article DOI',
+                    'got_value': '10.1590/1518-8345.2927.3231',
+                    'message': 'Got 10.1590/1518-8345.2927.3231 expected a DOI',
+                    'advice': 'XML research-article does not present a DOI'
+                }
+            ]
+        """
+        return [
             {
                 'title': 'Article DOI element',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'article DOI',
-                'got_value': '10.1590/1518-8345.2927.3231',
-                'message': 'Got 10.1590/1518-8345.2927.3231 expected a DOI',
-                'advice': 'XML research-article does not present a DOI'
+                'response': 'OK' if self.doi else 'ERROR',
+                'expected_value': self.doi if self.doi else 'article DOI',
+                'got_value': self.doi,
+                'message': 'Got {} expected {}'.format(self.doi, self.doi if self.doi else 'a DOI'),
+                'advice': None if self.doi else 'Provide a valid DOI for the {}'.format(self.articles.main_article_type)
             }
-        """
-        return {
-            'title': 'Article DOI element',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist',
-            'response': 'OK' if self.doi else 'ERROR',
-            'expected_value': self.doi if self.doi else 'article DOI',
-            'got_value': self.doi,
-            'message': 'Got {} expected {}'.format(self.doi, self.doi if self.doi else 'a DOI'),
-            'advice': None if self.doi else 'Provide a valid DOI for the {}'.format(self.articles.main_article_type)
-        }
+        ]
 
     def validate_translations_doi_exists(self):
         """

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -324,7 +324,17 @@ class ArticleDoiValidation:
                 # gera os resultados das validações
                 for validation in validations:
                     yield {
-                        'title': 'Article DOI is registered (lang: {}, element: {})'.format(lang, validation[0]),
+                            'title': 'Article DOI is registered (lang: {}, element: {})'.format(lang, validation[0]),
+                            'xpath': './article-id[@pub-id-type="doi"]',
+                            'validation_type': 'exist',
+                            'response': 'OK' if validation[1] else 'ERROR',
+                            'expected_value': validation[3],
+                            'got_value': validation[2],
+                            'message': 'Got {} expected {}'.format(validation[2], validation[3]),
+                            'advice': None if validation[1] else 'DOI not registered or validator not found, '
+                                                                 'provide a value for {} element that matches the record '
+                                                                 'for DOI.'.format(validation[0])
+                        }
                         'xpath': './article-id[@pub-id-type="doi"]',
                         'validation_type': 'exist',
                         'response': 'OK' if validation[1] else 'ERROR',

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -298,18 +298,16 @@ class ArticleDoiValidation:
         """
         callable_get_data = callable_get_data or _callable_extern_validate_default
 
-        obtained_authors = list(f"{author.get('surname')}, {author.get('given_names')}" for author in self.authors)
-
         for doi in self.dois:
-            validations = []
             expected = callable_get_data(doi)
-
+            # verifica se houve resposta da aplicação
             if expected:
+                validations = []
                 lang = doi.get('lang')
-
+                # valores obtidos
                 obtained_doi = doi.get('value')
                 obtained_title = self.titles.get(lang)
-
+                obtained_authors = list(f"{author.get('surname')}, {author.get('given_names')}" for author in self.authors)
                 expected_doi = expected.get(lang).get('doi')
                 expected_title = expected.get(lang).get('title')
                 expected_authors = expected.get('authors') or []

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -296,7 +296,7 @@ class ArticleDoiValidation:
                 ...
             ]
         """
-        callable_get_validate = callable_get_validate or _callable_extern_validate_default
+        callable_get_data = callable_get_data or _callable_extern_validate_default
 
         obtained_authors = list(f"{author.get('surname')}, {author.get('given_names')}" for author in self.authors)
 

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -284,31 +284,16 @@ class ArticleDoiValidation:
             A list of dictionaries, such as:
             [
                 {
-                    'title': 'Article DOI element is registered',
+                    'title': 'Article DOI is registered (lang: en, element: doi)',
                     'xpath': './article-id[@pub-id-type="doi"]',
                     'validation_type': 'exist',
                     'response': 'OK',
-                    'expected_value': [
-                        'en',
-                        '10.1590/2176-4573p59270',
-                        'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                        ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                    ],
-                    'got_value': [
-                        'en',
-                        '10.1590/2176-4573p59270',
-                        'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                        ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                    ],
-                    'message': "Got "
-                               "['en', '10.1590/2176-4573p59270', "
-                               "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                               "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
-                               "['en', '10.1590/2176-4573p59270', "
-                               "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                               "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                    'expected_value': '10.1590/2176-4573p59270',
+                    'got_value': '10.1590/2176-4573p59270',
+                    'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
                     'advice': None
-                },...
+                },
+                ...
             ]
         """
         callable_get_validate = callable_get_validate or _callable_extern_validate_default

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -5,7 +5,7 @@ from packtools.sps.models.article_titles import ArticleTitles
 
 
 def _callable_extern_validate_default(doi):
-    return 'Validate not found'
+    raise NotImplementedError
 
 
 class ArticleDoiValidation:

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -202,19 +202,81 @@ class ArticleDoiValidation:
         <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
-            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
-            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
-            <article-id pub-id-type="doi">10.1590/1518-8345.2927.3231</article-id>
-            <article-id pub-id-type="other">00303</article-id>
+                <article-meta>
+                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
+                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
+                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                <title-group>
+                    <article-title>Analysis of the evolution of competences in the clinical practice of the nursing degree</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
             </front>
-        </article>
+            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
+            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                        <title-group>
+                            <article-title>Análise da evolução de competências da prática clínica no curso de enfermagem</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                        </contrib-group>
+                </front-stub>
+            </sub-article>
+            </article>
 
         Params
 
         ------
         callable_get_validation : function
             A function that will be passed as an argument.
-            This function must have the signature 'def callable_get_validate(doi_name):' and returns True if the doi_name is valid or False otherwise
+            This function must have the signature 'def callable_get_validate(doi_name):' and returns a dict, such as:
+            {
+                'en': {
+                        'title': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                        'doi': '10.1590/2176-4573p59270'
+                    },
+                'pt': {
+                        'title': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                        'doi': '10.1590/2176-4573e59270'
+                    },
+                'authors': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+            }
 
         Returns
         -------
@@ -226,11 +288,27 @@ class ArticleDoiValidation:
                     'xpath': './article-id[@pub-id-type="doi"]',
                     'validation_type': 'exist',
                     'response': 'OK',
-                    'expected_value': 10.1590/1518-8345.2927.3231,
-                    'got_value': 10.1590/1518-8345.2927.3231,
-                    'message': 'Got 10.1590/1518-8345.2927.3231 expected 10.1590/1518-8345.2927.3231',
+                    'expected_value': [
+                        'en',
+                        '10.1590/2176-4573p59270',
+                        'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                        ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                    ],
+                    'got_value': [
+                        'en',
+                        '10.1590/2176-4573p59270',
+                        'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                        ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                    ],
+                    'message': "Got "
+                               "['en', '10.1590/2176-4573p59270', "
+                               "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                               "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
+                               "['en', '10.1590/2176-4573p59270', "
+                               "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                               "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
                     'advice': None
-                }
+                },...
             ]
         """
         callable_get_validate = callable_get_validate or _callable_extern_validate_default

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -2,6 +2,10 @@ from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.article_doi_with_lang import DoiWithLang
 
 
+def _callable_extern_validate_default(doi):
+    return False
+
+
 class ArticleDoiValidation:
     def __init__(self, xmltree):
         self.xmltree = xmltree

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -22,14 +22,14 @@ def callable_get_validate_ok(doi):
 def callable_get_validate_not_ok(doi):
     return {
         "en": {
-                "title": "Analysis of the evolution of competences in the clinical practice of the nursing degree",
-                "doi": "10.1590/2176-4573p59270"
+                "title": "Analysis of the evolution of competences in the clinical practice",
+                "doi": "10.1590/2176-4573p59271"
             },
         "pt": {
-                "title": "Análise da evolução de competências da prática clínica no curso de enfermagem",
-                "doi": "10.1590/2176-4573e59270"
+                "title": "Análise da evolução de competências da prática clínica",
+                "doi": "10.1590/2176-4573e59271"
             },
-        "authors": ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+        "authors": ['Martínez Momblán, Maria Antonia', 'Colina Torralva, Javier']
     }
 
 
@@ -405,57 +405,88 @@ class ArticleDoiTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'Article DOI element is registered',
+                'title': 'Article DOI is registered (lang: en, element: doi)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': [
-                    'en',
-                    '10.1590/2176-4573p59270',
-                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'got_value': [
-                    'en',
-                    '10.1590/2176-4573p59270',
-                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'message': "Got "
-                           "['en', '10.1590/2176-4573p59270', "
-                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
-                           "['en', '10.1590/2176-4573p59270', "
-                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
                 'advice': None
             },
             {
-                'title': 'Article DOI element is registered',
+                'title': 'Article DOI is registered (lang: en, element: title)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': [
-                    'pt',
-                    '10.1590/2176-4573e59270',
-                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'got_value': [
-                    'pt',
-                    '10.1590/2176-4573e59270',
-                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'message': "Got "
-                           "['pt', '10.1590/2176-4573e59270', "
-                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
-                           "['pt', '10.1590/2176-4573e59270', "
-                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'expected_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                'got_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                'message': 'Got Analysis of the evolution of competences in the clinical practice of the nursing degree '
+                           'expected Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'got_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'message': 'Got Análise da evolução de competências da prática clínica no curso de enfermagem '
+                           'expected Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
                 'advice': None
             }
+
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
@@ -532,56 +563,94 @@ class ArticleDoiTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'Article DOI element is registered',
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': [
-                    'pt',
-                    '10.1590/2176-4573e59270',
-                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'got_value': [
-                    'pt',
-                    '10.1590/2176-4573p59270',
-                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'message': "Got "
-                           "['pt', '10.1590/2176-4573p59270', "
-                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
-                           "['pt', '10.1590/2176-4573e59270', "
-                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
-                'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
+                'expected_value': '10.1590/2176-4573e59271',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573e59271',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
+                          'matches the record for DOI.'
             },
             {
-                'title': 'Article DOI element is registered',
+                'title': 'Article DOI is registered (lang: pt, element: title)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': [
-                    'en',
-                    '10.1590/2176-4573p59270',
-                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'got_value': [
-                    'en',
-                    '10.1590/2176-4573e59270',
-                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
-                ],
-                'message': "Got "
-                           "['en', '10.1590/2176-4573e59270', "
-                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
-                           "['en', '10.1590/2176-4573p59270', "
-                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
-                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
-                'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
+                'expected_value': 'Análise da evolução de competências da prática clínica',
+                'got_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                'message': 'Got Analysis of the evolution of competences in the clinical practice of the nursing degree '
+                           'expected Análise da evolução de competências da prática clínica',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': '10.1590/2176-4573p59271',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573p59271',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Analysis of the evolution of competences in the clinical practice',
+                'got_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'message': 'Got Análise da evolução de competências da prática clínica no curso de enfermagem expected '
+                           'Analysis of the evolution of competences in the clinical practice',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
             }
         ]
         for i, item in enumerate(obtained):

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -5,6 +5,14 @@ from packtools.sps.utils.xml_utils import get_xml_tree
 from packtools.sps.validation.article_doi import ArticleDoiValidation
 
 
+def callable_get_validate_ok(doi):
+    return True
+
+
+def callable_get_validate_not_ok(doi):
+    return False
+
+
 class ArticleDoiTest(unittest.TestCase):
     def test_validate_article_has_doi(self):
         self.maxDiff = None
@@ -21,17 +29,21 @@ class ArticleDoiTest(unittest.TestCase):
             """
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_main_article_doi_exists()
-        expected = {
-            'title': 'Article DOI element',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist',
-            'response': 'OK',
-            'expected_value': '10.1590/1518-8345.2927.3231',
-            'got_value': '10.1590/1518-8345.2927.3231',
-            'message': 'Got 10.1590/1518-8345.2927.3231 expected 10.1590/1518-8345.2927.3231',
-            'advice': None
-        }
-        self.assertDictEqual(obtained, expected)
+        expected = [
+            {
+                'title': 'Article DOI element',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/1518-8345.2927.3231',
+                'got_value': '10.1590/1518-8345.2927.3231',
+                'message': 'Got 10.1590/1518-8345.2927.3231 expected 10.1590/1518-8345.2927.3231',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_article_has_no_doi(self):
         self.maxDiff = None
@@ -47,17 +59,21 @@ class ArticleDoiTest(unittest.TestCase):
             """
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_main_article_doi_exists()
-        expected = {
-            'title': 'Article DOI element',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist',
-            'response': 'ERROR',
-            'expected_value': 'article DOI',
-            'got_value': None,
-            'message': 'Got None expected a DOI',
-            'advice': 'Provide a valid DOI for the research-article'
-        }
-        self.assertDictEqual(obtained, expected)
+        expected = [
+            {
+                'title': 'Article DOI element',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'article DOI',
+                'got_value': None,
+                'message': 'Got None expected a DOI',
+                'advice': 'Provide a valid DOI for the research-article'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_translation_subarticle_has_one_translation_and_one_doi(self):
         self.maxDiff = None
@@ -233,17 +249,21 @@ class ArticleDoiTest(unittest.TestCase):
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_all_dois_are_unique()
 
-        expected = {
-            'title': 'Article DOI element is unique',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist/verification',
-            'response': 'OK',
-            'expected_value': 'Unique DOI values',
-            'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
-            'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
-            'advice': None
-        }
-        self.assertDictEqual(obtained, expected)
+        expected = [
+            {
+                'title': 'Article DOI element is unique',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist/verification',
+                'response': 'OK',
+                'expected_value': 'Unique DOI values',
+                'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
+                'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_all_dois_are_not_unique(self):
         self.maxDiff = None
@@ -276,15 +296,93 @@ class ArticleDoiTest(unittest.TestCase):
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_all_dois_are_unique()
 
+        expected = [
+            {
+                'title': 'Article DOI element is unique',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist/verification',
+                'response': 'ERROR',
+                'expected_value': 'Unique DOI values',
+                'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
+                'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 3)",
+                'advice': 'Consider replacing the following DOIs that are not unique: 10.1590/2176-4573e59270'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_ok(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            <front>
+                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
+                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
+                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+            </front>
+            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
+            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
+            <sub-article article-type="translation" id="s1" xml:lang="en">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                </front-stub>
+            </sub-article>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_validate_ok
+        )
+
         expected = {
-            'title': 'Article DOI element is unique',
+            'title': 'Article DOI element is registered',
             'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist/verification',
+            'validation_type': 'exist',
+            'response': 'OK',
+            'expected_value': '10.1590/2176-4573p59270',
+            'got_value': '10.1590/2176-4573p59270',
+            'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+            'advice': None
+        }
+        self.assertDictEqual(obtained, expected)
+
+    def test_validate_doi_registered_not_ok(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            <front>
+                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
+                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
+                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+            </front>
+            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
+            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
+            <sub-article article-type="translation" id="s1" xml:lang="en">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                </front-stub>
+            </sub-article>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_validate_not_ok
+        )
+
+        expected = {
+            'title': 'Article DOI element is registered',
+            'xpath': './article-id[@pub-id-type="doi"]',
+            'validation_type': 'exist',
             'response': 'ERROR',
-            'expected_value': 'Unique DOI values',
-            'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
-            'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 3)",
-            'advice': 'Consider replacing the following DOIs that are not unique: 10.1590/2176-4573e59270'
+            'expected_value': 'An article DOI registered',
+            'got_value': '10.1590/2176-4573p59270',
+            'message': 'Got 10.1590/2176-4573p59270 expected An article DOI registered',
+            'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
         }
         self.assertDictEqual(obtained, expected)
 

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -569,7 +569,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'expected_value': 'Data registered to the DOI 10.1590/2176-4573e59270',
                 'got_value': None,
                 'message': 'Got None expected data registered to the DOI 10.1590/2176-4573e59270',
-                'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
+                'advice': 'Consult again after DOI has been registered'
             },
             {
                 'title': 'Article DOI is registered',
@@ -579,7 +579,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'expected_value': 'Data registered to the DOI 10.1590/2176-4573p59270',
                 'got_value': None,
                 'message': 'Got None expected data registered to the DOI 10.1590/2176-4573p59270',
-                'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
+                'advice': 'Consult again after DOI has been registered'
             }
         ]
         for i, item in enumerate(obtained):

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -5,31 +5,60 @@ from packtools.sps.utils.xml_utils import get_xml_tree
 from packtools.sps.validation.article_doi import ArticleDoiValidation
 
 
-def callable_get_validate_ok(doi):
+def callable_get_data_ok(doi):
     return {
         'en': {
-                'title': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                'doi': '10.1590/2176-4573p59270'
+                'title': 'Title in English',
+                'doi': '10.1590/2176-4573e59270'
             },
         'pt': {
-                'title': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                'doi': '10.1590/2176-4573e59270'
+                'title': 'Título em Português',
+                'doi': '10.1590/2176-4573p59270'
             },
         'authors': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
     }
 
 
-def callable_get_validate_not_ok(doi):
+def callable_get_data_not_ok(doi):
     return {
-        "en": {
-                "title": "Analysis of the evolution of competences in the clinical practice",
-                "doi": "10.1590/2176-4573p59271"
+        'en': {
+                'title': 'Title English',
+                'doi': '10.1590/2176-4573e59271'
             },
-        "pt": {
-                "title": "Análise da evolução de competências da prática clínica",
-                "doi": "10.1590/2176-4573e59271"
+        'pt': {
+                'title': 'Título Português',
+                'doi': '10.1590/2176-4573e59271'
             },
-        "authors": ['Martínez Momblán, Maria Antonia', 'Colina Torralva, Javier']
+        'authors': ['Martínez Momblán, Maria Antonia', 'Colina Torralva, Javier']
+    }
+
+
+def callable_get_data_not_registered(doi):
+    return None
+
+
+def callable_get_data_missing_title(doi):
+    return {
+        'en': {
+                'doi': '10.1590/2176-4573e59270'
+            },
+        'pt': {
+                'doi': '10.1590/2176-4573p59270'
+            },
+        'authors': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+    }
+
+
+def callable_get_data_missing_authors(doi):
+    return {
+        'en': {
+                'title': 'Title in English',
+                'doi': '10.1590/2176-4573e59270'
+            },
+        'pt': {
+                'title': 'Título em Português',
+                'doi': '10.1590/2176-4573p59270'
+            }
     }
 
 
@@ -334,7 +363,342 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_ok(self):
+    def test_validate_doi_registered_sucess(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                        <title-group>
+                            <article-title>Título em Português</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                </front-stub>
+            </sub-article>      
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_ok
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Title in English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title in English',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Título em Português',
+                'got_value': 'Título em Português',
+                'message': 'Got Título em Português expected Título em Português',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            }
+
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_fail_items(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                        <title-group>
+                            <article-title>Título em Português</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                </front-stub>
+            </sub-article>      
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_not_ok
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': '10.1590/2176-4573e59271',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59271',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Title English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title English',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': '10.1590/2176-4573e59271',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573e59271',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Título Português',
+                'got_value': 'Título em Português',
+                'message': 'Got Título em Português expected Título Português',
+                'advice': 'DOI not registered or validator not found, provide a value for title element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element '
+                          'that matches the record for DOI.'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_fail_doi(self):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -400,53 +764,87 @@ class ArticleDoiTest(unittest.TestCase):
             """
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
-            callable_get_validate_ok
+            callable_get_data_not_registered
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Data registered to the DOI 10.1590/2176-4573p59270',
+                'got_value': None,
+                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573p59270',
+                'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
+            },
+            {
+                'title': 'Article DOI is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Data registered to the DOI 10.1590/2176-4573e59270',
+                'got_value': None,
+                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573e59270',
+                'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_missing_title_XML(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                </front-stub>
+            </sub-article>      
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_ok
         )
 
         expected = [
             {
                 'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573p59270',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                'got_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                'message': 'Got Analysis of the evolution of competences in the clinical practice of the nursing degree '
-                           'expected Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
@@ -456,14 +854,65 @@ class ArticleDoiTest(unittest.TestCase):
                 'advice': None
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Title in English',
+                'got_value': None,
+                'message': 'Got None expected Title in English',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                'got_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                'message': 'Got Análise da evolução de competências da prática clínica no curso de enfermagem '
-                           'expected Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Título em Português',
+                'got_value': None,
+                'message': 'Got None expected Título em Português',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
                 'advice': None
             },
             {
@@ -475,6 +924,130 @@ class ArticleDoiTest(unittest.TestCase):
                 'got_value': 'Martínez-Momblán, Maria Antonia',
                 'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
                 'advice': None
+            }
+
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_missing_title_function(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                        <title-group>
+                            <article-title>Título em Português</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                </front-stub>
+            </sub-article>      
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_missing_title
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Título em Português',
+                'message': 'Got Título em Português expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.',
             },
             {
                 'title': 'Article DOI is registered (lang: pt, element: author)',
@@ -485,6 +1058,16 @@ class ArticleDoiTest(unittest.TestCase):
                 'got_value': 'Colina-Torralva, Javier',
                 'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
                 'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': None
             }
 
         ]
@@ -492,64 +1075,168 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_not_ok(self):
+    def test_validate_doi_registered_missing_author_XML(self):
         self.maxDiff = None
         xml_str = """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            <article xml:lang="en">
             <front>
                 <article-meta>
-                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
-                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
-                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
-                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
                 <title-group>
-                    <article-title>Analysis of the evolution of competences in the clinical practice of the nursing degree</article-title>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                        <title-group>
+                            <article-title>Título em Português</article-title>
+                        </title-group>
+                </front-stub>
+            </sub-article>      
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_ok
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Title in English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title in English',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina-Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez-Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Título em Português',
+                'got_value': 'Título em Português',
+                'message': 'Got Título em Português expected Título em Português',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': None,
+                'message': 'Got None expected Colina-Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': None,
+                'message': 'Got None expected Martínez-Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            }
+
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_missing_author_function(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
                 </title-group>
                 <contrib-group>
                     <contrib contrib-type="author">
-                      <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
                       <name>
                         <surname>Martínez-Momblán</surname>
                         <given-names>Maria Antonia</given-names>
                       </name>
-                      <xref ref-type="aff" rid="aff1">1</xref>
                     </contrib>
                     <contrib contrib-type="author">
-                      <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
                       <name>
                         <surname>Colina-Torralva</surname>
                         <given-names>Javier</given-names>
                       </name>
-                      <xref ref-type="aff" rid="aff1">1</xref>
                     </contrib>
                 </contrib-group>
                 </article-meta>
             </front>
-            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
-            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
-            <sub-article article-type="translation" id="s1" xml:lang="en">
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
                 <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
                         <title-group>
-                            <article-title>Análise da evolução de competências da prática clínica no curso de enfermagem</article-title>
+                            <article-title>Título em Português</article-title>
                         </title-group>
                         <contrib-group>
                             <contrib contrib-type="author">
-                            <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
                                 <name>
                                 <surname>Martínez-Momblán</surname>
                                 <given-names>Maria Antonia</given-names>
                                 </name>
-                            <xref ref-type="aff" rid="aff2">1</xref>
                             </contrib>
                             <contrib contrib-type="author">
-                            <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
                                 <name>
                                 <surname>Colina-Torralva</surname>
                                 <given-names>Javier</given-names>
                                 </name>
-                            <xref ref-type="aff" rid="aff2">1</xref>
                             </contrib>
                         </contrib-group>
                 </front-stub>
@@ -558,100 +1245,95 @@ class ArticleDoiTest(unittest.TestCase):
             """
         xml_tree = get_xml_tree(xml_str)
         obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
-            callable_get_validate_not_ok
+            callable_get_data_missing_authors
         )
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': '10.1590/2176-4573e59271',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573e59271',
-                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Análise da evolução de competências da prática clínica',
-                'got_value': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
-                'message': 'Got Analysis of the evolution of competences in the clinical practice of the nursing degree '
-                           'expected Análise da evolução de competências da prática clínica',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Martínez Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez Momblán, Maria Antonia',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Colina Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina Torralva, Javier',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
                 'title': 'Article DOI is registered (lang: en, element: doi)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': '10.1590/2176-4573p59271',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573p59271',
-                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
-                          'matches the record for DOI.'
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: title)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Analysis of the evolution of competences in the clinical practice',
-                'got_value': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
-                'message': 'Got Análise da evolução de competências da prática clínica no curso de enfermagem expected '
-                           'Analysis of the evolution of competences in the clinical practice',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.'
+                'response': 'OK',
+                'expected_value': 'Title in English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title in English',
+                'advice': None
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: author)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Martínez Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez Momblán, Maria Antonia',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
+                'expected_value': None,
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: author)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Colina Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina Torralva, Javier',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
+                'expected_value': None,
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573p59270',
+                'got_value': '10.1590/2176-4573p59270',
+                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Título em Português',
+                'got_value': 'Título em Português',
+                'message': 'Got Título em Português expected Título em Português',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: pt, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
             }
+
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -6,11 +6,31 @@ from packtools.sps.validation.article_doi import ArticleDoiValidation
 
 
 def callable_get_validate_ok(doi):
-    return True
+    return {
+        'en': {
+                'title': 'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                'doi': '10.1590/2176-4573p59270'
+            },
+        'pt': {
+                'title': 'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                'doi': '10.1590/2176-4573e59270'
+            },
+        'authors': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+    }
 
 
 def callable_get_validate_not_ok(doi):
-    return False
+    return {
+        "en": {
+                "title": "Analysis of the evolution of competences in the clinical practice of the nursing degree",
+                "doi": "10.1590/2176-4573p59270"
+            },
+        "pt": {
+                "title": "Análise da evolução de competências da prática clínica no curso de enfermagem",
+                "doi": "10.1590/2176-4573e59270"
+            },
+        "authors": ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+    }
 
 
 class ArticleDoiTest(unittest.TestCase):
@@ -146,7 +166,8 @@ class ArticleDoiTest(unittest.TestCase):
                 'expected_value': 'sub-article DOI',
                 'got_value': None,
                 'message': 'Got None expected sub-article DOI',
-                'advice': 'Provide a valid DOI for the sub-article translation (s3) which language is es'
+                'advice': 'Provide a valid DOI for the sub-article represented by the following '
+                          'tag: <sub-article article-type="translation" id="s3" xml:lang="es">'
             },
             {
                 'title': 'Sub-article translation DOI element',
@@ -199,7 +220,8 @@ class ArticleDoiTest(unittest.TestCase):
                 'expected_value': 'sub-article DOI',
                 'got_value': None,
                 'message': 'Got None expected sub-article DOI',
-                'advice': 'Provide a valid DOI for the sub-article translation (s2) which language is fr'
+                'advice': 'Provide a valid DOI for the sub-article represented by the following '
+                          'tag: <sub-article article-type="translation" id="s2" xml:lang="fr">'
             },
             {
                 'title': 'Sub-article translation DOI element',
@@ -256,7 +278,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'validation_type': 'exist/verification',
                 'response': 'OK',
                 'expected_value': 'Unique DOI values',
-                'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
+                'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],
                 'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
                 'advice': None
             }
@@ -303,7 +325,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'validation_type': 'exist/verification',
                 'response': 'ERROR',
                 'expected_value': 'Unique DOI values',
-                'got_value': 'DOIs identified: 10.1590/2176-4573p59270 | 10.1590/2176-4573e59270',
+                'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],
                 'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 3)",
                 'advice': 'Consider replacing the following DOIs that are not unique: 10.1590/2176-4573e59270'
             }
@@ -316,20 +338,64 @@ class ArticleDoiTest(unittest.TestCase):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
+                <article-meta>
                 <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
                 <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
                 <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
                 <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                <title-group>
+                    <article-title>Analysis of the evolution of competences in the clinical practice of the nursing degree</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
             </front>
             <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
             <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
-            <sub-article article-type="translation" id="s1" xml:lang="en">
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
                 <front-stub>
                     <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                        <title-group>
+                            <article-title>Análise da evolução de competências da prática clínica no curso de enfermagem</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                        </contrib-group>
                 </front-stub>
-            </sub-article>
+            </sub-article>      
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
@@ -337,17 +403,63 @@ class ArticleDoiTest(unittest.TestCase):
             callable_get_validate_ok
         )
 
-        expected = {
-            'title': 'Article DOI element is registered',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist',
-            'response': 'OK',
-            'expected_value': '10.1590/2176-4573p59270',
-            'got_value': '10.1590/2176-4573p59270',
-            'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-            'advice': None
-        }
-        self.assertDictEqual(obtained, expected)
+        expected = [
+            {
+                'title': 'Article DOI element is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': [
+                    'en',
+                    '10.1590/2176-4573p59270',
+                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'got_value': [
+                    'en',
+                    '10.1590/2176-4573p59270',
+                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'message': "Got "
+                           "['en', '10.1590/2176-4573p59270', "
+                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
+                           "['en', '10.1590/2176-4573p59270', "
+                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'advice': None
+            },
+            {
+                'title': 'Article DOI element is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': [
+                    'pt',
+                    '10.1590/2176-4573e59270',
+                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'got_value': [
+                    'pt',
+                    '10.1590/2176-4573e59270',
+                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'message': "Got "
+                           "['pt', '10.1590/2176-4573e59270', "
+                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
+                           "['pt', '10.1590/2176-4573e59270', "
+                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_validate_doi_registered_not_ok(self):
         self.maxDiff = None
@@ -355,18 +467,62 @@ class ArticleDoiTest(unittest.TestCase):
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
             article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
             <front>
+                <article-meta>
                 <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
                 <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
                 <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
                 <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                <title-group>
+                    <article-title>Analysis of the evolution of competences in the clinical practice of the nursing degree</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                      <xref ref-type="aff" rid="aff1">1</xref>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
             </front>
             <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
             <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
             <sub-article article-type="translation" id="s1" xml:lang="en">
                 <front-stub>
                     <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                        <title-group>
+                            <article-title>Análise da evolução de competências da prática clínica no curso de enfermagem</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
+                                <name>
+                                <surname>Martínez-Momblán</surname>
+                                <given-names>Maria Antonia</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                            <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
+                                <name>
+                                <surname>Colina-Torralva</surname>
+                                <given-names>Javier</given-names>
+                                </name>
+                            <xref ref-type="aff" rid="aff2">1</xref>
+                            </contrib>
+                        </contrib-group>
                 </front-stub>
-            </sub-article>
+            </sub-article>      
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
@@ -374,17 +530,63 @@ class ArticleDoiTest(unittest.TestCase):
             callable_get_validate_not_ok
         )
 
-        expected = {
-            'title': 'Article DOI element is registered',
-            'xpath': './article-id[@pub-id-type="doi"]',
-            'validation_type': 'exist',
-            'response': 'ERROR',
-            'expected_value': 'An article DOI registered',
-            'got_value': '10.1590/2176-4573p59270',
-            'message': 'Got 10.1590/2176-4573p59270 expected An article DOI registered',
-            'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
-        }
-        self.assertDictEqual(obtained, expected)
+        expected = [
+            {
+                'title': 'Article DOI element is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': [
+                    'pt',
+                    '10.1590/2176-4573e59270',
+                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'got_value': [
+                    'pt',
+                    '10.1590/2176-4573p59270',
+                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'message': "Got "
+                           "['pt', '10.1590/2176-4573p59270', "
+                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
+                           "['pt', '10.1590/2176-4573e59270', "
+                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
+            },
+            {
+                'title': 'Article DOI element is registered',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': [
+                    'en',
+                    '10.1590/2176-4573p59270',
+                    'Analysis of the evolution of competences in the clinical practice of the nursing degree',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'got_value': [
+                    'en',
+                    '10.1590/2176-4573e59270',
+                    'Análise da evolução de competências da prática clínica no curso de enfermagem',
+                    ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']
+                ],
+                'message': "Got "
+                           "['en', '10.1590/2176-4573e59270', "
+                           "'Análise da evolução de competências da prática clínica no curso de enfermagem', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']] expected "
+                           "['en', '10.1590/2176-4573p59270', "
+                           "'Analysis of the evolution of competences in the clinical practice of the nursing degree', "
+                           "['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier']]",
+                'advice': 'DOI not registered or validator not found, provide a registered DOI or check validator'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 if __name__ == '__main__':

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -19,17 +19,17 @@ def callable_get_data_ok(doi):
     }
 
 
-def callable_get_data_not_ok(doi):
+def callable_get_data_one_author(doi):
     return {
         'en': {
-                'title': 'Title English',
-                'doi': '10.1590/2176-4573e59271'
-            },
+            'title': 'Title in English',
+            'doi': '10.1590/2176-4573e59270'
+        },
         'pt': {
-                'title': 'Título Português',
-                'doi': '10.1590/2176-4573e59271'
-            },
-        'authors': ['Martínez Momblán, Maria Antonia', 'Colina Torralva, Javier']
+            'title': 'Título em Português',
+            'doi': '10.1590/2176-4573p59270'
+        },
+        'authors': ['Colina-Torralva, Javier']
     }
 
 
@@ -363,7 +363,7 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_sucess(self):
+    def test_validate_doi_registered_success(self):
         self.maxDiff = None
         xml_str = """
             <article xml:lang="en">
@@ -444,9 +444,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
                 'advice': None
             },
             {
@@ -454,9 +454,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
                 'advice': None
             },
             {
@@ -484,9 +484,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
                 'advice': None
             },
             {
@@ -494,9 +494,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
                 'advice': None
             }
 
@@ -505,7 +505,7 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_fail_items(self):
+    def test_validate_doi_registered_doi_is_not_registered(self):
         self.maxDiff = None
         xml_str = """
             <article xml:lang="en">
@@ -549,213 +549,6 @@ class ArticleDoiTest(unittest.TestCase):
                                 <surname>Colina-Torralva</surname>
                                 <given-names>Javier</given-names>
                                 </name>
-                            </contrib>
-                        </contrib-group>
-                </front-stub>
-            </sub-article>      
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
-            callable_get_data_not_ok
-        )
-
-        expected = [
-            {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': '10.1590/2176-4573e59271',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59271',
-                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Title English',
-                'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title English',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Colina Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina Torralva, Javier',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Martínez Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez Momblán, Maria Antonia',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': '10.1590/2176-4573e59271',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573e59271',
-                'advice': 'DOI not registered or validator not found, provide a value for doi element '
-                          'that matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Título Português',
-                'got_value': 'Título em Português',
-                'message': 'Got Título em Português expected Título Português',
-                'advice': 'DOI not registered or validator not found, provide a value for title element '
-                          'that matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Colina Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina Torralva, Javier',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Martínez Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez Momblán, Maria Antonia',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element '
-                          'that matches the record for DOI.'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_doi_registered_fail_doi(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-                <article-meta>
-                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
-                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
-                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
-                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-                <title-group>
-                    <article-title>Analysis of the evolution of competences in the clinical practice of the nursing degree</article-title>
-                </title-group>
-                <contrib-group>
-                    <contrib contrib-type="author">
-                      <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
-                      <name>
-                        <surname>Martínez-Momblán</surname>
-                        <given-names>Maria Antonia</given-names>
-                      </name>
-                      <xref ref-type="aff" rid="aff1">1</xref>
-                    </contrib>
-                    <contrib contrib-type="author">
-                      <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
-                      <name>
-                        <surname>Colina-Torralva</surname>
-                        <given-names>Javier</given-names>
-                      </name>
-                      <xref ref-type="aff" rid="aff1">1</xref>
-                    </contrib>
-                </contrib-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
-            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
-                        <title-group>
-                            <article-title>Análise da evolução de competências da prática clínica no curso de enfermagem</article-title>
-                        </title-group>
-                        <contrib-group>
-                            <contrib contrib-type="author">
-                            <contrib-id contrib-id-type="orcid">0000-0002-5364-5270</contrib-id>
-                                <name>
-                                <surname>Martínez-Momblán</surname>
-                                <given-names>Maria Antonia</given-names>
-                                </name>
-                            <xref ref-type="aff" rid="aff2">1</xref>
-                            </contrib>
-                            <contrib contrib-type="author">
-                            <contrib-id contrib-id-type="orcid">0000-0002-6406-0120</contrib-id>
-                                <name>
-                                <surname>Colina-Torralva</surname>
-                                <given-names>Javier</given-names>
-                                </name>
-                            <xref ref-type="aff" rid="aff2">1</xref>
                             </contrib>
                         </contrib-group>
                 </front-stub>
@@ -773,9 +566,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Data registered to the DOI 10.1590/2176-4573p59270',
+                'expected_value': 'Data registered to the DOI 10.1590/2176-4573e59270',
                 'got_value': None,
-                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573p59270',
+                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573e59270',
                 'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
             },
             {
@@ -783,9 +576,9 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Data registered to the DOI 10.1590/2176-4573e59270',
+                'expected_value': 'Data registered to the DOI 10.1590/2176-4573p59270',
                 'got_value': None,
-                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573e59270',
+                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573p59270',
                 'advice': 'DOI not registered or validator not found, provide a DOI value that has a valid registration'
             }
         ]
@@ -793,48 +586,32 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_missing_title_XML(self):
+    def test_validate_doi_registered_only_doi_is_correct(self):
         self.maxDiff = None
         xml_str = """
             <article xml:lang="en">
             <front>
                 <article-meta>
                 <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title English</article-title>
+                </title-group>
                 <contrib-group>
                     <contrib contrib-type="author">
                       <name>
-                        <surname>Martínez-Momblán</surname>
+                        <surname>Martínez</surname>
                         <given-names>Maria Antonia</given-names>
                       </name>
                     </contrib>
                     <contrib contrib-type="author">
                       <name>
-                        <surname>Colina-Torralva</surname>
+                        <surname>Colina</surname>
                         <given-names>Javier</given-names>
                       </name>
                     </contrib>
                 </contrib-group>
                 </article-meta>
             </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-                        <contrib-group>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Martínez-Momblán</surname>
-                                <given-names>Maria Antonia</given-names>
-                                </name>
-                            </contrib>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Colina-Torralva</surname>
-                                <given-names>Javier</given-names>
-                                </name>
-                            </contrib>
-                        </contrib-group>
-                </front-stub>
-            </sub-article>      
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
@@ -859,242 +636,64 @@ class ArticleDoiTest(unittest.TestCase):
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'Title in English',
-                'got_value': None,
-                'message': 'Got None expected Title in English',
+                'got_value': 'Title English',
+                'message': 'Got Title English expected Title in English',
                 'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.',
+                          'matches the record for DOI.'
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573p59270',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Título em Português',
-                'got_value': None,
-                'message': 'Got None expected Título em Português',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
+                'got_value': 'Martínez, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina, Javier',
+                'message': 'Got Colina, Javier expected Colina-Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
             }
-
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_missing_title_function(self):
+    def test_validate_doi_registered_only_title_is_correct(self):
         self.maxDiff = None
         xml_str = """
             <article xml:lang="en">
             <front>
                 <article-meta>
-                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59271</article-id>
                 <title-group>
                     <article-title>Title in English</article-title>
                 </title-group>
                 <contrib-group>
                     <contrib contrib-type="author">
                       <name>
-                        <surname>Martínez-Momblán</surname>
+                        <surname>Martínez</surname>
                         <given-names>Maria Antonia</given-names>
                       </name>
                     </contrib>
                     <contrib contrib-type="author">
                       <name>
-                        <surname>Colina-Torralva</surname>
+                        <surname>Colina</surname>
                         <given-names>Javier</given-names>
                       </name>
                     </contrib>
                 </contrib-group>
                 </article-meta>
             </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-                        <title-group>
-                            <article-title>Título em Português</article-title>
-                        </title-group>
-                        <contrib-group>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Martínez-Momblán</surname>
-                                <given-names>Maria Antonia</given-names>
-                                </name>
-                            </contrib>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Colina-Torralva</surname>
-                                <given-names>Javier</given-names>
-                                </name>
-                            </contrib>
-                        </contrib-group>
-                </front-stub>
-            </sub-article>      
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
-            callable_get_data_missing_title
-        )
-
-        expected = [
-            {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573e59270',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Title in English',
-                'message': 'Got Title in English expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573p59270',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Título em Português',
-                'message': 'Got Título em Português expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
-            }
-
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_doi_registered_missing_author_XML(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xml:lang="en">
-            <front>
-                <article-meta>
-                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
-                <title-group>
-                    <article-title>Title in English</article-title>
-                </title-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-                        <title-group>
-                            <article-title>Título em Português</article-title>
-                        </title-group>
-                </front-stub>
-            </sub-article>      
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
@@ -1107,11 +706,12 @@ class ArticleDoiTest(unittest.TestCase):
                 'title': 'Article DOI is registered (lang: en, element: doi)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
-                'response': 'OK',
+                'response': 'ERROR',
                 'expected_value': '10.1590/2176-4573e59270',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'got_value': '10.1590/2176-4573e59271',
+                'message': 'Got 10.1590/2176-4573e59271 expected 10.1590/2176-4573e59270',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
+                          'matches the record for DOI.'
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: title)',
@@ -1128,11 +728,83 @@ class ArticleDoiTest(unittest.TestCase):
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'Colina-Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina-Torralva, Javier',
+                'expected_value': 'Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Colina, Javier',
+                'message': 'Got Colina, Javier expected Colina-Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_only_one_author_is_correct(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59271</article-id>
+                <title-group>
+                    <article-title>Title English</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_ok
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59271',
+                'message': 'Got 10.1590/2176-4573e59271 expected 10.1590/2176-4573e59270',
+                'advice': 'DOI not registered or validator not found, provide a value for doi element that '
+                          'matches the record for DOI.'
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Title in English',
+                'got_value': 'Title English',
+                'message': 'Got Title English expected Title in English',
+                'advice': 'DOI not registered or validator not found, provide a value for title element that '
+                          'matches the record for DOI.'
             },
             {
                 'title': 'Article DOI is registered (lang: en, element: author)',
@@ -1140,60 +812,27 @@ class ArticleDoiTest(unittest.TestCase):
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez-Momblán, Maria Antonia',
+                'got_value': 'Martínez, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
+                          'matches the record for DOI.'
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
+                'title': 'Article DOI is registered (lang: en, element: author)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': '10.1590/2176-4573p59270',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Título em Português',
-                'got_value': 'Título em Português',
-                'message': 'Got Título em Português expected Título em Português',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
                 'expected_value': 'Colina-Torralva, Javier',
-                'got_value': None,
-                'message': 'Got None expected Colina-Torralva, Javier',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'Martínez-Momblán, Maria Antonia',
-                'got_value': None,
-                'message': 'Got None expected Martínez-Momblán, Maria Antonia',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
+                'got_value': 'Colina-Torralva, Javier',
+                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
+                'advice': None
             }
-
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_doi_registered_missing_author_function(self):
+    def test_validate_doi_registered_no_expected_authors(self):
         self.maxDiff = None
         xml_str = """
             <article xml:lang="en">
@@ -1219,28 +858,6 @@ class ArticleDoiTest(unittest.TestCase):
                 </contrib-group>
                 </article-meta>
             </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-                        <title-group>
-                            <article-title>Título em Português</article-title>
-                        </title-group>
-                        <contrib-group>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Martínez-Momblán</surname>
-                                <given-names>Maria Antonia</given-names>
-                                </name>
-                            </contrib>
-                            <contrib contrib-type="author">
-                                <name>
-                                <surname>Colina-Torralva</surname>
-                                <given-names>Javier</given-names>
-                                </name>
-                            </contrib>
-                        </contrib-group>
-                </front-stub>
-            </sub-article>      
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
@@ -1270,70 +887,150 @@ class ArticleDoiTest(unittest.TestCase):
                 'advice': None
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
+                'title': 'Article DOI is registered (lang: en, element: authors)',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573p59270',
-                'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Título em Português',
-                'got_value': 'Título em Português',
-                'message': 'Got Título em Português expected Título em Português',
-                'advice': None
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
-            },
-            {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected None',
-                'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.',
+                'expected_value': [],
+                'got_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
+                'message': 'The following items are surplus in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
+                'advice': 'Remove the following items from the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
             }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
+    def test_validate_doi_registered_no_obtained_authors(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                </article-meta>
+            </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_ok
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Title in English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title in English',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: authors)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
+                'got_value': [],
+                'message': 'The following items are not found in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
+                'advice': 'Complete the following items in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_doi_registered_expected_one_author_obtained_two_authors(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xml:lang="en">
+            <front>
+                <article-meta>
+                <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                <title-group>
+                    <article-title>Title in English</article-title>
+                </title-group>
+                <contrib-group>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Martínez-Momblán</surname>
+                        <given-names>Maria Antonia</given-names>
+                      </name>
+                    </contrib>
+                    <contrib contrib-type="author">
+                      <name>
+                        <surname>Colina-Torralva</surname>
+                        <given-names>Javier</given-names>
+                      </name>
+                    </contrib>
+                </contrib-group>
+                </article-meta>
+            </front>  
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+            callable_get_data_one_author
+        )
+
+        expected = [
+            {
+                'title': 'Article DOI is registered (lang: en, element: doi)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: title)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Title in English',
+                'got_value': 'Title in English',
+                'message': 'Got Title in English expected Title in English',
+                'advice': None
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: author)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'Colina-Torralva, Javier',
+                'got_value': 'Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez-Momblán, Maria Antonia expected Colina-Torralva, Javier',
+                'advice': 'DOI not registered or validator not found, provide a value for author element that '
+                          'matches the record for DOI.',
+            },
+            {
+                'title': 'Article DOI is registered (lang: en, element: authors)',
+                'xpath': './article-id[@pub-id-type="doi"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['Colina-Torralva, Javier'],
+                'got_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
+                'message': 'The following items are surplus in the XML: Colina-Torralva, Javier',
+                'advice': 'Remove the following items from the XML: Colina-Torralva, Javier',
+            }
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona procedimento de validação para a verificação se o DOI é registrado. Além disso, padroniza o retorno de outras funções de validação, envolvendo DOI, para retornarem uma lista de dicionários ao invés de um único dicionário. Essa última atualização tem por objetivo padronizar os retornos das funções de validação.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_doi.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

