### PR TITLE
Adiciona o parâmetro pretty_print=False para tostring() em XMLWithPre e PidProviderXMLAdapter

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_adapter.py
+++ b/packtools/sps/pid_provider/xml_sps_adapter.py
@@ -13,8 +13,8 @@ class PidProviderXMLAdapter:
         self.xml_with_pre = xml_with_pre
         self.pkg_name = pkg_name
 
-    def tostring(self):
-        return self.xml_with_pre.tostring()
+    def tostring(self, pretty_print=False):
+        return self.xml_with_pre.tostring(pretty_print=pretty_print)
 
     @property
     def sps_pkg_name(self):

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -338,8 +338,12 @@ class XMLWithPre:
             front.append(parent)
             return parent
 
-    def tostring(self):
-        return self.xmlpre + etree.tostring(self.xmltree, encoding="utf-8").decode(
+    def tostring(self, pretty_print=False):
+        return self.xmlpre + etree.tostring(
+            self.xmltree,
+            encoding="utf-8",
+            pretty_print=pretty_print,
+        ).decode(
             "utf-8"
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o parâmetro pretty_print=False para tostring() em XMLWithPre e PidProviderXMLAdapter

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
```python
>>> from packtools.sps.pid_provider.xml_sps_lib import get_xml_with_pre
>>> x = get_xml_with_pre("<root><a>dlafdjafj<b>djadlfjlafj</b></a></root>")
>>> x.tostring()
'<root>\n  <a>dlafdjafj<b>djadlfjlafj</b></a>\n</root>\n'
>>> x = get_xml_with_pre("<root><a>dlafdjafj <b>djadlfjlafj</b></a></root>")
>>> x.tostring()
'<root>\n  <a>dlafdjafj <b>djadlfjlafj</b></a>\n</root>\n'

```
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

