### PR TITLE
Feat and Fix: Journal Meta validation

### DIFF
--- a/packtools/sps/models/journal_meta.py
+++ b/packtools/sps/models/journal_meta.py
@@ -1,6 +1,7 @@
 """
 <journal-meta>
     <journal-id journal-id-type="publisher-id">tinf</journal-id>
+    <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
     <journal-title-group>
         <journal-title>Transinformação</journal-title>
         <abbrev-journal-title abbrev-type="publisher">Transinformação</abbrev-journal-title>
@@ -80,3 +81,12 @@ class Publisher:
         for node in self.xmltree.xpath('.//journal-meta//publisher//publisher-name'):
             names.append(node.text)
         return names
+
+
+class JournalID:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def nlm_ta(self):
+        return self.xmltree.findtext('.//journal-meta//journal-id[@journal-id-type="nlm-ta"]')

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -64,3 +64,6 @@ class ValidationDataAvailabilityException(Exception):
 
 class ValidationIssueMissingValue(Exception):
     ...
+
+class ValidationJournalMetaException(Exception):
+    ...

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -235,6 +235,29 @@ class PublisherNameValidation:
             }
 
 
+class JournalIdValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.nlm_ta = JournalID(xmltree).nlm_ta
+
+    def nlm_ta_id_validation(self, expected_value):
+        if not expected_value:
+            raise ValidationJournalMetaException('Function requires a value to nlm-ta ID')
+        is_valid = self.nlm_ta == expected_value
+        return [
+            {
+                'title': 'Journal ID element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="nlm-ta"]',
+                'validation_type': 'value',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected_value,
+                'got_value': self.nlm_ta,
+                'message': 'Got {} expected {}'.format(self.nlm_ta, expected_value),
+                'advice': None if is_valid else 'Provide an nlm-ta value as expected: {}'.format(expected_value)
+            }
+        ]
+
+
 class JournalMetaValidation:
     def __init__(self, xmltree):
         self.xmltree = xmltree

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -110,14 +110,22 @@ class TitleValidation:
         self.xmltree = xmltree
         self.journal_titles = Title(xmltree)
 
-    def validate_journal_title(self, expected_value):
-        resp_journal_title = dict(
-            object='journal title',
-            output_expected=expected_value,
-            output_obteined=self.journal_titles.journal_title,
-            match=(expected_value == self.journal_titles.journal_title)
-        )
-        return resp_journal_title
+    def journal_title_validation(self, expected_value):
+        if not expected_value:
+            raise ValidationJournalMetaException('Function requires a value to journal title')
+        is_valid = self.journal_titles.journal_title == expected_value
+        return [
+            {
+                'title': 'Journal title element validation',
+                'xpath': './journal-meta/journal-title-group/journal-title',
+                'validation_type': 'value',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected_value,
+                'got_value': self.journal_titles.journal_title,
+                'message': 'Got {} expected {}'.format(self.journal_titles.journal_title, expected_value),
+                'advice': None if is_valid else 'Provide a journal title value as expected: {}'.format(expected_value)
+            }
+        ]
 
     def validate_abbreviated_journal_title(self, expected_value):
         resp_abbreviated_journal_title = dict(

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -127,14 +127,22 @@ class TitleValidation:
             }
         ]
 
-    def validate_abbreviated_journal_title(self, expected_value):
-        resp_abbreviated_journal_title = dict(
-            object='abbreviated journal title',
-            output_expected=expected_value,
-            output_obteined=self.journal_titles.abbreviated_journal_title,
-            match=(expected_value == self.journal_titles.abbreviated_journal_title)
-        )
-        return resp_abbreviated_journal_title
+    def abbreviated_journal_title_validation(self, expected_value):
+        if not expected_value:
+            raise ValidationJournalMetaException('Function requires a value to abbreviated journal title')
+        is_valid = self.journal_titles.abbreviated_journal_title == expected_value
+        return [
+            {
+                'title': 'Abbreviated journal title element validation',
+                'xpath': './journal-meta/journal-title-group/abbrev-journal-title',
+                'validation_type': 'value',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected_value,
+                'got_value': self.journal_titles.abbreviated_journal_title,
+                'message': 'Got {} expected {}'.format(self.journal_titles.abbreviated_journal_title, expected_value),
+                'advice': None if is_valid else 'Provide a journal title value as expected: {}'.format(expected_value)
+            }
+        ]
 
 
 class PublisherNameValidation:

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -273,7 +273,8 @@ class JournalMetaValidation:
         'acronym': 'hcsm',
         'journal-title': 'História, Ciências, Saúde-Manguinhos',
         'abbrev-journal-title': 'Hist. cienc. saude-Manguinhos',
-        'publisher-name': ['Casa de Oswaldo Cruz, Fundação Oswaldo Cruz']
+        'publisher-name': ['Casa de Oswaldo Cruz, Fundação Oswaldo Cruz'],
+        'nlm-ta': 'Rev Saude Publica'
         }
         '''
 
@@ -281,15 +282,13 @@ class JournalMetaValidation:
         acronym = AcronymValidation(self.xmltree)
         title = TitleValidation(self.xmltree)
         publisher = PublisherNameValidation(self.xmltree)
+        nlm_ta = JournalIdValidation(self.xmltree)
 
-        resp_journal_meta = list(issn.validate_issn(expected_values['issns']))
+        resp_journal_meta = list(issn.validate_issn(expected_values['issns'])) + \
+                            acronym.acronym_validation(expected_values['acronym']) + \
+                            title.journal_title_validation(expected_values['journal-title']) + \
+                            title.abbreviated_journal_title_validation(expected_values['abbrev-journal-title']) + \
+                            list(publisher.validate_publisher_names(expected_values['publisher-name'])) + \
+                            nlm_ta.nlm_ta_id_validation(expected_values['nlm-ta'])
 
-        resp_journal_meta.extend(
-            [
-                acronym.validate_text(expected_values['acronym']),
-                title.validate_journal_title(expected_values['journal-title']),
-                title.validate_abbreviated_journal_title(expected_values['abbrev-journal-title']),
-                publisher.validate_publisher_names(expected_values['publisher-name'])
-            ]
-        )
         return resp_journal_meta

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -1,6 +1,9 @@
-from ..models.journal_meta import ISSN, Acronym, Title, Publisher
-from packtools.sps.validation.exceptions import ValidationPublisherException
-from packtools.sps.validation.exceptions import ValidationIssnsException
+from ..models.journal_meta import ISSN, Acronym, Title, Publisher, JournalID
+from packtools.sps.validation.exceptions import (
+    ValidationPublisherException,
+    ValidationIssnsException,
+    ValidationJournalMetaException
+)
 
 
 class ISSNValidation:
@@ -84,14 +87,22 @@ class AcronymValidation:
         self.xmltree = xmltree
         self.journal_acronym = Acronym(xmltree)
 
-    def validate_text(self, expected_value):
-        resp_text = dict(
-            object='journal acronym',
-            output_expected=expected_value,
-            output_obteined=self.journal_acronym.text,
-            match=(expected_value == self.journal_acronym.text)
-        )
-        return resp_text
+    def acronym_validation(self, expected_value):
+        if not expected_value:
+            raise ValidationJournalMetaException('Function requires a value to acronym')
+        is_valid = self.journal_acronym.text == expected_value
+        return [
+            {
+                'title': 'Journal acronym element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="publisher-id"]',
+                'validation_type': 'value',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected_value,
+                'got_value': self.journal_acronym.text,
+                'message': 'Got {} expected {}'.format(self.journal_acronym.text, expected_value),
+                'advice': None if is_valid else 'Provide an acronym value as expected: {}'.format(expected_value)
+            }
+        ]
 
 
 class TitleValidation:

--- a/tests/sps/models/test_journal_meta.py
+++ b/tests/sps/models/test_journal_meta.py
@@ -99,4 +99,21 @@ class PublisherTest(TestCase):
     ]
     publishers_names = journal_meta.Publisher(xmltree).publishers_names
     self.assertListEqual(expected, publishers_names)
-  
+
+
+class JournalIDTest(TestCase):
+    def test_nlm_ta(self):
+        xml = """
+        <article>
+            <front>
+                <journal-meta>
+                    <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
+                </journal-meta>
+            </front>	
+		</article>
+        """
+        xmltree = _get_xmltree(xml)
+
+        expected = 'Rev Saude Publica'
+        obtained = journal_meta.JournalID(xmltree).nlm_ta
+        self.assertEqual(expected, obtained)

--- a/tests/sps/validation/test_journal_meta.py
+++ b/tests/sps/validation/test_journal_meta.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from lxml import etree
 
 from packtools.sps.validation.journal_meta import ISSNValidation, AcronymValidation, TitleValidation, \
-    PublisherNameValidation, JournalMetaValidation
+    PublisherNameValidation, JournalMetaValidation, JournalIdValidation
 
 
 class ISSNTest(TestCase):
@@ -109,25 +109,43 @@ class AcronymTest(TestCase):
         )
         self.acronym = AcronymValidation(self.xmltree)
 
-    def test_acronym_match(self):
-        expected = dict(
-            object='journal acronym',
-            output_expected='hcsm',
-            output_obteined='hcsm',
-            match=True
-        )
-        obtained = self.acronym.validate_text('hcsm')
-        self.assertDictEqual(expected, obtained)
+    def test_acronym_validation_success(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal acronym element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="publisher-id"]',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'hcsm',
+                'got_value': 'hcsm',
+                'message': 'Got hcsm expected hcsm',
+                'advice': None
+            }
+        ]
+        obtained = self.acronym.acronym_validation('hcsm')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
-    def test_acronym_no_match(self):
-        expected = dict(
-            object='journal acronym',
-            output_expected='hcs',
-            output_obteined='hcsm',
-            match=False
-        )
-        obtained = self.acronym.validate_text('hcs')
-        self.assertDictEqual(expected, obtained)
+    def test_acronym_validation_fail(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal acronym element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="publisher-id"]',
+                'validation_type': 'value',
+                'response': 'ERROR',
+                'expected_value': 'hcs',
+                'got_value': 'hcsm',
+                'message': 'Got hcsm expected hcs',
+                'advice': 'Provide an acronym value as expected: hcs'
+            }
+        ]
+        obtained = self.acronym.acronym_validation('hcs')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 class TitleTest(TestCase):
@@ -151,45 +169,81 @@ class TitleTest(TestCase):
         )
         self.title = TitleValidation(self.xmltree)
 
-    def test_journal_title_match(self):
-        expected = dict(
-            object='journal title',
-            output_expected='História, Ciências, Saúde-Manguinhos',
-            output_obteined='História, Ciências, Saúde-Manguinhos',
-            match=True
-        )
-        obtained = self.title.validate_journal_title('História, Ciências, Saúde-Manguinhos')
-        self.assertDictEqual(expected, obtained)
+    def test_journal_title_validation_success(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal title element validation',
+                'xpath': './journal-meta/journal-title-group/journal-title',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'História, Ciências, Saúde-Manguinhos',
+                'got_value': 'História, Ciências, Saúde-Manguinhos',
+                'message': 'Got História, Ciências, Saúde-Manguinhos expected História, Ciências, Saúde-Manguinhos',
+                'advice': None
+            }
+        ]
+        obtained = self.title.journal_title_validation('História, Ciências, Saúde-Manguinhos')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
-    def test_journal_title_no_match(self):
-        expected = dict(
-            object='journal title',
-            output_expected='História, Ciências, Saúde-Manguinho',
-            output_obteined='História, Ciências, Saúde-Manguinhos',
-            match=False
-        )
-        obtained = self.title.validate_journal_title('História, Ciências, Saúde-Manguinho')
-        self.assertDictEqual(expected, obtained)
+    def test_journal_title_validation_fail(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal title element validation',
+                'xpath': './journal-meta/journal-title-group/journal-title',
+                'validation_type': 'value',
+                'response': 'ERROR',
+                'expected_value': 'História, Ciências, Saúde Manguinhos',
+                'got_value': 'História, Ciências, Saúde-Manguinhos',
+                'message': 'Got História, Ciências, Saúde-Manguinhos expected História, Ciências, Saúde Manguinhos',
+                'advice': 'Provide a journal title value as expected: História, Ciências, Saúde Manguinhos'
+            }
+        ]
+        obtained = self.title.journal_title_validation('História, Ciências, Saúde Manguinhos')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
-    def test_abbreviated_journal_title_match(self):
-        expected = dict(
-            object='abbreviated journal title',
-            output_expected='Hist. cienc. saude-Manguinhos',
-            output_obteined='Hist. cienc. saude-Manguinhos',
-            match=True
-        )
-        obtained = self.title.validate_abbreviated_journal_title('Hist. cienc. saude-Manguinhos')
-        self.assertDictEqual(expected, obtained)
+    def test_abbreviated_journal_title_validation_success(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Abbreviated journal title element validation',
+                'xpath': './journal-meta/journal-title-group/abbrev-journal-title',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'Hist. cienc. saude-Manguinhos',
+                'got_value': 'Hist. cienc. saude-Manguinhos',
+                'message': 'Got Hist. cienc. saude-Manguinhos expected Hist. cienc. saude-Manguinhos',
+                'advice': None
+            }
+        ]
+        obtained = self.title.abbreviated_journal_title_validation('Hist. cienc. saude-Manguinhos')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
-    def test_abbreviated_journal_title_no_match(self):
-        expected = dict(
-            object='abbreviated journal title',
-            output_expected='Hist. cienc. saude-Manguinho',
-            output_obteined='Hist. cienc. saude-Manguinhos',
-            match=False
-        )
-        obtained = self.title.validate_abbreviated_journal_title('Hist. cienc. saude-Manguinho')
-        self.assertDictEqual(expected, obtained)
+    def test_abbreviated_journal_title_validation_fail(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Abbreviated journal title element validation',
+                'xpath': './journal-meta/journal-title-group/abbrev-journal-title',
+                'validation_type': 'value',
+                'response': 'ERROR',
+                'expected_value': 'Hist. cienc. saude Manguinhos',
+                'got_value': 'Hist. cienc. saude-Manguinhos',
+                'message': 'Got Hist. cienc. saude-Manguinhos expected Hist. cienc. saude Manguinhos',
+                'advice': 'Provide a journal title value as expected: Hist. cienc. saude Manguinhos'
+            }
+        ]
+        obtained = self.title.abbreviated_journal_title_validation('Hist. cienc. saude Manguinhos')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 class PublisherTest(TestCase):
@@ -385,6 +439,59 @@ class PublisherTest(TestCase):
                 self.assertDictEqual(expected[i], item)
 
 
+class JournalIdValidationTest(TestCase):
+    def setUp(self):
+        self.xmltree = etree.fromstring(
+            """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
+                    </journal-meta>
+                </front>
+            </article>
+            """
+        )
+
+    def test_nlm_ta_id_validation_success(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal ID element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="nlm-ta"]',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'Rev Saude Publica',
+                'got_value': 'Rev Saude Publica',
+                'message': 'Got Rev Saude Publica expected Rev Saude Publica',
+                'advice': None
+            }
+        ]
+        obtained = JournalIdValidation(self.xmltree).nlm_ta_id_validation('Rev Saude Publica')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_nlm_ta_id_validation_fail(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'title': 'Journal ID element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="nlm-ta"]',
+                'validation_type': 'value',
+                'response': 'ERROR',
+                'expected_value': 'Rev de Saude Publica',
+                'got_value': 'Rev Saude Publica',
+                'message': 'Got Rev Saude Publica expected Rev de Saude Publica',
+                'advice': 'Provide an nlm-ta value as expected: Rev de Saude Publica'
+            }
+        ]
+        obtained = JournalIdValidation(self.xmltree).nlm_ta_id_validation('Rev de Saude Publica')
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+
 class JournalMetaValidationTest(TestCase):
     def setUp(self):
         self.xmltree = etree.fromstring(
@@ -394,7 +501,7 @@ class JournalMetaValidationTest(TestCase):
                     <journal-meta>
                         <issn pub-type="ppub">0103-5053</issn>
                         <issn pub-type="epub">1678-4790</issn>
-                        <journal-id journal-id-type="nlm-ta">Hist Cienc Saude Manguinhos</journal-id>
+                        <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
                         <journal-id journal-id-type="publisher-id">hcsm</journal-id>
                         <journal-title-group>
                                 <journal-title>História, Ciências, Saúde-Manguinhos</journal-title>
@@ -433,24 +540,36 @@ class JournalMetaValidationTest(TestCase):
                 'message': 'Got <issn pub-type="epub">1678-4790</issn> expected <issn pub-type="epub">1678-4790</issn>',
                 'advice': None
             },
-            dict(
-                object='journal acronym',
-                output_expected='hcsm',
-                output_obteined='hcsm',
-                match=True
-            ),
-            dict(
-                object='journal title',
-                output_expected='História, Ciências, Saúde-Manguinhos',
-                output_obteined='História, Ciências, Saúde-Manguinhos',
-                match=True
-            ),
-            dict(
-                object='abbreviated journal title',
-                output_expected='Hist. cienc. saude-Manguinhos',
-                output_obteined='Hist. cienc. saude-Manguinhos',
-                match=True
-            ),
+            {
+                'title': 'Journal acronym element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="publisher-id"]',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'hcsm',
+                'got_value': 'hcsm',
+                'message': 'Got hcsm expected hcsm',
+                'advice': None
+            },
+            {
+                'title': 'Journal title element validation',
+                'xpath': './journal-meta/journal-title-group/journal-title',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'História, Ciências, Saúde-Manguinhos',
+                'got_value': 'História, Ciências, Saúde-Manguinhos',
+                'message': 'Got História, Ciências, Saúde-Manguinhos expected História, Ciências, Saúde-Manguinhos',
+                'advice': None
+            },
+            {
+                'title': 'Abbreviated journal title element validation',
+                'xpath': './journal-meta/journal-title-group/abbrev-journal-title',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'Hist. cienc. saude-Manguinhos',
+                'got_value': 'Hist. cienc. saude-Manguinhos',
+                'message': 'Got Hist. cienc. saude-Manguinhos expected Hist. cienc. saude-Manguinhos',
+                'advice': None
+            },
             {
                 'title': 'Publisher name element validation',
                 'xpath': './/publisher//publisher-name',
@@ -459,6 +578,16 @@ class JournalMetaValidationTest(TestCase):
                 'expected_value': 'Casa de Oswaldo Cruz, Fundação Oswaldo Cruz',
                 'got_value': 'Casa de Oswaldo Cruz, Fundação Oswaldo Cruz',
                 'message': 'Got Casa de Oswaldo Cruz, Fundação Oswaldo Cruz expected Casa de Oswaldo Cruz, Fundação Oswaldo Cruz',
+                'advice': None
+            },
+            {
+                'title': 'Journal ID element validation',
+                'xpath': './/journal-meta//journal-id[@journal-id-type="nlm-ta"]',
+                'validation_type': 'value',
+                'response': 'OK',
+                'expected_value': 'Rev Saude Publica',
+                'got_value': 'Rev Saude Publica',
+                'message': 'Got Rev Saude Publica expected Rev Saude Publica',
                 'advice': None
             }
         ]
@@ -470,6 +599,10 @@ class JournalMetaValidationTest(TestCase):
             'acronym': 'hcsm',
             'journal-title': 'História, Ciências, Saúde-Manguinhos',
             'abbrev-journal-title': 'Hist. cienc. saude-Manguinhos',
-            'publisher-name': ['Casa de Oswaldo Cruz, Fundação Oswaldo Cruz']
+            'publisher-name': ['Casa de Oswaldo Cruz, Fundação Oswaldo Cruz'],
+            'nlm-ta': 'Rev Saude Publica'
         })
-        self.assertListEqual(expected, obtained)
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validação para `<journal-id journal-id-type="nlm-ta">` e adapta as seguintes funções de validação ao padrão atual:

- `<journal-title>`
- `<abbrev-journal-title>`
- `<journal-id journal-id-type="publisher-id">`

Além disso, corrige a classe `JournalMetaValidation`

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_journal_meta.py`

#### Algum cenário de contexto que queira dar?
As funções de validação que foram padronizadas não contam da relação atual, porém, como estavam prontas considerou-se que a padronização era adequada.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

