### PR TITLE
Fix: Missing sub-article keyword lang

### DIFF
--- a/packtools/sps/models/kwd_group.py
+++ b/packtools/sps/models/kwd_group.py
@@ -11,17 +11,23 @@ def get_node_without_subtag(node):
 class KwdGroup:
     def __init__(self, xmltree):
         self._xmltree = xmltree
-    
+
     def extract_kwd_data_with_lang_text(self, subtag):
-        
         _data = []
         kwd_text = xml_utils.node_text_without_xref if subtag else get_node_without_subtag
 
-        for kwd_group in self._xmltree.xpath('.//kwd-group'):
-            _lang = kwd_group.get("{http://www.w3.org/XML/1998/namespace}lang")
-            for kwd in kwd_group.xpath("kwd"):
-                kwd = kwd_text(kwd)
-                _data.append({"lang": _lang, "text": kwd})
+        nodes = self._xmltree.xpath('.//article-meta | .//sub-article')
+
+        for node in nodes:
+            node_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
+
+            for kwd_group in node.xpath('.//kwd-group'):
+                kwd_group_lang = kwd_group.get("{http://www.w3.org/XML/1998/namespace}lang", node_lang)
+
+                for kwd in kwd_group.xpath("kwd"):
+                    keyword_text = kwd_text(kwd)
+                    _data.append({"lang": kwd_group_lang, "text": keyword_text})
+
         return _data
 
     def extract_kwd_extract_data_by_lang(self, subtag):

--- a/tests/sps/models/test_kwd_group.py
+++ b/tests/sps/models/test_kwd_group.py
@@ -122,3 +122,47 @@ class KwdGroupTest(TestCase):
             }
         
         self.assertEqual(kwd_extract_kwd_with_subtag, expected_output)
+
+    def test_extract_kwd_data_with_lang_text_kwd_group_without_lang(self):
+        self.maxDiff = None
+        xmltree = xml_utils.get_xml_tree('tests/samples/example_xml_keywords_error.xml')
+        kwd_extract_data_with_lang_text = KwdGroup(xmltree).extract_kwd_data_with_lang_text(subtag=False)
+
+        expected_output = [
+            {'lang': 'pt', 'text': 'Enfermagem'},
+            {'lang': 'pt', 'text': 'Idoso de 80 Anos ou Mais'},
+            {'lang': 'pt', 'text': 'Relações Familiares'},
+            {'lang': 'es', 'text': 'Enfermería'},
+            {'lang': 'es', 'text': 'Anciano de 80 Años o Más'},
+            {'lang': 'es', 'text': 'Relaciones Familiares'},
+            {'lang': 'en', 'text': 'Nursing'},
+            {'lang': 'en', 'text': 'Aged, 80 Years or More'},
+            {'lang': 'en', 'text': 'Family Relationships'}
+        ]
+
+        self.assertEqual(expected_output, kwd_extract_data_with_lang_text)
+
+    def test_extract_kwd_extract_data_by_lang_kwd_group_without_lang(self):
+        self.maxDiff = None
+        xmltree = xml_utils.get_xml_tree('tests/samples/example_xml_keywords_error.xml')
+        kwd_extract_data_with_lang_text = KwdGroup(xmltree).extract_kwd_extract_data_by_lang(subtag=False)
+
+        expected_output = {
+            'pt': [
+                'Enfermagem',
+                'Idoso de 80 Anos ou Mais',
+                'Relações Familiares'
+            ],
+            'es': [
+                'Enfermería',
+                'Anciano de 80 Años o Más',
+                'Relaciones Familiares'
+            ],
+            'en': [
+                'Nursing',
+                'Aged, 80 Years or More',
+                'Family Relationships'
+            ]
+        }
+
+        self.assertEqual(expected_output, kwd_extract_data_with_lang_text)


### PR DESCRIPTION
#### O que esse PR faz?
Modifica modelo, de obtenção de palavras-chave e idiomas correspondentes, para tratar ausência de idioma em `<kwd-group>`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_kwd_group.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #534 

### Referências
NA.

