### PR TITLE
Feat: adiciona validações para ORCID

### DIFF
--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -317,8 +317,8 @@ class ArticleAuthorsValidation:
                 'expected_value': [orcid, expected_author_name],
                 'got_value': [orcid, obtained_author_name],
                 'message': 'Got {} expected {}'.format([orcid, obtained_author_name], [orcid, expected_author_name]),
-                'advice': None if is_valid else "The author {} has {} as ORCID and its register is not valid. Provide "
-                                                "a registered ORCID.".format(expected_author_name, orcid)
+                'advice': None if is_valid else "ORCID {} is not registered for the obtained author or did not"
+                                                " return any authors".format(orcid)
             }
 
     def validate(self, data):

--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -3,6 +3,10 @@ import re
 from packtools.sps.models.article_authors import Authors
 
 
+def _callable_extern_validate_default(orcid):
+    raise NotImplementedError
+
+
 class ArticleAuthorsValidation:
     def __init__(self, xmltree):
         self._xmltree = xmltree

--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -304,9 +304,9 @@ class ArticleAuthorsValidation:
         """
         callable_get_validate = callable_get_validate or _callable_extern_validate_default
         for author in self.article_authors.contribs:
-            expected_author_name = f"{author.get('given_names')} {author.get('surname')}"
+            obtained_author_name = f"{author.get('given_names')} {author.get('surname')}"
             orcid = author.get('orcid')
-            obtained_author_name = callable_get_validate(orcid)
+            expected_author_name = callable_get_validate(orcid)
             is_valid = obtained_author_name == expected_author_name
 
             yield {

--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -317,8 +317,7 @@ class ArticleAuthorsValidation:
                 'expected_value': [orcid, expected_author_name],
                 'got_value': [orcid, obtained_author_name],
                 'message': 'Got {} expected {}'.format([orcid, obtained_author_name], [orcid, expected_author_name]),
-                'advice': None if is_valid else "ORCID {} is not registered for the obtained author or did not"
-                                                " return any authors".format(orcid)
+                'advice': None if is_valid else "ORCID {} is not registered to any authors".format(orcid)
             }
 
     def validate(self, data):

--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -96,7 +96,7 @@ class ArticleAuthorsValidation:
                     'advice': f"The author {_author_name} does not have a valid role. Provide a role from the list: {expected_value}"
                 }
 
-    def validate_authors_orcid(self):
+    def validate_authors_orcid_format(self):
         """
         Checks whether a contributor's ORCID is valid.
 

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -884,11 +884,11 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'xpath': './/contrib-id[@contrib-id-type="orcid"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
-                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
-                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\'] expected '
-                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\']',
-                'advice': "The author FRANCISCO VENEGAS MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
+                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
+                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\']',
+                'advice': "The author FRANCISCO VENEGAS-MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
                           "not valid. Provide a registered ORCID."
             },
             {
@@ -896,10 +896,10 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'xpath': './/contrib-id[@contrib-id-type="orcid"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
-                'got_value': ['0000-3333-1238-6874', None],
-                'message': 'Got [\'0000-3333-1238-6874\', None] expected [\'0000-3333-1238-6874\', \'Vanessa M. Higa\']',
-                'advice': "The author Vanessa M. Higa has 0000-3333-1238-6874 as ORCID and its register is "
+                'expected_value': ['0000-3333-1238-6874', None],
+                'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
+                'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
+                'advice': "The author None has 0000-3333-1238-6874 as ORCID and its register is "
                           "not valid. Provide a registered ORCID."
             }
         ]
@@ -950,11 +950,11 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'xpath': './/contrib-id[@contrib-id-type="orcid"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
-                'got_value': ['0990-0001-0058-4853', None],
-                'message': 'Got [\'0990-0001-0058-4853\', None] expected '
-                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\']',
-                'advice': "The author FRANCISCO VENEGAS MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
+                'expected_value': ['0990-0001-0058-4853', None],
+                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
+                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', None]',
+                'advice': "The author None has 0990-0001-0058-4853 as ORCID and its register is "
                           "not valid. Provide a registered ORCID."
             },
             {
@@ -962,10 +962,10 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'xpath': './/contrib-id[@contrib-id-type="orcid"]',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
-                'got_value': ['0000-3333-1238-6874', None],
-                'message': 'Got [\'0000-3333-1238-6874\', None] expected [\'0000-3333-1238-6874\', \'Vanessa M. Higa\']',
-                'advice': "The author Vanessa M. Higa has 0000-3333-1238-6874 as ORCID and its register is "
+                'expected_value': ['0000-3333-1238-6874', None],
+                'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
+                'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
+                'advice': "The author None has 0000-3333-1238-6874 as ORCID and its register is "
                           "not valid. Provide a registered ORCID."
             }
         ]

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -18,10 +18,18 @@ credit_taxonomy_terms_and_urls = [
 ]
 
 
-def callable_get_validate(orcid):
+def callable_get_data(orcid):
     tests = {
         '0990-0001-0058-4853': 'FRANCISCO VENEGAS-MARTÍNEZ',
         '0000-3333-1238-6873': 'Vanessa M. Higa'
+    }
+    return tests.get(orcid)
+
+
+def callable_get_data_empty(orcid):
+    tests = {
+        '0990-0001-0058-4853': None,
+        '0000-3333-1238-6873': None
     }
     return tests.get(orcid)
 
@@ -802,7 +810,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
 
         xmltree = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_registered(
-            callable_get_validate
+            callable_get_data
         )
 
         expected_output = [
@@ -867,7 +875,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
 
         xmltree = etree.fromstring(xml)
         messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_registered(
-            callable_get_validate
+            callable_get_data
         )
 
         expected_output = [
@@ -879,6 +887,72 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
                 'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
                 'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\']',
+                'advice': "The author FRANCISCO VENEGAS MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
+                          "not valid. Provide a registered ORCID."
+            },
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
+                'got_value': ['0000-3333-1238-6874', None],
+                'message': 'Got [\'0000-3333-1238-6874\', None] expected [\'0000-3333-1238-6874\', \'Vanessa M. Higa\']',
+                'advice': "The author Vanessa M. Higa has 0000-3333-1238-6874 as ORCID and its register is "
+                          "not valid. Provide a registered ORCID."
+            }
+        ]
+
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
+
+    def test_validate_authors_orcid_is_registered_fail_empty(self):
+        self.maxDiff = None
+        xml = """
+                <article>
+                <front>
+                    <article-meta>
+                      <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                          <name>
+                            <surname>VENEGAS MARTÍNEZ</surname>
+                            <given-names>FRANCISCO</given-names>
+                            <prefix>Prof</prefix>
+                            <suffix>Nieto</suffix>
+                          </name>
+                          <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-3333-1238-6874</contrib-id>
+                          <name>
+                            <surname>Higa</surname>
+                            <given-names>Vanessa M.</given-names>
+                          </name>
+                          <xref ref-type="aff" rid="aff1">a</xref>
+                        </contrib>
+                      </contrib-group>
+                    </article-meta>
+                  </front>
+                </article>
+                """
+
+        xmltree = etree.fromstring(xml)
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_registered(
+            callable_get_data_empty
+        )
+
+        expected_output = [
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
+                'got_value': ['0990-0001-0058-4853', None],
+                'message': 'Got [\'0990-0001-0058-4853\', None] expected '
                            '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\']',
                 'advice': "The author FRANCISCO VENEGAS MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
                           "not valid. Provide a registered ORCID."

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -18,6 +18,14 @@ credit_taxonomy_terms_and_urls = [
 ]
 
 
+def callable_get_validate(orcid):
+    tests = {
+        '0990-0001-0058-4853': 'FRANCISCO VENEGAS-MARTÍNEZ',
+        '0000-3333-1238-6873': 'Vanessa M. Higa'
+    }
+    return tests.get(orcid)
+
+
 class ArticleAuthorsValidationTest(TestCase):
     def test_without_role(self):
         self.maxDiff = None
@@ -653,6 +661,239 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'message': f'Got 0000-3333-1238-6873 expected 0000-3333-1238-6873',
                 'advice': None
             },
+        ]
+
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
+
+    def test_validate_authors_orcid_is_unique_ok(self):
+        self.maxDiff = None
+        xml = """
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                  <xref ref-type="aff" rid="aff1"/>
+                </contrib>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0000-3333-1238-6873</contrib-id>
+                  <name>
+                    <surname>Higa</surname>
+                    <given-names>Vanessa M.</given-names>
+                  </name>
+                  <xref ref-type="aff" rid="aff1">a</xref>
+                </contrib>
+              </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_unique()
+
+        expected_output = [
+            {
+                'title': 'Author ORCID element is unique',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist/verification',
+                'response': 'OK',
+                'expected_value': 'Unique ORCID values',
+                'got_value': ['0990-0001-0058-4853', '0000-3333-1238-6873'],
+                'message': 'Got ORCIDs and frequencies (\'0990-0001-0058-4853\', 1) | (\'0000-3333-1238-6873\', 1)',
+                'advice': None
+            }
+        ]
+
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
+
+    def test_validate_authors_orcid_is_unique_not_ok(self):
+        self.maxDiff = None
+        xml = """
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                  <xref ref-type="aff" rid="aff1"/>
+                </contrib>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                  <name>
+                    <surname>Higa</surname>
+                    <given-names>Vanessa M.</given-names>
+                  </name>
+                  <xref ref-type="aff" rid="aff1">a</xref>
+                </contrib>
+              </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_unique()
+
+        expected_output = [
+            {
+                'title': 'Author ORCID element is unique',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist/verification',
+                'response': 'ERROR',
+                'expected_value': 'Unique ORCID values',
+                'got_value': ['0990-0001-0058-4853', '0990-0001-0058-4853'],
+                'message': 'Got ORCIDs and frequencies (\'0990-0001-0058-4853\', 2)',
+                'advice': 'Consider replacing the following ORCIDs that are not unique: 0990-0001-0058-4853',
+            }
+        ]
+
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
+
+    def test_validate_authors_orcid_is_registered_sucess(self):
+        self.maxDiff = None
+        xml = """
+                <article>
+                <front>
+                    <article-meta>
+                      <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                          <name>
+                            <surname>VENEGAS-MARTÍNEZ</surname>
+                            <given-names>FRANCISCO</given-names>
+                            <prefix>Prof</prefix>
+                            <suffix>Nieto</suffix>
+                          </name>
+                          <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-3333-1238-6873</contrib-id>
+                          <name>
+                            <surname>Higa</surname>
+                            <given-names>Vanessa M.</given-names>
+                          </name>
+                          <xref ref-type="aff" rid="aff1">a</xref>
+                        </contrib>
+                      </contrib-group>
+                    </article-meta>
+                  </front>
+                </article>
+                """
+
+        xmltree = etree.fromstring(xml)
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_registered(
+            callable_get_validate
+        )
+
+        expected_output = [
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\']',
+                'advice': None
+            },
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': ['0000-3333-1238-6873', 'Vanessa M. Higa'],
+                'got_value': ['0000-3333-1238-6873', 'Vanessa M. Higa'],
+                'message': 'Got [\'0000-3333-1238-6873\', \'Vanessa M. Higa\'] expected '
+                           '[\'0000-3333-1238-6873\', \'Vanessa M. Higa\']',
+                'advice': None
+            }
+        ]
+
+        for i, item in enumerate(messages):
+            with self.subTest(i):
+                self.assertDictEqual(expected_output[i], item)
+
+    def test_validate_authors_orcid_is_registered_fail(self):
+        self.maxDiff = None
+        xml = """
+                <article>
+                <front>
+                    <article-meta>
+                      <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                          <name>
+                            <surname>VENEGAS MARTÍNEZ</surname>
+                            <given-names>FRANCISCO</given-names>
+                            <prefix>Prof</prefix>
+                            <suffix>Nieto</suffix>
+                          </name>
+                          <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0000-3333-1238-6874</contrib-id>
+                          <name>
+                            <surname>Higa</surname>
+                            <given-names>Vanessa M.</given-names>
+                          </name>
+                          <xref ref-type="aff" rid="aff1">a</xref>
+                        </contrib>
+                      </contrib-group>
+                    </article-meta>
+                  </front>
+                </article>
+                """
+
+        xmltree = etree.fromstring(xml)
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_is_registered(
+            callable_get_validate
+        )
+
+        expected_output = [
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
+                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\']',
+                'advice': "The author FRANCISCO VENEGAS MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
+                          "not valid. Provide a registered ORCID."
+            },
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
+                'got_value': ['0000-3333-1238-6874', None],
+                'message': 'Got [\'0000-3333-1238-6874\', None] expected [\'0000-3333-1238-6874\', \'Vanessa M. Higa\']',
+                'advice': "The author Vanessa M. Higa has 0000-3333-1238-6874 as ORCID and its register is "
+                          "not valid. Provide a registered ORCID."
+            }
         ]
 
         for i, item in enumerate(messages):

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -481,7 +481,7 @@ class ArticleAuthorsValidationTest(TestCase):
 
 
 class ArticleAuthorsValidationOrcidTest(TestCase):
-    def test_validation_format_orcid(self):
+    def test_validate_authors_orcid_format_fail(self):
         self.maxDiff = None
         xml = """
         <article>
@@ -512,7 +512,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
         </article>
         """
         xmltree = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_format()
 
         expected_output = [
             {
@@ -540,7 +540,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected_output[i], item)
 
-    def test_without_orcid(self):
+    def test_validate_authors_orcid_format_without_orcid(self):
         self.maxDiff = None
         xml = """
         <article>
@@ -569,7 +569,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
         </article>
         """
         xmltree = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_format()
 
         expected_output = [
             {
@@ -598,7 +598,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected_output[i], item)
 
-    def test_success_orcid(self):
+    def test_validate_authors_orcid_format_success(self):
         self.maxDiff = None
         xml = """
         <article>
@@ -630,7 +630,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
         """
 
         xmltree = etree.fromstring(xml)
-        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid()
+        messages = ArticleAuthorsValidation(xmltree=xmltree).validate_authors_orcid_format()
 
         expected_output = [
             {

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -888,7 +888,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
                 'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
                            '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\']',
-                'advice': 'ORCID 0990-0001-0058-4853 is not registered for the obtained author or did not return any authors'
+                'advice': 'ORCID 0990-0001-0058-4853 is not registered to any authors'
             },
             {
                 'title': 'Author ORCID element is registered',
@@ -898,7 +898,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'expected_value': ['0000-3333-1238-6874', None],
                 'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
                 'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
-                'advice': 'ORCID 0000-3333-1238-6874 is not registered for the obtained author or did not return any authors'
+                'advice': 'ORCID 0000-3333-1238-6874 is not registered to any authors'
             }
         ]
 
@@ -952,7 +952,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
                 'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
                            '[\'0990-0001-0058-4853\', None]',
-                'advice': 'ORCID 0990-0001-0058-4853 is not registered for the obtained author or did not return any authors'
+                'advice': 'ORCID 0990-0001-0058-4853 is not registered to any authors'
             },
             {
                 'title': 'Author ORCID element is registered',
@@ -962,7 +962,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'expected_value': ['0000-3333-1238-6874', None],
                 'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
                 'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
-                'advice': 'ORCID 0000-3333-1238-6874 is not registered for the obtained author or did not return any authors'
+                'advice': 'ORCID 0000-3333-1238-6874 is not registered to any authors'
             }
         ]
 

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -888,8 +888,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
                 'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
                            '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\']',
-                'advice': "The author FRANCISCO VENEGAS-MARTÍNEZ has 0990-0001-0058-4853 as ORCID and its register is "
-                          "not valid. Provide a registered ORCID."
+                'advice': 'ORCID 0990-0001-0058-4853 is not registered for the obtained author or did not return any authors'
             },
             {
                 'title': 'Author ORCID element is registered',
@@ -899,8 +898,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'expected_value': ['0000-3333-1238-6874', None],
                 'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
                 'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
-                'advice': "The author None has 0000-3333-1238-6874 as ORCID and its register is "
-                          "not valid. Provide a registered ORCID."
+                'advice': 'ORCID 0000-3333-1238-6874 is not registered for the obtained author or did not return any authors'
             }
         ]
 
@@ -954,8 +952,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS MARTÍNEZ'],
                 'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS MARTÍNEZ\'] expected '
                            '[\'0990-0001-0058-4853\', None]',
-                'advice': "The author None has 0990-0001-0058-4853 as ORCID and its register is "
-                          "not valid. Provide a registered ORCID."
+                'advice': 'ORCID 0990-0001-0058-4853 is not registered for the obtained author or did not return any authors'
             },
             {
                 'title': 'Author ORCID element is registered',
@@ -965,8 +962,7 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
                 'expected_value': ['0000-3333-1238-6874', None],
                 'got_value': ['0000-3333-1238-6874', 'Vanessa M. Higa'],
                 'message': 'Got [\'0000-3333-1238-6874\', \'Vanessa M. Higa\'] expected [\'0000-3333-1238-6874\', None]',
-                'advice': "The author None has 0000-3333-1238-6874 as ORCID and its register is "
-                          "not valid. Provide a registered ORCID."
+                'advice': 'ORCID 0000-3333-1238-6874 is not registered for the obtained author or did not return any authors'
             }
         ]
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validações para verificação se o elemento ORCID é único e possui registro válido.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_authors.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.
