### PR TITLE
Corrige ausência de apresentação do rótulo dentro da seção "Edited by"

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
@@ -144,15 +144,7 @@
     </xsl:template>
 
     <xsl:template match="fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']" mode="back-section-content">
-        <xsl:apply-templates select="p"/>
-    </xsl:template>
-
-    <xsl:template match="fn[@fn-type='edited-by']/label | fn[@fn-type='data-availability']/label" mode="back-section-content">
-        <!-- nao apresentar -->
-    </xsl:template>
-
-    <xsl:template match="fn[@fn-type='edited-by']/p | fn[@fn-type='data-availability']/p" mode="back-section-content">
-        <p><xsl:apply-templates select="*|text()"/></p>
+        <xsl:apply-templates select="label|p" mode="div-fn-list-item"/>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-fn.xsl
@@ -46,16 +46,4 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']" mode="back-section-content">
-        <xsl:apply-templates select="p"/>
-    </xsl:template>
-
-    <xsl:template match="fn[@fn-type='edited-by']/label | fn[@fn-type='data-availability']/label" mode="back-section-content">
-        <!-- nao apresentar -->
-    </xsl:template>
-
-    <xsl:template match="fn[@fn-type='edited-by']/p | fn[@fn-type='data-availability']/p" mode="back-section-content">
-        <p><xsl:apply-templates select="*|text()"/></p>
-    </xsl:template>
-
 </xsl:stylesheet>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige ausência de apresentação do rótulo dentro da seção "Edited by"

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python3 packtools/htmlgenerator.py --nonetwork --nochecks --loglevel DEBUG  edited-by-twice.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
<img width="214" alt="Captura de Tela 2024-01-30 às 10 17 16" src="https://github.com/scieloorg/packtools/assets/505143/ad410f5b-9288-4f30-bbed-b19e4e4f77ff">
<img width="220" alt="Captura de Tela 2024-01-30 às 10 17 22" src="https://github.com/scieloorg/packtools/assets/505143/cd2cd0a7-ae2d-4ee2-b7d4-00095768f6d3">

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2892

### Referências
n/a
