### PR TITLE
Feat: adiciona procedimento de validação para idiomas correspondentes

### DIFF
--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -154,8 +154,8 @@ class Abstract:
         Formato padrão: inline
 
         """
-        abstract_node = self.xmltree.find(".//abstract")
-        if abstract_node:
+        abstract_node = self.xmltree.find(".//article-meta//abstract")
+        if abstract_node is not None:
             abstract = self._format_abstract(
                 abstract_node=abstract_node,
                 style=style,
@@ -165,9 +165,9 @@ class Abstract:
             if not style:
                 abstract["lang"] = abstract_lang or article_lang
             return {
+                "parent_name": "article",
                 "lang": abstract_lang or article_lang,
-                "abstract": abstract,
-                "id": "main"
+                "abstract": abstract
             }
 
     def _get_sub_article_abstracts(self, style=None):
@@ -180,6 +180,7 @@ class Abstract:
                 sub_article_lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
                 abstract_lang = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
                 item = {}
+                item["parent_name"] = "sub-article"
                 item["lang"] = abstract_lang or sub_article_lang
                 item["abstract"] = self._format_abstract(
                     abstract_node=abstract_node,
@@ -196,12 +197,12 @@ class Abstract:
         """
         for trans_abstract in self.xmltree.xpath(".//trans-abstract"):
             item = {}
+            item["parent_name"] = "article"
             item["lang"] = trans_abstract.get("{http://www.w3.org/XML/1998/namespace}lang")
             item["abstract"] = self._format_abstract(
                 abstract_node=trans_abstract,
                 style=style
             )
-            item["id"] = "trans"
             yield item
 
     def get_abstracts(self, style=None):

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -186,17 +186,20 @@ class Abstract:
         Formato padrão: inline
 
         """
-        lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
-        abstract = self._format_abstract(
-            abstract_node=self.xmltree.find(".//abstract"),
-            style=style,
-        )
-        if not style:
-            abstract["lang"] = lang
-        return {
-            "lang": lang,
-            "abstract": abstract,
-        }
+        abstract_node = self.xmltree.find(".//abstract")
+        if abstract_node:
+            abstract = self._format_abstract(
+                abstract_node=abstract_node,
+                style=style,
+            )
+            article_lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
+            abstract_lang = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
+            if not style:
+                abstract["lang"] = abstract_lang or article_lang
+            return {
+                "lang": abstract_lang or article_lang,
+                "abstract": abstract,
+            }
 
     @property
     def main_abstract_without_tags(self):
@@ -238,15 +241,19 @@ class Abstract:
         Retorna gerador de resumos em sub-article
         """
         for sub_article in self.xmltree.xpath(".//sub-article"):
-            item = {}
-            item["lang"] = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
-            item["abstract"] = self._format_abstract(
-                abstract_node=sub_article.find(".//front-stub//abstract"),
-                style=style
-            )
-            if not style:
-                item["abstract"]["lang"] = item["lang"]
-            yield item
+            abstract_node = sub_article.find(".//front-stub//abstract")
+            if abstract_node is not None:
+                sub_article_lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
+                abstract_lang = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
+                item = {}
+                item["lang"] = abstract_lang or sub_article_lang
+                item["abstract"] = self._format_abstract(
+                    abstract_node=abstract_node,
+                    style=style
+                )
+                if not style:
+                    item["abstract"]["lang"] = item["lang"]
+                yield item
 
     @property
     def _sub_article_abstract_with_tags(self):

--- a/packtools/sps/models/article_titles.py
+++ b/packtools/sps/models/article_titles.py
@@ -37,10 +37,10 @@ class ArticleTitles:
                 self.xmltree,
                 ".", ".//article-meta//article-title"):
             return {
+                "parent_name": "article",
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
-                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
-                "id": 'main'
+                "plain_text": xml_utils.node_plain_text(node_with_lang["node"])
             }
 
     @property
@@ -53,10 +53,10 @@ class ArticleTitles:
                 self.xmltree,
                 ".//article-meta//trans-title-group", "trans-title"):
             _title = {
+                "parent_name": "article",
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
-                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
-                "id": 'trans'
+                "plain_text": xml_utils.node_plain_text(node_with_lang["node"])
             }
             _titles.append(_title)
         return _titles
@@ -69,6 +69,7 @@ class ArticleTitles:
                 ".//sub-article[@article-type='translation']",
                 ".//front-stub//article-title"):
             _title = {
+                "parent_name": "sub-article",
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
                 "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),

--- a/packtools/sps/models/article_titles.py
+++ b/packtools/sps/models/article_titles.py
@@ -40,6 +40,7 @@ class ArticleTitles:
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
                 "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                "id": 'main'
             }
 
     @property
@@ -55,6 +56,7 @@ class ArticleTitles:
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
                 "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                "id": 'trans'
             }
             _titles.append(_title)
         return _titles
@@ -70,6 +72,7 @@ class ArticleTitles:
                 "lang": node_with_lang["lang"],
                 "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
                 "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                "id": node_with_lang["id"]
             }
             _titles.append(_title)
         return _titles

--- a/packtools/sps/models/kwd_group.py
+++ b/packtools/sps/models/kwd_group.py
@@ -34,4 +34,24 @@ class KwdGroup:
                 _data_dict[d['lang']] = []
             _data_dict[d['lang']].append(d['text'])
         return _data_dict
- 
+
+    def extract_kwd_data_with_lang_text_by_article_type(self, subtag):
+        kwd_text = xml_utils.node_text_without_xref if subtag else get_node_without_subtag
+
+        dict_nodes = {
+            'article': self._xmltree.xpath('.//article-meta'),
+            'sub-article': self._xmltree.xpath('.//sub-article')
+        }
+
+        for tp, nodes in dict_nodes.items():
+            for node in nodes:
+                node_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
+
+                for kwd_group in node.xpath('.//kwd-group'):
+                    kwd_group_lang = kwd_group.get("{http://www.w3.org/XML/1998/namespace}lang", node_lang)
+
+                    keyword_text = []
+                    for kwd in kwd_group.xpath("kwd"):
+                        keyword_text.append(kwd_text(kwd))
+                    yield {"type": tp, "lang": kwd_group_lang, "text": keyword_text}
+

--- a/packtools/sps/models/kwd_group.py
+++ b/packtools/sps/models/kwd_group.py
@@ -46,13 +46,15 @@ class KwdGroup:
 
         dict_nodes = {
             'article': self._xmltree.xpath('.//article-meta'),
-            'sub-article': self._xmltree.xpath('.//sub-article')
+            'sub-article': self._xmltree.xpath('./sub-article')
         }
 
         for tp, nodes in dict_nodes.items():
             for node in nodes:
                 node_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
-                node_id = node.get("id") if tp == "sub-article" else "main"
+                resp = {}
+                if node.get("id") is not None:
+                    resp['id'] = node.get("id")
 
                 for kwd_group in node.xpath('.//kwd-group'):
                     kwd_group_lang = kwd_group.get("{http://www.w3.org/XML/1998/namespace}lang", node_lang)
@@ -60,4 +62,8 @@ class KwdGroup:
                     keyword_text = []
                     for kwd in kwd_group.xpath("kwd"):
                         keyword_text.append(kwd_text(kwd))
-                    yield {"element_name": tp, "id": node_id, "lang": kwd_group_lang, "text": keyword_text}
+                    resp["parent_name"] = tp
+                    resp["lang"] = kwd_group_lang
+                    resp["text"] = keyword_text
+
+                    yield resp

--- a/packtools/sps/models/kwd_group.py
+++ b/packtools/sps/models/kwd_group.py
@@ -31,7 +31,7 @@ class KwdGroup:
         return _data
 
     def extract_kwd_extract_data_by_lang(self, subtag):
-        
+
         _data_dict = {}
         _data = self.extract_kwd_data_with_lang_text(subtag)
 
@@ -52,6 +52,7 @@ class KwdGroup:
         for tp, nodes in dict_nodes.items():
             for node in nodes:
                 node_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
+                node_id = node.get("id") if tp == "sub-article" else "main"
 
                 for kwd_group in node.xpath('.//kwd-group'):
                     kwd_group_lang = kwd_group.get("{http://www.w3.org/XML/1998/namespace}lang", node_lang)
@@ -59,5 +60,4 @@ class KwdGroup:
                     keyword_text = []
                     for kwd in kwd_group.xpath("kwd"):
                         keyword_text.append(kwd_text(kwd))
-                    yield {"type": tp, "lang": kwd_group_lang, "text": keyword_text}
-
+                    yield {"element_name": tp, "id": node_id, "lang": kwd_group_lang, "text": keyword_text}

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -18,6 +18,7 @@ def get_nodes_with_lang(xmltree, lang_xpath, node_xpath=None):
         else:
             _item["node"] = node
         _item["lang"] = node.get('{http://www.w3.org/XML/1998/namespace}lang')
+        _item["id"] = node.get('id')
         _items.append(_item)
     return _items
 
@@ -141,7 +142,7 @@ def node_text(node):
 
 def get_node_without_subtag(node, remove_extra_spaces=False):
     """
-        Função que retorna nó sem subtags. 
+        Função que retorna nó sem subtags.
     """
     if remove_extra_spaces:
         return " ".join([text.strip()for text in node.xpath(".//text()") if text.strip()])

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -126,9 +126,19 @@ class ArticleLangValidation:
         # obtem um dicionário com códigos de idiomas para palavras-chave: {'article': ['pt', 'en'], 'sub-article': ['es']}
         keyword_langs_dict = get_keyword_langs(self.article_kwd)
 
-        # verifica a exsitência dos elementos no XML
-        exist, element, xpath, expected, lang = _elements_exist(self.article_title, abstract_lang_list,
-                                                                keyword_lang_list)
+        # verifica a existência dos elementos no XML
+        for article_type, title_langs in title_langs_dict.items():
+            if not title_langs:
+                yield {
+                    'title': f'{article_type} title element lang attribute validation',
+                    'xpath': f'.//article-title/@xml:lang',
+                    'validation_type': 'exist',
+                    'response': 'ERROR',
+                    'expected_value': f'title for the {article_type}',
+                    'got_value': None,
+                    'message': f'Got None expected title for the {article_type}',
+                    'advice': f'Provide title for the {article_type}'
+                }
 
         if exist:
             # validação de correspondência entre os idiomas, usando como base o título

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -150,12 +150,23 @@ class ArticleLangValidation:
 
         if exist:
             # validação de correspondência entre os idiomas, usando como base o título
-            for element, langs in zip(['abstract', 'kwd-group'], [abstract_lang_list, keyword_lang_list]):
-                for title_lang, element_lang in zip(title_lang_list, langs):
-                    is_valid = title_lang == element_lang
-                    expected = title_lang
-                    obtained = element_lang
-                    advice = None if is_valid else f'Provide {element} in the language \'{title_lang}\''
+                if exist and is_required:
+                    # validação de correspondência entre os idiomas, usando como base o título
+                    for element, langs in zip(['abstract', 'kwd-group'], [abstract_langs_dict.get(article_type), keyword_langs_dict.get(article_type)]):
+                        is_valid = title_lang in langs
+                        expected = title_lang
+                        obtained = langs
+                        advice = None if is_valid else f'Provide {element} in the language {title_lang}'
+                        yield {
+                            'title': f'{article_type} {element} element lang attribute validation',
+                            'xpath': f'.//article-title/@xml:lang .//{element}/@xml:lang',
+                            'validation_type': 'match',
+                            'response': 'OK' if is_valid else 'ERROR',
+                            'expected_value': expected,
+                            'got_value': obtained,
+                            'message': f'Got {obtained} expected {expected}',
+                            'advice': advice
+                        }
                     yield {
                         'title': f'{element} element lang attribute validation',
                         'xpath': f'.//article-title/@xml:lang .//{element}/@xml:lang',

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -54,6 +54,15 @@ def get_abstract_langs(abstracts):
     }
 
 
+def get_keyword_langs(kwd):
+    resp = {
+        'article': [],
+        'sub-article': []
+    }
+    for item in kwd:
+        resp[item['type']].append(item.get('lang'))
+
+    return resp
 
 
 class ArticleLangValidation:

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -69,7 +69,7 @@ class ArticleLangValidation:
     def __init__(self, xml_tree):
         self.article_title = article_titles.ArticleTitles(xml_tree)
         self.article_abstract = article_abstract.Abstract(xml_tree)
-        self.article_kwd = kwd_group.KwdGroup(xml_tree).extract_kwd_extract_data_by_lang(None)
+        self.article_kwd = kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None)
 
     def validate_article_lang(self):
         """

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -18,3 +18,103 @@ def _elements_exist(title, abstract, keyword):
     return True, None, None, None, None
 
 
+class ArticleLangValidation:
+    def __init__(self, xml_tree):
+        self.article_title = article_titles.ArticleTitles(xml_tree)
+        self.article_abstract = article_abstract.Abstract(xml_tree)
+        self.article_kwd = kwd_group.KwdGroup(xml_tree).extract_kwd_extract_data_by_lang(None)
+
+    def validate_article_lang(self):
+        """
+        Checks whether the title, abstract and keyword elements are present in the XML and whether the respective languages match.
+
+        XML input
+        ---------
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'abstract element lang attribute validation',
+                    'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                    'validation_type': 'match',
+                    'response': 'OK',
+                    'expected_value': 'pt',
+                    'got_value': 'pt',
+                    'message': 'Got pt expected pt',
+                    'advice': None
+                },...
+            ]
+        """
+        # obtem uma lista com códigos de idiomas para títulos: ['pt', 'en', 'es']
+        title_lang_list = [self.article_title.article_title.get('lang')] + \
+                          [item.get('lang') for item in self.article_title.trans_titles]
+
+        # obtem uma lista com códigos de idiomas para resumos: ['pt', 'en', 'es']
+        try:
+            abstract_lang_list = [self.article_abstract.get_main_abstract().get('lang')] + \
+                                 [item.get('lang') for item in self.article_abstract._get_trans_abstracts()]
+        except AttributeError:
+            abstract_lang_list = []
+
+        # obtem uma lista com códigos de idiomas para palavras-chave: ['pt', 'en', 'es']
+        keyword_lang_list = list(self.article_kwd.keys())
+
+        # verifica a exsitência dos elementos no XML
+        exist, element, xpath, expected, lang = _elements_exist(self.article_title, abstract_lang_list,
+                                                                keyword_lang_list)
+
+        if exist:
+            # validação de correspondência entre os idiomas, usando como base o título
+            for element, langs in zip(['abstract', 'kwd-group'], [abstract_lang_list, keyword_lang_list]):
+                for title_lang, element_lang in zip(title_lang_list, langs):
+                    is_valid = title_lang == element_lang
+                    expected = title_lang
+                    obtained = element_lang
+                    advice = None if is_valid else f'Provide {element} in the language \'{title_lang}\''
+                    yield {
+                        'title': f'{element} element lang attribute validation',
+                        'xpath': f'.//article-title/@xml:lang .//{element}/@xml:lang',
+                        'validation_type': 'match',
+                        'response': 'OK' if is_valid else 'ERROR',
+                        'expected_value': expected,
+                        'got_value': obtained,
+                        'message': f'Got {obtained} expected {expected}',
+                        'advice': advice
+                    }
+        else:
+            # resposta para a verificação de ausência de elementos
+            yield {
+                'title': f'{element} element lang attribute validation',
+                'xpath': xpath,
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': expected,
+                'got_value': None,
+                'message': f'Got None expected {expected}',
+                'advice': f'Provide a {element} in the language \'{lang}\''
+            }

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -139,6 +139,14 @@ class ArticleLangValidation:
                     'message': f'Got None expected title for the {article_type}',
                     'advice': f'Provide title for the {article_type}'
                 }
+            for title_lang in title_langs:
+                exist, is_required, element, xpath, expected = _elements_exist(
+                    article_type,
+                    title_lang,
+                    self.article_title,
+                    abstract_langs_dict.get(article_type),
+                    keyword_langs_dict.get(article_type)
+                )
 
         if exist:
             # validação de correspondência entre os idiomas, usando como base o título

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -148,8 +148,6 @@ class ArticleLangValidation:
                     keyword_langs_dict.get(article_type)
                 )
 
-        if exist:
-            # validação de correspondência entre os idiomas, usando como base o título
                 if exist and is_required:
                     # validação de correspondência entre os idiomas, usando como base o título
                     for element, langs in zip(['abstract', 'kwd-group'], [abstract_langs_dict.get(article_type), keyword_langs_dict.get(article_type)]):
@@ -167,25 +165,15 @@ class ArticleLangValidation:
                             'message': f'Got {obtained} expected {expected}',
                             'advice': advice
                         }
+                elif is_required:
+                    # resposta para a verificação de ausência de elementos
                     yield {
-                        'title': f'{element} element lang attribute validation',
-                        'xpath': f'.//article-title/@xml:lang .//{element}/@xml:lang',
-                        'validation_type': 'match',
-                        'response': 'OK' if is_valid else 'ERROR',
+                        'title': f'{article_type} {element} element lang attribute validation',
+                        'xpath': xpath,
+                        'validation_type': 'exist',
+                        'response': 'ERROR',
                         'expected_value': expected,
-                        'got_value': obtained,
-                        'message': f'Got {obtained} expected {expected}',
-                        'advice': advice
+                        'got_value': None,
+                        'message': f'Got None expected {expected}',
+                        'advice': f'Provide {element} in the language {title_lang}'
                     }
-        else:
-            # resposta para a verificação de ausência de elementos
-            yield {
-                'title': f'{element} element lang attribute validation',
-                'xpath': xpath,
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': expected,
-                'got_value': None,
-                'message': f'Got None expected {expected}',
-                'advice': f'Provide a {element} in the language \'{lang}\''
-            }

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -1,0 +1,20 @@
+from packtools.sps.models import (
+    article_titles,
+    article_abstract,
+    kwd_group
+)
+
+
+def _elements_exist(title, abstract, keyword):
+    # verifica se existe título no XML
+    if not title.article_title.get('text'):
+        return False, 'title', './/article-title/@xml:lang', 'title for the article', title.article_title.get('lang')
+    # verifica se existe palavras-chave sem resumo
+    if abstract == [] and keyword != []:
+        return False, 'abstract', './/abstract/@xml:lang', 'abstract for the article', " | ".join(keyword)
+    # verifica se existe resumo sem palavras-chave
+    if abstract != [] and keyword == []:
+        return False, 'kwd-group', './/kwd-group/@xml:lang', 'keywords for the article', " | ".join(abstract)
+    return True, None, None, None, None
+
+

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -117,19 +117,14 @@ class ArticleLangValidation:
                 },...
             ]
         """
-        # obtem uma lista com códigos de idiomas para títulos: ['pt', 'en', 'es']
-        title_lang_list = [self.article_title.article_title.get('lang')] + \
-                          [item.get('lang') for item in self.article_title.trans_titles]
+        # obtem um dicionário com códigos de idiomas para títulos: {'article': ['pt', 'en'], 'sub-article': ['es']}
+        title_langs_dict = get_title_langs(self.article_title)
 
-        # obtem uma lista com códigos de idiomas para resumos: ['pt', 'en', 'es']
-        try:
-            abstract_lang_list = [self.article_abstract.get_main_abstract().get('lang')] + \
-                                 [item.get('lang') for item in self.article_abstract._get_trans_abstracts()]
-        except AttributeError:
-            abstract_lang_list = []
+        # obtem um dicionário com códigos de idiomas para resumos: {'article': ['pt', 'en'], 'sub-article': ['es']}
+        abstract_langs_dict = get_abstract_langs(self.article_abstract)
 
-        # obtem uma lista com códigos de idiomas para palavras-chave: ['pt', 'en', 'es']
-        keyword_lang_list = list(self.article_kwd.keys())
+        # obtem um dicionário com códigos de idiomas para palavras-chave: {'article': ['pt', 'en'], 'sub-article': ['es']}
+        keyword_langs_dict = get_keyword_langs(self.article_kwd)
 
         # verifica a exsitência dos elementos no XML
         exist, element, xpath, expected, lang = _elements_exist(self.article_title, abstract_lang_list,

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -5,17 +5,22 @@ from packtools.sps.models import (
 )
 
 
-def _elements_exist(title, abstract, keyword):
+def _elements_exist(article_type, title_lang, title, abstract, keyword):
     # verifica se existe título no XML
-    if not title.article_title.get('text'):
-        return False, 'title', './/article-title/@xml:lang', 'title for the article', title.article_title.get('lang')
+    if not title.article_title_dict.get(title_lang):
+        return False, True, 'title', './/article-title/@xml:lang', f'title for the {article_type}'
     # verifica se existe palavras-chave sem resumo
     if abstract == [] and keyword != []:
-        return False, 'abstract', './/abstract/@xml:lang', 'abstract for the article', " | ".join(keyword)
+        return False, True, 'abstract', './/abstract/@xml:lang', f'abstract for the {article_type}'
     # verifica se existe resumo sem palavras-chave
     if abstract != [] and keyword == []:
-        return False, 'kwd-group', './/kwd-group/@xml:lang', 'keywords for the article', " | ".join(abstract)
-    return True, None, None, None, None
+        return False, True, 'kwd-group', './/kwd-group/@xml:lang', f'keywords for the {article_type}'
+    # verifica se o teste é necessário
+    if abstract == [] and keyword == []:
+        return True, False, None, None, None
+    return True, True, None, None, None
+
+
 
 
 class ArticleLangValidation:

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -37,6 +37,23 @@ def get_title_langs(titles):
     return resp
 
 
+def get_abstract_langs(abstracts):
+    main_abstract = abstracts.get_main_abstract(style='inline')
+    if main_abstract:
+        main_abstract_lang = [main_abstract.get('lang')] if main_abstract.get('abstract') else []
+    else:
+        main_abstract_lang = []
+
+    trans_abstract_langs = [item.get('lang') for item in abstracts._get_trans_abstracts(style='inline') if item.get('abstract')]
+
+    sub_article_abstract_langs = [item.get('lang') for item in abstracts._get_sub_article_abstracts(style='inline') if item.get('abstract')]
+
+    return {
+        'article': main_abstract_lang + trans_abstract_langs,
+        'sub-article': sub_article_abstract_langs
+    }
+
+
 
 
 class ArticleLangValidation:

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -21,6 +21,22 @@ def _elements_exist(article_type, title_lang, title, abstract, keyword):
     return True, True, None, None, None
 
 
+def get_title_langs(titles):
+    article_langs = (
+        ([titles.article_title.get('lang')] if titles.article_title.get('text') else []) +
+        [item.get('lang') for item in titles.trans_titles if item.get('text')]
+    )
+
+    sub_article_langs = [item.get('lang') for item in titles.sub_article_titles if item.get('text')]
+
+    resp = {'article': article_langs}
+
+    if sub_article_langs:
+        resp['sub-article'] = sub_article_langs
+
+    return resp
+
+
 
 
 class ArticleLangValidation:

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -2,339 +2,7 @@ from unittest import TestCase
 
 from lxml import etree as ET
 
-from packtools.sps.utils import xml_utils
 from packtools.sps.models.article_abstract import Abstract
-
-
-class AbstractTest(TestCase):
-    maxDiff = None
-
-    def setUp(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-            <abstract>
-                <title>Abstract</title>
-                    <sec>
-                    <title>Objective:</title>
-                        <p>objective</p>
-                    </sec>
-                    <sec>
-                    <title>Method:</title>
-                        <p>method</p>
-                    </sec>
-                    <sec>
-                    <title>Results:</title>
-                        <p>results</p>
-                    </sec>
-                    <sec>
-                    <title>Conclusion:</title>
-                        <p>conclusion</p>
-                    </sec>
-            </abstract>
-            </article-meta>
-            </front>
-            </article>
-            """
-        )
-        xmltree = ET.fromstring(xml)
-        self.abstract = Abstract(xmltree)
-
-    def test_main_abstract_with_tags(self):
-        obtained = self.abstract.main_abstract_with_tags
-        expected = {
-            "lang": "en",
-            "title": "Abstract",
-            "sections": {
-                "Objective:": "objective",
-                "Method:": "method",
-                "Results:": "results",
-                "Conclusion:": "conclusion"
-            }
-        }
-        self.assertEqual(obtained, expected)
-
-    def test_main_abstract_without_tags(self):
-        obtained = self.abstract.main_abstract_without_tags
-        expected = {'en': 'objective method results conclusion'}
-        self.assertEqual(obtained, expected)
-
-    def test_get_abstracts_inline_error(self):
-        self.maxDiff = None
-        xmltree = xml_utils.get_xml_tree('tests/samples/example_xml_abstract_error.xml')
-        obtained = Abstract(xmltree=xmltree).get_abstracts(style="inline")
-        expected = [
-            {'lang': 'pt', 'abstract': 'FUNDAMENTO: A relação entre atividade inflamatória e pró-trombótica na cardiomiopatia chagásica e em outras etiologias é obscura. OBJETIVO: Estudar o perfil de marcadores pró-trombóticos e pró-inflamatórios em pacientes com insuficiência cardíaca chagásica e compará-los com os de etiologia não chagásica. MÉTODOS: Coorte transversal. Critérios de inclusão: fração de ejeção do VE (FEVE) < 45% e tempo de início de sintomas > um mês. Os pacientes foram divididos em dois grupos: grupo 1 (G1) - sorologias positivas para Chagas - e grupo 2 (G2) - sorologias negativas para Chagas. Fator pró-inflamatório: PCR ultrassensível. Fatores pró-trombóticos: fator trombina-antitrombina, fibrinogênio, antígeno do fator de von Willebrand, P-selectina plasmática e tromboelastograma. Amostra calculada para poder de 80%, assumindo-se diferença de 1/3 de desvio-padrão; p significativo se < 0,05. Análise estatística: teste exato de Fischer para variáveis categóricas; teste t de Student não pareado para variáveis contínuas paramétricas e teste de Mann-Whitney para variáveis contínuas não paramétricas. RESULTADOS: Entre janeiro e junho de 2008, foram incluídos 150 pacientes, 80 no G1 e 70 no G2. Ambos os grupos mantinham médias de PCR ultrassensível acima dos valores de referência, porém, sem diferença significativa (p=0,328). Os níveis de fibrinogênio foram maiores no G2 do que no G1 (p=0,015). Entre as variáveis do tromboelastograma, os parâmetros MA (p=0,0013), G (p=0,0012) e TG (p=0,0005) foram maiores no G2 em comparação ao G1. CONCLUSÃO: Não há indícios de maior status pró-trombótico entre chagásicos. A dosagem de fibrinogênio e dos parâmetros MA, G e TG do tromboelastograma apontam para status pró-trombótico entre não chagásicos. Ambos os grupos tinham atividade inflamatória exacerbada.'},
-            {'lang': 'en', 'abstract': "BACKGROUND: The relationship between inflammatory and prothrombotic activity in chagas cardiomyopathy and in other etiologies is unclear. OBJECTIVE: To study the profile of pro-thrombotic and pro-inflammatory markers in patients with Chagas\\\\\\' heart failure and compare them with patients of non-chagas etiology. METHODS: Cross-sectional cohort. Inclusion criteria: left ventricle ejection fraction (LVEF) < 45% and onset time to symptoms > one month. The patients were divided into two groups: group 1 (G1) - seropositive for Chagas - and group 2 (G2) - seronegative for Chagas. Pro-inflammatory factor: Ultra-sensitive CRP. Pro-thrombotic factors: thrombin-antithrombin factor, fibrinogen, von Willebrand factor antigen, plasma P-selectin and thromboelastography. Sample calculated for 80% power, assuming a standard deviation difference of 1/3; significant p if it is < 0.05. Statistical analysis: Fisher\\\\\\'s exact test for categorical variables; unpaired Student\\\\\\'s t-test for parametric continuous variables and Mann-Whitney test for nonparametric continuous variables. RESULTS: Between January and June 2008, 150 patients were included, 80 in G1 and 70 in G2. Both groups maintained the averages of high sensitivity CRP above baseline values, however, there was no significant difference (p = 0.328). The fibrinogen levels were higher in G2 than in G1 (p = 0.015). Among the thromboelastography variables, the parameters MA (p=0.0013), G (p=0.0012) and TG (p =0.0005) were greater in G2 than in G1. CONCLUSION: There is no evidence of greater pro-thrombotic status among patients with Chagas disease. The levels of fibrinogen and the MA, G and TG parameters of the thromboelastography point to pro-thrombotic status among non-chagas patients. Both groups had increased inflammatory activity."},
-            {'lang': 'es', 'abstract': None}
-        ]
-
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-
-class SubArticleAbstractTest(TestCase):
-    maxDiff = None
-
-    def setUp(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-                <sub-article article-type="translation" id="s1" xml:lang="pt">
-                    <front-stub>
-                        <article-id pub-id-type="doi">10.1590/1980-220X-REEUSP-2021-0569pt</article-id>
-                        <abstract>
-                            <title>RESUMO</title>
-                            <sec>
-                                <title>Objetivo:</title>
-                                <p>objetivo</p>
-                            </sec>
-                            <sec>
-                                <title>Método:</title>
-                                <p>metodo</p>
-                            </sec>
-                            <sec>
-                                <title>Resultados:</title>
-                                <p>resultados</p>
-                            </sec>
-                            <sec>
-                                <title>Conclusão:</title>
-                                <p>conclusão</p>
-                            </sec>
-                        </abstract>
-                    </front-stub>
-                </sub-article>
-            </article>
-            """
-        )
-        xmltree = ET.fromstring(xml)
-        self.abstract = Abstract(xmltree)
-
-    def test_sub_article_abstract_with_tags(self):
-        obtained = self.abstract._sub_article_abstract_with_tags
-
-        expected = {
-            "lang": "pt",
-            "title": "RESUMO",
-            "sections": {
-                "Objetivo:": "objetivo",
-                "Método:": "metodo",
-                "Resultados:": "resultados",
-                "Conclusão:": "conclusão"
-            }
-        }
-
-        self.assertEqual(obtained, expected)
-
-
-class ArticleTransAbstractTest(TestCase):
-    maxDiff = None
-
-    def setUp(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-            <trans-abstract xml:lang="es">
-            <title>RESUMEN</title>
-            <sec>
-            <title>Objetivo:</title>
-            <p>objetivo</p>
-            </sec>
-            <sec>
-            <title>Método:</title>
-            <p>metodo</p>
-            </sec>
-            <sec>
-            <title>Resultados:</title>
-            <p>resultados</p>
-            </sec>
-            <sec>
-            <title>Conclusión:</title>
-            <p>conclusion</p>
-            </sec>
-            </trans-abstract>
-            </article-meta>
-            </front>
-            </article>
-            """
-        )
-        xmltree = ET.fromstring(xml)
-        self.abstract = Abstract(xmltree)
-
-    def test_trans_abstract_with_tags(self):
-        obtained = self.abstract._trans_abstract_with_tags
-
-        expected = {
-            "lang": "es",
-            "title": "RESUMEN",
-            "sections": {
-                "Objetivo:": "objetivo",
-                "Método:": "metodo",
-                "Resultados:": "resultados",
-                "Conclusión:": "conclusion"
-            }
-        }
-
-        self.assertEqual(obtained, expected)
-
-
-class ArticleAbstractsTest(TestCase):
-    maxDiff = None
-
-    def setUp(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-                <abstract>
-                    <title>Abstract</title>
-                        <sec>
-                        <title>Objective:</title>
-                            <p>objective</p>
-                        </sec>
-                        <sec>
-                        <title>Method:</title>
-                            <p>method</p>
-                        </sec>
-                        <sec>
-                        <title>Results:</title>
-                            <p>results</p>
-                        </sec>
-                        <sec>
-                        <title>Conclusion:</title>
-                            <p>conclusion</p>
-                        </sec>
-                </abstract>
-                    <trans-abstract xml:lang="es">
-                    <title>RESUMEN</title>
-                    <sec>
-                    <title>Objetivo:</title>
-                        <p>objetivo</p>
-                    </sec>
-                    <sec>
-                    <title>Método:</title>
-                        <p>metodo</p>
-                    </sec>
-                    <sec>
-                    <title>Resultados:</title>
-                        <p>resultados</p>
-                    </sec>
-                    <sec>
-                    <title>Conclusión:</title>
-                        <p>conclusion</p>
-                    </sec>
-                </trans-abstract>
-            </article-meta>
-            </front>
-            <sub-article article-type="translation" id="s1" xml:lang="pt">
-                    <front-stub>
-                        <article-id pub-id-type="doi">10.1590/1980-220X-REEUSP-2021-0569pt</article-id>
-                        <abstract>
-                            <title>RESUMO</title>
-                            <sec>
-                                <title>Objetivo:</title>
-                                <p>objetivo</p>
-                            </sec>
-                            <sec>
-                                <title>Método:</title>
-                                <p>metodo</p>
-                            </sec>
-                            <sec>
-                                <title>Resultados:</title>
-                                <p>resultados</p>
-                            </sec>
-                            <sec>
-                                <title>Conclusão:</title>
-                                <p>conclusão</p>
-                            </sec>
-                        </abstract>
-                    </front-stub>
-                </sub-article>
-            </article>
-            """
-        )
-        xmltree = ET.fromstring(xml)
-        self.abstract = Abstract(xmltree)
-
-    def test_abstracts_with_tags(self):
-        obtained = self.abstract.abstracts_with_tags
-
-        expected = [
-            {
-                "lang": "en",
-                "title": "Abstract",
-                "sections": {
-                    "Objective:": "objective",
-                    "Method:": "method",
-                    "Results:": "results",
-                    "Conclusion:": "conclusion"
-                }
-            },
-            {
-                "lang": "es",
-                "title": "RESUMEN",
-                "sections": {
-                    "Objetivo:": "objetivo",
-                    "Método:": "metodo",
-                    "Resultados:": "resultados",
-                    "Conclusión:": "conclusion"
-                }
-            },
-            {
-                "lang": "pt",
-                "title": "RESUMO",
-                "sections": {
-                    "Objetivo:": "objetivo",
-                    "Método:": "metodo",
-                    "Resultados:": "resultados",
-                    "Conclusão:": "conclusão"
-                }
-            }
-
-        ]
-
-        self.assertEqual(obtained, expected)
-
-    def test_abstracts_without_tags(self):
-
-        obtained = self.abstract.abstracts_without_tags
-
-        expected = {
-            'en': 'objective method results conclusion',
-            'pt': 'objetivo metodo resultados conclusão',
-            'es': 'objetivo metodo resultados conclusion'
-        }
-
-        self.assertEqual(obtained, expected)
-
-    def test_without_trans_abstract_with_tags(self):
-        xml = (
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <article-meta>
-            </article-meta>
-            </front>
-            </article>
-            """
-        )
-        data = ET.fromstring(xml)
-        obtained = Abstract(data)._trans_abstract_with_tags
-
-        expected = None
-
-        self.assertEqual(obtained, expected)
 
 
 class AbstractWithSectionsTest(TestCase):
@@ -382,7 +50,7 @@ class AbstractWithSectionsTest(TestCase):
             </trans-abstract>
             </article-meta>
             </front>
-            <sub-article article-type="translation" xml:lang="es">
+            <sub-article article-type="translation" id="01" xml:lang="es">
                 <front-stub>
                     <abstract>
                         <title>Resumen</title>
@@ -397,7 +65,7 @@ class AbstractWithSectionsTest(TestCase):
                       </abstract>
                 </front-stub>
             </sub-article>
-            <sub-article article-type="translation" xml:lang="de">
+            <sub-article article-type="translation" id="02" xml:lang="de">
                 <front-stub>
                     <abstract>
                         <title>Zusammenfassung</title>
@@ -416,20 +84,14 @@ class AbstractWithSectionsTest(TestCase):
             """)
         self.abstract = Abstract(xmltree)
 
-    def test__get_section_titles_and_paragraphs(self):
-        expected = {
-            "Objective": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.",
-            "Design": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-        }
-        result = self.abstract._get_section_titles_and_paragraphs(
-            ".//front//abstract",
-        )
-        self.assertDictEqual(expected, result)
-
     def test__main_abstract_without_tags(self):
+        self.maxDiff = None
         expected = {
-            "en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
-        result = self.abstract.main_abstract_without_tags
+            "lang": "en",
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
+        }
+        result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):
@@ -458,7 +120,8 @@ class AbstractWithSectionsTest(TestCase):
                     "p": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
 
                 }],
-            }
+            },
+            "id": "main"
         }
         result = self.abstract.get_main_abstract()
         self.assertDictEqual(expected, result)
@@ -478,6 +141,7 @@ class AbstractWithSectionsTest(TestCase):
         expected = {
             "lang": "en",
             "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Design Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
         }
         result = self.abstract.get_main_abstract(style="inline")
         self.assertDictEqual(expected, result)
@@ -528,7 +192,8 @@ class AbstractWithSectionsTest(TestCase):
         """
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
@@ -566,6 +231,7 @@ class AbstractWithSectionsTest(TestCase):
             </front-stub>
         </sub-article>
         """
+        self.maxDiff = None
         expected = (
             {
                 "lang": "es",
@@ -582,7 +248,8 @@ class AbstractWithSectionsTest(TestCase):
                             "p": "Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. "
                         },
                     ]
-                }
+                },
+                "id": "01"
             },
             {
                 "lang": "de",
@@ -599,7 +266,8 @@ class AbstractWithSectionsTest(TestCase):
                             "p": "Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben."
                         },
                     ]
-                }
+                },
+                "id": "02"
             },
         )
         result = self.abstract._get_sub_article_abstracts()
@@ -636,6 +304,7 @@ class AbstractWithSectionsTest(TestCase):
         expected = (
             {
                 "lang": "pt",
+                "id": "trans",
                 "abstract": {
                     "lang": "pt",
                     "title": "Resumo",
@@ -653,6 +322,7 @@ class AbstractWithSectionsTest(TestCase):
             },
             {
                 "lang": "fr",
+                "id": "trans",
                 "abstract": {
                     "lang": "fr",
                     "title": "Résumé",
@@ -698,7 +368,7 @@ class AbstractWithoutSectionsTest(TestCase):
             </trans-abstract>
             </article-meta>
             </front>
-            <sub-article article-type="translation" xml:lang="es">
+            <sub-article article-type="translation" id="01" xml:lang="es">
                 <front-stub>
                     <abstract>
                         <title>Resumen</title>
@@ -707,7 +377,7 @@ class AbstractWithoutSectionsTest(TestCase):
                       </abstract>
                 </front-stub>
             </sub-article>
-            <sub-article article-type="translation" xml:lang="it">
+            <sub-article article-type="translation" id="02" xml:lang="it">
                 <front-stub>
                     <abstract>
                         <title>Riepilogo</title>
@@ -720,16 +390,14 @@ class AbstractWithoutSectionsTest(TestCase):
         """)
         self.abstract = Abstract(xmltree)
 
-    def test__get_section_titles_and_paragraphs(self):
-        expected = {}
-        result = self.abstract._get_section_titles_and_paragraphs(
-            ".//front//abstract",
-        )
-        self.assertDictEqual(expected, result)
-
     def test__main_abstract_without_tags(self):
-        expected = {"en": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."}
-        result = self.abstract.main_abstract_without_tags
+        self.maxDiff = None
+        expected = {
+            "lang": "en",
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
+        }
+        result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):
@@ -739,7 +407,8 @@ class AbstractWithoutSectionsTest(TestCase):
                 "lang": "en",
                 "title": "Abstract",
                 "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            }
+            },
+            "id": "main"
         }
         result = self.abstract.get_main_abstract()
         self.assertDictEqual(expected, result)
@@ -748,6 +417,7 @@ class AbstractWithoutSectionsTest(TestCase):
         expected = {
             "lang": "en",
             "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
         }
         result = self.abstract.get_main_abstract(style="inline")
         self.assertDictEqual(expected, result)
@@ -765,34 +435,39 @@ class AbstractWithoutSectionsTest(TestCase):
         self.assertIn("<p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>", result["abstract"])
 
     def test_get_main_abstract_only_p(self):
+        self.maxDiff = None
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+            "id": "main"
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
 
     def test__get_sub_article_abstracts(self):
         """
-        <sub-article article-type="translation" xml:lang="es">
-            <front-stub>
-                <abstract>
-                    <title>Resumen</title>
-                    <p>
-                      Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).</p>
-                  </abstract>
-            </front-stub>
+        <article>
+        <sub-article article-type="translation" id="01" xml:lang="es">
+        <front-stub>
+        <abstract>
+        <title>Resumen</title>
+        <p>
+        Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).</p>
+        </abstract>
+        </front-stub>
         </sub-article>
-        <sub-article article-type="translation" xml:lang="it">
-            <front-stub>
-                <abstract>
-                    <title>Riepilogo</title>
-                    <p>
-                      Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
-                  </abstract>
-            </front-stub>
+        <sub-article article-type="translation" id="02" xml:lang="it">
+        <front-stub>
+        <abstract>
+        <title>Riepilogo</title>
+        <p>
+        Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
+        </abstract>
+        </front-stub>
         </sub-article>
+        </article>
         """
+        self.maxDiff = None
         expected = (
             {
                 "lang": "es",
@@ -800,7 +475,8 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "es",
                     "title": "Resumen",
                     "p": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
-                }
+                },
+                "id": "01"
             },
             {
                 "lang": "it",
@@ -808,7 +484,8 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "it",
                     "title": "Riepilogo",
                     "p": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
-                }
+                },
+                "id": "02"
             },
         )
         result = self.abstract._get_sub_article_abstracts()
@@ -817,6 +494,7 @@ class AbstractWithoutSectionsTest(TestCase):
                 self.assertDictEqual(exp, res)
 
     def test__get_trans_abstracts(self):
+        self.maxDiff = None
         """
         <trans-abstract xml:lang="pt">
             <title>Resumo</title>
@@ -834,7 +512,8 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "pt",
                     "title": "Resumo",
                     "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
-                }
+                },
+                "id": "trans"
             },
             {
                 "lang": "fr",
@@ -842,7 +521,8 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "fr",
                     "title": "Résumé",
                     "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
-                }
+                },
+                "id": "trans"
             },
         )
         result = self.abstract._get_trans_abstracts()

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -88,8 +88,8 @@ class AbstractWithSectionsTest(TestCase):
         self.maxDiff = None
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
@@ -108,6 +108,7 @@ class AbstractWithSectionsTest(TestCase):
         """
         expected = {
             "lang": "en",
+            'parent_name': 'article',
             "abstract": {
                 "lang": "en",
                 "title": "Abstract",
@@ -120,8 +121,7 @@ class AbstractWithSectionsTest(TestCase):
                     "p": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
 
                 }],
-            },
-            "id": "main"
+            }
         }
         result = self.abstract.get_main_abstract()
         self.assertDictEqual(expected, result)
@@ -140,8 +140,8 @@ class AbstractWithSectionsTest(TestCase):
         """
         expected = {
             "lang": "en",
-            "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Design Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Design Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="inline")
         self.assertDictEqual(expected, result)
@@ -160,6 +160,7 @@ class AbstractWithSectionsTest(TestCase):
         """
         expected = {
             "lang": "en",
+            'parent_name': 'article',
             "abstract": """<title>Abstract</title>
         <sec>
             <title>Objective</title>
@@ -192,8 +193,8 @@ class AbstractWithSectionsTest(TestCase):
         """
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
@@ -235,6 +236,7 @@ class AbstractWithSectionsTest(TestCase):
         expected = (
             {
                 "lang": "es",
+                'parent_name': 'sub-article',
                 "abstract": {
                     "lang": "es",
                     "title": "Resumen",
@@ -253,6 +255,7 @@ class AbstractWithSectionsTest(TestCase):
             },
             {
                 "lang": "de",
+                'parent_name': 'sub-article',
                 "abstract": {
                     "lang": "de",
                     "title": "Zusammenfassung",
@@ -304,7 +307,7 @@ class AbstractWithSectionsTest(TestCase):
         expected = (
             {
                 "lang": "pt",
-                "id": "trans",
+                'parent_name': 'article',
                 "abstract": {
                     "lang": "pt",
                     "title": "Resumo",
@@ -322,7 +325,7 @@ class AbstractWithSectionsTest(TestCase):
             },
             {
                 "lang": "fr",
-                "id": "trans",
+                'parent_name': 'article',
                 "abstract": {
                     "lang": "fr",
                     "title": "Résumé",
@@ -394,8 +397,8 @@ class AbstractWithoutSectionsTest(TestCase):
         self.maxDiff = None
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
@@ -403,12 +406,12 @@ class AbstractWithoutSectionsTest(TestCase):
     def test_get_main_abstract_default_style(self):
         expected = {
             "lang": "en",
+            'parent_name': 'article',
             "abstract": {
                 "lang": "en",
                 "title": "Abstract",
                 "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            },
-            "id": "main"
+            }
         }
         result = self.abstract.get_main_abstract()
         self.assertDictEqual(expected, result)
@@ -416,8 +419,8 @@ class AbstractWithoutSectionsTest(TestCase):
     def test_get_main_abstract_inline(self):
         expected = {
             "lang": "en",
-            "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="inline")
         self.assertDictEqual(expected, result)
@@ -425,6 +428,7 @@ class AbstractWithoutSectionsTest(TestCase):
     def test_get_main_abstract_xml(self):
         expected = {
             "lang": "en",
+            'parent_name': 'article',
             "abstract": """<title>Abstract</title>
                 <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>""",
         }
@@ -438,8 +442,8 @@ class AbstractWithoutSectionsTest(TestCase):
         self.maxDiff = None
         expected = {
             "lang": "en",
-            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
-            "id": "main"
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
         self.assertDictEqual(expected, result)
@@ -471,6 +475,7 @@ class AbstractWithoutSectionsTest(TestCase):
         expected = (
             {
                 "lang": "es",
+                'parent_name': 'sub-article',
                 "abstract": {
                     "lang": "es",
                     "title": "Resumen",
@@ -480,6 +485,7 @@ class AbstractWithoutSectionsTest(TestCase):
             },
             {
                 "lang": "it",
+                'parent_name': 'sub-article',
                 "abstract": {
                     "lang": "it",
                     "title": "Riepilogo",
@@ -508,21 +514,21 @@ class AbstractWithoutSectionsTest(TestCase):
         expected = (
             {
                 "lang": "pt",
+                'parent_name': 'article',
                 "abstract": {
                     "lang": "pt",
                     "title": "Resumo",
                     "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
-                },
-                "id": "trans"
+                }
             },
             {
                 "lang": "fr",
+                'parent_name': 'article',
                 "abstract": {
                     "lang": "fr",
                     "title": "Résumé",
                     "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
-                },
-                "id": "trans"
+                }
             },
         )
         result = self.abstract._get_trans_abstracts()

--- a/tests/sps/models/test_article_titles.py
+++ b/tests/sps/models/test_article_titles.py
@@ -116,8 +116,8 @@ class ArticleTitlesTest(TestCase):
 
     def test_data(self):
         expected = [{
-            "id": 'main',
             "lang": "es",
+            "parent_name": "article",
             "text": (
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
                 "de Tasas de Interés: un Análisis de Duración y"
@@ -130,8 +130,8 @@ class ArticleTitlesTest(TestCase):
             ),
         },
         {
-            "id": 'trans',
             "lang": "en",
+            "parent_name": "article",
             "text": (
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
                 "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "
@@ -177,8 +177,8 @@ class SubArticleTitlesTest(TestCase):
 
     def test_data(self):
         expected = [{
-            "id": 'main',
             "lang": "es",
+            "parent_name": "article",
             "text": (
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
                 "de Tasas de Interés: un Análisis de Duración y"
@@ -193,6 +193,7 @@ class SubArticleTitlesTest(TestCase):
         {
             "id": "1",
             "lang": "en",
+            "parent_name": "sub-article",
             "text": (
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
                 "FUTURES CONTRACTS: A DURATION AND CONVEXITY ANALYSIS UNDER "

--- a/tests/sps/models/test_article_titles.py
+++ b/tests/sps/models/test_article_titles.py
@@ -116,6 +116,7 @@ class ArticleTitlesTest(TestCase):
 
     def test_data(self):
         expected = [{
+            "id": 'main',
             "lang": "es",
             "text": (
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
@@ -129,6 +130,7 @@ class ArticleTitlesTest(TestCase):
             ),
         },
         {
+            "id": 'trans',
             "lang": "en",
             "text": (
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "
@@ -158,7 +160,7 @@ class SubArticleTitlesTest(TestCase):
               </title-group>
             </article-meta>
           </front>
-            <sub-article article-type="translation" xml:lang="en">
+            <sub-article article-type="translation" id="1" xml:lang="en">
 
             <front-stub>
 
@@ -175,6 +177,7 @@ class SubArticleTitlesTest(TestCase):
 
     def test_data(self):
         expected = [{
+            "id": 'main',
             "lang": "es",
             "text": (
                 "Inmunización de <bold>Flujos Financieros</bold> con Futuros "
@@ -188,6 +191,7 @@ class SubArticleTitlesTest(TestCase):
             ),
         },
         {
+            "id": "1",
             "lang": "en",
             "text": (
                 ">HEDGING FUTURE CASH FLOWS WITH INTEREST-RATE "

--- a/tests/sps/models/test_kwd_group.py
+++ b/tests/sps/models/test_kwd_group.py
@@ -2,125 +2,119 @@ from unittest import TestCase
 
 from packtools.sps.utils import xml_utils
 
-from packtools.sps.models.kwd_group import KwdGroup 
+from packtools.sps.models.kwd_group import KwdGroup
 
 
 class KwdGroupTest(TestCase):
 
     def test_extract_kwd_data_with_lang(self):
-
-        xmltree = xml_utils.get_xml_tree('tests/samples/0034-7094-rba-69-03-0227.xml')    
+        xmltree = xml_utils.get_xml_tree('tests/samples/0034-7094-rba-69-03-0227.xml')
         kwd_extract_data_with_lang_text = KwdGroup(xmltree).extract_kwd_data_with_lang_text(subtag=False)
 
         expected_output = [
-            {'lang': 'en', 'text': 'Primary health care'}, 
-            {'lang': 'en', 'text': 'Ambulatory care facilities'}, 
-            {'lang': 'en', 'text': 'Chronic pain'}, 
-            {'lang': 'en', 'text': 'Analgesia'}, 
-            {'lang': 'en', 'text': 'Pain management'}, 
-            {'lang': 'pt', 'text': 'Atenção primária à saúde'}, 
-            {'lang': 'pt', 'text': 'Instituições de assistência ambulatorial'}, 
-            {'lang': 'pt', 'text': 'Dor crônica'}, 
-            {'lang': 'pt', 'text': 'Analgesia'}, 
+            {'lang': 'en', 'text': 'Primary health care'},
+            {'lang': 'en', 'text': 'Ambulatory care facilities'},
+            {'lang': 'en', 'text': 'Chronic pain'},
+            {'lang': 'en', 'text': 'Analgesia'},
+            {'lang': 'en', 'text': 'Pain management'},
+            {'lang': 'pt', 'text': 'Atenção primária à saúde'},
+            {'lang': 'pt', 'text': 'Instituições de assistência ambulatorial'},
+            {'lang': 'pt', 'text': 'Dor crônica'},
+            {'lang': 'pt', 'text': 'Analgesia'},
             {'lang': 'pt', 'text': 'Tratamento da dor'}
         ]
-        
+
         self.assertEqual(kwd_extract_data_with_lang_text, expected_output)
 
     def test_extract_kwd_data_by_lang_without_key_text(self):
-
         xmltree = xml_utils.get_xml_tree('tests/samples/0034-7094-rba-69-03-0227.xml')
         kwd_extract_by_lang = KwdGroup(xmltree).extract_kwd_extract_data_by_lang(subtag=False)
-        
+
         expected_output = {
             'en': [
-                'Primary health care', 
-                'Ambulatory care facilities', 
-                'Chronic pain', 
-                'Analgesia', 
+                'Primary health care',
+                'Ambulatory care facilities',
+                'Chronic pain',
+                'Analgesia',
                 'Pain management'
-            ], 
+            ],
             'pt': [
-                'Atenção primária à saúde', 
-                'Instituições de assistência ambulatorial', 
-                'Dor crônica', 
-                'Analgesia', 
+                'Atenção primária à saúde',
+                'Instituições de assistência ambulatorial',
+                'Dor crônica',
+                'Analgesia',
                 'Tratamento da dor'
-                ]
-            }
+            ]
+        }
 
         self.assertEqual(kwd_extract_by_lang, expected_output)
 
     def test_extract_kwd_data_with_lang_subtag(self):
-
         xmltree = xml_utils.get_xml_tree('tests/samples/0034-8910-rsp-48-2-0296.xml')
         kwd_extract_kwd_with_lang_subtag = KwdGroup(xmltree).extract_kwd_data_with_lang_text(subtag=True)
 
         expected_output = [
-            {'lang': 'en', 'text': 'Chagas Disease, transmission'}, 
-            {'lang': 'en', 'text': 'Triatominae, <italic>Trypanosoma cruzi</italic>, isolation'}, 
-            {'lang': 'en', 'text': 'Communicable Diseases, epidemiology'}, 
-            {'lang': 'pt', 'text': 'Doença de Chagas, transmissão'}, 
-            {'lang': 'pt', 'text': 'Triatominae, <italic>Trypanosoma cruzi</italic>, isolamento'}, 
+            {'lang': 'en', 'text': 'Chagas Disease, transmission'},
+            {'lang': 'en', 'text': 'Triatominae, <italic>Trypanosoma cruzi</italic>, isolation'},
+            {'lang': 'en', 'text': 'Communicable Diseases, epidemiology'},
+            {'lang': 'pt', 'text': 'Doença de Chagas, transmissão'},
+            {'lang': 'pt', 'text': 'Triatominae, <italic>Trypanosoma cruzi</italic>, isolamento'},
             {'lang': 'pt', 'text': 'Doenças Transmissíveis, epidemiologia'}
         ]
 
         self.assertEqual(kwd_extract_kwd_with_lang_subtag, expected_output)
 
     def test_extract_kwd_data_without_lang_subtag(self):
-        
         xmltree = xml_utils.get_xml_tree('tests/samples/0034-8910-rsp-48-2-0296.xml')
         kwd_extract_kwd_without_subtag = KwdGroup(xmltree).extract_kwd_data_with_lang_text(subtag=False)
 
         expected_output = [
-            {'lang': 'en', 'text': 'Chagas Disease, transmission'}, 
-            {'lang': 'en', 'text': 'Triatominae, Trypanosoma cruzi, isolation'}, 
-            {'lang': 'en', 'text': 'Communicable Diseases, epidemiology'}, 
-            {'lang': 'pt', 'text': 'Doença de Chagas, transmissão'}, 
-            {'lang': 'pt', 'text': 'Triatominae, Trypanosoma cruzi, isolamento'}, 
+            {'lang': 'en', 'text': 'Chagas Disease, transmission'},
+            {'lang': 'en', 'text': 'Triatominae, Trypanosoma cruzi, isolation'},
+            {'lang': 'en', 'text': 'Communicable Diseases, epidemiology'},
+            {'lang': 'pt', 'text': 'Doença de Chagas, transmissão'},
+            {'lang': 'pt', 'text': 'Triatominae, Trypanosoma cruzi, isolamento'},
             {'lang': 'pt', 'text': 'Doenças Transmissíveis, epidemiologia'}
         ]
 
         self.assertEqual(kwd_extract_kwd_without_subtag, expected_output)
 
     def test_extract_kwd_data_by_lang_with_subtag(self):
-                
         xmltree = xml_utils.get_xml_tree('tests/samples/0034-8910-rsp-48-2-0296.xml')
         kwd_extract_kwd_with_subtag = KwdGroup(xmltree).extract_kwd_extract_data_by_lang(subtag=True)
-        
+
         expected_output = {
             'en': [
-                'Chagas Disease, transmission', 
-                'Triatominae, <italic>Trypanosoma cruzi</italic>, isolation', 
+                'Chagas Disease, transmission',
+                'Triatominae, <italic>Trypanosoma cruzi</italic>, isolation',
                 'Communicable Diseases, epidemiology'
-            ], 
+            ],
             'pt': [
-                'Doença de Chagas, transmissão', 
-                'Triatominae, <italic>Trypanosoma cruzi</italic>, isolamento', 
+                'Doença de Chagas, transmissão',
+                'Triatominae, <italic>Trypanosoma cruzi</italic>, isolamento',
                 'Doenças Transmissíveis, epidemiologia'
-                ]
-            }
-        
+            ]
+        }
+
         self.assertEqual(kwd_extract_kwd_with_subtag, expected_output)
-    
+
     def test_extract_kwd_data_by_lang_without_subtag(self):
-                
         xmltree = xml_utils.get_xml_tree('tests/samples/0034-8910-rsp-48-2-0296.xml')
         kwd_extract_kwd_with_subtag = KwdGroup(xmltree).extract_kwd_extract_data_by_lang(subtag=False)
 
         expected_output = {
             'en': [
-                'Chagas Disease, transmission', 
-                'Triatominae, Trypanosoma cruzi, isolation', 
+                'Chagas Disease, transmission',
+                'Triatominae, Trypanosoma cruzi, isolation',
                 'Communicable Diseases, epidemiology'
-            ], 
+            ],
             'pt': [
-                'Doença de Chagas, transmissão', 
-                'Triatominae, Trypanosoma cruzi, isolamento', 
+                'Doença de Chagas, transmissão',
+                'Triatominae, Trypanosoma cruzi, isolamento',
                 'Doenças Transmissíveis, epidemiologia'
-                ]
-            }
-        
+            ]
+        }
+
         self.assertEqual(kwd_extract_kwd_with_subtag, expected_output)
 
     def test_extract_kwd_data_with_lang_text_kwd_group_without_lang(self):
@@ -166,19 +160,21 @@ class KwdGroupTest(TestCase):
         }
 
         self.assertEqual(expected_output, kwd_extract_data_with_lang_text)
-        
+
     def test_extract_kwd_data_with_lang_text_by_article_type(self):
         self.maxDiff = None
         xmltree = xml_utils.get_xml_tree('tests/samples/example_xml_keywords_error.xml')
         obtained = KwdGroup(xmltree).extract_kwd_data_with_lang_text_by_article_type(subtag=False)
 
         expected = [
-            {'type': 'article', 'lang': 'pt', 'text': ['Enfermagem', 'Idoso de 80 Anos ou Mais', 'Relações Familiares']},
-            {'type': 'article', 'lang': 'es', 'text': ['Enfermería', 'Anciano de 80 Años o Más', 'Relaciones Familiares']},
-            {'type': 'sub-article', 'lang': 'en', 'text': ['Nursing', 'Aged, 80 Years or More', 'Family Relationships']}
+            {'element_name': 'article', 'id': 'main', 'lang': 'pt',
+             'text': ['Enfermagem', 'Idoso de 80 Anos ou Mais', 'Relações Familiares']},
+            {'element_name': 'article', 'id': 'main', 'lang': 'es',
+             'text': ['Enfermería', 'Anciano de 80 Años o Más', 'Relaciones Familiares']},
+            {'element_name': 'sub-article', 'id': 'SA1', 'lang': 'en',
+             'text': ['Nursing', 'Aged, 80 Years or More', 'Family Relationships']}
         ]
 
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
-                

--- a/tests/sps/models/test_kwd_group.py
+++ b/tests/sps/models/test_kwd_group.py
@@ -167,11 +167,11 @@ class KwdGroupTest(TestCase):
         obtained = KwdGroup(xmltree).extract_kwd_data_with_lang_text_by_article_type(subtag=False)
 
         expected = [
-            {'element_name': 'article', 'id': 'main', 'lang': 'pt',
+            {'parent_name': 'article', 'lang': 'pt',
              'text': ['Enfermagem', 'Idoso de 80 Anos ou Mais', 'Relações Familiares']},
-            {'element_name': 'article', 'id': 'main', 'lang': 'es',
+            {'parent_name': 'article', 'lang': 'es',
              'text': ['Enfermería', 'Anciano de 80 Años o Más', 'Relaciones Familiares']},
-            {'element_name': 'sub-article', 'id': 'SA1', 'lang': 'en',
+            {'parent_name': 'sub-article', 'id': 'SA1', 'lang': 'en',
              'text': ['Nursing', 'Aged, 80 Years or More', 'Family Relationships']}
         ]
 

--- a/tests/sps/models/test_kwd_group.py
+++ b/tests/sps/models/test_kwd_group.py
@@ -122,3 +122,18 @@ class KwdGroupTest(TestCase):
             }
         
         self.assertEqual(kwd_extract_kwd_with_subtag, expected_output)
+
+    def test_extract_kwd_data_with_lang_text_by_article_type(self):
+        self.maxDiff = None
+        xmltree = xml_utils.get_xml_tree('tests/samples/example_xml_keywords_error.xml')
+        obtained = KwdGroup(xmltree).extract_kwd_data_with_lang_text_by_article_type(subtag=False)
+
+        expected = [
+            {'type': 'article', 'lang': 'pt', 'text': ['Enfermagem', 'Idoso de 80 Anos ou Mais', 'Relações Familiares']},
+            {'type': 'article', 'lang': 'es', 'text': ['Enfermería', 'Anciano de 80 Años o Más', 'Relaciones Familiares']},
+            {'type': 'sub-article', 'lang': 'en', 'text': ['Nursing', 'Aged, 80 Years or More', 'Family Relationships']}
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -286,3 +286,48 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_without_abstract(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/abstract/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'abstract for the article',
+                'got_value': None,
+                'message': 'Got None expected abstract for the article',
+                'advice': 'Provide a abstract in the language \'pt | en\''
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -373,6 +373,92 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
 
 class ArticleLangTest(unittest.TestCase):
+    def test_validate_article_lang_without_title(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'article title element lang attribute validation',
+                'xpath': './/article-title/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'title for the article',
+                'got_value': None,
+                'message': 'Got None expected title for the article',
+                'advice': 'Provide title for the article',
+            }
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_sub_article_lang_without_title(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <abstract xml:lang="en">
+                        Abstract in english
+                    </abstract>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'sub-article title element lang attribute validation',
+                'xpath': './/article-title/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'title for the sub-article',
+                'got_value': None,
+                'message': 'Got None expected title for the sub-article',
+                'advice': 'Provide title for the sub-article',
+            }
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
     def test_validate_article_lang_success(self):
         self.maxDiff = None
         xml_str = """
@@ -405,48 +491,106 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'abstract element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected pt',
                 'advice': None
 
             },
             {
-                'title': 'abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected pt',
                 'advice': None
 
             },
             {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected en',
                 'advice': None
 
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_sub_article_lang_success(self):
+        self.maxDiff = None
+        xml_str = """
+        <article xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                    <abstract xml:lang="en">
+                        Abstract in english
+                    </abstract>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'sub-article abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['en'],
+                'message': 'Got [\'en\'] expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'sub-article kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['en'],
+                'message': 'Got [\'en\'] expected en',
+                'advice': None
             }
         ]
         for i, item in enumerate(obtained):
@@ -485,46 +629,105 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'abstract element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
+                'got_value': ['pt', 'pt'],
+                'message': 'Got [\'pt\', \'pt\'] expected pt',
                 'advice': None
 
             },
             {
-                'title': 'abstract element lang attribute validation',
+                'title': 'article kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'article abstract element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
                 'validation_type': 'match',
                 'response': 'ERROR',
                 'expected_value': 'en',
-                'got_value': 'pt',
-                'message': 'Got pt expected en',
-                'advice': 'Provide abstract in the language \'en\''
+                'got_value': ['pt', 'pt'],
+                'message': 'Got [\'pt\', \'pt\'] expected en',
+                'advice': 'Provide abstract in the language en'
 
             },
             {
-                'title': 'kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected en',
+                'advice': None
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_sub_article_lang_fail_abstract_does_not_match(self):
+        self.maxDiff = None
+        xml_str = """
+        <article>
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                <abstract xml:lang="pt">
+                    Abstract in english
+                </abstract>
+                <kwd-group xml:lang="en">
+                    <kwd>Keyword 1</kwd>
+                    <kwd>Keyword 2</kwd>
+                </kwd-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'sub-article abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'en',
+                'got_value': ['pt'],
+                'message': 'Got [\'pt\'] expected en',
+                'advice': 'Provide abstract in the language en'
+
+            },
+            {
+                'title': 'sub-article kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['en'],
+                'message': 'Got [\'en\'] expected en',
                 'advice': None
 
             }
@@ -565,46 +768,46 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'abstract element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected pt',
                 'advice': None
 
             },
             {
-                'title': 'abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
                 'validation_type': 'match',
                 'response': 'ERROR',
                 'expected_value': 'pt',
-                'got_value': 'en',
-                'message': 'Got en expected pt',
-                'advice': 'Provide kwd-group in the language \'pt\''
+                'got_value': ['en', 'en'],
+                'message': 'Got [\'en\', \'en\'] expected pt',
+                'advice': 'Provide kwd-group in the language pt'
 
             },
             {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['pt', 'en'],
+                'message': 'Got [\'pt\', \'en\'] expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
                 'validation_type': 'match',
                 'response': 'OK',
                 'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
+                'got_value': ['en', 'en'],
+                'message': 'Got [\'en\', \'en\'] expected en',
                 'advice': None
 
             }
@@ -613,24 +816,31 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_validate_article_lang_without_title(self):
+    def test_validate_sub_article_lang_fail_kwd_group_does_not_match(self):
         self.maxDiff = None
         xml_str = """
-        <article  xml:lang="pt">
+        <article>
             <front>
                 <article-meta>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
                 </article-meta>
             </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                <abstract xml:lang="en">
+                    Abstract in english
+                </abstract>
+                <kwd-group xml:lang="pt">
+                    <kwd>Keyword 1</kwd>
+                    <kwd>Keyword 2</kwd>
+                </kwd-group>
+                </front-stub>
+            </sub-article>
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
@@ -639,17 +849,28 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'title element lang attribute validation',
-                'xpath': './/article-title/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'sub-article abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': ['en'],
+                'message': 'Got [\'en\'] expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'sub-article kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'title for the article',
-                'got_value': None,
-                'message': 'Got None expected title for the article',
-                'advice': 'Provide a title in the language \'pt\'',
+                'expected_value': 'en',
+                'got_value': ['pt'],
+                'message': 'Got [\'pt\'] expected en',
+                'advice': 'Provide kwd-group in the language en',
+
             }
         ]
-
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -684,15 +905,69 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'abstract element lang attribute validation',
+                'title': 'article abstract element lang attribute validation',
                 'xpath': './/abstract/@xml:lang',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'abstract for the article',
                 'got_value': None,
                 'message': 'Got None expected abstract for the article',
-                'advice': 'Provide a abstract in the language \'pt | en\''
+                'advice': 'Provide abstract in the language pt'
 
+            },
+            {
+                'title': 'article abstract element lang attribute validation',
+                'xpath': './/abstract/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'abstract for the article',
+                'got_value': None,
+                'message': 'Got None expected abstract for the article',
+                'advice': 'Provide abstract in the language en'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_sub_article_lang_without_abstract(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'sub-article abstract element lang attribute validation',
+                'xpath': './/abstract/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'abstract for the sub-article',
+                'got_value': None,
+                'message': 'Got None expected abstract for the sub-article',
+                'advice': 'Provide abstract in the language en'
             }
         ]
         for i, item in enumerate(obtained):
@@ -723,15 +998,69 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'kwd-group element lang attribute validation',
+                'title': 'article kwd-group element lang attribute validation',
                 'xpath': './/kwd-group/@xml:lang',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'keywords for the article',
                 'got_value': None,
                 'message': 'Got None expected keywords for the article',
-                'advice': 'Provide a kwd-group in the language \'pt | en\''
+                'advice': 'Provide kwd-group in the language pt'
 
+            },
+            {
+                'title': 'article kwd-group element lang attribute validation',
+                'xpath': './/kwd-group/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'keywords for the article',
+                'got_value': None,
+                'message': 'Got None expected keywords for the article',
+                'advice': 'Provide kwd-group in the language en'
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_sub_article_lang_without_kwd_group(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                    <abstract xml:lang="en">
+                        Abstract in english
+                    </abstract>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'sub-article kwd-group element lang attribute validation',
+                'xpath': './/kwd-group/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'keywords for the sub-article',
+                'got_value': None,
+                'message': 'Got None expected keywords for the sub-article',
+                'advice': 'Provide kwd-group in the language en'
             }
         ]
         for i, item in enumerate(obtained):
@@ -752,6 +1081,36 @@ class ArticleLangTest(unittest.TestCase):
                     </title-group>
                 </article-meta>
             </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = []
+        self.assertEqual(list(obtained), expected)
+
+    def test_validate_sub_article_lang_with_title_only(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+                <front-stub>
+                    <title-group>
+                        <article-title xml:lang="en">Title in english</article-title>
+                    </title-group>
+                </front-stub>
+            </sub-article>
         </article>
         """
         xml_tree = get_xml_tree(xml_str)

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -165,3 +165,83 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_fail_kwd_group_does_not_match(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="en">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': 'pt',
+                'message': 'Got pt expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'pt',
+                'got_value': 'en',
+                'message': 'Got en expected pt',
+                'advice': 'Provide kwd-group in the language \'pt\''
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -1,0 +1,87 @@
+import unittest
+
+from packtools.sps.utils.xml_utils import get_xml_tree
+from packtools.sps.validation.article_lang import ArticleLangValidation
+
+
+class ArticleLangTest(unittest.TestCase):
+    def test_validate_article_lang_success(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': 'pt',
+                'message': 'Got pt expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': 'pt',
+                'message': 'Got pt expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -85,3 +85,83 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_fail_abstract_does_not_match(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="pt">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': 'pt',
+                'message': 'Got pt expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'abstract element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'en',
+                'got_value': 'pt',
+                'message': 'Got pt expected en',
+                'advice': 'Provide abstract in the language \'en\''
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'pt',
+                'got_value': 'pt',
+                'message': 'Got pt expected pt',
+                'advice': None
+
+            },
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -57,17 +57,15 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
         expected = [
             {
-                'element_name': 'article',
-                'lang': 'pt',
-                'id': 'main'
+                'parent_name': 'article',
+                'lang': 'pt'
             },
             {
-                'element_name': 'article',
-                'lang': 'en',
-                'id': 'trans'
+                'parent_name': 'article',
+                'lang': 'en'
             },
             {
-                'element_name': 'sub-article',
+                'parent_name': 'sub-article',
                 'lang': 'en',
                 'id': 'TRen'
             }
@@ -123,17 +121,15 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
         expected = [
             {
-                'element_name': 'article',
-                'lang': 'pt',
-                'id': 'main'
+                'parent_name': 'article',
+                'lang': 'pt'
             },
             {
-                'element_name': 'article',
-                'lang': 'en',
-                'id': 'trans'
+                'parent_name': 'article',
+                'lang': 'en'
             },
             {
-                'element_name': 'sub-article',
+                'parent_name': 'sub-article',
                 'lang': 'en',
                 'id': 'TRen'
             }
@@ -189,17 +185,15 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
         expected = [
             {
-                'element_name': 'article',
-                'lang': 'pt',
-                'id': 'main'
+                'parent_name': 'article',
+                'lang': 'pt'
             },
             {
-                'element_name': 'article',
-                'lang': 'en',
-                'id': 'main'
+                'parent_name': 'article',
+                'lang': 'en'
             },
             {
-                'element_name': 'sub-article',
+                'parent_name': 'sub-article',
                 'lang': 'en',
                 'id': 'TRen'
             }
@@ -249,14 +243,19 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
-        title = {
-                'element_name': 'article',
-                'lang': 'en',
-                'id': 'main'
-            }
+        title = {'parent_name': 'article', 'lang': 'en'}
         title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = get_element_langs(article_abstract.Abstract(xml_tree).get_abstracts(style='inline'))
-        keywords = get_element_langs(kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None))
+        abstracts = [
+            {'parent_name': 'article', 'lang': 'pt'},
+            {'parent_name': 'article', 'lang': 'en'},
+            {'parent_name': 'sub-article', 'lang': 'en', 'id': 'TRen'}
+        ]
+
+        keywords = [
+            {'parent_name': 'article', 'lang': 'en'},
+            {'parent_name': 'article', 'lang': 'en'},
+            {'parent_name': 'sub-article', 'lang': 'en', 'id': 'TRen'}
+        ]
 
         obtained = _elements_exist(title, title_object, abstracts, keywords)
 
@@ -279,13 +278,12 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
         title = {
-            'element_name': 'article',
-            'lang': 'en',
-            'id': 'main'
+            'parent_name': 'article',
+            'lang': 'en'
         }
         title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = get_element_langs(article_abstract.Abstract(xml_tree).get_abstracts(style='inline'))
-        keywords = get_element_langs(kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None))
+        abstracts = []
+        keywords = []
 
         obtained = _elements_exist(title, title_object, abstracts, keywords)
 
@@ -319,13 +317,12 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
         title = {
-            'element_name': 'article',
-            'lang': 'pt',
-            'id': 'main'
+            'parent_name': 'article',
+            'lang': 'pt'
         }
         title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = get_element_langs(article_abstract.Abstract(xml_tree).get_abstracts(style='inline'))
-        keywords = get_element_langs(kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None))
+        abstracts = []
+        keywords = [{'element_name': 'article', 'lang': 'pt'}, {'element_name': 'article', 'lang': 'en'}]
 
         obtained = _elements_exist(title, title_object, abstracts, keywords)
 
@@ -349,13 +346,13 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
         title = {
-            'element_name': 'article',
+            'parent_name': 'article',
             'lang': 'pt',
             'id': 'main'
         }
         title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = get_element_langs(article_abstract.Abstract(xml_tree).get_abstracts(style='inline'))
-        keywords = get_element_langs(kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None))
+        abstracts = [{'element_name': 'article', 'lang': 'pt'}]
+        keywords = []
 
         obtained = _elements_exist(title, title_object, abstracts, keywords)
 
@@ -378,13 +375,13 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
         title = {
-            'element_name': 'article',
+            'parent_name': 'article',
             'lang': 'pt',
             'id': 'main'
         }
         title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = get_element_langs(article_abstract.Abstract(xml_tree).get_abstracts(style='inline'))
-        keywords = get_element_langs(kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None))
+        abstracts = []
+        keywords = []
 
         obtained = _elements_exist(title, title_object, abstracts, keywords)
 
@@ -427,7 +424,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'title for the article',
                 'got_value': None,
                 'message': 'Got None expected title for the article',
-                'advice': 'Provide title in the \'pt\' language for article (main)'
+                'advice': 'Provide title in the \'pt\' language for article'
             }
         ]
 
@@ -679,7 +676,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'en',
                 'got_value': None,
                 'message': 'Got None expected en',
-                'advice': "Provide abstract in the 'en' language for article (trans)",
+                'advice': "Provide abstract in the 'en' language for article",
 
             },
             {
@@ -807,7 +804,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'pt',
                 'got_value': None,
                 'message': 'Got None expected pt',
-                'advice': "Provide kwd-group in the 'pt' language for article (main)",
+                'advice': "Provide kwd-group in the 'pt' language for article",
 
             },
             {
@@ -933,7 +930,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'abstract for the article',
                 'got_value': None,
                 'message': 'Got None expected abstract for the article',
-                'advice': "Provide abstract in the 'pt' language for article (main)",
+                'advice': "Provide abstract in the 'pt' language for article",
 
             },
             {
@@ -944,7 +941,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'abstract for the article',
                 'got_value': None,
                 'message': 'Got None expected abstract for the article',
-                'advice': "Provide abstract in the 'en' language for article (trans)",
+                'advice': "Provide abstract in the 'en' language for article",
             }
         ]
         for i, item in enumerate(obtained):
@@ -1026,7 +1023,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'keywords for the article',
                 'got_value': None,
                 'message': 'Got None expected keywords for the article',
-                'advice': "Provide kwd-group in the 'pt' language for article (main)"
+                'advice': "Provide kwd-group in the 'pt' language for article"
 
             },
             {
@@ -1037,7 +1034,7 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'keywords for the article',
                 'got_value': None,
                 'message': 'Got None expected keywords for the article',
-                'advice': "Provide kwd-group in the 'en' language for article (trans)"
+                'advice': "Provide kwd-group in the 'en' language for article"
 
             }
         ]

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -245,3 +245,44 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_without_title(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                    <kwd-group xml:lang="pt">
+                        <kwd>Palavra chave 1</kwd>
+                        <kwd>Palavra chave 2</kwd>
+                    </kwd-group>
+                    <kwd-group xml:lang="en">
+                        <kwd>Keyword 1</kwd>
+                        <kwd>Keyword 2</kwd>
+                    </kwd-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'title element lang attribute validation',
+                'xpath': './/article-title/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'title for the article',
+                'got_value': None,
+                'message': 'Got None expected title for the article',
+                'advice': 'Provide a title in the language \'pt\'',
+            }
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -331,3 +331,42 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_without_kwd_group(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                    <abstract><p>Resumo em português</p></abstract>
+                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = [
+            {
+                'title': 'kwd-group element lang attribute validation',
+                'xpath': './/kwd-group/@xml:lang',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'keywords for the article',
+                'got_value': None,
+                'message': 'Got None expected keywords for the article',
+                'advice': 'Provide a kwd-group in the language \'pt | en\''
+
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -370,3 +370,29 @@ class ArticleLangTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_validate_article_lang_with_title_only(self):
+        self.maxDiff = None
+        xml_str = """
+        <article  xml:lang="pt">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título em português</article-title>
+                        <trans-title-group xml:lang="en">
+                            <trans-title>Title in english</trans-title>
+                        </trans-title-group>
+                    </title-group>
+                </article-meta>
+            </front>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+
+        expected = []
+        self.assertEqual(list(obtained), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona procedimento de validação para:

- Verificação da existência de `title`;
- Verificação da existência de `abstract` sem `keywords`;
- Verificação da existência de `keywords` sem `abstract`;
- Verificação da correspondência entre os idiomas dos elementos anteriormente descritos. 

#### Onde a revisão poderia começar?
Por _commit_, preferencialmente iniciando pelos testes.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_lang.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.
