### PR TITLE
Remove a duplicidade de apresentação da seção de disponibilidade de dados

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
@@ -3,21 +3,27 @@
     version="1.0">
 
     <xsl:template match="article" mode="data-availability">
-        <xsl:if test=".//*[@fn-type='data-availability'] or .//article-meta/supplementary-material or .//element-citation[@publication-type='data' or @publication-type='database']">
-            <xsl:apply-templates select="." mode="data-availability-menu-title"/>
-            <xsl:choose>
-                <xsl:when test="sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
-                    <!-- sub-article -->
-                    <xsl:apply-templates select="sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']" mode="doc-version-data-availability"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <!-- article -->
-                    <xsl:apply-templates select="." mode="doc-version-data-availability"/>
-                </xsl:otherwise>
-            </xsl:choose>
-            <xsl:apply-templates select=".//article-meta/supplementary-material" mode="data-availability"/>
-            <xsl:apply-templates select="back//ref-list" mode="data-availability"/>
-        </xsl:if>
+        <xsl:choose>
+            <xsl:when test=".//*[@sec-type='data-availability']">
+                <!-- ficará destacado naturalmente por ser uma seção -->
+            </xsl:when>
+            <xsl:when test=".//*[@fn-type='data-availability'] or .//article-meta/supplementary-material or .//element-citation[@publication-type='data' or @publication-type='database']">
+                <xsl:apply-templates select="." mode="data-availability-menu-title"/>
+                <xsl:choose>
+                    <xsl:when test="sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']">
+                        <!-- sub-article -->
+                        <xsl:apply-templates select="sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']" mode="doc-version-data-availability"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <!-- article -->
+                        <xsl:apply-templates select="." mode="doc-version-data-availability"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:apply-templates select=".//article-meta/supplementary-material" mode="data-availability"/>
+                <xsl:apply-templates select="back//ref-list" mode="data-availability"/>
+            </xsl:when>
+        </xsl:choose>
+        
     </xsl:template>
 
     <xsl:template match="article | sub-article" mode="doc-version-data-availability">


### PR DESCRIPTION

#### O que esse PR faz?
Remove a duplicidade de apresentação da seção de disponibilidade de dados

Isso ocorre porque há tanto a seção como também o elemento supplementary-material Neste caso, a lógica foi se há seção, não faz nada, pois na apresentação do texto, naturalmente a seção será apresentada. Além disso, desconsiderar a apresentação de article-meta/supplementary-material.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando:

```console
python packtools/htmlgenerator.py --nonetwork --nochecks --loglevel DEBUG arquivo.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2878

### Referências
n/a

