### PR TITLE
Fix: adaptar a classe de validação de ISSN's ao padrão adotado

### DIFF
--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -41,3 +41,7 @@ class ValidationArticleAndSubArticlesSubjectsException(Exception):
 
 class ValidationRelatedArticleException(Exception):
     ...
+
+
+class ValidationIssnsException(Exception):
+    ...

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -1,29 +1,75 @@
 from ..models.journal_meta import ISSN, Acronym, Title, Publisher
+from packtools.sps.validation.exceptions import ValidationIssnsException
 
 
 class ISSNValidation:
-    def __init__(self, xmltree):
+    def __init__(self, xmltree, issns_dict=None):
         self.xmltree = xmltree
-        self.journal_issns = ISSN(xmltree)
+        self.journal_issns = ISSN(xmltree).data
+        self.issns_dict = issns_dict
 
-    def validate_epub(self, expected_value):
-        resp_epub = dict(
-            object='issn epub',
-            output_expected=expected_value,
-            output_obteined=self.journal_issns.epub,
-            match=(expected_value == self.journal_issns.epub)
+    def validate_issn(self, issns_dict=None):
+        """
+        Checks whether the ISSN value is as expected.
 
-        )
-        return resp_epub
+        XML input
+        ---------
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <front>
+                <journal-meta>
+                    <issn pub-type="ppub">0034-8910</issn>
+			        <issn pub-type="epub">1518-8787</issn>
+                </journal-meta>
+            </front>
+        </article>
 
-    def validate_ppub(self, expected_value):
-        resp_ppub = dict(
-            object='issn ppub',
-            output_expected=expected_value,
-            output_obteined=self.journal_issns.ppub,
-            match=(expected_value == self.journal_issns.ppub)
-        )
-        return resp_ppub
+        Params
+        ------
+        issns_dict : dict, such as:
+            {
+            'ppub': '0034-8910',
+            'epub': '1518-8787'
+            }
+
+        Returns
+        -------
+        list of dictionaries, such as:
+            [
+                {
+                    'title': 'Journal ISSN element validation',
+                    'xpath': './/journal-meta//issn[@pub-type=*]',
+                    'validation_type': 'value in list',
+                    'response': 'OK',
+                    'expected_value': ['0034-8910', '1518-8787'],
+                    'got_value': '0034-8910',
+                    'message': 'Got <issn pub-type="ppub">0034-8910</issn> expected one item of this list: 0034-8910 | 1518-8787',
+                    'advice': None
+                },...
+            ]
+        """
+        issns_dict = issns_dict or self.issns_dict
+        if not issns_dict or type(issns_dict) is not dict:
+            raise ValidationIssnsException("The function requires a list of ISSNs in dictionary format")
+
+        for issn in self.journal_issns:
+            issn_value = issn.get('value')
+            issn_type = issn.get('type')
+            is_valid = issn_value == issns_dict.get(issn_type)
+            yield {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': issns_dict,
+                'got_value': issn_value,
+                'message': 'Got <issn pub-type="{}">{}</issn> expected one item of this list: {}'.format(
+                    issn_type,
+                    issn_value,
+                    " | ".join([f"{t}: {v}" for t, v in issns_dict.items()])
+                ),
+                'advice': None if is_valid else 'Provide a ISSN value as per the list: {}'.format(
+                    " | ".join([f"{t}: {v}" for t, v in issns_dict.items()]))
+            }
 
 
 class AcronymValidation:
@@ -88,8 +134,10 @@ class JournalMetaValidation:
         '''
         expected_values is a dict like:
         {
-        'issn_epub': '0103-5053',
-        'issn_ppub': '1678-4790',
+        'issns': {
+                    'ppub': '0103-5053',
+                    'epub': '1678-4790'
+                },
         'acronym': 'hcsm',
         'journal-title': 'História, Ciências, Saúde-Manguinhos',
         'abbrev-journal-title': 'Hist. cienc. saude-Manguinhos',
@@ -102,12 +150,14 @@ class JournalMetaValidation:
         title = TitleValidation(self.xmltree)
         publisher = PublisherValidation(self.xmltree)
 
-        resp_journal_meta = [
-            issn.validate_epub(expected_values['issn_epub']),
-            issn.validate_ppub(expected_values['issn_ppub']),
-            acronym.validate_text(expected_values['acronym']),
-            title.validate_journal_title(expected_values['journal-title']),
-            title.validate_abbreviated_journal_title(expected_values['abbrev-journal-title']),
-            publisher.validate_publishers_names(expected_values['publisher-name'])
-        ]
+        resp_journal_meta = list(issn.validate_issn(expected_values['issns']))
+
+        resp_journal_meta.extend(
+            [
+                acronym.validate_text(expected_values['acronym']),
+                title.validate_journal_title(expected_values['journal-title']),
+                title.validate_abbreviated_journal_title(expected_values['abbrev-journal-title']),
+                publisher.validate_publishers_names(expected_values['publisher-name'])
+            ]
+        )
         return resp_journal_meta

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -61,24 +61,20 @@ class ISSNValidation:
         if not issns_dict or type(issns_dict) is not dict:
             raise ValidationIssnsException("The function requires a list of ISSNs in dictionary format")
 
-        for issn in self.journal_issns:
-            issn_value = issn.get('value')
-            issn_type = issn.get('type')
-            is_valid = issn_value == issns_dict.get(issn_type)
+        for tp, issn_expected in issns_dict.items():
+            issn_obtained = self.journal_issns.epub if tp == "epub" else self.journal_issns.ppub
+            is_valid = issn_expected == issn_obtained
             yield {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="{}"]'.format(tp),
+                'validation_type': 'value',
                 'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': issns_dict,
-                'got_value': issn_value,
-                'message': 'Got <issn pub-type="{}">{}</issn> expected one item of this list: {}'.format(
-                    issn_type,
-                    issn_value,
-                    " | ".join([f"{t}: {v}" for t, v in issns_dict.items()])
+                'expected_value': '<issn pub-type="{}">{}</issn>'.format(tp, issn_expected),
+                'got_value': '<issn pub-type="{}">{}</issn>'.format(tp, issn_obtained),
+                'message': 'Got <issn pub-type="{}">{}</issn> expected <issn pub-type="{}">{}</issn>'.format(
+                    tp, issn_obtained, tp, issn_expected
                 ),
-                'advice': None if is_valid else 'Provide a ISSN value as per the list: {}'.format(
-                    " | ".join([f"{t}: {v}" for t, v in issns_dict.items()]))
+                'advice': None if is_valid else 'Provide an ISSN value as expected: <issn pub-type="{}">{}</issn>'.format(tp, issn_expected),
             }
 
 

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -37,14 +37,24 @@ class ISSNValidation:
             [
                 {
                     'title': 'Journal ISSN element validation',
-                    'xpath': './/journal-meta//issn[@pub-type=*]',
-                    'validation_type': 'value in list',
+                    'xpath': './/journal-meta//issn[@pub-type="ppub"]',
+                    'validation_type': 'value',
                     'response': 'OK',
-                    'expected_value': {'epub': '1518-8787', 'ppub': '0034-8910'},
-                    'got_value': '0034-8910',
-                    'message': 'Got <issn pub-type="ppub">0034-8910</issn> expected one item of this list: ppub: 0034-8910 | epub: 1518-8787',
+                    'expected_value': '<issn pub-type="ppub">0034-8910</issn>',
+                    'got_value': '<issn pub-type="ppub">0034-8910</issn>',
+                    'message': 'Got <issn pub-type="ppub">0034-8910</issn> expected <issn pub-type="ppub">0034-8910</issn>',
                     'advice': None
-                },...
+                },
+                {
+                    'title': 'Journal ISSN element validation',
+                    'xpath': './/journal-meta//issn[@pub-type="epub"]',
+                    'validation_type': 'value',
+                    'response': 'OK',
+                    'expected_value': '<issn pub-type="epub">1518-8787</issn>',
+                    'got_value': '<issn pub-type="epub">1518-8787</issn>',
+                    'message': 'Got <issn pub-type="epub">1518-8787</issn> expected <issn pub-type="epub">1518-8787</issn>',
+                    'advice': None
+                }
             ]
         """
         issns_dict = issns_dict or self.issns_dict

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -5,7 +5,7 @@ from packtools.sps.validation.exceptions import ValidationIssnsException
 class ISSNValidation:
     def __init__(self, xmltree, issns_dict=None):
         self.xmltree = xmltree
-        self.journal_issns = ISSN(xmltree).data
+        self.journal_issns = ISSN(xmltree)
         self.issns_dict = issns_dict
 
     def validate_issn(self, issns_dict=None):

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -8,7 +8,7 @@ class ISSNValidation:
         self.journal_issns = ISSN(xmltree)
         self.issns_dict = issns_dict
 
-    def validate_issn(self, issns_dict=None):
+    def validate_issn(self, issns_dict):
         """
         Checks whether the ISSN value is as expected.
 

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -40,9 +40,9 @@ class ISSNValidation:
                     'xpath': './/journal-meta//issn[@pub-type=*]',
                     'validation_type': 'value in list',
                     'response': 'OK',
-                    'expected_value': ['0034-8910', '1518-8787'],
+                    'expected_value': {'epub': '1518-8787', 'ppub': '0034-8910'},
                     'got_value': '0034-8910',
-                    'message': 'Got <issn pub-type="ppub">0034-8910</issn> expected one item of this list: 0034-8910 | 1518-8787',
+                    'message': 'Got <issn pub-type="ppub">0034-8910</issn> expected one item of this list: ppub: 0034-8910 | epub: 1518-8787',
                     'advice': None
                 },...
             ]

--- a/tests/sps/validation/test_journal_meta.py
+++ b/tests/sps/validation/test_journal_meta.py
@@ -21,45 +21,74 @@ class ISSNTest(TestCase):
         )
         self.issns = ISSNValidation(self.xmltree)
 
-    def test_issn_epub_match(self):
-        expected = dict(
-            object='issn epub',
-            output_expected='1678-4790',
-            output_obteined='1678-4790',
-            match=True
+    def test_validate_issn_ok(self):
+        obtained = self.issns.validate_issn(
+            {
+                'ppub': '0103-5053',
+                'epub': '1678-4790'
+            }
         )
-        obtained = self.issns.validate_epub('1678-4790')
-        self.assertDictEqual(expected, obtained)
 
-    def test_issn_epub_no_match(self):
-        expected = dict(
-            object='issn epub',
-            output_expected='1678-4791',
-            output_obteined='1678-4790',
-            match=False
-        )
-        obtained = self.issns.validate_epub('1678-4791')
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
+                'got_value': '0103-5053',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'advice': None
+            },
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
+                'got_value': '1678-4790',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
-    def test_issn_ppub_match(self):
-        expected = dict(
-            object='issn ppub',
-            output_expected='0103-5053',
-            output_obteined='0103-5053',
-            match=True
+    def test_validate_issn_not_ok(self):
+        self.maxDiff = None
+        obtained = self.issns.validate_issn(
+            {
+                'ppub': '0103-5054',
+                'epub': '1678-4791'
+            }
         )
-        obtained = self.issns.validate_ppub('0103-5053')
-        self.assertDictEqual(expected, obtained)
 
-    def test_issn_ppub_no_match(self):
-        expected = dict(
-            object='issn ppub',
-            output_expected='0103-5051',
-            output_obteined='0103-5053',
-            match=False
-        )
-        obtained = self.issns.validate_ppub('0103-5051')
-        self.assertDictEqual(expected, obtained)
+        expected = [
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': {'epub': '1678-4791', 'ppub': '0103-5054'},
+                'got_value': '0103-5053',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5054 | epub: 1678-4791',
+                'advice': 'Provide a ISSN value as per the list: ppub: 0103-5054 | epub: 1678-4791'
+            },
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': {'epub': '1678-4791', 'ppub': '0103-5054'},
+                'got_value': '1678-4790',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5054 | epub: 1678-4791',
+                'advice': 'Provide a ISSN value as per the list: ppub: 0103-5054 | epub: 1678-4791'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 class AcronymTest(TestCase):
@@ -285,19 +314,28 @@ class JournalMetaValidationTest(TestCase):
         self.journal_meta = JournalMetaValidation(self.xmltree)
 
     def test_journal_meta_match(self):
+        self.maxDiff = None
         expected = [
-            dict(
-                object='issn epub',
-                output_expected='1678-4790',
-                output_obteined='1678-4790',
-                match=True
-            ),
-            dict(
-                object='issn ppub',
-                output_expected='0103-5053',
-                output_obteined='0103-5053',
-                match=True
-            ),
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
+                'got_value': '0103-5053',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'advice': None
+            },
+            {
+                'title': 'Journal ISSN element validation',
+                'xpath': './/journal-meta//issn[@pub-type=*]',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
+                'got_value': '1678-4790',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'advice': None
+            },
             dict(
                 object='journal acronym',
                 output_expected='hcsm',
@@ -324,8 +362,10 @@ class JournalMetaValidationTest(TestCase):
             )
         ]
         obtained = self.journal_meta.validate({
-            'issn_epub': '1678-4790',
-            'issn_ppub': '0103-5053',
+            'issns': {
+                'ppub': '0103-5053',
+                'epub': '1678-4790'
+            },
             'acronym': 'hcsm',
             'journal-title': 'História, Ciências, Saúde-Manguinhos',
             'abbrev-journal-title': 'Hist. cienc. saude-Manguinhos',

--- a/tests/sps/validation/test_journal_meta.py
+++ b/tests/sps/validation/test_journal_meta.py
@@ -22,6 +22,7 @@ class ISSNTest(TestCase):
         self.issns = ISSNValidation(self.xmltree)
 
     def test_validate_issn_ok(self):
+        self.maxDiff = None
         obtained = self.issns.validate_issn(
             {
                 'ppub': '0103-5053',
@@ -32,22 +33,22 @@ class ISSNTest(TestCase):
         expected = [
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="ppub"]',
+                'validation_type': 'value',
                 'response': 'OK',
-                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
-                'got_value': '0103-5053',
-                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'expected_value': '<issn pub-type="ppub">0103-5053</issn>',
+                'got_value': '<issn pub-type="ppub">0103-5053</issn>',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected <issn pub-type="ppub">0103-5053</issn>',
                 'advice': None
             },
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="epub"]',
+                'validation_type': 'value',
                 'response': 'OK',
-                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
-                'got_value': '1678-4790',
-                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'expected_value': '<issn pub-type="epub">1678-4790</issn>',
+                'got_value': '<issn pub-type="epub">1678-4790</issn>',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected <issn pub-type="epub">1678-4790</issn>',
                 'advice': None
             }
         ]
@@ -67,23 +68,23 @@ class ISSNTest(TestCase):
         expected = [
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="ppub"]',
+                'validation_type': 'value',
                 'response': 'ERROR',
-                'expected_value': {'epub': '1678-4791', 'ppub': '0103-5054'},
-                'got_value': '0103-5053',
-                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5054 | epub: 1678-4791',
-                'advice': 'Provide a ISSN value as per the list: ppub: 0103-5054 | epub: 1678-4791'
+                'expected_value': '<issn pub-type="ppub">0103-5054</issn>',
+                'got_value': '<issn pub-type="ppub">0103-5053</issn>',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected <issn pub-type="ppub">0103-5054</issn>',
+                'advice': 'Provide an ISSN value as expected: <issn pub-type="ppub">0103-5054</issn>'
             },
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="epub"]',
+                'validation_type': 'value',
                 'response': 'ERROR',
-                'expected_value': {'epub': '1678-4791', 'ppub': '0103-5054'},
-                'got_value': '1678-4790',
-                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5054 | epub: 1678-4791',
-                'advice': 'Provide a ISSN value as per the list: ppub: 0103-5054 | epub: 1678-4791'
+                'expected_value': '<issn pub-type="epub">1678-4791</issn>',
+                'got_value': '<issn pub-type="epub">1678-4790</issn>',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected <issn pub-type="epub">1678-4791</issn>',
+                'advice': 'Provide an ISSN value as expected: <issn pub-type="epub">1678-4791</issn>'
             }
         ]
         for i, item in enumerate(obtained):
@@ -318,22 +319,22 @@ class JournalMetaValidationTest(TestCase):
         expected = [
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="ppub"]',
+                'validation_type': 'value',
                 'response': 'OK',
-                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
-                'got_value': '0103-5053',
-                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'expected_value': '<issn pub-type="ppub">0103-5053</issn>',
+                'got_value': '<issn pub-type="ppub">0103-5053</issn>',
+                'message': 'Got <issn pub-type="ppub">0103-5053</issn> expected <issn pub-type="ppub">0103-5053</issn>',
                 'advice': None
             },
             {
                 'title': 'Journal ISSN element validation',
-                'xpath': './/journal-meta//issn[@pub-type=*]',
-                'validation_type': 'value in list',
+                'xpath': './/journal-meta//issn[@pub-type="epub"]',
+                'validation_type': 'value',
                 'response': 'OK',
-                'expected_value': {'epub': '1678-4790', 'ppub': '0103-5053'},
-                'got_value': '1678-4790',
-                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected one item of this list: ppub: 0103-5053 | epub: 1678-4790',
+                'expected_value': '<issn pub-type="epub">1678-4790</issn>',
+                'got_value': '<issn pub-type="epub">1678-4790</issn>',
+                'message': 'Got <issn pub-type="epub">1678-4790</issn> expected <issn pub-type="epub">1678-4790</issn>',
                 'advice': None
             },
             dict(


### PR DESCRIPTION
#### O que esse PR faz?
Refatora o procedimento de validação para ISSN's de modo a atender ao padrão adotado para validações.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_journal_meta.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

