### PR TITLE
Feat: adiciona validação para informações de financiamento

### DIFF
--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -16,6 +16,12 @@ def _strip_and_remove_final_dot(text):
     return text
 
 
+def _is_award_id(text):
+    # TODO outros casos podem ser considerados, além do DOI
+    invalid_patterns = ['doi.org', ]
+    return not any(pattern in text for pattern in invalid_patterns)
+
+
 class FundingGroup:
     """
     Class that performs the extraction of values for funding-source and award-id.

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -50,7 +50,9 @@ class FundingGroup:
 
     @property
     def funding_statement(self):
-        return self._xmltree.xpath(".//funding-group/funding-statement")[0].text
+        funding_statements = self._xmltree.xpath(".//funding-group/funding-statement")
+        if funding_statements:
+            return funding_statements[0].text
 
     @property
     def principal_award_recipients(self):

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -51,3 +51,11 @@ class FundingGroup:
     @property
     def funding_statement(self):
         return self._xmltree.xpath(".//funding-group/funding-statement")[0].text
+
+    @property
+    def principal_award_recipients(self):
+        items = []
+        for node in self._xmltree.xpath(".//funding-group/award-group/principal-award-recipient"):
+            items.append(node.text)
+        return items
+

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -17,7 +17,7 @@ def _looks_like_institution_name(text, special_chars):
     return all(char.isalpha() or char.isspace() or char in special_chars for char in text)
 
 
-def _is_award_id(text):
+def _looks_like_award_id(text):
     # TODO outros casos podem ser considerados, além do DOI
     invalid_patterns = ['doi.org', ]
     return not any(pattern in text for pattern in invalid_patterns)

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -28,17 +28,24 @@ def _get_first_number_sequence(text, special_chars):
 
     # encontra o primeiro caracter numérico em text
     for i, item in enumerate(text):
-        if text[i].isdigit():
+        if item.isdigit():
             text = text[i:]
             break
     # pega primeira sequência de caracteres numéricos ou permitidos na lista
     for i, item in enumerate(text):
-        if text[i].isdigit() or text[i] in special_chars:
-            number += text[i]
+        if item.isdigit() or item in special_chars:
+            number += item
         else:
             break
 
     return number or None
+
+
+def has_digit(text):
+    for n in range(10):
+        if str(n) in text:
+            return True
+    return False
 
 
 class FundingGroup:
@@ -69,7 +76,7 @@ class FundingGroup:
             for nodes in self._xmltree.xpath(f".//fn-group/fn[@fn-type='{fn_type}']"):
                 for node in nodes.xpath('p'):
                     text = xml_utils.node_plain_text(node)
-                    if any([char.isdigit() for char in text]):
+                    if has_digit(text):
                         number = _get_first_number_sequence(text, special_chars_award_id)
                         if _looks_like_award_id(text) and number is not None:
                             award_ids.append(number)

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -83,8 +83,9 @@ class FundingGroup:
         items = []
         for node in self._xmltree.xpath(".//funding-group/award-group"):
             d = {
-                "funding-source": [source.text for source in node.xpath("funding-source")],
-                "award-id": [id.text for id in node.xpath("award-id")]
+                "funding-source": [xml_utils.get_node_without_subtag(source) for source in
+                                   node.xpath("funding-source")],
+                "award-id": [xml_utils.get_node_without_subtag(id) for id in node.xpath("award-id")]
             }
             items.append(d)
         return items
@@ -93,20 +94,22 @@ class FundingGroup:
     def funding_sources(self):
         items = []
         for node in self._xmltree.xpath(".//funding-group/award-group/funding-source"):
-            items.append(node.text)
+            items.append(xml_utils.get_node_without_subtag(node))
         return items
 
     @property
     def funding_statement(self):
-        funding_statements = self._xmltree.xpath(".//funding-group/funding-statement")
-        if funding_statements:
-            return funding_statements[0].text
+        """
+        De acordo com https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt-br/latest/tagset/elemento-funding-statement.html?highlight=funding-statement
+        <funding-statement> ocorre zero ou uma vez.
+        """
+        return self._xmltree.findtext(".//funding-group/funding-statement")
 
     @property
     def principal_award_recipients(self):
         items = []
         for node in self._xmltree.xpath(".//funding-group/award-group/principal-award-recipient"):
-            items.append(node.text)
+            items.append(xml_utils.get_node_without_subtag(node))
         return items
 
     @property
@@ -126,8 +129,8 @@ class FundingGroup:
         for node in self._xmltree.xpath(".//back//ack"):
             items.append(
                 {
-                "title": node.findtext("title"),
-                "text": " ".join([paragraph.text for paragraph in node.xpath("p")])
+                    "title": node.findtext("title"),
+                    "text": " ".join([xml_utils.get_node_without_subtag(paragraph) for paragraph in node.xpath("p")])
                 }
             )
         return items

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -14,13 +14,19 @@ def _looks_like_institution_name(text, special_chars):
 
     In other words, it checks whether a text is, potentially, the name of a funding source.
     """
-    return all(char.isalpha() or char.isspace() or char in special_chars for char in text)
+    for char in text:
+        if not (char.isalpha() or char.isspace() or char in special_chars):
+            return False
+    return True
 
 
 def _looks_like_award_id(text):
     # TODO outros casos podem ser considerados, além do DOI
     invalid_patterns = ['doi.org', ]
-    return not any(pattern in text for pattern in invalid_patterns)
+    for pattern in invalid_patterns:
+        if pattern in text:
+            return False
+    return True
 
 
 def _get_first_number_sequence(text, special_chars):

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -1,7 +1,12 @@
 import logging
-from lxml import etree
+
+from packtools.sps.utils import xml_utils
 
 logger = logging.getLogger(__name__)
+
+
+def _is_funding_source(text):
+    return all(char.isalpha() or char.isspace() for char in text)
 
 
 class FundingGroup:

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -71,3 +71,15 @@ class FundingGroup:
             }
             items.append(d)
         return items
+
+    @property
+    def ack(self):
+        items = []
+        for node in self._xmltree.xpath(".//back//ack"):
+            items.append(
+                {
+                "title": node.findtext("title"),
+                "text": " ".join([paragraph.text for paragraph in node.xpath("p")])
+                }
+            )
+        return items

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -9,6 +9,13 @@ def _is_funding_source(text):
     return all(char.isalpha() or char.isspace() for char in text)
 
 
+def _strip_and_remove_final_dot(text):
+    text = text.strip()
+    if text.endswith('.'):
+        text = text[:-1]
+    return text
+
+
 class FundingGroup:
     """
     Class that performs the extraction of values for funding-source and award-id.

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -46,26 +46,25 @@ class FundingGroup:
     def __init__(self, xmltree):
         self._xmltree = xmltree
 
-    @property
-    def fn_financial_information(self):
+    def fn_financial_information(self, special_chars_funding=[], special_chars_award_id=[]):
         items = []
         for fn_type in ('financial-disclosure', 'supported-by'):
             funding_sources = []
             award_ids = []
             for nodes in self._xmltree.xpath(f".//fn-group/fn[@fn-type='{fn_type}']"):
                 for node in nodes.xpath('p'):
-                    text = _strip_and_remove_final_dot(xml_utils.node_plain_text(node))
-                    if _is_funding_source(text):
+                    text = xml_utils.node_plain_text(node)
+                    if _is_funding_source(text, special_chars_funding):
                         funding_sources.append(text)
                     if _is_award_id(text):
-                        if number := _get_first_number_sequence(text):
+                        if number := _get_first_number_sequence(text, special_chars_award_id):
                             award_ids.append(number)
 
                 items.append(
                     {
                         "fn-type": fn_type,
-                        "funding-source": funding_sources,
-                        "award-id": award_ids
+                        "look-like-funding-source": funding_sources,
+                        "look-like-award-id": award_ids
                     }
                 )
         return items

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -5,10 +5,8 @@ from packtools.sps.utils import xml_utils
 logger = logging.getLogger(__name__)
 
 
-def _is_funding_source(text):
-    return all(char.isalpha() or char.isspace() for char in text)
-
-
+def _is_funding_source(text, special_chars):
+    return all(char.isalpha() or char.isspace() or char in special_chars for char in text)
 
 
 def _is_award_id(text):

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -25,12 +25,19 @@ def _looks_like_award_id(text):
 
 def _get_first_number_sequence(text, special_chars):
     number = ""
-    i = 0
-    while i < len(text) and not text[i].isdigit():
-        i += 1
-    while i < len(text) and (text[i].isdigit() or text[i] in special_chars):
-        number += text[i]
-        i += 1
+
+    # encontra o primeiro caracter numérico em text
+    for i, item in enumerate(text):
+        if text[i].isdigit():
+            text = text[i:]
+            break
+    # pega primeira sequência de caracteres numéricos ou permitidos na lista
+    for i, item in enumerate(text):
+        if text[i].isdigit() or text[i] in special_chars:
+            number += text[i]
+        else:
+            break
+
     return number or None
 
 

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -5,7 +5,15 @@ from packtools.sps.utils import xml_utils
 logger = logging.getLogger(__name__)
 
 
-def _is_funding_source(text, special_chars):
+def _looks_like_institution_name(text, special_chars):
+    """
+    Checks whether all characters in text are alphanumeric, spaces or belong to the list of characters considered valid
+     in composing the name of the funding source.
+
+    Example: special_chars = ['.', ',', '-']
+
+    In other words, it checks whether a text is, potentially, the name of a funding source.
+    """
     return all(char.isalpha() or char.isspace() or char in special_chars for char in text)
 
 

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -59,3 +59,13 @@ class FundingGroup:
             items.append(node.text)
         return items
 
+    @property
+    def principal_investigators(self):
+        items = []
+        for node in self._xmltree.xpath(".//funding-group/award-group/principal-investigator/string-name"):
+            d = {
+                "given-names": node.findtext("given-names"),
+                "surname": node.findtext("surname")
+            }
+            items.append(d)
+        return items

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -22,6 +22,18 @@ def _is_award_id(text):
     return not any(pattern in text for pattern in invalid_patterns)
 
 
+def _get_first_number_sequence(text):
+    number = ""
+    special_chars = ('.', '-', '/')
+    i = 0
+    while i < len(text) and not text[i].isdigit():
+        i += 1
+    while i < len(text) and (text[i].isdigit() or text[i] in special_chars):
+        number += text[i]
+        i += 1
+    return number or None
+
+
 class FundingGroup:
     """
     Class that performs the extraction of values for funding-source and award-id.

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -9,11 +9,6 @@ def _is_funding_source(text):
     return all(char.isalpha() or char.isspace() for char in text)
 
 
-def _strip_and_remove_final_dot(text):
-    text = text.strip()
-    if text.endswith('.'):
-        text = text[:-1]
-    return text
 
 
 def _is_award_id(text):

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -15,9 +15,8 @@ def _is_award_id(text):
     return not any(pattern in text for pattern in invalid_patterns)
 
 
-def _get_first_number_sequence(text):
+def _get_first_number_sequence(text, special_chars):
     number = ""
-    special_chars = ('.', '-', '/')
     i = 0
     while i < len(text) and not text[i].isdigit():
         i += 1

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -69,11 +69,13 @@ class FundingGroup:
             for nodes in self._xmltree.xpath(f".//fn-group/fn[@fn-type='{fn_type}']"):
                 for node in nodes.xpath('p'):
                     text = xml_utils.node_plain_text(node)
-                    if _is_funding_source(text, special_chars_funding):
-                        funding_sources.append(text)
-                    if _is_award_id(text):
-                        if number := _get_first_number_sequence(text, special_chars_award_id):
+                    if any([char.isdigit() for char in text]):
+                        number = _get_first_number_sequence(text, special_chars_award_id)
+                        if _looks_like_award_id(text) and number is not None:
                             award_ids.append(number)
+                    else:
+                        if _looks_like_institution_name(text, special_chars_funding):
+                            funding_sources.append(text)
 
                 items.append(
                     {

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -54,3 +54,17 @@ class FundingGroupValidation:
                 'advice': None if is_valid else 'Provide {}'.format(expected)
             }
 
+    def principal_investigator_validation(self):
+        for principal in self.principal_investigator or [None]:
+            is_valid = principal is not None
+            expected = principal if is_valid else 'value to <principal-investigator>'
+            yield {
+                'title': 'Principal investigator element validation',
+                'xpath': './/funding-group/award-group/principal-investigator/string-name',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected,
+                'got_value': principal,
+                'message': 'Got {} expected {}'.format(principal, expected),
+                'advice': None if is_valid else 'Provide {}'.format(expected)
+            }

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -88,3 +88,19 @@ class FundingGroupValidation:
                         award_id, award_id if is_valid else 'a valid value for <award-id>'),
                     'advice': None if is_valid else 'Provide a valid value for <award-id>'
                 }
+
+    def ack_exist_validation(self):
+        for ack in self.ack or [None]:
+            is_valid = ack is not None
+            expected = ack if is_valid else 'value to <ack>'
+            yield {
+                'title': 'Acknowledgment element validation',
+                'xpath': './/back//ack',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected,
+                'got_value': ack,
+                'message': 'Got {} expected {}'.format(ack, expected),
+                'advice': None if is_valid else 'Provide {}'.format(expected)
+            }
+

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -71,9 +71,8 @@ class FundingGroupValidation:
 
     def award_id_format_validation(self, callable_validation=None):
         callable_validation = callable_validation or _callable_extern_validate_default
-
-        for funding in self.funding_group or [None]:
-            for award_id in funding.get("award-id") if funding else []:
+        for funding in self.funding_group:
+            for award_id in funding.get("award-id"):
                 is_valid = callable_validation(award_id)
                 yield {
                     'title': 'Funding source element validation',

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -71,11 +71,11 @@ class FundingGroupValidation:
                     'xpath': './/funding-group/award-group/award-id',
                     'validation_type': 'format',
                     'response': 'OK' if is_valid else 'ERROR',
-                    'expected_value': award_id if is_valid else 'a valid value for <award-id>',
+                    'expected_value': award_id if is_valid else 'a valid value for award id',
                     'got_value': award_id,
                     'message': 'Got {} expected {}'.format(
-                        award_id, award_id if is_valid else 'a valid value for <award-id>'),
-                    'advice': None if is_valid else 'Provide a valid value for <award-id>'
+                        award_id, award_id if is_valid else 'a valid value for award id'),
+                    'advice': None if is_valid else 'Provide a valid value for award id'
                 }
 
     def ack_exist_validation(self):

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -77,22 +77,6 @@ class FundingGroupValidation:
                         award_id, award_id if is_valid else 'a valid value for award id'),
                     'advice': None if is_valid else 'Provide a valid value for award id'
                 }
-
-    def ack_exist_validation(self):
-        for ack in self.ack or [None]:
-            is_valid = ack is not None
-            expected = ack if is_valid else 'value to <ack>'
-            yield {
-                'title': 'Acknowledgment element validation',
-                'xpath': './/back//ack',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': expected,
-                'got_value': ack,
-                'message': 'Got {} expected {}'.format(ack, expected),
-                'advice': None if is_valid else 'Provide {}'.format(expected)
-            }
-
     def funding_statement_exist_validation(self):
         is_valid = self.funding_statement is not None
         expected = self.funding_statement if is_valid else 'value to <funding-statement>'

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -57,20 +57,6 @@ class FundingGroupValidation:
                 else:
                     is_valid = True
 
-    def principal_award_recipient_exist_validation(self):
-        for principal in self.principal_award_recipients or [None]:
-            is_valid = principal is not None
-            expected = principal if is_valid else 'value to <principal-award-recipient>'
-            yield {
-                'title': 'Principal award recipient element validation',
-                'xpath': './/funding-group/award-group/principal-award-recipient',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': expected,
-                'got_value': principal,
-                'message': 'Got {} expected {}'.format(principal, expected),
-                'advice': None if is_valid else 'Provide {}'.format(expected)
-            }
             yield _create_response(title, xpath, validation_type, is_valid, expected, obtained, message, advice)
 
     def principal_investigator_exist_validation(self):

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -10,3 +10,32 @@ def equalize_list_sizes(list1, list2):
     return list1, list2
 
 
+class FundingGroupValidation:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+        self.funding_sources = FundingGroup(xml_tree).award_groups
+        self.principal_award_recipients = FundingGroup(xml_tree).principal_award_recipients
+        self.principal_investigator = FundingGroup(xml_tree).principal_investigators
+
+    def funding_sources_validation(self):
+        for funding in self.funding_sources or [None]:
+            if funding:
+                is_valid = funding.get("funding-source") != [] and funding.get("award-id") != []
+                fundings, awards = equalize_list_sizes(funding.get("funding-source"), funding.get("award-id"))
+                obtained = ' | '.join([f'{fund} ({award})' for fund, award in zip(fundings, awards)])
+            else:
+                is_valid = False
+                obtained = None
+
+            yield {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': obtained if is_valid else 'values to <funding-source> and <award-id>',
+                'got_value': obtained,
+                'message': 'Got {} expected {}'.format(
+                    obtained, obtained if is_valid else 'values to <funding-source> and <award-id>'),
+                'advice': None if is_valid else 'Provide values to <funding-source> and <award-id>'
+            }
+

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -59,20 +59,6 @@ class FundingGroupValidation:
 
             yield _create_response(title, xpath, validation_type, is_valid, expected, obtained, message, advice)
 
-    def principal_investigator_exist_validation(self):
-        for principal in self.principal_investigator or [None]:
-            is_valid = principal is not None
-            expected = principal if is_valid else 'value to <principal-investigator>'
-            yield {
-                'title': 'Principal investigator element validation',
-                'xpath': './/funding-group/award-group/principal-investigator/string-name',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': expected,
-                'got_value': principal,
-                'message': 'Got {} expected {}'.format(principal, expected),
-                'advice': None if is_valid else 'Provide {}'.format(expected)
-            }
 
     def award_id_format_validation(self, callable_validation=None):
         callable_validation = callable_validation or _callable_extern_validate_default

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -8,9 +8,12 @@ def _callable_extern_validate_default(award_id):
 class FundingGroupValidation:
     def __init__(self, xml_tree):
         self.xml_tree = xml_tree
-        self.funding_sources = FundingGroup(xml_tree).award_groups
-        self.principal_award_recipients = FundingGroup(xml_tree).principal_award_recipients
-        self.principal_investigator = FundingGroup(xml_tree).principal_investigators
+        self.funding_group_object = FundingGroup(xml_tree)
+        self.funding_sources = self.funding_group_object.award_groups
+        self.principal_award_recipients = self.funding_group_object.principal_award_recipients
+        self.principal_investigator = self.funding_group_object.principal_investigators
+        self.ack = self.funding_group_object.ack
+        self.funding_statement = self.funding_group_object.funding_statement
 
     def funding_sources_exist_validation(self):
         for funding in self.funding_sources or [None]:

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -1,6 +1,8 @@
 from packtools.sps.models.funding_group import FundingGroup
 
 
+def _callable_extern_validate_default(award_id):
+    raise NotImplementedError
 
 
 class FundingGroupValidation:
@@ -65,3 +67,21 @@ class FundingGroupValidation:
                 'message': 'Got {} expected {}'.format(principal, expected),
                 'advice': None if is_valid else 'Provide {}'.format(expected)
             }
+
+    def award_id_format_validation(self, callable_validation=None):
+        callable_validation = callable_validation or _callable_extern_validate_default
+
+        for funding in self.funding_sources or [None]:
+            for award_id in funding.get("award-id") if funding else []:
+                is_valid = callable_validation(award_id)
+                yield {
+                    'title': 'Funding source element validation',
+                    'xpath': './/funding-group/award-group/award-id',
+                    'validation_type': 'format',
+                    'response': 'OK' if is_valid else 'ERROR',
+                    'expected_value': award_id if is_valid else 'a valid value for <award-id>',
+                    'got_value': award_id,
+                    'message': 'Got {} expected {}'.format(
+                        award_id, award_id if is_valid else 'a valid value for <award-id>'),
+                    'advice': None if is_valid else 'Provide a valid value for <award-id>'
+                }

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -1,0 +1,12 @@
+from packtools.sps.models.funding_group import FundingGroup
+
+
+def equalize_list_sizes(list1, list2):
+    len1, len2 = len(list1), len(list2)
+    if len1 < len2:
+        list1.extend([None] * (len2 - len1))
+    elif len2 < len1:
+        list2.extend([None] * (len1 - len2))
+    return list1, list2
+
+

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -36,7 +36,7 @@ class FundingGroupValidation:
                 'advice': None if is_valid else 'Provide values to {}'.format(' and '.join(advice))
             }
 
-    def principal_award_recipient_validation(self):
+    def principal_award_recipient_exist_validation(self):
         for principal in self.principal_award_recipients or [None]:
             is_valid = principal is not None
             expected = principal if is_valid else 'value to <principal-award-recipient>'
@@ -51,7 +51,7 @@ class FundingGroupValidation:
                 'advice': None if is_valid else 'Provide {}'.format(expected)
             }
 
-    def principal_investigator_validation(self):
+    def principal_investigator_exist_validation(self):
         for principal in self.principal_investigator or [None]:
             is_valid = principal is not None
             expected = principal if is_valid else 'value to <principal-investigator>'

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -22,11 +22,8 @@ class FundingGroupValidation:
     def __init__(self, xml_tree):
         self.xml_tree = xml_tree
         self.funding_group_object = FundingGroup(xml_tree)
-        self.funding_sources = self.funding_group_object.award_groups
-        self.principal_award_recipients = self.funding_group_object.principal_award_recipients
-        self.principal_investigator = self.funding_group_object.principal_investigators
-        self.ack = self.funding_group_object.ack
-        self.funding_statement = self.funding_group_object.funding_statement
+        self.funding_group = self.funding_group_object.award_groups
+        self.funding_fn = self.funding_group_object.fn_financial_information
 
     def funding_sources_exist_validation(self):
         for funding in self.funding_sources or [None]:

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -5,6 +5,19 @@ def _callable_extern_validate_default(award_id):
     raise NotImplementedError
 
 
+def _create_response(title, xpath, validation_type, is_valid, expected, obtained, message, advice):
+    return {
+                'title': title,
+                'xpath': xpath,
+                'validation_type': validation_type,
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected,
+                'got_value': obtained,
+                'message': message,
+                'advice': advice
+            }
+
+
 class FundingGroupValidation:
     def __init__(self, xml_tree):
         self.xml_tree = xml_tree

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -77,18 +77,3 @@ class FundingGroupValidation:
                         award_id, award_id if is_valid else 'a valid value for award id'),
                     'advice': None if is_valid else 'Provide a valid value for award id'
                 }
-    def funding_statement_exist_validation(self):
-        is_valid = self.funding_statement is not None
-        expected = self.funding_statement if is_valid else 'value to <funding-statement>'
-        return [
-            {
-                'title': 'Funding statement element validation',
-                'xpath': './/funding-group/funding-statement',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': expected,
-                'got_value': self.funding_statement,
-                'message': 'Got {} expected {}'.format(self.funding_statement, expected),
-                'advice': None if is_valid else 'Provide {}'.format(expected)
-            }
-        ]

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -63,7 +63,7 @@ class FundingGroupValidation:
     def award_id_format_validation(self, callable_validation=None):
         callable_validation = callable_validation or _callable_extern_validate_default
 
-        for funding in self.funding_sources or [None]:
+        for funding in self.funding_group or [None]:
             for award_id in funding.get("award-id") if funding else []:
                 is_valid = callable_validation(award_id)
                 yield {

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -104,3 +104,18 @@ class FundingGroupValidation:
                 'advice': None if is_valid else 'Provide {}'.format(expected)
             }
 
+    def funding_statement_exist_validation(self):
+        is_valid = self.funding_statement is not None
+        expected = self.funding_statement if is_valid else 'value to <funding-statement>'
+        return [
+            {
+                'title': 'Funding statement element validation',
+                'xpath': './/funding-group/funding-statement',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected,
+                'got_value': self.funding_statement,
+                'message': 'Got {} expected {}'.format(self.funding_statement, expected),
+                'advice': None if is_valid else 'Provide {}'.format(expected)
+            }
+        ]

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -19,11 +19,11 @@ def _create_response(title, xpath, validation_type, is_valid, expected, obtained
 
 
 class FundingGroupValidation:
-    def __init__(self, xml_tree):
+    def __init__(self, xml_tree, special_chars_funding=[], special_chars_award_id=[]):
         self.xml_tree = xml_tree
         self.funding_group_object = FundingGroup(xml_tree)
         self.funding_group = self.funding_group_object.award_groups
-        self.funding_fn = self.funding_group_object.fn_financial_information
+        self.funding_fn = self.funding_group_object.fn_financial_information(special_chars_funding, special_chars_award_id)
 
     def funding_sources_exist_validation(self):
         title = 'Funding source element validation'

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -29,36 +29,45 @@ class FundingGroupValidation:
         title = 'Funding source element validation'
         validation_type = 'exist'
         for funding in self.funding_group + self.funding_fn:
+            fn_type = funding.get('fn-type')
             is_valid = False
             advice = None
-            funding_list = funding.get("funding-source")
-            award_list = funding.get("award-id")
+            funding_list = funding.get("funding-source") or funding.get("look-like-funding-source") or []
+            award_list = funding.get("award-id") or funding.get("look-like-award-id") or []
             has_funding = len(funding_list) > 0
             has_award = len(award_list) > 0
-            obtained = '{} values to funding source and {} values to award id'.format(len(funding_list), len(award_list))
-            message = 'Got {} as funding source and {} as award id'.format(funding_list, award_list)
+            obtained = '{} values {} and {} values {}'.format(
+                len(funding_list),
+                'that look like funding source' if fn_type else 'for funding source',
+                len(award_list),
+                'that look like award id' if fn_type else 'for award id'
+            )
+            message = 'Got {} {} and {} {}'.format(
+                funding_list,
+                'that look like funding source' if fn_type else 'as funding source',
+                award_list,
+                'that look like award id' if fn_type else 'as award id'
+            )
 
-            fn_type = funding.get('fn-type')
             xpath = f".//fn-group/fn[@fn-type='{fn_type}']//p" if fn_type else './/funding-group/award-group/funding-source'
             if fn_type == 'supported-by':
-                expected = 'at least 1 value to funding source'
+                expected = 'at least 1 value for funding source'
                 if not has_funding:
-                    advice = 'Provide value to funding source'
+                    advice = 'Provide value for funding source'
                 else:
                     is_valid = True
             else:
-                expected = 'at least 1 value to funding source and at least 1 value to award id'
+                expected = 'at least 1 value for funding source and at least 1 value for award id'
                 if not has_award and not has_funding:
-                    advice = 'Provide values to award id and funding source'
+                    advice = 'Provide values for award id and funding source'
                 elif not has_award and has_funding:
-                    advice = 'Provide value to award id or move funding source to <fn fn-type="supported-by">'
+                    advice = 'Provide value for award id or move funding source to <fn fn-type="supported-by">'
                 elif has_award and not has_funding:
-                    advice = 'Provide value to funding source'
+                    advice = 'Provide value for funding source'
                 else:
                     is_valid = True
 
             yield _create_response(title, xpath, validation_type, is_valid, expected, obtained, message, advice)
-
 
     def award_id_format_validation(self, callable_validation=None):
         callable_validation = callable_validation or _callable_extern_validate_default

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -1,13 +1,6 @@
 from packtools.sps.models.funding_group import FundingGroup
 
 
-def equalize_list_sizes(list1, list2):
-    len1, len2 = len(list1), len(list2)
-    if len1 < len2:
-        list1.extend([None] * (len2 - len1))
-    elif len2 < len1:
-        list2.extend([None] * (len1 - len2))
-    return list1, list2
 
 
 class FundingGroupValidation:

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -39,3 +39,18 @@ class FundingGroupValidation:
                 'advice': None if is_valid else 'Provide values to <funding-source> and <award-id>'
             }
 
+    def principal_award_recipient_validation(self):
+        for principal in self.principal_award_recipients or [None]:
+            is_valid = principal is not None
+            expected = principal if is_valid else 'value to <principal-award-recipient>'
+            yield {
+                'title': 'Principal award recipient element validation',
+                'xpath': './/funding-group/award-group/principal-award-recipient',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': expected,
+                'got_value': principal,
+                'message': 'Got {} expected {}'.format(principal, expected),
+                'advice': None if is_valid else 'Provide {}'.format(expected)
+            }
+

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -189,3 +189,26 @@ class FundingTest(TestCase):
         ]
         obtained = self.funding.ack
         self.assertEqual(expected, obtained)
+
+    def test__looks_like_institution_name_success(self):
+        self.assertTrue(funding_group._looks_like_institution_name(
+            "Natural Science, Foundation of-Hunan Province.",
+            ['.', ',', '-']
+        ))
+
+    def test__looks_like_institution_name_fail(self):
+        self.assertFalse(funding_group._looks_like_institution_name(
+            "Natural Science Foundation 1 of Hunan Province",
+            ['.', ',', '-']
+        ))
+
+    def test__looks_like_award_id_success(self):
+        self.assertTrue(funding_group._looks_like_award_id(
+            "123.456.789-0"
+        ))
+
+    def test__looks_like_award_id_fail(self):
+        self.assertFalse(funding_group._looks_like_award_id(
+            "doi.org.//123.456.789-0"
+        ))
+

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -19,10 +19,24 @@ class FundingTest(TestCase):
         <award-group>
         <funding-source>Natural Science Foundation of Hunan Province</funding-source>
         <award-id>2019JJ40269</award-id>
+        <principal-award-recipient>Stanford</principal-award-recipient>
+        <principal-investigator>
+            <string-name>
+                <given-names>Sharon R.</given-names>
+                <surname>Kaufman</surname>
+            </string-name>
+        </principal-investigator>
         </award-group>
         <award-group>
         <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
         <award-id>2020CFB547</award-id>
+        <principal-award-recipient>Berkeley</principal-award-recipient>
+        <principal-investigator>
+            <string-name>
+                <given-names>João</given-names>
+                <surname>Silva</surname>
+            </string-name>
+        </principal-investigator>
         </award-group>
         <funding-statement>Natural Science Foundation of Hunan Province Grant No. 2019JJ40269 Hubei Provincial Natural Science Foundation of China Grant No. 2020CFB547</funding-statement>
         </funding-group>
@@ -115,4 +129,24 @@ class FundingTest(TestCase):
         obtained = self.funding.funding_statement
         self.assertEqual(expected, obtained)
 
+    def test_principal_award_recipients(self):
+        expected = [
+            "Stanford",
+            "Berkeley"
+        ]
+        obtained = self.funding.principal_award_recipients
+        self.assertEqual(expected, obtained)
 
+    def test_principal_investigators(self):
+        expected = [
+            {
+                "given-names": 'Sharon R.',
+                "surname": 'Kaufman'
+            },
+            {
+                "given-names": 'João',
+                "surname": 'Silva'
+            }
+        ]
+        obtained = self.funding.principal_investigators
+        self.assertEqual(expected, obtained)

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -45,7 +45,7 @@ class FundingTest(TestCase):
         <back>
         <ack>
             <title>Acknowledgments</title>
-            <p>Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and Anesthesiology, RJ, Brazil, provided important support for this research.</p>
+            <p>Federal University of Rio de Janeiro (UFRJ), School of Medicine, <b>Department of Surgery and Anesthesiology</b>, RJ, Brazil, provided important support for this research.</p>
             <p>This study was funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment (CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil.</p>
             <p>This study was presented as a poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 November 2018, Belém do Pará, Brazil.</p>
         </ack>
@@ -82,6 +82,12 @@ class FundingTest(TestCase):
         <fn fn-type="other">
         <p>Research performed at the Immunopharmacology Laboratory, Universidade São Francisco (USF), Bragança Paulista (SP), Brazil. Part of a master degree thesis of the Postgraduate Program in Health Science. Tutor: Alessandra Gambero.</p>
         </fn>
+        <fn fn-type="supported-by">
+        <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+        <p>
+        Número 123.456-7
+        </p>
+        </fn>
         </fn-group>
         </back>
         </article>
@@ -89,23 +95,31 @@ class FundingTest(TestCase):
         xml_tree = etree.fromstring(xml)
         self.funding = funding_group.FundingGroup(xml_tree)
 
-    def test_financial_disclosure(self):
+    def test_fn_financial_information(self):
+        self.maxDiff = None
         expected = [
-            'Funding '
-            'Conselho Nacional de Desenvolvimento Científico e Tecnológico '
-            '[ https://doi.org/10.13039/501100003593 ] '
-            'Grant No: 303625/2019-8 '
-            'Fundação de Amparo à Pesquisa do Estado de São Paulo '
-            '[ https://doi.org/10.13039/501100001807 ] '
-            'Grant No: 2016/17640-0 '
-            'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior. '
-            '[ https://doi.org/10.13039/501100002322 ] '
-            'Finance code 0001.'
+            {
+                'fn-type': 'financial-disclosure',
+                'funding-source': [
+                    'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
+                    'Fundação de Amparo à Pesquisa do Estado de São Paulo',
+                    'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior'
+                ],
+                'award-id': [
+                    '303625/2019-8',
+                    '2016/17640-0',
+                    '0001'
+                ]
+            },
+            {
+                'fn-type': 'supported-by',
+                'funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'],
+                'award-id': ['123.456-7'],
+            }
         ]
-        obtained = [item for item in self.funding.financial_disclosure]
-        for i, expect_output in enumerate(expected):
-            with self.subTest(i):
-                self.assertEqual(expect_output, obtained[i])
+
+        obtained = self.funding.fn_financial_information
+        self.assertEqual(expected, obtained)
 
     def test_award_groups(self):
         expected = [

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -100,25 +100,28 @@ class FundingTest(TestCase):
         expected = [
             {
                 'fn-type': 'financial-disclosure',
-                'funding-source': [
+                'look-like-funding-source': [
                     'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
                     'Fundação de Amparo à Pesquisa do Estado de São Paulo',
-                    'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior'
+                    'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.'
                 ],
-                'award-id': [
+                'look-like-award-id': [
                     '303625/2019-8',
                     '2016/17640-0',
-                    '0001'
+                    '0001.'
                 ]
             },
             {
                 'fn-type': 'supported-by',
-                'funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'],
-                'award-id': ['123.456-7'],
+                'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'],
+                'look-like-award-id': ['123.456-7'],
             }
         ]
 
-        obtained = self.funding.fn_financial_information
+        obtained = self.funding.fn_financial_information(
+            special_chars_funding=['.', ','],
+            special_chars_award_id=['/', '.', '-']
+        )
         self.assertEqual(expected, obtained)
 
     def test_award_groups(self):

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -43,6 +43,12 @@ class FundingTest(TestCase):
         </article-meta>
         </front>
         <back>
+        <ack>
+            <title>Acknowledgments</title>
+            <p>Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and Anesthesiology, RJ, Brazil, provided important support for this research.</p>
+            <p>This study was funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment (CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil.</p>
+            <p>This study was presented as a poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 November 2018, Belém do Pará, Brazil.</p>
+        </ack>
         <fn-group>
         <fn fn-type="financial-disclosure">
         <label>Funding</label>
@@ -149,4 +155,20 @@ class FundingTest(TestCase):
             }
         ]
         obtained = self.funding.principal_investigators
+        self.assertEqual(expected, obtained)
+
+    def test_ack(self):
+        self.maxDiff = None
+        expected = [
+            {
+                "title": 'Acknowledgments',
+                "text": 'Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and '
+                        'Anesthesiology, RJ, Brazil, provided important support for this research. This study was '
+                        'funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment ('
+                        'CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil. This study was presented as a '
+                        'poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 '
+                        'November 2018, Belém do Pará, Brazil.'
+            }
+        ]
+        obtained = self.funding.ack
         self.assertEqual(expected, obtained)

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -1,0 +1,339 @@
+import unittest
+
+from packtools.sps.utils.xml_utils import get_xml_tree
+from packtools.sps.validation.funding_group import FundingGroupValidation
+
+
+class FundingGroupValidationTest(unittest.TestCase):
+    def test_funding_sources_validation_success(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Natural Science Foundation of Hunan Province (2019JJ40269)',
+                'got_value': 'Natural Science Foundation of Hunan Province (2019JJ40269)',
+                'message': 'Got Natural Science Foundation of Hunan Province (2019JJ40269) '
+                           'expected Natural Science Foundation of Hunan Province (2019JJ40269)',
+                'advice': None
+            },
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Hubei Provincial Natural Science Foundation of China (2020CFB547)',
+                'got_value': 'Hubei Provincial Natural Science Foundation of China (2020CFB547)',
+                'message': 'Got Hubei Provincial Natural Science Foundation of China (2020CFB547) '
+                           'expected Hubei Provincial Natural Science Foundation of China (2020CFB547)',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'values to <funding-source> and <award-id>',
+                'got_value': None,
+                'message': 'Got None expected values to <funding-source> and <award-id>',
+                'advice': 'Provide values to <funding-source> and <award-id>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_without_award_id(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'values to <funding-source> and <award-id>',
+                'got_value': 'Natural Science Foundation of Hunan Province (None)',
+                'message': 'Got Natural Science Foundation of Hunan Province (None) '
+                           'expected values to <funding-source> and <award-id>',
+                'advice': 'Provide values to <funding-source> and <award-id>',
+            },
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'values to <funding-source> and <award-id>',
+                'got_value': 'Hubei Provincial Natural Science Foundation of China (None)',
+                'message': 'Got Hubei Provincial Natural Science Foundation of China (None) '
+                           'expected values to <funding-source> and <award-id>',
+                'advice': 'Provide values to <funding-source> and <award-id>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_principal_award_recipient_validation_success(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                                <principal-award-recipient>Stanford</principal-award-recipient>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                                <principal-award-recipient>Berkeley</principal-award-recipient>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_validation()
+        expected = [
+            {
+                'title': 'Principal award recipient element validation',
+                'xpath': './/funding-group/award-group/principal-award-recipient',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Stanford',
+                'got_value': 'Stanford',
+                'message': 'Got Stanford expected Stanford',
+                'advice': None
+            },
+            {
+                'title': 'Principal award recipient element validation',
+                'xpath': './/funding-group/award-group/principal-award-recipient',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Berkeley',
+                'got_value': 'Berkeley',
+                'message': 'Got Berkeley expected Berkeley',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_principal_award_recipient_validation_fail(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_validation()
+        expected = [
+            {
+                'title': 'Principal award recipient element validation',
+                'xpath': './/funding-group/award-group/principal-award-recipient',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'value to <principal-award-recipient>',
+                'got_value': None,
+                'message': 'Got None expected value to <principal-award-recipient>',
+                'advice': 'Provide value to <principal-award-recipient>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_principal_investigator_validation_success(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                                <principal-award-recipient>Stanford</principal-award-recipient>
+                                <principal-investigator>
+                                    <string-name>
+                                        <given-names>Sharon R.</given-names>
+                                        <surname>Kaufman</surname>
+                                    </string-name>
+                                </principal-investigator>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                                <principal-award-recipient>Berkeley</principal-award-recipient>
+                                <principal-investigator>
+                                    <string-name>
+                                        <given-names>João</given-names>
+                                        <surname>Silva</surname>
+                                    </string-name>
+                                </principal-investigator>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).principal_investigator_validation()
+        expected = [
+            {
+                'title': 'Principal investigator element validation',
+                'xpath': './/funding-group/award-group/principal-investigator/string-name',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': {
+                    "given-names": 'Sharon R.',
+                    "surname": 'Kaufman'
+                },
+                'got_value': {
+                    "given-names": 'Sharon R.',
+                    "surname": 'Kaufman'
+                },
+                'message': "Got {'given-names': 'Sharon R.', 'surname': 'Kaufman'} expected {'given-names': 'Sharon R.', 'surname': 'Kaufman'}",
+                'advice': None
+            },
+            {
+                'title': 'Principal investigator element validation',
+                'xpath': './/funding-group/award-group/principal-investigator/string-name',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': {
+                    "given-names": 'João',
+                    "surname": 'Silva'
+                },
+                'got_value': {
+                    "given-names": 'João',
+                    "surname": 'Silva'
+                },
+                'message': "Got {'given-names': 'João', 'surname': 'Silva'} expected {'given-names': 'João', 'surname': 'Silva'}",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_principal_investigator_validation_fail(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                                <principal-award-recipient>Stanford</principal-award-recipient>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                                <principal-award-recipient>Berkeley</principal-award-recipient>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).principal_investigator_validation()
+        expected = [
+            {
+                'title': 'Principal investigator element validation',
+                'xpath': './/funding-group/award-group/principal-investigator/string-name',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'value to <principal-investigator>',
+                'got_value': None,
+                'message': 'Got None expected value to <principal-investigator>',
+                'advice': 'Provide value to <principal-investigator>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -25,7 +25,9 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).funding_sources_exist_validation())
+        obtained = list(FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                               special_chars_award_id=['/', '.',
+                                                                       '-']).funding_sources_exist_validation())
 
         self.assertListEqual([], obtained)
 
@@ -47,15 +49,16 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '2 values to funding source and 1 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '2 values for funding source and 1 values for award id',
                 'message': "Got ['Natural Science Foundation of Hunan Province', "
                            "'Hubei Provincial Natural Science Foundation of China'] "
                            "as funding source and ['2019JJ40269'] as award id",
@@ -83,18 +86,19 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '2 values to funding source and 2 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '2 values that look like funding source and 2 values that look like award id',
                 'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico', "
-                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] as funding source and "
-                           "['303625/2019-8', '2016/17640-0'] as award id",
+                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] that look like funding source and "
+                           "['303625/2019-8', '2016/17640-0'] that look like award id",
                 'advice': None
             }
         ]
@@ -119,18 +123,19 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source',
-                'got_value': '2 values to funding source and 2 values to award id',
+                'expected_value': 'at least 1 value for funding source',
+                'got_value': '2 values that look like funding source and 2 values that look like award id',
                 'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico', "
-                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] as funding source and "
-                           "['303625/2019-8', '2016/17640-0'] as award id",
+                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] that look like funding source and "
+                           "['303625/2019-8', '2016/17640-0'] that look like award id",
                 'advice': None
             }
         ]
@@ -156,15 +161,16 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '1 values to funding source and 2 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '1 values for funding source and 2 values for award id',
                 'message': "Got ['Natural Science Foundation of Hunan Province'] as funding source and "
                            "['2019JJ40269', '2020CFB547'] as award id",
                 'advice': None
@@ -190,17 +196,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '1 values to funding source and 2 values to award id',
-                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source and "
-                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '1 values that look like funding source and 2 values that look like award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] that look like"
+                           " funding source and ['303625/2019-8', '2016/17640-0'] that look like award id",
                 'advice': None
             }
         ]
@@ -224,17 +231,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source',
-                'got_value': '1 values to funding source and 2 values to award id',
-                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source and "
-                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'expected_value': 'at least 1 value for funding source',
+                'got_value': '1 values that look like funding source and 2 values that look like award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] that look like "
+                           "funding source and ['303625/2019-8', '2016/17640-0'] that look like award id",
                 'advice': None
             }
         ]
@@ -258,17 +266,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '0 values to funding source and 0 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '0 values for funding source and 0 values for award id',
                 'message': 'Got [] as funding source and [] as award id',
-                'advice': 'Provide values to award id and funding source'
+                'advice': 'Provide values for award id and funding source'
             }
         ]
         for i, item in enumerate(obtained):
@@ -289,17 +298,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '0 values to funding source and 0 values to award id',
-                'message': 'Got [] as funding source and [] as award id',
-                'advice': 'Provide values to award id and funding source'
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '0 values that look like funding source and 0 values that look like award id',
+                'message': 'Got [] that look like funding source and [] that look like award id',
+                'advice': 'Provide values for award id and funding source'
             }
         ]
         for i, item in enumerate(obtained):
@@ -320,17 +330,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source',
-                'got_value': '0 values to funding source and 0 values to award id',
-                'message': 'Got [] as funding source and [] as award id',
-                'advice': 'Provide value to funding source'
+                'expected_value': 'at least 1 value for funding source',
+                'got_value': '0 values that look like funding source and 0 values that look like award id',
+                'message': 'Got [] that look like funding source and [] that look like award id',
+                'advice': 'Provide value for funding source'
             }
         ]
         for i, item in enumerate(obtained):
@@ -353,17 +364,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '1 values to funding source and 0 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '1 values for funding source and 0 values for award id',
                 'message': "Got ['Natural Science Foundation of Hunan Province'] as funding source and [] as award id",
-                'advice': 'Provide value to award id or move funding source to <fn fn-type="supported-by">'
+                'advice': 'Provide value for award id or move funding source to <fn fn-type="supported-by">'
             }
         ]
         for i, item in enumerate(obtained):
@@ -384,18 +396,19 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '1 values to funding source and 0 values to award id',
-                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source "
-                           "and [] as award id",
-                'advice': 'Provide value to award id or move funding source to <fn fn-type="supported-by">'
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '1 values that look like funding source and 0 values that look like award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] that look like "
+                           "funding source and [] that look like award id",
+                'advice': 'Provide value for award id or move funding source to <fn fn-type="supported-by">'
             }
         ]
         for i, item in enumerate(obtained):
@@ -416,17 +429,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at least 1 value to funding source',
-                'got_value': '1 values to funding source and 0 values to award id',
-                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source "
-                           "and [] as award id",
+                'expected_value': 'at least 1 value for funding source',
+                'got_value': '1 values that look like funding source and 0 values that look like award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] that look like "
+                           "funding source and [] that look like award id",
                 'advice': None
             }
         ]
@@ -450,17 +464,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '0 values to funding source and 1 values to award id',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '0 values for funding source and 1 values for award id',
                 'message': "Got [] as funding source and ['2019JJ40269'] as award id",
-                'advice': 'Provide value to funding source',
+                'advice': 'Provide value for funding source',
             }
         ]
         for i, item in enumerate(obtained):
@@ -481,17 +496,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
-                'got_value': '0 values to funding source and 1 values to award id',
-                'message': "Got [] as funding source and ['2016/17640-0'] as award id",
-                'advice': 'Provide value to funding source',
+                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
+                'got_value': '0 values that look like funding source and 1 values that look like award id',
+                'message': "Got [] that look like funding source and ['2016/17640-0'] that look like award id",
+                'advice': 'Provide value for funding source',
             }
         ]
         for i, item in enumerate(obtained):
@@ -512,17 +528,18 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        obtained = FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
+                                          special_chars_award_id=['/', '.', '-']).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at least 1 value to funding source',
-                'got_value': '0 values to funding source and 1 values to award id',
-                'message': "Got [] as funding source and ['2016/17640-0'] as award id",
-                'advice': 'Provide value to funding source',
+                'expected_value': 'at least 1 value for funding source',
+                'got_value': '0 values that look like funding source and 1 values that look like award id',
+                'message': "Got [] that look like funding source and ['2016/17640-0'] that look like award id",
+                'advice': 'Provide value for funding source',
             }
         ]
         for i, item in enumerate(obtained):
@@ -624,6 +641,43 @@ class FundingGroupValidationTest(unittest.TestCase):
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
+
+    def test_award_id_format_validation_fail_without_funding_group(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail))
+        self.assertEqual([], obtained)
+
+    def test_award_id_format_validation_fail_without_award_id(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail))
+        self.assertEqual([], obtained)
 
 
 if __name__ == '__main__':

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -4,8 +4,16 @@ from packtools.sps.utils.xml_utils import get_xml_tree
 from packtools.sps.validation.funding_group import FundingGroupValidation
 
 
+def callable_validation_success(award_id):
+    return True
+
+
+def callable_validation_fail(award_id):
+    return False
+
+
 class FundingGroupValidationTest(unittest.TestCase):
-    def test_funding_sources_validation_success(self):
+    def test_funding_sources_validation_success_1_funding_1_award(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -26,17 +34,17 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Natural Science Foundation of Hunan Province (2019JJ40269)',
-                'got_value': 'Natural Science Foundation of Hunan Province (2019JJ40269)',
-                'message': 'Got Natural Science Foundation of Hunan Province (2019JJ40269) '
-                           'expected Natural Science Foundation of Hunan Province (2019JJ40269)',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '1 values to <funding-source> and 1 values to <award-id>',
+                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> "
+                           "['2019JJ40269'] as <award-id>",
                 'advice': None
             },
             {
@@ -44,10 +52,9 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'Hubei Provincial Natural Science Foundation of China (2020CFB547)',
-                'got_value': 'Hubei Provincial Natural Science Foundation of China (2020CFB547)',
-                'message': 'Got Hubei Provincial Natural Science Foundation of China (2020CFB547) '
-                           'expected Hubei Provincial Natural Science Foundation of China (2020CFB547)',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '1 values to <funding-source> and 1 values to <award-id>',
+                'message': "Got ['Hubei Provincial Natural Science Foundation of China'] as <funding-source> ['2020CFB547'] as <award-id>",
                 'advice': None
             }
         ]
@@ -55,28 +62,101 @@ class FundingGroupValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_fail(self):
+    def test_funding_sources_validation_success_2_funding_1_award(self):
         self.maxDiff = None
         xml_str = """
             <article>
                 <front>
                     <article-meta>
-                        
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                        </funding-group>
                     </article-meta>
                 </front>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '2 values to <funding-source> and 1 values to <award-id>',
+                'message': "Got ['Natural Science Foundation of Hunan Province', "
+                           "'Hubei Provincial Natural Science Foundation of China'] "
+                           "as <funding-source> ['2019JJ40269'] as <award-id>",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_success_1_funding_2_award(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                                <award-id>2020CFB547</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '1 values to <funding-source> and 2 values to <award-id>',
+                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> "
+                           "['2019JJ40269', '2020CFB547'] as <award-id>",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_0_funding_0_award(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'values to <funding-source> and <award-id>',
-                'got_value': None,
-                'message': 'Got None expected values to <funding-source> and <award-id>',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '0 values to <funding-source> and 0 values to <award-id>',
+                'message': 'Got [] as <funding-source> [] as <award-id>',
                 'advice': 'Provide values to <funding-source> and <award-id>',
             }
         ]
@@ -84,7 +164,7 @@ class FundingGroupValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_fail_without_award_id(self):
+    def test_funding_sources_validation_fail_1_funding_0_award(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -94,8 +174,38 @@ class FundingGroupValidationTest(unittest.TestCase):
                             <award-group>
                                 <funding-source>Natural Science Foundation of Hunan Province</funding-source>
                             </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/funding-source',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '1 values to <funding-source> and 0 values to <award-id>',
+                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> [] as <award-id>",
+                'advice': 'Provide values to <award-id>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_0_funding_1_award(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
                             <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2019JJ40269</award-id>
                             </award-group>
                         </funding-group>
                     </article-meta>
@@ -103,29 +213,17 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_validation()
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
         expected = [
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'values to <funding-source> and <award-id>',
-                'got_value': 'Natural Science Foundation of Hunan Province (None)',
-                'message': 'Got Natural Science Foundation of Hunan Province (None) '
-                           'expected values to <funding-source> and <award-id>',
-                'advice': 'Provide values to <funding-source> and <award-id>',
-            },
-            {
-                'title': 'Funding source element validation',
-                'xpath': './/funding-group/award-group/funding-source',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'values to <funding-source> and <award-id>',
-                'got_value': 'Hubei Provincial Natural Science Foundation of China (None)',
-                'message': 'Got Hubei Provincial Natural Science Foundation of China (None) '
-                           'expected values to <funding-source> and <award-id>',
-                'advice': 'Provide values to <funding-source> and <award-id>',
+                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
+                'got_value': '0 values to <funding-source> and 1 values to <award-id>',
+                'message': "Got [] as <funding-source> ['2019JJ40269'] as <award-id>",
+                'advice': 'Provide values to <funding-source>',
             }
         ]
         for i, item in enumerate(obtained):
@@ -155,7 +253,7 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_validation()
+        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_exist_validation()
         expected = [
             {
                 'title': 'Principal award recipient element validation',
@@ -203,7 +301,7 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_validation()
+        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_exist_validation()
         expected = [
             {
                 'title': 'Principal award recipient element validation',
@@ -255,7 +353,7 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_investigator_validation()
+        obtained = FundingGroupValidation(xml_tree).principal_investigator_exist_validation()
         expected = [
             {
                 'title': 'Principal investigator element validation',
@@ -317,7 +415,7 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_investigator_validation()
+        obtained = FundingGroupValidation(xml_tree).principal_investigator_exist_validation()
         expected = [
             {
                 'title': 'Principal investigator element validation',
@@ -328,6 +426,102 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'got_value': None,
                 'message': 'Got None expected value to <principal-investigator>',
                 'advice': 'Provide value to <principal-investigator>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_award_id_format_validation_success(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_success)
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/award-id',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '2019JJ40269',
+                'got_value': '2019JJ40269',
+                'message': 'Got 2019JJ40269 expected 2019JJ40269',
+                'advice': None
+            },
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/award-id',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '2020CFB547',
+                'got_value': '2020CFB547',
+                'message': 'Got 2020CFB547 expected 2020CFB547',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_award_id_format_validation_fail(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                            <award-group>
+                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <award-id>2020CFB547</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail)
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/award-id',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'a valid value for <award-id>',
+                'got_value': '2019JJ40269',
+                'message': 'Got 2019JJ40269 expected a valid value for <award-id>',
+                'advice': 'Provide a valid value for <award-id>'
+            },
+            {
+                'title': 'Funding source element validation',
+                'xpath': './/funding-group/award-group/award-id',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'a valid value for <award-id>',
+                'got_value': '2020CFB547',
+                'message': 'Got 2020CFB547 expected a valid value for <award-id>',
+                'advice': 'Provide a valid value for <award-id>'
             }
         ]
         for i, item in enumerate(obtained):

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -528,6 +528,182 @@ class FundingGroupValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
+    def test_ack_exist_validation_success_article_ack(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <ack>
+                        <title>Acknowledgments</title>
+                        <p>Paragraph 1.</p>
+                        <p>Paragraph 2.</p>
+                        <p>Paragraph 3.</p>
+                    </ack>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
+        expected = [
+            {
+                'title': 'Acknowledgment element validation',
+                'xpath': './/back//ack',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': {
+                    "title": 'Acknowledgments',
+                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
+                },
+                'got_value': {
+                    "title": 'Acknowledgments',
+                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
+                },
+                'message': "Got {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'} "
+                           "expected {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'}",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_ack_exist_validation_success_sub_article_ack(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <sub-article>
+                    <back>
+                        <ack>
+                            <title>Acknowledgments</title>
+                            <p>Paragraph 1.</p>
+                            <p>Paragraph 2.</p>
+                            <p>Paragraph 3.</p>
+                        </ack>
+                    </back>
+                </sub-article>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
+        expected = [
+            {
+                'title': 'Acknowledgment element validation',
+                'xpath': './/back//ack',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': {
+                    "title": 'Acknowledgments',
+                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
+                },
+                'got_value': {
+                    "title": 'Acknowledgments',
+                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
+                },
+                'message': "Got {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'} "
+                           "expected {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'}",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_ack_exist_validation_fail_article_ack(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
+        expected = [
+            {
+                'title': 'Acknowledgment element validation',
+                'xpath': './/back//ack',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'value to <ack>',
+                'got_value': None,
+                'message': 'Got None expected value to <ack>',
+                'advice': 'Provide value to <ack>'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_statement_exist_validation_success(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                            <funding-statement>declaração de financiamento</funding-statement>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_statement_exist_validation()
+        expected = [
+            {
+                'title': 'Funding statement element validation',
+                'xpath': './/funding-group/funding-statement',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'declaração de financiamento',
+                'got_value': 'declaração de financiamento',
+                'message': 'Got declaração de financiamento expected declaração de financiamento',
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_statement_exist_validation_fail(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <front>
+                    <article-meta>
+                        <funding-group>
+                            <award-group>
+                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <award-id>2019JJ40269</award-id>
+                            </award-group>
+                        </funding-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_statement_exist_validation()
+        expected = [
+            {
+                'title': 'Funding statement element validation',
+                'xpath': './/funding-group/funding-statement',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'value to <funding-statement>',
+                'got_value': None,
+                'message': 'Got None expected value to <funding-statement>',
+                'advice': 'Provide value to <funding-statement>',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -13,56 +13,23 @@ def callable_validation_fail(award_id):
 
 
 class FundingGroupValidationTest(unittest.TestCase):
-    def test_funding_sources_validation_success_1_funding_1_award(self):
+    def test_funding_sources_validation_success_without_funding_information(self):
         self.maxDiff = None
         xml_str = """
             <article>
                 <front>
                     <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
-                            </award-group>
-                        </funding-group>
+                        
                     </article-meta>
                 </front>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'xpath': './/funding-group/award-group/funding-source',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '1 values to <funding-source> and 1 values to <award-id>',
-                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> "
-                           "['2019JJ40269'] as <award-id>",
-                'advice': None
-            },
-            {
-                'title': 'Funding source element validation',
-                'xpath': './/funding-group/award-group/funding-source',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '1 values to <funding-source> and 1 values to <award-id>',
-                'message': "Got ['Hubei Provincial Natural Science Foundation of China'] as <funding-source> ['2020CFB547'] as <award-id>",
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+        obtained = list(FundingGroupValidation(xml_tree).funding_sources_exist_validation())
 
-    def test_funding_sources_validation_success_2_funding_1_award(self):
+        self.assertListEqual([], obtained)
+
+    def test_funding_sources_validation_success_2_funding_1_award_in_funding_group(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -87,11 +54,11 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '2 values to <funding-source> and 1 values to <award-id>',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '2 values to funding source and 1 values to award id',
                 'message': "Got ['Natural Science Foundation of Hunan Province', "
                            "'Hubei Provincial Natural Science Foundation of China'] "
-                           "as <funding-source> ['2019JJ40269'] as <award-id>",
+                           "as funding source and ['2019JJ40269'] as award id",
                 'advice': None
             }
         ]
@@ -99,7 +66,79 @@ class FundingGroupValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_success_1_funding_2_award(self):
+    def test_funding_sources_validation_success_2_funding_1_award_in_fn_group_financial_disclosure(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                            <p>Grant No: 303625/2019-8</p>
+                            <p>Fundação de Amparo à Pesquisa do Estado de São Paulo</p>
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '2 values to funding source and 2 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico', "
+                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] as funding source and "
+                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_success_2_funding_1_award_in_fn_group_supported_by(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                            <p>Grant No: 303625/2019-8</p>
+                            <p>Fundação de Amparo à Pesquisa do Estado de São Paulo</p>
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 value to funding source',
+                'got_value': '2 values to funding source and 2 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico', "
+                           "'Fundação de Amparo à Pesquisa do Estado de São Paulo'] as funding source and "
+                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_success_1_funding_2_award_in_funding_group(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -124,10 +163,10 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'OK',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '1 values to <funding-source> and 2 values to <award-id>',
-                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> "
-                           "['2019JJ40269', '2020CFB547'] as <award-id>",
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '1 values to funding source and 2 values to award id',
+                'message': "Got ['Natural Science Foundation of Hunan Province'] as funding source and "
+                           "['2019JJ40269', '2020CFB547'] as award id",
                 'advice': None
             }
         ]
@@ -135,13 +174,85 @@ class FundingGroupValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_fail_0_funding_0_award(self):
+    def test_funding_sources_validation_success_1_funding_2_award_in_fn_group_financial_disclosure(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                            <p>Grant No: 303625/2019-8</p>
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '1 values to funding source and 2 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source and "
+                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_success_1_funding_2_award_in_fn_group_supported_by(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                            <p>Grant No: 303625/2019-8</p>
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 value to funding source',
+                'got_value': '1 values to funding source and 2 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source and "
+                           "['303625/2019-8', '2016/17640-0'] as award id",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_0_funding_0_award_in_funding_group(self):
         self.maxDiff = None
         xml_str = """
             <article>
                 <front>
                     <article-meta>
-
+                        <funding-group>
+                            <award-group>
+                                
+                            </award-group>
+                        </funding-group>
                     </article-meta>
                 </front>
             </article>
@@ -154,17 +265,79 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '0 values to <funding-source> and 0 values to <award-id>',
-                'message': 'Got [] as <funding-source> [] as <award-id>',
-                'advice': 'Provide values to <funding-source> and <award-id>',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '0 values to funding source and 0 values to award id',
+                'message': 'Got [] as funding source and [] as award id',
+                'advice': 'Provide values to award id and funding source'
             }
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_fail_1_funding_0_award(self):
+    def test_funding_sources_validation_fail_0_funding_0_award_in_fn_group_financial_disclosure(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '0 values to funding source and 0 values to award id',
+                'message': 'Got [] as funding source and [] as award id',
+                'advice': 'Provide values to award id and funding source'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_0_funding_0_award_in_fn_group_supported_by(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'at least 1 value to funding source',
+                'got_value': '0 values to funding source and 0 values to award id',
+                'message': 'Got [] as funding source and [] as award id',
+                'advice': 'Provide value to funding source'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_1_funding_0_award_in_funding_group(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -187,17 +360,81 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '1 values to <funding-source> and 0 values to <award-id>',
-                'message': "Got ['Natural Science Foundation of Hunan Province'] as <funding-source> [] as <award-id>",
-                'advice': 'Provide values to <award-id>',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '1 values to funding source and 0 values to award id',
+                'message': "Got ['Natural Science Foundation of Hunan Province'] as funding source and [] as award id",
+                'advice': 'Provide value to award id or move funding source to <fn fn-type="supported-by">'
             }
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_funding_sources_validation_fail_0_funding_1_award(self):
+    def test_funding_sources_validation_fail_1_funding_0_award_in_fn_group_financial_disclosure(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '1 values to funding source and 0 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source "
+                           "and [] as award id",
+                'advice': 'Provide value to award id or move funding source to <fn fn-type="supported-by">'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_1_funding_0_award_in_fn_group_supported_by(self):
+        self.maxDiff = None
+        xml_str = """
+            <article>
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
+        expected = [
+            {
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 value to funding source',
+                'got_value': '1 values to funding source and 0 values to award id',
+                'message': "Got ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'] as funding source "
+                           "and [] as award id",
+                'advice': None
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_funding_sources_validation_fail_0_funding_1_award_in_funding_group(self):
         self.maxDiff = None
         xml_str = """
             <article>
@@ -220,212 +457,72 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/funding-source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'at leats 1 value to <funding-source> and at least 1 value to <award-id>',
-                'got_value': '0 values to <funding-source> and 1 values to <award-id>',
-                'message': "Got [] as <funding-source> ['2019JJ40269'] as <award-id>",
-                'advice': 'Provide values to <funding-source>',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '0 values to funding source and 1 values to award id',
+                'message': "Got [] as funding source and ['2019JJ40269'] as award id",
+                'advice': 'Provide value to funding source',
             }
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_principal_award_recipient_validation_success(self):
+    def test_funding_sources_validation_fail_0_funding_1_award_in_fn_group_financial_disclosure(self):
         self.maxDiff = None
         xml_str = """
             <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                                <principal-award-recipient>Stanford</principal-award-recipient>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
-                                <principal-award-recipient>Berkeley</principal-award-recipient>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
+                <back>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_exist_validation()
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
         expected = [
             {
-                'title': 'Principal award recipient element validation',
-                'xpath': './/funding-group/award-group/principal-award-recipient',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Stanford',
-                'got_value': 'Stanford',
-                'message': 'Got Stanford expected Stanford',
-                'advice': None
-            },
-            {
-                'title': 'Principal award recipient element validation',
-                'xpath': './/funding-group/award-group/principal-award-recipient',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'Berkeley',
-                'got_value': 'Berkeley',
-                'message': 'Got Berkeley expected Berkeley',
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_principal_award_recipient_validation_fail(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_award_recipient_exist_validation()
-        expected = [
-            {
-                'title': 'Principal award recipient element validation',
-                'xpath': './/funding-group/award-group/principal-award-recipient',
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='financial-disclosure']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'value to <principal-award-recipient>',
-                'got_value': None,
-                'message': 'Got None expected value to <principal-award-recipient>',
-                'advice': 'Provide value to <principal-award-recipient>',
+                'expected_value': 'at least 1 value to funding source and at least 1 value to award id',
+                'got_value': '0 values to funding source and 1 values to award id',
+                'message': "Got [] as funding source and ['2016/17640-0'] as award id",
+                'advice': 'Provide value to funding source',
             }
         ]
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
 
-    def test_principal_investigator_validation_success(self):
+    def test_funding_sources_validation_fail_0_funding_1_award_in_fn_group_supported_by(self):
         self.maxDiff = None
         xml_str = """
             <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                                <principal-award-recipient>Stanford</principal-award-recipient>
-                                <principal-investigator>
-                                    <string-name>
-                                        <given-names>Sharon R.</given-names>
-                                        <surname>Kaufman</surname>
-                                    </string-name>
-                                </principal-investigator>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
-                                <principal-award-recipient>Berkeley</principal-award-recipient>
-                                <principal-investigator>
-                                    <string-name>
-                                        <given-names>João</given-names>
-                                        <surname>Silva</surname>
-                                    </string-name>
-                                </principal-investigator>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+                            <p>Grant No: 2016/17640-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_investigator_exist_validation()
+        obtained = FundingGroupValidation(xml_tree).funding_sources_exist_validation()
         expected = [
             {
-                'title': 'Principal investigator element validation',
-                'xpath': './/funding-group/award-group/principal-investigator/string-name',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': {
-                    "given-names": 'Sharon R.',
-                    "surname": 'Kaufman'
-                },
-                'got_value': {
-                    "given-names": 'Sharon R.',
-                    "surname": 'Kaufman'
-                },
-                'message': "Got {'given-names': 'Sharon R.', 'surname': 'Kaufman'} expected {'given-names': 'Sharon R.', 'surname': 'Kaufman'}",
-                'advice': None
-            },
-            {
-                'title': 'Principal investigator element validation',
-                'xpath': './/funding-group/award-group/principal-investigator/string-name',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': {
-                    "given-names": 'João',
-                    "surname": 'Silva'
-                },
-                'got_value': {
-                    "given-names": 'João',
-                    "surname": 'Silva'
-                },
-                'message': "Got {'given-names': 'João', 'surname': 'Silva'} expected {'given-names': 'João', 'surname': 'Silva'}",
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_principal_investigator_validation_fail(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                                <principal-award-recipient>Stanford</principal-award-recipient>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
-                                <principal-award-recipient>Berkeley</principal-award-recipient>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).principal_investigator_exist_validation()
-        expected = [
-            {
-                'title': 'Principal investigator element validation',
-                'xpath': './/funding-group/award-group/principal-investigator/string-name',
+                'title': 'Funding source element validation',
+                'xpath': ".//fn-group/fn[@fn-type='supported-by']//p",
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'value to <principal-investigator>',
-                'got_value': None,
-                'message': 'Got None expected value to <principal-investigator>',
-                'advice': 'Provide value to <principal-investigator>',
+                'expected_value': 'at least 1 value to funding source',
+                'got_value': '0 values to funding source and 1 values to award id',
+                'message': "Got [] as funding source and ['2016/17640-0'] as award id",
+                'advice': 'Provide value to funding source',
             }
         ]
         for i, item in enumerate(obtained):
@@ -508,196 +605,20 @@ class FundingGroupValidationTest(unittest.TestCase):
                 'xpath': './/funding-group/award-group/award-id',
                 'validation_type': 'format',
                 'response': 'ERROR',
-                'expected_value': 'a valid value for <award-id>',
+                'expected_value': 'a valid value for award id',
                 'got_value': '2019JJ40269',
-                'message': 'Got 2019JJ40269 expected a valid value for <award-id>',
-                'advice': 'Provide a valid value for <award-id>'
+                'message': 'Got 2019JJ40269 expected a valid value for award id',
+                'advice': 'Provide a valid value for award id'
             },
             {
                 'title': 'Funding source element validation',
                 'xpath': './/funding-group/award-group/award-id',
                 'validation_type': 'format',
                 'response': 'ERROR',
-                'expected_value': 'a valid value for <award-id>',
+                'expected_value': 'a valid value for award id',
                 'got_value': '2020CFB547',
-                'message': 'Got 2020CFB547 expected a valid value for <award-id>',
-                'advice': 'Provide a valid value for <award-id>'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_ack_exist_validation_success_article_ack(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <back>
-                    <ack>
-                        <title>Acknowledgments</title>
-                        <p>Paragraph 1.</p>
-                        <p>Paragraph 2.</p>
-                        <p>Paragraph 3.</p>
-                    </ack>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
-        expected = [
-            {
-                'title': 'Acknowledgment element validation',
-                'xpath': './/back//ack',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': {
-                    "title": 'Acknowledgments',
-                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
-                },
-                'got_value': {
-                    "title": 'Acknowledgments',
-                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
-                },
-                'message': "Got {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'} "
-                           "expected {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'}",
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_ack_exist_validation_success_sub_article_ack(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <sub-article>
-                    <back>
-                        <ack>
-                            <title>Acknowledgments</title>
-                            <p>Paragraph 1.</p>
-                            <p>Paragraph 2.</p>
-                            <p>Paragraph 3.</p>
-                        </ack>
-                    </back>
-                </sub-article>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
-        expected = [
-            {
-                'title': 'Acknowledgment element validation',
-                'xpath': './/back//ack',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': {
-                    "title": 'Acknowledgments',
-                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
-                },
-                'got_value': {
-                    "title": 'Acknowledgments',
-                    "text": 'Paragraph 1. Paragraph 2. Paragraph 3.'
-                },
-                'message': "Got {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'} "
-                           "expected {'title': 'Acknowledgments', 'text': 'Paragraph 1. Paragraph 2. Paragraph 3.'}",
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_ack_exist_validation_fail_article_ack(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <back>
-                    
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).ack_exist_validation()
-        expected = [
-            {
-                'title': 'Acknowledgment element validation',
-                'xpath': './/back//ack',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'value to <ack>',
-                'got_value': None,
-                'message': 'Got None expected value to <ack>',
-                'advice': 'Provide value to <ack>'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_funding_statement_exist_validation_success(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                            <funding-statement>declaração de financiamento</funding-statement>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_statement_exist_validation()
-        expected = [
-            {
-                'title': 'Funding statement element validation',
-                'xpath': './/funding-group/funding-statement',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': 'declaração de financiamento',
-                'got_value': 'declaração de financiamento',
-                'message': 'Got declaração de financiamento expected declaração de financiamento',
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_funding_statement_exist_validation_fail(self):
-        self.maxDiff = None
-        xml_str = """
-            <article>
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = FundingGroupValidation(xml_tree).funding_statement_exist_validation()
-        expected = [
-            {
-                'title': 'Funding statement element validation',
-                'xpath': './/funding-group/funding-statement',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'value to <funding-statement>',
-                'got_value': None,
-                'message': 'Got None expected value to <funding-statement>',
-                'advice': 'Provide value to <funding-statement>',
+                'message': 'Got 2020CFB547 expected a valid value for award id',
+                'advice': 'Provide a valid value for award id'
             }
         ]
         for i, item in enumerate(obtained):


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona procedimento de validação para informações sobre financiamento, especificamente:

- [x] `funding_source`
- [x] `principal_award_recipient`
- [x] `principal_investigator`
- [x] `award_id`
- [x] `ack`
- [x] `funding_statement`

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_funding_group.py`

#### Algum cenário de contexto que queira dar?
![image](https://github.com/scieloorg/packtools/assets/41302084/e2d63b98-a3bd-4163-9996-4774a7b714b2)
[Fonte: scielo publishing schema](https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt-br/latest/tagset/elemento-award-group.html#elemento-award-group)

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

