### PR TITLE
Modifica pmc_pipeline, pubmed_pipeline e crossref_pipeline para retornar str no lugar de xmltree (2)

### DIFF
--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -21,12 +21,12 @@ from packtools.sps.models import (
     article_citations,
 )
 
-SUPPLBEG_REGEX = re.compile(r'^0 ')
-SUPPLEND_REGEX = re.compile(r' 0$')
+SUPPLBEG_REGEX = re.compile(r"^0 ")
+SUPPLEND_REGEX = re.compile(r" 0$")
 
 
 def get_timestamp():
-    return datetime.now().strftime('%Y%m%d%H%M%S')
+    return datetime.now().strftime("%Y%m%d%H%M%S")
 
 
 def get_doi_batch_id():
@@ -35,48 +35,48 @@ def get_doi_batch_id():
 
 def create_journal_title(item, citation):
     """
-        Adiciona o título do periódico ao elemento 'citation'
+    Adiciona o título do periódico ao elemento 'citation'
 
-        Parameters
-        ----------
-        item : dict
-            Dicionário com dados de citação, como por exemplo:
-            {
-                "label": "1",
-                "source": "Drug Alcohol Depend.",
-                "main_author": {"surname": "Tran", "given_name": "B"},
-                "all_authors": [
-                    {"surname": "Tran", "given_name": "B"},
-                    {"surname": "Falster", "given_name": "MO"},
-                    {"surname": "Douglas", "given_name": "K"},
-                    {"surname": "Blyth", "given_name": "F"},
-                    {"surname": "Jorm", "given_name": "LR"},
-                ],
-                "volume": "150",
-                "fpage": "85",
-                "lpage": "91",
-                "year": "2015",
-                "article_title": "Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in
-                                  older ages",
-                "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable
-                                   hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend.
-                                   2015;150:85-91. DOI:\n            https://doi.org/10.1016/j.drugalcdep.2015.02.028",
-            }
+    Parameters
+    ----------
+    item : dict
+        Dicionário com dados de citação, como por exemplo:
+        {
+            "label": "1",
+            "source": "Drug Alcohol Depend.",
+            "main_author": {"surname": "Tran", "given_name": "B"},
+            "all_authors": [
+                {"surname": "Tran", "given_name": "B"},
+                {"surname": "Falster", "given_name": "MO"},
+                {"surname": "Douglas", "given_name": "K"},
+                {"surname": "Blyth", "given_name": "F"},
+                {"surname": "Jorm", "given_name": "LR"},
+            ],
+            "volume": "150",
+            "fpage": "85",
+            "lpage": "91",
+            "year": "2015",
+            "article_title": "Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in
+                              older ages",
+            "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable
+                               hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend.
+                               2015;150:85-91. DOI:\n            https://doi.org/10.1016/j.drugalcdep.2015.02.028",
+        }
 
-        citation : lxml.etree._Element
-            Elemento xml, como por exemplo:
-            <citation key="ref1" />
+    citation : lxml.etree._Element
+        Elemento xml, como por exemplo:
+        <citation key="ref1" />
 
-        Returns
-        -------
-        lxml.etree._Element
-            <citation key="ref1">
-                <source>Drug Alcohol Depend.</source>
-            </citation>
-        """
-    if item.get('source') is not None:
-        el = ET.Element('journal_title')
-        el.text = item.get('source')
+    Returns
+    -------
+    lxml.etree._Element
+        <citation key="ref1">
+            <source>Drug Alcohol Depend.</source>
+        </citation>
+    """
+    if item.get("source") is not None:
+        el = ET.Element("journal_title")
+        el.text = item.get("source")
         citation.append(el)
 
 
@@ -122,9 +122,9 @@ def create_author(item, citation):
         </citation>
     """
     try:
-        main_author = item.get('main_author')
-        el = ET.Element('author')
-        el.text = ' '.join([main_author.get('surname'), main_author.get('given_name')])
+        main_author = item.get("main_author")
+        el = ET.Element("author")
+        el.text = " ".join([main_author.get("surname"), main_author.get("given_name")])
         citation.append(el)
     except TypeError:
         pass
@@ -171,9 +171,9 @@ def create_volume(item, citation):
             <volume>150</volume>
         </citation>
     """
-    if item.get('volume') is not None:
-        el = ET.Element('volume')
-        el.text = item.get('volume')
+    if item.get("volume") is not None:
+        el = ET.Element("volume")
+        el.text = item.get("volume")
         citation.append(el)
 
 
@@ -219,9 +219,9 @@ def create_issue(item, citation):
             <issue>4</issue>
         </citation>
     """
-    if item.get('issue') is not None:
-        el = ET.Element('issue')
-        el.text = item.get('issue')
+    if item.get("issue") is not None:
+        el = ET.Element("issue")
+        el.text = item.get("issue")
         citation.append(el)
 
 
@@ -267,9 +267,9 @@ def create_first_page(item, citation):
             <first_page>85</first_page>
         </citation>
     """
-    if item.get('fpage') is not None:
-        el = ET.Element('first_page')
-        el.text = item.get('fpage')
+    if item.get("fpage") is not None:
+        el = ET.Element("first_page")
+        el.text = item.get("fpage")
         citation.append(el)
 
 
@@ -315,9 +315,9 @@ def create_year(item, citation):
             <year>2015</year>
         </citation>
     """
-    if item.get('year') is not None:
-        el = ET.Element('cYear')
-        el.text = item.get('year')
+    if item.get("year") is not None:
+        el = ET.Element("cYear")
+        el.text = item.get("year")
         citation.append(el)
 
 
@@ -364,57 +364,57 @@ def create_article_title(item, citation):
                               older ages</article_title>
         </citation>
     """
-    if item.get('article_title') is not None:
-        el = ET.Element('article_title')
-        el.text = item.get('article_title')
+    if item.get("article_title") is not None:
+        el = ET.Element("article_title")
+        el.text = item.get("article_title")
         citation.append(el)
 
 
 def get_citation(item):
     """
-        Cria o elemento 'citation'.
+    Cria o elemento 'citation'.
 
-        Parameters
-        ----------
-        item : dict
-            Dicionário com dados de citação, como por exemplo:
-            {
-                "label": "1",
-                "source": "Drug Alcohol Depend.",
-                "main_author": {"surname": "Tran", "given_name": "B"},
-                "all_authors": [
-                    {"surname": "Tran", "given_name": "B"},
-                    {"surname": "Falster", "given_name": "MO"},
-                    {"surname": "Douglas", "given_name": "K"},
-                    {"surname": "Blyth", "given_name": "F"},
-                    {"surname": "Jorm", "given_name": "LR"},
-                ],
-                "volume": "150",
-                "fpage": "85",
-                "lpage": "91",
-                "year": "2015",
-                "issue": "4",
-                "article_title": "Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in
-                                  older ages",
-                "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable
-                                   hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend.
-                                   2015;150:85-91. DOI:\n            https://doi.org/10.1016/j.drugalcdep.2015.02.028",
-            }
+    Parameters
+    ----------
+    item : dict
+        Dicionário com dados de citação, como por exemplo:
+        {
+            "label": "1",
+            "source": "Drug Alcohol Depend.",
+            "main_author": {"surname": "Tran", "given_name": "B"},
+            "all_authors": [
+                {"surname": "Tran", "given_name": "B"},
+                {"surname": "Falster", "given_name": "MO"},
+                {"surname": "Douglas", "given_name": "K"},
+                {"surname": "Blyth", "given_name": "F"},
+                {"surname": "Jorm", "given_name": "LR"},
+            ],
+            "volume": "150",
+            "fpage": "85",
+            "lpage": "91",
+            "year": "2015",
+            "issue": "4",
+            "article_title": "Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in
+                              older ages",
+            "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable
+                               hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend.
+                               2015;150:85-91. DOI:\n            https://doi.org/10.1016/j.drugalcdep.2015.02.028",
+        }
 
-        Returns
-        -------
-        lxml.etree._Element
-            <citation key="ref1">
-                <journal_title>Drug Alcohol Depend.</journal_title>
-                <author>Tran B</author>
-                <volume>150</volume>
-                <first_page>85</first_page>
-                <cYear>2015</cYear>
-                <article_title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article_title>
-            </citation>
-        """
-    citation = ET.Element('citation')
-    citation.set('key', 'ref' + item.get('label'))
+    Returns
+    -------
+    lxml.etree._Element
+        <citation key="ref1">
+            <journal_title>Drug Alcohol Depend.</journal_title>
+            <author>Tran B</author>
+            <volume>150</volume>
+            <first_page>85</first_page>
+            <cYear>2015</cYear>
+            <article_title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article_title>
+        </citation>
+    """
+    citation = ET.Element("citation")
+    citation.set("key", "ref" + item.get("label"))
 
     create_journal_title(item, citation)
     create_author(item, citation)
@@ -457,35 +457,37 @@ def get_one_contributor(seq, author):
             <affiliation>Universidade do Estado do Rio de Janeiro, Brasil</affiliation>
         </person_name>
     """
-    person_name = ET.Element('person_name')
-    person_name.set('contributor_role', author.get('contrib-type'))
+    person_name = ET.Element("person_name")
+    person_name.set("contributor_role", author.get("contrib-type"))
     if seq == 0:
-        person_name.set('sequence', 'first')
+        person_name.set("sequence", "first")
     else:
-        person_name.set('sequence', 'additional')
+        person_name.set("sequence", "additional")
 
-    _given_name = author.get('given_names')
+    _given_name = author.get("given_names")
     if _given_name:
-        given_name = ET.Element('given_name')
-        given_name.text = author.get('given_names')
+        given_name = ET.Element("given_name")
+        given_name.text = author.get("given_names")
         person_name.append(given_name)
 
-    _surname = author.get('surname')
+    _surname = author.get("surname")
     if _surname:
-        surname = ET.Element('surname')
-        surname.text = author.get('surname')
+        surname = ET.Element("surname")
+        surname.text = author.get("surname")
         person_name.append(surname)
 
-    _author_aff = author.get('affs')[0]
+    _author_aff = author.get("affs")[0]
     if _author_aff:
-        affiliation = ET.Element('affiliation')
-        affiliation.text = ', '.join([_author_aff.get('orgname'), _author_aff.get('country_name')])
+        affiliation = ET.Element("affiliation")
+        affiliation.text = ", ".join(
+            [_author_aff.get("orgname"), _author_aff.get("country_name")]
+        )
         person_name.append(affiliation)
 
-    _orcid = author.get('orcid')
+    _orcid = author.get("orcid")
     if _orcid:
-        orcid = ET.Element('ORCID')
-        orcid.text = 'http://orcid.org/' + _orcid
+        orcid = ET.Element("ORCID")
+        orcid.text = "http://orcid.org/" + _orcid
         person_name.append(orcid)
 
     return person_name
@@ -546,40 +548,41 @@ def setupdoibatch_pipe():
     """
 
     nsmap = {
-        'ai': 'http://www.crossref.org/AccessIndicators.xsd',
-        'jats': 'http://www.ncbi.nlm.nih.gov/JATS1',
-        'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-        'xml': 'http://www.w3.org/XML/1998/namespace'
-
+        "ai": "http://www.crossref.org/AccessIndicators.xsd",
+        "jats": "http://www.ncbi.nlm.nih.gov/JATS1",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xml": "http://www.w3.org/XML/1998/namespace",
     }
 
-    el = ET.Element('doi_batch', nsmap=nsmap)
-    el.set('version', '4.4.0')
-    el.set('xmlns', 'http://www.crossref.org/schema/4.4.0')
-    el.set('{http://www.w3.org/2001/XMLSchema-instance}schemaLocation',
-           'http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd')
+    el = ET.Element("doi_batch", nsmap=nsmap)
+    el.set("version", "4.4.0")
+    el.set("xmlns", "http://www.crossref.org/schema/4.4.0")
+    el.set(
+        "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation",
+        "http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd",
+    )
 
     return el
 
 
 def xml_crossref_head_pipe(xml_crossref):
     """
-        Adiciona o elemento 'head' ao xml_crossref.
+    Adiciona o elemento 'head' ao xml_crossref.
 
-        Parameters
-        ----------
-        xml_crossref : lxml.etree._Element
-            Elemento XML no padrão CrossRef em construção
+    Parameters
+    ----------
+    xml_crossref : lxml.etree._Element
+        Elemento XML no padrão CrossRef em construção
 
-        Returns
-        -------
-        lxml.etree._Element
-            <?xml version="1.0" encoding="UTF-8"?>
-            <doi_batch ...>
-                <head />
-            </doi_batch>
-        """
-    head = ET.Element('head')
+    Returns
+    -------
+    lxml.etree._Element
+        <?xml version="1.0" encoding="UTF-8"?>
+        <doi_batch ...>
+            <head />
+        </doi_batch>
+    """
+    head = ET.Element("head")
 
     xml_crossref.append(head)
 
@@ -603,10 +606,10 @@ def xml_crossref_doibatchid_pipe(xml_crossref):
             </head>
         </doi_batch>
     """
-    doi_batch_id = ET.Element('doi_batch_id')
+    doi_batch_id = ET.Element("doi_batch_id")
     doi_batch_id.text = get_doi_batch_id()
 
-    xml_crossref.find('./head').append(doi_batch_id)
+    xml_crossref.find("./head").append(doi_batch_id)
 
 
 def xml_crossref_timestamp_pipe(xml_crossref):
@@ -628,10 +631,10 @@ def xml_crossref_timestamp_pipe(xml_crossref):
             </head>
         </doi_batch>
     """
-    timestamp = ET.Element('timestamp')
+    timestamp = ET.Element("timestamp")
     timestamp.text = get_timestamp()
 
-    xml_crossref.find('./head').append(timestamp)
+    xml_crossref.find("./head").append(timestamp)
 
 
 def xml_crossref_depositor_pipe(xml_crossref, data):
@@ -662,18 +665,18 @@ def xml_crossref_depositor_pipe(xml_crossref, data):
                 </depositor>
             </head>
         </doi_batch>
-        """
-    depositor = ET.Element('depositor')
-    depositor_name = ET.Element('depositor_name')
-    email_address = ET.Element('email_address')
+    """
+    depositor = ET.Element("depositor")
+    depositor_name = ET.Element("depositor_name")
+    email_address = ET.Element("email_address")
 
-    depositor_name.text = data.get('depositor_name')
-    email_address.text = data.get('depositor_email_address')
+    depositor_name.text = data.get("depositor_name")
+    email_address.text = data.get("depositor_email_address")
 
     depositor.append(depositor_name)
     depositor.append(email_address)
 
-    xml_crossref.find('./head').append(depositor)
+    xml_crossref.find("./head").append(depositor)
 
 
 def xml_crossref_registrant_pipe(xml_crossref, data):
@@ -701,10 +704,10 @@ def xml_crossref_registrant_pipe(xml_crossref, data):
             </head>
         </doi_batch>
     """
-    registrant = ET.Element('registrant')
-    registrant.text = data.get('registrant')
+    registrant = ET.Element("registrant")
+    registrant.text = data.get("registrant")
 
-    xml_crossref.find('./head').append(registrant)
+    xml_crossref.find("./head").append(registrant)
 
 
 def xml_crossref_body_pipe(xml_crossref):
@@ -725,7 +728,7 @@ def xml_crossref_body_pipe(xml_crossref):
             <body/>
         </doi_batch>
     """
-    body = ET.Element('body')
+    body = ET.Element("body")
 
     xml_crossref.append(body)
 
@@ -750,9 +753,9 @@ def xml_crossref_journal_pipe(xml_crossref):
             </body>
         </doi_batch>
     """
-    journal = ET.Element('journal')
+    journal = ET.Element("journal")
 
-    xml_crossref.find('./body').append(journal)
+    xml_crossref.find("./body").append(journal)
 
 
 def xml_crossref_journalmetadata_pipe(xml_crossref):
@@ -777,9 +780,9 @@ def xml_crossref_journalmetadata_pipe(xml_crossref):
             </body>
         </doi_batch>
     """
-    journal_metadata = ET.Element('journal_metadata')
+    journal_metadata = ET.Element("journal_metadata")
 
-    xml_crossref.find('./body/journal').append(journal_metadata)
+    xml_crossref.find("./body/journal").append(journal_metadata)
 
 
 def xml_crossref_journaltitle_pipe(xml_crossref, xml_tree):
@@ -808,10 +811,10 @@ def xml_crossref_journaltitle_pipe(xml_crossref, xml_tree):
         </doi_batch>
     """
     titles = journal_meta.Title(xml_tree)
-    full_title = ET.Element('full_title')
+    full_title = ET.Element("full_title")
     full_title.text = titles.journal_title
 
-    xml_crossref.find('./body/journal/journal_metadata').append(full_title)
+    xml_crossref.find("./body/journal/journal_metadata").append(full_title)
 
 
 def xml_crossref_abbreviatedjournaltitle_pipe(xml_crossref, xml_tree):
@@ -840,10 +843,10 @@ def xml_crossref_abbreviatedjournaltitle_pipe(xml_crossref, xml_tree):
     </doi_batch>
     """
     titles = journal_meta.Title(xml_tree)
-    abbrev_title = ET.Element('abbrev_title')
+    abbrev_title = ET.Element("abbrev_title")
     abbrev_title.text = titles.abbreviated_journal_title
 
-    xml_crossref.find('./body/journal/journal_metadata').append(abbrev_title)
+    xml_crossref.find("./body/journal/journal_metadata").append(abbrev_title)
 
 
 def xml_crossref_issn_pipe(xml_crossref, xml_tree):
@@ -874,15 +877,15 @@ def xml_crossref_issn_pipe(xml_crossref, xml_tree):
     """
     issns = journal_meta.ISSN(xml_tree)
 
-    issn = ET.Element('issn')
+    issn = ET.Element("issn")
     issn.text = issns.epub
-    issn.set('media_type', 'electronic')
-    xml_crossref.find('./body/journal/journal_metadata').append(issn)
+    issn.set("media_type", "electronic")
+    xml_crossref.find("./body/journal/journal_metadata").append(issn)
 
-    issn = ET.Element('issn')
+    issn = ET.Element("issn")
     issn.text = issns.ppub
-    issn.set('media_type', 'print')
-    xml_crossref.find('./body/journal/journal_metadata').append(issn)
+    issn.set("media_type", "print")
+    xml_crossref.find("./body/journal/journal_metadata").append(issn)
 
 
 def xml_crossref_journalissue_pipe(xml_crossref):
@@ -905,9 +908,9 @@ def xml_crossref_journalissue_pipe(xml_crossref):
        </body>
     </doi_batch>
     """
-    journal_issue = ET.Element('journal_issue')
+    journal_issue = ET.Element("journal_issue")
 
-    xml_crossref.find('./body/journal').append(journal_issue)
+    xml_crossref.find("./body/journal").append(journal_issue)
 
 
 def xml_crossref_pubdate_pipe(xml_crossref, xml_tree):
@@ -938,14 +941,14 @@ def xml_crossref_pubdate_pipe(xml_crossref, xml_tree):
     </doi_batch>
     """
     try:
-        year = ET.Element('year')
-        year.text = dates.ArticleDates(xml_tree).article_date.get('year')
+        year = ET.Element("year")
+        year.text = dates.ArticleDates(xml_tree).article_date.get("year")
 
-        publication_date = ET.Element('publication_date')
-        publication_date.set('media_type', 'online')
+        publication_date = ET.Element("publication_date")
+        publication_date.set("media_type", "online")
         publication_date.append(year)
 
-        xml_crossref.find('./body/journal/journal_issue').append(publication_date)
+        xml_crossref.find("./body/journal/journal_issue").append(publication_date)
 
     except AttributeError:
         pass
@@ -973,9 +976,9 @@ def xml_crossref_journalvolume_pipe(xml_crossref):
        </body>
     </doi_batch>
     """
-    journal_volume = ET.Element('journal_volume')
+    journal_volume = ET.Element("journal_volume")
 
-    xml_crossref.find('./body/journal/journal_issue').append(journal_volume)
+    xml_crossref.find("./body/journal/journal_issue").append(journal_volume)
 
 
 def xml_crossref_volume_pipe(xml_crossref, xml_tree):
@@ -1005,10 +1008,10 @@ def xml_crossref_volume_pipe(xml_crossref, xml_tree):
        </body>
     </doi_batch>
     """
-    volume = ET.Element('volume')
+    volume = ET.Element("volume")
     volume.text = front_articlemeta_issue.ArticleMetaIssue(xml_tree).volume
 
-    xml_crossref.find('./body/journal/journal_issue/journal_volume').append(volume)
+    xml_crossref.find("./body/journal/journal_issue/journal_volume").append(volume)
 
 
 def xml_crossref_issue_pipe(xml_crossref, xml_tree):
@@ -1038,10 +1041,10 @@ def xml_crossref_issue_pipe(xml_crossref, xml_tree):
        </body>
     </doi_batch>
     """
-    issue = ET.Element('issue')
+    issue = ET.Element("issue")
     issue.text = front_articlemeta_issue.ArticleMetaIssue(xml_tree).issue
 
-    xml_crossref.find('./body/journal/journal_issue/journal_volume').append(issue)
+    xml_crossref.find("./body/journal/journal_issue/journal_volume").append(issue)
 
 
 def xml_crossref_journalarticle_pipe(xml_crossref, xml_tree):
@@ -1070,11 +1073,11 @@ def xml_crossref_journalarticle_pipe(xml_crossref, xml_tree):
     """
     articles = article_and_subarticles.ArticleAndSubArticles(xml_tree).data
     for article in articles:
-        journal_article = ET.Element('journal_article')
-        journal_article.set('language', article['lang'])
-        journal_article.set('publication_type', article['article_type'])
-        journal_article.set('reference_distribution_opts', 'any')
-        xml_crossref.find('./body/journal').append(journal_article)
+        journal_article = ET.Element("journal_article")
+        journal_article.set("language", article["lang"])
+        journal_article.set("publication_type", article["article_type"])
+        journal_article.set("reference_distribution_opts", "any")
+        xml_crossref.find("./body/journal").append(journal_article)
 
 
 def xml_crossref_articletitles_pipe(xml_crossref, xml_tree):
@@ -1112,19 +1115,24 @@ def xml_crossref_articletitles_pipe(xml_crossref, xml_tree):
     </doi_batch>
     """
     art_titles = article_titles.ArticleTitles(xml_tree).article_title_dict
-    art_lang = [lang.get('lang') for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data]
+    art_lang = [
+        lang.get("lang")
+        for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data
+    ]
 
     for lang in art_lang:
-        titles = ET.Element('titles')
-        title = ET.Element('title')
+        titles = ET.Element("titles")
+        title = ET.Element("title")
         title.text = art_titles.get(lang)
         titles.append(title)
-        original_language_title = ET.Element('original_language_title')
-        orig_lang = 'pt' if lang == 'en' else 'en'
-        original_language_title.set('language', orig_lang)
+        original_language_title = ET.Element("original_language_title")
+        orig_lang = "pt" if lang == "en" else "en"
+        original_language_title.set("language", orig_lang)
         original_language_title.text = art_titles.get(orig_lang)
         titles.append(original_language_title)
-        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']").append(titles)
+        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']").append(
+            titles
+        )
 
 
 def xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree):
@@ -1209,14 +1217,16 @@ def xml_crossref_articlecontributors_pipe(xml_crossref, xml_tree):
     """
     articles = article_and_subarticles.ArticleAndSubArticles(xml_tree).data
     authors = article_authors.Authors(xml_tree).contribs_with_affs
-    contributors = ET.Element('contributors')
+    contributors = ET.Element("contributors")
     for seq, author in enumerate(authors):
         person_name = get_one_contributor(seq, author)
         contributors.append(person_name)
 
     for article in articles:
-        if article.get('article_type') != 'reviewer-report':
-            xml_crossref.find(f"./body/journal/journal_article[@language='{article['lang']}']").append(deepcopy(contributors))
+        if article.get("article_type") != "reviewer-report":
+            xml_crossref.find(
+                f"./body/journal/journal_article[@language='{article['lang']}']"
+            ).append(deepcopy(contributors))
 
 
 def xml_crossref_articleabstract_pipe(xml_crossref, xml_tree):
@@ -1263,16 +1273,20 @@ def xml_crossref_articleabstract_pipe(xml_crossref, xml_tree):
     for article in articles:
         for abstract in abstracts:
             if abstract:
-                jats = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}abstract')
-                jats.set('{http://www.w3.org/XML/1998/namespace}lang', abstract.get('lang'))
-                jats_p = ET.Element('{http://www.ncbi.nlm.nih.gov/JATS1}p')
-                text = [abstract.get('title')]
-                for key, value in abstract.get('sections').items():
+                jats = ET.Element("{http://www.ncbi.nlm.nih.gov/JATS1}abstract")
+                jats.set(
+                    "{http://www.w3.org/XML/1998/namespace}lang", abstract.get("lang")
+                )
+                jats_p = ET.Element("{http://www.ncbi.nlm.nih.gov/JATS1}p")
+                text = [abstract.get("title")]
+                for key, value in abstract.get("sections").items():
                     text.append(key)
                     text.append(value)
-                jats_p.text = ' '.join(text)
+                jats_p.text = " ".join(text)
                 jats.append(jats_p)
-                xml_crossref.find(f"./body/journal/journal_article[@language='{article['lang']}']").append(deepcopy(jats))
+                xml_crossref.find(
+                    f"./body/journal/journal_article[@language='{article['lang']}']"
+                ).append(deepcopy(jats))
 
 
 def xml_crossref_articlepubdate_pipe(xml_crossref, xml_tree):
@@ -1311,15 +1325,17 @@ def xml_crossref_articlepubdate_pipe(xml_crossref, xml_tree):
     pub_date = dates.ArticleDates(xml_tree).collection_date
 
     for article in articles:
-        publication_date = ET.Element('publication_date')
-        publication_date.set('media_type', 'online')
+        publication_date = ET.Element("publication_date")
+        publication_date.set("media_type", "online")
 
-        year = ET.Element('year')
-        year.text = pub_date.get('year')
+        year = ET.Element("year")
+        year.text = pub_date.get("year")
 
         publication_date.append(year)
 
-        xml_crossref.find(f"./body/journal/journal_article[@language='{article['lang']}']").append(publication_date)
+        xml_crossref.find(
+            f"./body/journal/journal_article[@language='{article['lang']}']"
+        ).append(publication_date)
 
 
 def xml_crossref_pages_pipe(xml_crossref, xml_tree):
@@ -1352,14 +1368,14 @@ def xml_crossref_pages_pipe(xml_crossref, xml_tree):
     """
     _data = front_articlemeta_issue.ArticleMetaIssue(xml_tree).data
 
-    page = ET.Element('pages')
-    fpage = ET.Element('first_page')
-    lpage = ET.Element('last_page')
-    fpage.text = _data.get('fpage')
-    lpage.text = _data.get('lpage')
+    page = ET.Element("pages")
+    fpage = ET.Element("first_page")
+    lpage = ET.Element("last_page")
+    fpage.text = _data.get("fpage")
+    lpage.text = _data.get("lpage")
     page.append(fpage)
     page.append(lpage)
-    xml_crossref.find('./body/journal/journal_article').append(page)
+    xml_crossref.find("./body/journal/journal_article").append(page)
 
 
 def xml_crossref_pid_pipe(xml_crossref, xml_tree):
@@ -1391,14 +1407,14 @@ def xml_crossref_pid_pipe(xml_crossref, xml_tree):
     """
     pid_v2 = article_ids.ArticleIds(xml_tree).v2
 
-    identifier = ET.Element('identifier')
-    identifier.set('id_type', 'pii')
+    identifier = ET.Element("identifier")
+    identifier.set("id_type", "pii")
     identifier.text = pid_v2
 
-    publisher_item = ET.Element('publisher_item')
+    publisher_item = ET.Element("publisher_item")
     publisher_item.append(identifier)
 
-    xml_crossref.find('./body/journal/journal_article').append(publisher_item)
+    xml_crossref.find("./body/journal/journal_article").append(publisher_item)
 
 
 def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
@@ -1430,10 +1446,12 @@ def xml_crossref_elocation_pipe(xml_crossref, xml_tree):
     """
     _data = front_articlemeta_issue.ArticleMetaIssue(xml_tree).data
 
-    item_number = ET.Element('item_number')
-    item_number.set('item_number_type', 'article_number')
-    item_number.text = _data.get('elocation_id')
-    xml_crossref.find('./body/journal/journal_article/publisher_item').append(item_number)
+    item_number = ET.Element("item_number")
+    item_number.set("item_number_type", "article_number")
+    item_number.text = _data.get("elocation_id")
+    xml_crossref.find("./body/journal/journal_article/publisher_item").append(
+        item_number
+    )
 
 
 def xml_crossref_permissions_pipe(xml_crossref, xml_tree):
@@ -1478,19 +1496,25 @@ def xml_crossref_permissions_pipe(xml_crossref, xml_tree):
     articles = article_and_subarticles.ArticleAndSubArticles(xml_tree).data
 
     for article in articles:
-        free_to_read = ET.Element("{http://www.crossref.org/AccessIndicators.xsd}free_to_read")
+        free_to_read = ET.Element(
+            "{http://www.crossref.org/AccessIndicators.xsd}free_to_read"
+        )
 
         program = ET.Element("{http://www.crossref.org/AccessIndicators.xsd}program")
         program.set("name", "AccessIndicators")
         program.append(free_to_read)
 
         for context in ["vor", "am", "tdm"]:
-            license_ref = ET.Element("{http://www.crossref.org/AccessIndicators.xsd}license_ref")
+            license_ref = ET.Element(
+                "{http://www.crossref.org/AccessIndicators.xsd}license_ref"
+            )
             license_ref.set("applies_to", context)
-            license_ref.text = art_license[0].get('link')
+            license_ref.text = art_license[0].get("link")
             program.append(license_ref)
 
-        xml_crossref.find(f"./body/journal/journal_article[@language='{article['lang']}']").append(program)
+        xml_crossref.find(
+            f"./body/journal/journal_article[@language='{article['lang']}']"
+        ).append(program)
 
 
 def xml_crossref_programrelateditem_pipe(xml_crossref, xml_tree):
@@ -1532,31 +1556,38 @@ def xml_crossref_programrelateditem_pipe(xml_crossref, xml_tree):
     </doi_batch>
     """
     art_titles = article_titles.ArticleTitles(xml_tree).article_title_dict
-    art_lang = [lang.get('lang') for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data]
+    art_lang = [
+        lang.get("lang")
+        for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data
+    ]
     doi = {}
     for d in article_doi_with_lang.DoiWithLang(xml_tree).data:
-        doi[d.get('lang')] = d.get('value')
+        doi[d.get("lang")] = d.get("value")
     for lang in art_lang:
-        related_item = ET.Element('related_item')
+        related_item = ET.Element("related_item")
 
-        orig_lang = 'pt' if lang == 'en' else 'en'
-        description = ET.Element('description')
+        orig_lang = "pt" if lang == "en" else "en"
+        description = ET.Element("description")
         description.text = art_titles.get(orig_lang)
 
-        intra_work_relation = ET.Element('intra_work_relation')
-        intra_work_relation_type = 'isTranslationOf' if lang == 'en' else 'hasTranslation'
-        intra_work_relation.set('relationship-type', intra_work_relation_type)
-        intra_work_relation.set('identifier-type', 'doi')
+        intra_work_relation = ET.Element("intra_work_relation")
+        intra_work_relation_type = (
+            "isTranslationOf" if lang == "en" else "hasTranslation"
+        )
+        intra_work_relation.set("relationship-type", intra_work_relation_type)
+        intra_work_relation.set("identifier-type", "doi")
         intra_work_relation.text = doi.get(orig_lang)
 
         related_item.append(description)
         related_item.append(intra_work_relation)
 
-        program = ET.Element('program')
-        program.set('xmlns', 'http://www.crossref.org/relations.xsd')
+        program = ET.Element("program")
+        program.set("xmlns", "http://www.crossref.org/relations.xsd")
         program.append(related_item)
 
-        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']").append(program)
+        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']").append(
+            program
+        )
 
 
 def xml_crossref_doidata_pipe(xml_crossref):
@@ -1584,8 +1615,8 @@ def xml_crossref_doidata_pipe(xml_crossref):
        </body>
     </doi_batch>
     """
-    for journal_article in xml_crossref.findall('./body/journal//journal_article'):
-        doi_data = ET.Element('doi_data')
+    for journal_article in xml_crossref.findall("./body/journal//journal_article"):
+        doi_data = ET.Element("doi_data")
         journal_article.append(doi_data)
 
 
@@ -1621,15 +1652,20 @@ def xml_crossref_doi_pipe(xml_crossref, xml_tree):
        </body>
     </doi_batch>
     """
-    art_lang = [lang.get('lang') for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data]
+    art_lang = [
+        lang.get("lang")
+        for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data
+    ]
     dict_doi = {}
     for d in article_doi_with_lang.DoiWithLang(xml_tree).data:
-        dict_doi[d.get('lang')] = d.get('value')
+        dict_doi[d.get("lang")] = d.get("value")
     for lang in art_lang:
-        doi = ET.Element('doi')
+        doi = ET.Element("doi")
         doi.text = dict_doi.get(lang)
 
-        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']/doi_data").append(doi)
+        xml_crossref.find(
+            f"./body/journal/journal_article[@language='{lang}']/doi_data"
+        ).append(doi)
 
 
 def xml_crossref_resource_pipe(xml_crossref, xml_tree):
@@ -1664,15 +1700,20 @@ def xml_crossref_resource_pipe(xml_crossref, xml_tree):
        </body>
     </doi_batch>
     """
-    url = 'http://www.scielo.br/scielo.php?script=sci_arttext&pid={}&tlng={}'
+    url = "http://www.scielo.br/scielo.php?script=sci_arttext&pid={}&tlng={}"
 
-    art_lang = [lang.get('lang') for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data]
+    art_lang = [
+        lang.get("lang")
+        for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data
+    ]
     pid_v2 = article_ids.ArticleIds(xml_tree).v2
 
     for lang in art_lang:
-        resource = ET.Element('resource')
+        resource = ET.Element("resource")
         resource.text = url.format(pid_v2, lang)
-        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']/doi_data").append(resource)
+        xml_crossref.find(
+            f"./body/journal/journal_article[@language='{lang}']/doi_data"
+        ).append(resource)
 
 
 def xml_crossref_collection_pipe(xml_crossref, xml_tree):
@@ -1715,28 +1756,35 @@ def xml_crossref_collection_pipe(xml_crossref, xml_tree):
        </body>
     </doi_batch>
     """
-    url = 'http://www.scielo.br/scielo.php?script=sci_pdf&pid={}&tlng={}'
+    url = "http://www.scielo.br/scielo.php?script=sci_pdf&pid={}&tlng={}"
 
-    art_lang = [lang.get('lang') for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data]
+    art_lang = [
+        lang.get("lang")
+        for lang in article_and_subarticles.ArticleAndSubArticles(xml_tree).data
+    ]
     pid_v2 = article_ids.ArticleIds(xml_tree).v2
 
     for lang in art_lang:
-        collection = ET.Element('collection')
-        collection.set('property', 'crawler-based')
+        collection = ET.Element("collection")
+        collection.set("property", "crawler-based")
 
-        item = ET.Element('item')
-        item.set('crawler', 'iParadigms')
+        item = ET.Element("item")
+        item.set("crawler", "iParadigms")
 
-        resource = ET.Element('resource')
+        resource = ET.Element("resource")
         resource.text = url.format(pid_v2, lang)
 
         item.append(resource)
         collection.append(item)
-        xml_crossref.find(f"./body/journal/journal_article[@language='{lang}']/doi_data").append(collection)
+        xml_crossref.find(
+            f"./body/journal/journal_article[@language='{lang}']/doi_data"
+        ).append(collection)
 
 
 def xml_crossref_close_pipe(xml_crossref):
-    return '<?xml version="1.0" encoding="utf-8"?>' + ET.tostring(xml_crossref, encoding="utf-8", pretty_print=True).decode("utf-8")
+    return '<?xml version="1.0" encoding="utf-8"?>' + ET.tostring(
+        xml_crossref, encoding="utf-8", pretty_print=True
+    ).decode("utf-8")
 
 
 def xml_crossref_articlecitations_pipe(xml_crossref, xml_tree):
@@ -1806,10 +1854,10 @@ def xml_crossref_articlecitations_pipe(xml_crossref, xml_tree):
     </doi_batch>
     """
     citations = article_citations.ArticleCitations(xml_tree).article_citations
-    citation_list = ET.Element('citation_list')
+    citation_list = ET.Element("citation_list")
     for item in citations:
         citation = get_citation(item)
         citation_list.append(citation)
 
-    for journal_article in xml_crossref.findall('./body/journal//journal_article'):
+    for journal_article in xml_crossref.findall("./body/journal//journal_article"):
         journal_article.append(deepcopy(citation_list))

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -7,18 +7,18 @@ from datetime import datetime
 from lxml import etree as ET
 
 from packtools.sps.models import (
-    journal_meta,
-    dates,
-    front_articlemeta_issue,
-    article_and_subarticles,
-    article_authors,
     aff,
     article_abstract,
+    article_and_subarticles,
+    article_authors,
+    article_citations,
+    article_doi_with_lang,
     article_ids,
     article_license,
     article_titles,
-    article_doi_with_lang,
-    article_citations,
+    dates,
+    front_articlemeta_issue,
+    journal_meta,
 )
 
 SUPPLBEG_REGEX = re.compile(r"^0 ")
@@ -493,7 +493,7 @@ def get_one_contributor(seq, author):
     return person_name
 
 
-def pipeline_crossref(xml_tree, data):
+def pipeline_crossref(xml_tree, data, pretty_print=True):
     xml_crossref = setupdoibatch_pipe()
     xml_crossref_head_pipe(xml_crossref)
     xml_crossref_doibatchid_pipe(xml_crossref)
@@ -529,7 +529,8 @@ def pipeline_crossref(xml_tree, data):
     xml_crossref_articlecitations_pipe(xml_crossref, xml_tree)
     xml_crossref_close_pipe(xml_crossref)
 
-    return xml_crossref
+    tree = ET.ElementTree(xml_crossref)
+    return ET.tostring(tree, encode="utf-8", pretty_print=pretty_print)
 
 
 def setupdoibatch_pipe():

--- a/packtools/sps/formats/crossref.py
+++ b/packtools/sps/formats/crossref.py
@@ -529,8 +529,10 @@ def pipeline_crossref(xml_tree, data, pretty_print=True):
     xml_crossref_articlecitations_pipe(xml_crossref, xml_tree)
     xml_crossref_close_pipe(xml_crossref)
 
-    tree = ET.ElementTree(xml_crossref)
-    return ET.tostring(tree, encode="utf-8", pretty_print=pretty_print)
+    xml_tree = ET.ElementTree(xml_crossref)
+    return ET.tostring(xml_tree, pretty_print=pretty_print, encoding="utf-8").decode(
+        "utf-8"
+    )
 
 
 def setupdoibatch_pipe():

--- a/packtools/sps/formats/crossref_generator.py
+++ b/packtools/sps/formats/crossref_generator.py
@@ -1,6 +1,4 @@
 import argparse
-from lxml import etree as ET
-import xml.dom.minidom as minidom
 
 from packtools.sps.formats import crossref
 from packtools.sps.utils import xml_utils
@@ -59,9 +57,7 @@ def main():
     }
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
-    xml_crossref = ET.ElementTree(crossref.pipeline_crossref(xml_tree, data))
-    xml_string = ET.tostring(xml_crossref, encoding="utf-8")
-    xml_crossref_formated = minidom.parseString(xml_string).toprettyxml(indent="  ")
+    xml_crossref_formated = crossref.pipeline_crossref(xml_tree, data)
 
     with open(arguments.path_to_write, "w", encoding="utf-8") as file:
         file.write(xml_crossref_formated)

--- a/packtools/sps/formats/crossref_generator.py
+++ b/packtools/sps/formats/crossref_generator.py
@@ -7,23 +7,55 @@ from packtools.sps.utils import xml_utils
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Convert XML file from SciELO format to CrossRef format.')
-    parser.add_argument('-i', '--xml_scielo', action='store', dest='path_to_read', required=True,
-                        help='Path for reading the SciELO XML file.')
-    parser.add_argument('-n', '--depositor_name', action='store', dest='depositor_name', required=False,
-                        help='Value of the depositor name attribute.')
-    parser.add_argument('-e', '--depositor_email_address', action='store', dest='depositor_email_address', required=False,
-                        help='Value of the depositor email address attribute.')
-    parser.add_argument('-r', '--registrant', action='store', dest='registrant', required=False,
-                        help='Value of the registrant attribute.')
-    parser.add_argument('-o', '--xml_crossref', action='store', dest='path_to_write', required=True,
-                        help='Path for writing the CrossRef XML file.')
+    parser = argparse.ArgumentParser(
+        description="Convert XML file from SciELO format to CrossRef format."
+    )
+    parser.add_argument(
+        "-i",
+        "--xml_scielo",
+        action="store",
+        dest="path_to_read",
+        required=True,
+        help="Path for reading the SciELO XML file.",
+    )
+    parser.add_argument(
+        "-n",
+        "--depositor_name",
+        action="store",
+        dest="depositor_name",
+        required=False,
+        help="Value of the depositor name attribute.",
+    )
+    parser.add_argument(
+        "-e",
+        "--depositor_email_address",
+        action="store",
+        dest="depositor_email_address",
+        required=False,
+        help="Value of the depositor email address attribute.",
+    )
+    parser.add_argument(
+        "-r",
+        "--registrant",
+        action="store",
+        dest="registrant",
+        required=False,
+        help="Value of the registrant attribute.",
+    )
+    parser.add_argument(
+        "-o",
+        "--xml_crossref",
+        action="store",
+        dest="path_to_write",
+        required=True,
+        help="Path for writing the CrossRef XML file.",
+    )
     arguments = parser.parse_args()
 
     data = {
-        'depositor_name': arguments.depositor_name,
-        'depositor_email_address': arguments.depositor_email_address,
-        'registrant': arguments.registrant
+        "depositor_name": arguments.depositor_name,
+        "depositor_email_address": arguments.depositor_email_address,
+        "registrant": arguments.registrant,
     }
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
@@ -36,5 +68,5 @@ def main():
         print(f"Arquivo criado em: {arguments.path_to_write}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packtools/sps/formats/oai_dc.py
+++ b/packtools/sps/formats/oai_dc.py
@@ -26,8 +26,8 @@ class GetDescriptionError(Exception):
 def add_identifier(header, xml_tree):
     try:
         identifier = article_ids.ArticleIds(xml_tree).v2
-        el = ET.Element('identifier')
-        el.text = 'oai:scielo:' + identifier
+        el = ET.Element("identifier")
+        el.text = "oai:scielo:" + identifier
         header.append(el)
     except Exception as exc:
         raise AddIdentifierError(f"Unable to add identifier {exc}")
@@ -38,15 +38,15 @@ def get_datestamp():
 
 
 def add_datestamp(header):
-    el = ET.Element('datestamp')
+    el = ET.Element("datestamp")
     el.text = get_datestamp()
     header.append(el)
 
 
 def add_set_spec(header, xml_tree):
     issn = get_issn(xml_tree)
-    if issn != '':
-        el = ET.Element('setSpec')
+    if issn != "":
+        el = ET.Element("setSpec")
         el.text = issn
         header.append(el)
 
@@ -58,16 +58,16 @@ def get_issn(xml_tree):
 
 
 def add_creator(xml_oai_dc, author_name):
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}creator')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}creator")
     el.text = author_name.strip()
 
     xml_oai_dc.append(el)
 
 
 def add_subject(xml_oai_dc, kw, article):
-    if kw.get('lang') == article.main_lang:
-        el = ET.Element('{http://purl.org/dc/elements/1.1/}subject')
-        el.text = kw.get('text').strip()
+    if kw.get("lang") == article.main_lang:
+        el = ET.Element("{http://purl.org/dc/elements/1.1/}subject")
+        el.text = kw.get("text").strip()
 
         xml_oai_dc.append(el)
 
@@ -99,7 +99,7 @@ def xml_oai_dc_record_pipe():
         </record>
     """
 
-    return ET.Element('record')
+    return ET.Element("record")
 
 
 def xml_oai_dc_header_pipe(xml_oai_dc, xml_tree):
@@ -111,7 +111,7 @@ def xml_oai_dc_header_pipe(xml_oai_dc, xml_tree):
             <setSpec>0718-7181</setSpec>
         </header>
     """
-    header = ET.Element('header')
+    header = ET.Element("header")
 
     add_identifier(header, xml_tree)
 
@@ -129,7 +129,7 @@ def xml_oai_dc_metadata(xml_oai_dc):
             </metadata>
         </record>
     """
-    metadata = ET.Element('metadata')
+    metadata = ET.Element("metadata")
     xml_oai_dc.append(metadata)
 
 
@@ -144,14 +144,16 @@ def setup_oai_dc_header_pipe(xml_oai_dc):
         http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
     """
     nsmap = {
-        'oai-dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
-        'dc': 'http://purl.org/dc/elements/1.1/',
-        'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
+        "oai-dc": "http://www.openarchives.org/OAI/2.0/oai_dc/",
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
     }
 
-    el = ET.Element('{http://www.openarchives.org/OAI/2.0/oai_dc/}dc', nsmap=nsmap)
-    el.set('{http://www.w3.org/2001/XMLSchema-instance}schemaLocation',
-           'http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd')
+    el = ET.Element("{http://www.openarchives.org/OAI/2.0/oai_dc/}dc", nsmap=nsmap)
+    el.set(
+        "{http://www.w3.org/2001/XMLSchema-instance}schemaLocation",
+        "http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+    )
 
     xml_oai_dc.append(el)
 
@@ -177,9 +179,9 @@ def xml_oai_dc_title(xml_oai_dc, xml_tree):
         La canción reflexiva: en torno al estatuto crítico de la música popular en Brasil
     </dc:title>
     """
-    title = article_titles.ArticleTitles(xml_tree).article_title.get('text')
+    title = article_titles.ArticleTitles(xml_tree).article_title.get("text")
     if title is not None:
-        el = ET.Element('{http://purl.org/dc/elements/1.1/}title')
+        el = ET.Element("{http://purl.org/dc/elements/1.1/}title")
         el.text = title.strip()
 
         xml_oai_dc.append(el)
@@ -209,9 +211,9 @@ def xml_oai_dc_creator(xml_oai_dc, xml_tree):
     """
     for author in article_authors.Authors(xml_tree).contribs:
         try:
-            surname = author.get('surname')
-            given_name = author.get('given_names')
-            author_name = f' {surname.strip()}, {given_name.strip()} '
+            surname = author.get("surname")
+            given_name = author.get("given_names")
+            author_name = f" {surname.strip()}, {given_name.strip()} "
             add_creator(xml_oai_dc, author_name)
         except IndexError:
             pass
@@ -293,7 +295,7 @@ def xml_oai_dc_description(xml_oai_dc, xml_tree):
         abstracts = article_abstract.Abstract(xml_tree).get_abstracts(style="inline")
 
         for abstract in abstracts:
-            el = ET.Element('{http://purl.org/dc/elements/1.1/}description')
+            el = ET.Element("{http://purl.org/dc/elements/1.1/}description")
             el.text = abstract.get("abstract")
             xml_oai_dc.append(el)
 
@@ -327,7 +329,7 @@ def xml_oai_dc_publisher(xml_oai_dc, xml_tree):
     publisher = journal_meta.Publisher(xml_tree)
 
     try:
-        el = ET.Element('{http://purl.org/dc/elements/1.1/}publisher')
+        el = ET.Element("{http://purl.org/dc/elements/1.1/}publisher")
         el.text = publisher.publishers_names[0].strip()
 
         xml_oai_dc.append(el)
@@ -360,7 +362,7 @@ def xml_oai_dc_source(xml_oai_dc, xml_tree):
     """
     journal = journal_meta.Title(xml_tree)
 
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}source')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}source")
     el.text = journal.journal_title.strip()
 
     xml_oai_dc.append(el)
@@ -391,20 +393,20 @@ def xml_oai_dc_date(xml_oai_dc, xml_tree):
     dt_obj = dates.ArticleDates(xml_tree)
     dt = dt_obj.article_date if dt_obj.article_date else dt_obj.collection_date
 
-    year = dt.get('year')
+    year = dt.get("year")
     if year:
-        month = dt.get('month')
-        day = dt.get('day')
-        exceptions = [None, '', '0', '00']
+        month = dt.get("month")
+        day = dt.get("day")
+        exceptions = [None, "", "0", "00"]
 
         if month is None and day is None:
             dt_out = year
         else:
-            month = '01' if month in exceptions else month
-            day = '01' if day in exceptions else day
-            dt_out = '-'.join([year, month, day])
+            month = "01" if month in exceptions else month
+            day = "01" if day in exceptions else day
+            dt_out = "-".join([year, month, day])
 
-        el = ET.Element('{http://purl.org/dc/elements/1.1/}date')
+        el = ET.Element("{http://purl.org/dc/elements/1.1/}date")
         el.text = dt_out
         xml_oai_dc.append(el)
 
@@ -435,8 +437,8 @@ def xml_oai_dc_format(xml_oai_dc):
         <dc:format>text/javascript(.js)</dc:format>
         <dc:format>text/xml</dc:format>
     """
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}format')
-    el.text = 'text/html'
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}format")
+    el.text = "text/html"
     xml_oai_dc.append(el)
 
 
@@ -462,8 +464,8 @@ def xml_oai_dc_identifier(xml_oai_dc, xml_tree):
     """
     identifier = article_uri.ArticleUri(xml_tree)
 
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}identifier')
-    el.text = identifier.all_uris.get('sci_arttext')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}identifier")
+    el.text = identifier.all_uris.get("sci_arttext")
     xml_oai_dc.append(el)
 
 
@@ -488,7 +490,7 @@ def xml_oai_dc_language(xml_oai_dc, xml_tree):
         <dc:language>es</dc:language>
     """
     lang = article_and_subarticles.ArticleAndSubArticles(xml_tree)
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}language')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}language")
     el.text = lang.main_lang
     xml_oai_dc.append(el)
 
@@ -516,7 +518,7 @@ def xml_oai_dc_relation(xml_oai_dc, xml_tree):
     related_article = related_articles.RelatedItems(xml_tree)
     for relation in related_article.related_articles:
         if relation:
-            el = ET.Element('{http://purl.org/dc/elements/1.1/}relation')
-            el.text = relation.get('href')
+            el = ET.Element("{http://purl.org/dc/elements/1.1/}relation")
+            el.text = relation.get("href")
             xml_oai_dc.append(el)
             break

--- a/packtools/sps/formats/oai_dc_agris.py
+++ b/packtools/sps/formats/oai_dc_agris.py
@@ -44,28 +44,28 @@ def get_identifier(xml_tree):
     try:
         identifier = article_ids.ArticleIds(xml_tree).v2
         if len(identifier) == 23:
-            return ''.join([identifier[10:18], identifier[21:]])
+            return "".join([identifier[10:18], identifier[21:]])
     except TypeError:
         pass
 
 
 def add_identifier(header, xml_tree):
     """
-        Schema (https://agris.fao.org/agris_ods/dlio.dtd.txt):
-            <!-- ELEMENT identifier -->
-            <!ELEMENT dc:identifier (#PCDATA)>
-            <!ATTLIST dc:identifier
-                xml:lang CDATA #IMPLIED
-                scheme (ags:IPC | ags:RN | ags:PN | ags:ISBN | ags:JN | dcterms:URI | ags:DOI | ags:PC) #IMPLIED
-            >
+    Schema (https://agris.fao.org/agris_ods/dlio.dtd.txt):
+        <!-- ELEMENT identifier -->
+        <!ELEMENT dc:identifier (#PCDATA)>
+        <!ATTLIST dc:identifier
+            xml:lang CDATA #IMPLIED
+            scheme (ags:IPC | ags:RN | ags:PN | ags:ISBN | ags:JN | dcterms:URI | ags:DOI | ags:PC) #IMPLIED
+        >
 
-        Example:
-            <identifier>oai:agris.scielo:XS2021000111</identifier>
-        """
+    Example:
+        <identifier>oai:agris.scielo:XS2021000111</identifier>
+    """
     identifier = get_identifier(xml_tree)
     if identifier is not None:
-        value = f'oai:agris.scielo:XS{identifier}'
-        el = ET.Element('identifier')
+        value = f"oai:agris.scielo:XS{identifier}"
+        el = ET.Element("identifier")
         el.text = value
         header.append(el)
 
@@ -73,7 +73,7 @@ def add_identifier(header, xml_tree):
 def add_set_spec(header, xml_tree):
     issn = get_issn(xml_tree)
     if issn:
-        el = ET.Element('setSpec')
+        el = ET.Element("setSpec")
         el.text = issn
         header.append(el)
 
@@ -85,13 +85,15 @@ def get_issn(xml_tree):
 
 
 def add_creator(xml_oai_dc_agris, author_name):
-    ags = ET.Element('{http://purl.org/agmes/1.1/}creatorPersonal')
+    ags = ET.Element("{http://purl.org/agmes/1.1/}creatorPersonal")
     ags.text = author_name
 
-    dc = ET.Element('{http://purl.org/dc/elements/1.1/}creator')
+    dc = ET.Element("{http://purl.org/dc/elements/1.1/}creator")
     dc.append(ags)
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(dc)
 
 
 def xml_oai_dc_agris_record_pipe():
@@ -101,7 +103,7 @@ def xml_oai_dc_agris_record_pipe():
         </record>
     """
 
-    return ET.Element('record')
+    return ET.Element("record")
 
 
 def xml_oai_dc_agris_header_pipe(xml_oai_dc_agris, xml_tree):
@@ -120,7 +122,7 @@ def xml_oai_dc_agris_header_pipe(xml_oai_dc_agris, xml_tree):
             <setSpec>0718-7181</setSpec>
         </header>
     """
-    header = ET.Element('header')
+    header = ET.Element("header")
 
     add_identifier(header, xml_tree)
 
@@ -144,16 +146,16 @@ def xml_oai_dc_agris_metadata_pipe(xml_oai_dc_agris):
     """
 
     nsmap = {
-        'xsl': 'http://www.w3.org/1999/XSL/Transform',
-        'ags': 'http://purl.org/agmes/1.1/',
-        'dc': 'http://purl.org/dc/elements/1.1/',
-        'agls': 'http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2',
-        'dcterms': 'http://purl.org/dc/terms/'
+        "xsl": "http://www.w3.org/1999/XSL/Transform",
+        "ags": "http://purl.org/agmes/1.1/",
+        "dc": "http://purl.org/dc/elements/1.1/",
+        "agls": "http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2",
+        "dcterms": "http://purl.org/dc/terms/",
     }
 
-    el = ET.Element('{http://purl.org/agmes/1.1/}resources', nsmap=nsmap)
+    el = ET.Element("{http://purl.org/agmes/1.1/}resources", nsmap=nsmap)
 
-    metadata = ET.Element('metadata')
+    metadata = ET.Element("metadata")
     metadata.append(el)
     xml_oai_dc_agris.append(metadata)
 
@@ -196,10 +198,10 @@ def xml_oai_dc_agris_resouce_pipe(xml_oai_dc_agris, xml_tree):
             </metadata>
         </record>
     """
-    el = ET.Element('{http://purl.org/agmes/1.1/}resource')
-    el.set('{http://purl.org/agmes/1.1/}ARN', 'XS' + get_identifier(xml_tree))
+    el = ET.Element("{http://purl.org/agmes/1.1/}resource")
+    el.set("{http://purl.org/agmes/1.1/}ARN", "XS" + get_identifier(xml_tree))
 
-    xml_oai_dc_agris.find('./metadata/{http://purl.org/agmes/1.1/}resources').append(el)
+    xml_oai_dc_agris.find("./metadata/{http://purl.org/agmes/1.1/}resources").append(el)
 
 
 def xml_oai_dc_agris_title_pipe(xml_oai_dc_agris, xml_tree):
@@ -227,19 +229,21 @@ def xml_oai_dc_agris_title_pipe(xml_oai_dc_agris, xml_tree):
     title = article_titles.ArticleTitles(xml_tree)
     lang = article_and_subarticles.ArticleAndSubArticles(xml_tree)
 
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}title')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}title")
 
     try:
-        el.set('{http://www.w3.org/XML/1998/namespace}lang', lang.main_lang)
+        el.set("{http://www.w3.org/XML/1998/namespace}lang", lang.main_lang)
     except Exception as exc:
         raise AddLanguageError(f"Unable to add language {exc}")
 
     try:
-        el.text = title.article_title['text'].strip()
+        el.text = title.article_title["text"].strip()
     except Exception as exc:
         raise AddTitleError(f"Unable to add title {exc}")
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(el)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(el)
 
 
 def xml_oai_dc_agris_creator_pipe(xml_oai_dc_agris, xml_tree):
@@ -266,9 +270,9 @@ def xml_oai_dc_agris_creator_pipe(xml_oai_dc_agris, xml_tree):
     """
     author = article_authors.Authors(xml_tree)
     try:
-        surname = author.contribs[0].get('surname')
-        given_name = author.contribs[0].get('given_names')
-        author_name = f' {surname.strip()}, {given_name.strip()} '
+        surname = author.contribs[0].get("surname")
+        given_name = author.contribs[0].get("given_names")
+        author_name = f" {surname.strip()}, {given_name.strip()} "
         add_creator(xml_oai_dc_agris, author_name.strip())
     except IndexError:
         pass
@@ -290,35 +294,37 @@ def xml_oai_dc_agris_publisher_pipe(xml_oai_dc_agris, xml_tree):
     publishers = journal_meta.Publisher(xml_tree).publishers_names
 
     if publishers:
-        dc = ET.Element('{http://purl.org/dc/elements/1.1/}publisher')
+        dc = ET.Element("{http://purl.org/dc/elements/1.1/}publisher")
 
         for publisher in publishers:
-            ags = ET.Element('{http://purl.org/agmes/1.1/}publisherName')
+            ags = ET.Element("{http://purl.org/agmes/1.1/}publisherName")
             ags.text = publisher.strip()
             dc.append(ags)
 
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(dc)
 
 
 def get_date(dt, m=False, d=False):
     try:
-        year = dt.get('year')
+        year = dt.get("year")
         if year is None:
             return
 
-        month = dt.get('month')
-        day = dt.get('day')
-        exceptions = [None, '', '0', '00']
+        month = dt.get("month")
+        day = dt.get("day")
+        exceptions = [None, "", "0", "00"]
         if month is None and day is None:
             return year
 
-        month = '01' if month in exceptions else month
-        day = '01' if day in exceptions else day
+        month = "01" if month in exceptions else month
+        day = "01" if day in exceptions else day
 
         if d:
-            return '-'.join([year, month, day])
+            return "-".join([year, month, day])
         elif m:
-            return '-'.join([year, month])
+            return "-".join([year, month])
         else:
             return year
     except Exception as exc:
@@ -347,21 +353,25 @@ def xml_oai_dc_agris_date_pipe(xml_oai_dc_agris, xml_tree):
     dt_out = get_date(dates.ArticleDates(xml_tree).article_date)
 
     if dt_out is not None:
-        term = ET.Element('{http://purl.org/dc/terms/}dateIssued')
+        term = ET.Element("{http://purl.org/dc/terms/}dateIssued")
         term.text = dt_out
 
-        dc = ET.Element('{http://purl.org/dc/elements/1.1/}date')
+        dc = ET.Element("{http://purl.org/dc/elements/1.1/}date")
         dc.append(term)
 
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(dc)
 
 
 def add_subject(xml_oai_dc_agris, kw):
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}subject')
-    el.set('{http://www.w3.org/XML/1998/namespace}lang', kw.get('lang'))
-    el.text = kw.get('text')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}subject")
+    el.set("{http://www.w3.org/XML/1998/namespace}lang", kw.get("lang"))
+    el.text = kw.get("text")
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(el)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(el)
 
 
 def xml_oai_dc_agris_subject_pipe(xml_oai_dc_agris, xml_tree):
@@ -427,33 +437,39 @@ def xml_oai_dc_agris_description_pipe(xml_oai_dc_agris, xml_tree):
         abstracts = article_abstract.Abstract(xml_tree).get_abstracts(style="inline")
 
         for abstract in abstracts:
-            term = ET.Element('{http://purl.org/dc/terms/}abstract')
-            term.set('{http://www.w3.org/XML/1998/namespace}lang', abstract.get("lang"))
+            term = ET.Element("{http://purl.org/dc/terms/}abstract")
+            term.set("{http://www.w3.org/XML/1998/namespace}lang", abstract.get("lang"))
             term.text = abstract.get("abstract")
 
-            dc = ET.Element('{http://purl.org/dc/elements/1.1/}description')
+            dc = ET.Element("{http://purl.org/dc/elements/1.1/}description")
             dc.append(term)
 
-            xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+            xml_oai_dc_agris.find(
+                ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+            ).append(dc)
     except Exception as exc:
         raise GetDescriptionError(f"Unable to get description {exc}")
 
 
 def add_uri_identifier(xml_oai_dc_agris, identifier):
-    dc = ET.Element('{http://purl.org/dc/elements/1.1/}identifier')
-    dc.set('scheme', 'dcterms:URI')
+    dc = ET.Element("{http://purl.org/dc/elements/1.1/}identifier")
+    dc.set("scheme", "dcterms:URI")
     dc.text = identifier
     # dc.text = identifier.get('sci_arttext')
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(dc)
 
 
 def add_uri_doi(xml_oai_dc_agris, doi):
-    dc = ET.Element('{http://purl.org/dc/elements/1.1/}identifier')
-    dc.set('scheme', 'ags:DOI')
+    dc = ET.Element("{http://purl.org/dc/elements/1.1/}identifier")
+    dc.set("scheme", "ags:DOI")
     dc.text = doi
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(dc)
 
 
 def xml_oai_dc_agris_identifier_pipe(xml_oai_dc_agris, xml_tree, data):
@@ -479,7 +495,7 @@ def xml_oai_dc_agris_identifier_pipe(xml_oai_dc_agris, xml_tree, data):
     # add_uri_identifier(xml_oai_dc_agris, identifier.all_uris)
 
     doi = article_ids.ArticleIds(xml_tree).doi
-    add_uri_identifier(xml_oai_dc_agris, data.get('identifier'))
+    add_uri_identifier(xml_oai_dc_agris, data.get("identifier"))
     add_uri_doi(xml_oai_dc_agris, doi)
 
 
@@ -495,12 +511,14 @@ def xml_oai_dc_agris_type_pipe(xml_oai_dc_agris, data=None):
     Example:
         <dc:type>journal article</dc:type>
     """
-    tp = data and data.get('type') or 'journal article'
+    tp = data and data.get("type") or "journal article"
     if tp is not None:
-        dc = ET.Element('{http://purl.org/dc/elements/1.1/}type')
+        dc = ET.Element("{http://purl.org/dc/elements/1.1/}type")
         dc.text = tp
 
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(dc)
 
 
 def xml_oai_dc_agris_format_pipe(xml_oai_dc_agris, data):
@@ -519,15 +537,17 @@ def xml_oai_dc_agris_format_pipe(xml_oai_dc_agris, data):
             <dcterms:medium>text/xml</dcterms:medium>
         </dc:format>
     """
-    ft = data.get('format')
+    ft = data.get("format")
     if ft is not None:
-        term = ET.Element('{http://purl.org/dc/terms/}medium')
+        term = ET.Element("{http://purl.org/dc/terms/}medium")
         term.text = ft
 
-        dc = ET.Element('{http://purl.org/dc/elements/1.1/}format')
+        dc = ET.Element("{http://purl.org/dc/elements/1.1/}format")
         dc.append(term)
 
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(dc)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(dc)
 
 
 def xml_oai_dc_agris_language_pipe(xml_oai_dc_agris, xml_tree):
@@ -544,11 +564,13 @@ def xml_oai_dc_agris_language_pipe(xml_oai_dc_agris, xml_tree):
     """
     lang = article_and_subarticles.ArticleAndSubArticles(xml_tree)
 
-    el = ET.Element('{http://purl.org/dc/elements/1.1/}language')
-    el.set('scheme', 'ags:ISO639-1')
+    el = ET.Element("{http://purl.org/dc/elements/1.1/}language")
+    el.set("scheme", "ags:ISO639-1")
     el.text = lang.main_lang
 
-    xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(el)
+    xml_oai_dc_agris.find(
+        ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+    ).append(el)
 
 
 def xml_oai_dc_agris_availability_pipe(xml_oai_dc_agris, xml_tree, data=None):
@@ -565,48 +587,52 @@ def xml_oai_dc_agris_availability_pipe(xml_oai_dc_agris, xml_tree, data=None):
             <ags:availabilityNumber>10.7764/69.1</ags:availabilityNumber>
         </agls:availability>
     """
-    agls = ET.Element('{http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2}availability')
+    agls = ET.Element(
+        "{http://www.naa.gov.au/recordkeeping/gov_online/agls/1.2}availability"
+    )
 
     try:
-        loc = ET.Element('{http://purl.org/agmes/1.1/}availabilityLocation')
-        loc.text = data.get('location')
+        loc = ET.Element("{http://purl.org/agmes/1.1/}availabilityLocation")
+        loc.text = data.get("location")
         agls.append(loc)
     except AttributeError:
         pass
 
     doi = article_ids.ArticleIds(xml_tree).doi
     if doi:
-        number = ET.Element('{http://purl.org/agmes/1.1/}availabilityNumber')
+        number = ET.Element("{http://purl.org/agmes/1.1/}availabilityNumber")
         number.text = doi
         agls.append(number)
 
     if len(agls) > 0:
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(agls)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(agls)
 
 
 def get_citation_title(xml_tree):
     title = journal_meta.Title(xml_tree).journal_title
     if title is not None:
-        return title, 'citationTitle'
+        return title, "citationTitle"
 
 
 def get_citation_identifier(xml_tree):
     issn = journal_meta.ISSN(xml_tree).epub
-    if issn != '':
-        return issn, 'citationIdentifier'
+    if issn != "":
+        return issn, "citationIdentifier"
 
 
 def get_citation_number(xml_tree):
     volume = front_articlemeta_issue.ArticleMetaIssue(xml_tree).volume
     if volume is not None:
-        return volume, 'citationNumber'
+        return volume, "citationNumber"
 
 
 def get_citation_chronology(xml_tree):
     epub_date = dates.ArticleDates(xml_tree).article_date
     date = get_date(epub_date, d=True)
     if date is not None:
-        return date, 'citationChronology'
+        return date, "citationChronology"
 
 
 def add_citation_elements(citation, elements):
@@ -629,9 +655,9 @@ def add_citation_elements(citation, elements):
     """
     for element in elements:
         try:
-            el = ET.Element('{http://purl.org/agmes/1.1/}' + element[1])
-            if element[1] == 'citationIdentifier':
-                el.set('scheme', 'ags:ISSN')
+            el = ET.Element("{http://purl.org/agmes/1.1/}" + element[1])
+            if element[1] == "citationIdentifier":
+                el.set("scheme", "ags:ISSN")
             el.text = element[0]
             citation.append(el)
         except TypeError:
@@ -662,7 +688,7 @@ def xml_oai_dc_agris_citation_pipe(xml_oai_dc_agris, xml_tree):
             <ags:citationChronology>2021/07</ags:citationChronology>
         </ags:citation>
     """
-    citation = ET.Element('{http://purl.org/agmes/1.1/}citation')
+    citation = ET.Element("{http://purl.org/agmes/1.1/}citation")
 
     elements = [
         get_citation_title(xml_tree),
@@ -673,7 +699,9 @@ def xml_oai_dc_agris_citation_pipe(xml_oai_dc_agris, xml_tree):
 
     if elements:
         add_citation_elements(citation, elements)
-        xml_oai_dc_agris.find(".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}).append(citation)
+        xml_oai_dc_agris.find(
+            ".//ags:resource", {"ags": "http://purl.org/agmes/1.1/"}
+        ).append(citation)
 
 
 def pipeline_oai_dc_agris(xml_tree, data):

--- a/packtools/sps/formats/pmc.py
+++ b/packtools/sps/formats/pmc.py
@@ -46,7 +46,7 @@ def xml_pmc_aff(xml_tree):
         for institution in aff.findall(".//institution"):
             aff.remove(institution)
 
-        aff.remove(aff.find('./addr-line'))
+        aff.remove(aff.find("./addr-line"))
 
         aff.remove(aff.find("./country"))
 
@@ -60,96 +60,95 @@ def xml_pmc_aff(xml_tree):
 
 def xml_pmc_ref(xml_tree):
     """
-        Remove o elemento 'mixed-citation' do XML SciELO.
+    Remove o elemento 'mixed-citation' do XML SciELO.
 
-        Parameters
-        ----------
-        xml_tree : lxml.etree._Element
-            Elemento XML no padrão SciELO com os dados de origem, por exemplo:
-            <ref id="B1">
-                <label>1.</label>
-                <mixed-citation>
-                   1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI:
-                   <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
-                </mixed-citation>
-                <element-citation publication-type="journal">
-                   <person-group person-group-type="author">
-                      <name>
-                         <surname>Tran</surname>
-                         <given-names>B</given-names>
-                      </name>
-                      <name>
-                         <surname>Falster</surname>
-                         <given-names>MO</given-names>
-                      </name>
-                      <name>
-                         <surname>Douglas</surname>
-                         <given-names>K</given-names>
-                      </name>
-                      <name>
-                         <surname>Blyth</surname>
-                         <given-names>F</given-names>
-                      </name>
-                      <name>
-                         <surname>Jorm</surname>
-                         <given-names>LR</given-names>
-                      </name>
-                   </person-group>
-                   <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
-                   <source>Drug Alcohol Depend.</source>
-                   <year>2015</year>
-                   <volume>150</volume>
-                   <fpage>85</fpage>
-                   <lpage>91</lpage>
-                   <comment>
-                      DOI:
-                      <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
-                   </comment>
-                </element-citation>
-             </ref>
+    Parameters
+    ----------
+    xml_tree : lxml.etree._Element
+        Elemento XML no padrão SciELO com os dados de origem, por exemplo:
+        <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+               1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI:
+               <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+               <person-group person-group-type="author">
+                  <name>
+                     <surname>Tran</surname>
+                     <given-names>B</given-names>
+                  </name>
+                  <name>
+                     <surname>Falster</surname>
+                     <given-names>MO</given-names>
+                  </name>
+                  <name>
+                     <surname>Douglas</surname>
+                     <given-names>K</given-names>
+                  </name>
+                  <name>
+                     <surname>Blyth</surname>
+                     <given-names>F</given-names>
+                  </name>
+                  <name>
+                     <surname>Jorm</surname>
+                     <given-names>LR</given-names>
+                  </name>
+               </person-group>
+               <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+               <source>Drug Alcohol Depend.</source>
+               <year>2015</year>
+               <volume>150</volume>
+               <fpage>85</fpage>
+               <lpage>91</lpage>
+               <comment>
+                  DOI:
+                  <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
 
-        Returns
-        -------
-        lxml.etree._Element :
-            <ref id="B1">
-                <label>1.</label>
-                <element-citation publication-type="journal">
-                   <person-group person-group-type="author">
-                      <name>
-                         <surname>Tran</surname>
-                         <given-names>B</given-names>
-                      </name>
-                      <name>
-                         <surname>Falster</surname>
-                         <given-names>MO</given-names>
-                      </name>
-                      <name>
-                         <surname>Douglas</surname>
-                         <given-names>K</given-names>
-                      </name>
-                      <name>
-                         <surname>Blyth</surname>
-                         <given-names>F</given-names>
-                      </name>
-                      <name>
-                         <surname>Jorm</surname>
-                         <given-names>LR</given-names>
-                      </name>
-                   </person-group>
-                   <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
-                   <source>Drug Alcohol Depend.</source>
-                   <year>2015</year>
-                   <volume>150</volume>
-                   <fpage>85</fpage>
-                   <lpage>91</lpage>
-                   <comment>
-                      DOI:
-                      <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
-                   </comment>
-                </element-citation>
-             </ref>
-        """
+    Returns
+    -------
+    lxml.etree._Element :
+        <ref id="B1">
+            <label>1.</label>
+            <element-citation publication-type="journal">
+               <person-group person-group-type="author">
+                  <name>
+                     <surname>Tran</surname>
+                     <given-names>B</given-names>
+                  </name>
+                  <name>
+                     <surname>Falster</surname>
+                     <given-names>MO</given-names>
+                  </name>
+                  <name>
+                     <surname>Douglas</surname>
+                     <given-names>K</given-names>
+                  </name>
+                  <name>
+                     <surname>Blyth</surname>
+                     <given-names>F</given-names>
+                  </name>
+                  <name>
+                     <surname>Jorm</surname>
+                     <given-names>LR</given-names>
+                  </name>
+               </person-group>
+               <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+               <source>Drug Alcohol Depend.</source>
+               <year>2015</year>
+               <volume>150</volume>
+               <fpage>85</fpage>
+               <lpage>91</lpage>
+               <comment>
+                  DOI:
+                  <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+               </comment>
+            </element-citation>
+         </ref>
+    """
     refs = xml_tree.findall(".//ref")
     for ref in refs:
         ref.remove(ref.find("./mixed-citation"))
-

--- a/packtools/sps/formats/pmc.py
+++ b/packtools/sps/formats/pmc.py
@@ -2,11 +2,11 @@
 from lxml import etree as ET
 
 
-def pipeline_pmc(xml_tree):
+def pipeline_pmc(xml_tree, pretty_print=True):
     xml_pmc_aff(xml_tree)
     xml_pmc_ref(xml_tree)
 
-    return xml_tree
+    return ET.tostring(xml_tree, pretty_print=pretty_print)
 
 
 def xml_pmc_aff(xml_tree):

--- a/packtools/sps/formats/pmc.py
+++ b/packtools/sps/formats/pmc.py
@@ -6,7 +6,9 @@ def pipeline_pmc(xml_tree, pretty_print=True):
     xml_pmc_aff(xml_tree)
     xml_pmc_ref(xml_tree)
 
-    return ET.tostring(xml_tree, pretty_print=pretty_print)
+    return ET.tostring(xml_tree, pretty_print=pretty_print, encode="utf-8").decode(
+        "utf-8"
+    )
 
 
 def xml_pmc_aff(xml_tree):

--- a/packtools/sps/formats/pmc_generator.py
+++ b/packtools/sps/formats/pmc_generator.py
@@ -7,11 +7,25 @@ from packtools.sps.utils import xml_utils
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Convert XML file from SciELO format to PMC format.')
-    parser.add_argument('-i', '--xml_scielo', action='store', dest='xml_scielo', required=True,
-                        help='XML file in SciELO format to be converted.')
-    parser.add_argument('-o', '--xml_pmc', action='store', dest='path_to_write', required=True,
-                        help='Path for writing the PMC XML file.')
+    parser = argparse.ArgumentParser(
+        description="Convert XML file from SciELO format to PMC format."
+    )
+    parser.add_argument(
+        "-i",
+        "--xml_scielo",
+        action="store",
+        dest="xml_scielo",
+        required=True,
+        help="XML file in SciELO format to be converted.",
+    )
+    parser.add_argument(
+        "-o",
+        "--xml_pmc",
+        action="store",
+        dest="path_to_write",
+        required=True,
+        help="Path for writing the PMC XML file.",
+    )
     arguments = parser.parse_args()
 
     xml_tree = xml_utils.get_xml_tree(arguments.xml_scielo)
@@ -23,5 +37,5 @@ def main():
         print(f"Arquivo criado em: {arguments.path_to_write}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packtools/sps/formats/pmc_generator.py
+++ b/packtools/sps/formats/pmc_generator.py
@@ -1,7 +1,5 @@
 import argparse
 
-from lxml import etree as ET
-
 from packtools.sps.formats import pmc
 from packtools.sps.utils import xml_utils
 
@@ -29,8 +27,7 @@ def main():
     arguments = parser.parse_args()
 
     xml_tree = xml_utils.get_xml_tree(arguments.xml_scielo)
-    xml_pmc = ET.ElementTree(pmc.pipeline_pmc(xml_tree))
-    xml_string = xml_utils.tostring(xml_pmc, pretty_print=True)
+    xml_string = pmc.pipeline_pmc(xml_tree)
 
     with open(arguments.path_to_write, "w", encoding="utf-8") as file:
         file.write(xml_string)

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -2,25 +2,22 @@
 from lxml import etree as ET
 
 from packtools.sps.models import (
-    journal_meta,
-    front_articlemeta_issue,
-    dates,
-    article_titles,
-    article_ids,
+    aff,
+    article_abstract,
     article_and_subarticles,
     article_authors,
-    aff,
-    kwd_group,
     article_citations,
-    article_abstract,
+    article_ids,
+    article_titles,
+    dates,
+    front_articlemeta_issue,
+    journal_meta,
+    kwd_group,
 )
 
 
 def xml_pubmed_article_pipe():
-    root = ET.Element("Article")
-    tree = ET.ElementTree(root)
-
-    return root
+    return ET.Element("Article")
 
 
 def xml_pubmed_journal_pipe(xml_pubmed):
@@ -257,7 +254,7 @@ def xml_pubmed_language_pipe(xml_pubmed, xml_tree):
     add_langs(xml_pubmed, xml_tree)
 
 
-def pipeline_pubmed(xml_tree):
+def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed = xml_pubmed_article_pipe()
     xml_pubmed_journal_pipe(xml_pubmed)
     xml_pubmed_publisher_name_pipe(xml_pubmed, xml_tree)
@@ -274,7 +271,8 @@ def pipeline_pubmed(xml_tree):
     # TODO
     # As demais chamadas serão incluídas a partir da incorporação do PR #429
 
-    return xml_pubmed
+    xml_pubmed = ET.ElementTree(xml_pubmed)
+    return ET.tostring(xml_pubmed, encoding="utf-8", pretty_print=pretty_print)
 
 
 def get_authors(xml_tree):

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -271,8 +271,10 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     # TODO
     # As demais chamadas serão incluídas a partir da incorporação do PR #429
 
-    xml_pubmed = ET.ElementTree(xml_pubmed)
-    return ET.tostring(xml_pubmed, encoding="utf-8", pretty_print=pretty_print)
+    xml_tree = ET.ElementTree(xml_pubmed)
+    return ET.tostring(xml_tree, pretty_print=pretty_print, encoding="utf-8").decode(
+        "utf-8"
+    )
 
 
 def get_authors(xml_tree):

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -24,7 +24,7 @@ def xml_pubmed_article_pipe():
 
 
 def xml_pubmed_journal_pipe(xml_pubmed):
-    el = ET.Element('Journal')
+    el = ET.Element("Journal")
     xml_pubmed.append(el)
 
 
@@ -42,9 +42,9 @@ def xml_pubmed_publisher_name_pipe(xml_pubmed, xml_tree):
     """
     publisher = get_publisher(xml_tree)
     if publisher is not None:
-        el = ET.Element('PublisherName')
+        el = ET.Element("PublisherName")
         el.text = publisher
-        xml_pubmed.find('Journal').append(el)
+        xml_pubmed.find("Journal").append(el)
 
 
 def get_journal_title(xml_tree):
@@ -59,9 +59,9 @@ def xml_pubmed_journal_title_pipe(xml_pubmed, xml_tree):
     """
     journal_title = get_journal_title(xml_tree)
     if journal_title is not None:
-        el = ET.Element('JournalTitle')
+        el = ET.Element("JournalTitle")
         el.text = journal_title
-        xml_pubmed.find('Journal').append(el)
+        xml_pubmed.find("Journal").append(el)
 
 
 def get_issn(xml_tree):
@@ -75,10 +75,10 @@ def xml_pubmed_issn_pipe(xml_pubmed, xml_tree):
     <Issn>1678-2674</Issn>
     """
     issn = get_issn(xml_tree)
-    if issn != '':
-        el = ET.Element('Issn')
+    if issn != "":
+        el = ET.Element("Issn")
         el.text = issn
-        xml_pubmed.find('Journal').append(el)
+        xml_pubmed.find("Journal").append(el)
 
 
 def get_volume(xml_tree):
@@ -93,9 +93,9 @@ def xml_pubmed_volume_pipe(xml_pubmed, xml_tree):
     """
     volume = get_volume(xml_tree)
     if volume is not None:
-        el = ET.Element('Volume')
+        el = ET.Element("Volume")
         el.text = volume
-        xml_pubmed.find('Journal').append(el)
+        xml_pubmed.find("Journal").append(el)
 
 
 def get_issue(xml_tree):
@@ -110,9 +110,9 @@ def xml_pubmed_issue_pipe(xml_pubmed, xml_tree):
     """
     issue = get_issue(xml_tree)
     if issue is not None:
-        el = ET.Element('Issue')
+        el = ET.Element("Issue")
         el.text = issue
-        xml_pubmed.find('Journal').append(el)
+        xml_pubmed.find("Journal").append(el)
 
 
 def get_date(xml_tree):
@@ -131,9 +131,9 @@ def xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree):
     """
     date = get_date(xml_tree)
     if date is not None:
-        dt = ET.Element('PubDate')
-        dt.set('PubStatus', 'epublish')
-        for element in ['year', 'month', 'day']:
+        dt = ET.Element("PubDate")
+        dt.set("PubStatus", "epublish")
+        for element in ["year", "month", "day"]:
             # TODO
             # Season
             # The season of publication. e.g.,Winter, Spring, Summer, Fall. Do not use if a Month is available.
@@ -143,7 +143,7 @@ def xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree):
                 el = ET.Element(element.capitalize())
                 el.text = date.get(element)
                 dt.append(el)
-        xml_pubmed.find('Journal').append(dt)
+        xml_pubmed.find("Journal").append(dt)
 
 
 def xml_pubmed_replaces_pipe(xml_pubmed, xml_tree):
@@ -172,9 +172,9 @@ def xml_pubmed_article_title_pipe(xml_pubmed, xml_tree):
     </ArticleTitle>
     """
     title = get_article_titles(xml_tree)
-    if title.get('en') is not None:
-        el = ET.Element('ArticleTitle')
-        el.text = title.get('en')
+    if title.get("en") is not None:
+        el = ET.Element("ArticleTitle")
+        el.text = title.get("en")
         xml_pubmed.append(el)
 
 
@@ -187,7 +187,7 @@ def xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree):
     main_lang = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_lang
     title = get_article_titles(xml_tree)
     if title.get(main_lang) is not None:
-        el = ET.Element('VernacularTitle')
+        el = ET.Element("VernacularTitle")
         el.text = title.get(main_lang)
         xml_pubmed.append(el)
 
@@ -204,8 +204,8 @@ def xml_pubmed_first_page_pipe(xml_pubmed, xml_tree):
     """
     first_page = get_first_page(xml_tree)
     if first_page is not None:
-        el = ET.Element('FirstPage')
-        el.set('LZero', 'save')
+        el = ET.Element("FirstPage")
+        el.set("LZero", "save")
         el.text = first_page
         xml_pubmed.append(el)
 
@@ -218,8 +218,8 @@ def get_elocation(xml_tree):
 
 def add_elocation(xml_pubmed, value, key):
     if value is not None:
-        el = ET.Element('ELocationID')
-        el.set('EIdType', key)
+        el = ET.Element("ELocationID")
+        el.set("EIdType", key)
         el.text = value
         xml_pubmed.append(el)
 
@@ -230,8 +230,8 @@ def xml_pubmed_elocation_pipe(xml_pubmed, xml_tree):
     <ELocationID EIdType="doi">10.1590/0001-3765202220201894</ELocationID>
     """
     ids = get_elocation(xml_tree)
-    add_elocation(xml_pubmed, ids.get('v2'), 'pii')
-    add_elocation(xml_pubmed, ids.get('doi'), 'doi')
+    add_elocation(xml_pubmed, ids.get("v2"), "pii")
+    add_elocation(xml_pubmed, ids.get("doi"), "doi")
 
 
 def get_langs(xml_tree):
@@ -243,9 +243,9 @@ def get_langs(xml_tree):
 def add_langs(xml_pubmed, xml_tree):
     langs = get_langs(xml_tree)
     for lang in langs:
-        if lang.get('lang') is not None:
-            el = ET.Element('Language')
-            el.text = lang.get('lang').upper()
+        if lang.get("lang") is not None:
+            el = ET.Element("Language")
+            el.text = lang.get("lang").upper()
             xml_pubmed.append(el)
 
 
@@ -276,39 +276,41 @@ def pipeline_pubmed(xml_tree):
 
     return xml_pubmed
 
-  
+
 def get_authors(xml_tree):
     return article_authors.Authors(xml_tree).contribs
 
 
 def add_first_name(author_reg, author_tag):
-    if author_reg.get('given_names'):
-        first = ET.Element('FirstName')
-        first.text = author_reg.get('given_names')
+    if author_reg.get("given_names"):
+        first = ET.Element("FirstName")
+        first.text = author_reg.get("given_names")
         author_tag.append(first)
 
 
 def add_last_name(author_reg, author_tag):
-    if author_reg.get('surname'):
-        last = ET.Element('LastName')
-        last.text = author_reg.get('surname')
+    if author_reg.get("surname"):
+        last = ET.Element("LastName")
+        last.text = author_reg.get("surname")
         author_tag.append(last)
 
 
 def get_affiliations(author_reg, xml_tree):
     affiliations = aff.AffiliationExtractor(xml_tree).get_affiliation_dict(subtag=False)
     affiliation_list = []
-    for rid in author_reg.get('rid-aff'):
-        affiliation_list.append(affiliations.get(rid).get('institution')[0].get('original'))
+    for rid in author_reg.get("rid-aff"):
+        affiliation_list.append(
+            affiliations.get(rid).get("institution")[0].get("original")
+        )
     return affiliation_list
 
 
 def add_affiliations(affiliations, author_tag):
     for item in affiliations:
-        el_aff = ET.Element('Affiliation')
+        el_aff = ET.Element("Affiliation")
         el_aff.text = item
         if len(affiliations) > 1:
-            info = ET.Element('AffiliationInfo')
+            info = ET.Element("AffiliationInfo")
             info.append(el_aff)
             author_tag.append(info)
         else:
@@ -316,19 +318,19 @@ def add_affiliations(affiliations, author_tag):
 
 
 def add_orcid(author_reg, author_tag):
-    if author_reg.get('orcid'):
-        orcid = ET.Element('Identifier')
-        orcid.set('Source', 'orcid')
-        orcid.text = 'http://orcid.org/' + author_reg.get('orcid')
+    if author_reg.get("orcid"):
+        orcid = ET.Element("Identifier")
+        orcid.set("Source", "orcid")
+        orcid.text = "http://orcid.org/" + author_reg.get("orcid")
         author_tag.append(orcid)
 
 
 def xml_pubmed_author_list(xml_pubmed, xml_tree):
     authors = get_authors(xml_tree)
     if authors:
-        author_list_tag = ET.Element('AuthorList')
+        author_list_tag = ET.Element("AuthorList")
         for author_reg in authors:
-            author_tag = ET.Element('Author')
+            author_tag = ET.Element("Author")
             add_first_name(author_reg, author_tag)
 
             # TODO
@@ -389,9 +391,11 @@ def xml_pubmed_author_list(xml_pubmed, xml_tree):
 
 
 def get_publication_type(xml_tree):
-    publication_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
+    publication_type = article_and_subarticles.ArticleAndSubArticles(
+        xml_tree
+    ).main_article_type
     if publication_type is not None:
-        return publication_type.replace('-', ' ').title()
+        return publication_type.replace("-", " ").title()
 
 
 def xml_pubmed_publication_type(xml_pubmed, xml_tree):
@@ -400,7 +404,7 @@ def xml_pubmed_publication_type(xml_pubmed, xml_tree):
     """
     publication_type = get_publication_type(xml_tree)
     if publication_type is not None:
-        el = ET.Element('PublicationType')
+        el = ET.Element("PublicationType")
         el.text = publication_type
         xml_pubmed.append(el)
 
@@ -423,15 +427,15 @@ def xml_pubmed_article_id(xml_pubmed, xml_tree):
     pii = get_article_id_pii(xml_tree)
     doi = get_article_id_doi(xml_tree)
     if pii is not None or doi is not None:
-        article_id_list = ET.Element('ArticleIdList')
+        article_id_list = ET.Element("ArticleIdList")
         if pii is not None:
-            article_id = ET.Element('ArticleId')
-            article_id.set('IdType', 'pii')
+            article_id = ET.Element("ArticleId")
+            article_id.set("IdType", "pii")
             article_id.text = pii
             article_id_list.append(article_id)
         if doi is not None:
-            article_id = ET.Element('ArticleId')
-            article_id.set('IdType', 'doi')
+            article_id = ET.Element("ArticleId")
+            article_id.set("IdType", "doi")
             article_id.text = doi
             article_id_list.append(article_id)
         xml_pubmed.append(article_id_list)
@@ -443,7 +447,7 @@ def get_event_date(xml_tree, event):
 
 
 def add_date(date_tag, date_dict):
-    for event in ['year', 'month', 'day']:
+    for event in ["year", "month", "day"]:
         if date_dict.get(event):
             el = ET.Element(event.capitalize())
             el.text = date_dict.get(event)
@@ -477,16 +481,16 @@ def xml_pubmed_history(xml_pubmed, xml_tree):
     ecollection – used for electronic-only journals that publish individual articles and later collect them into an “issue” date, typically called an eCollection.
     """
     history_dates = {
-        'received': get_event_date(xml_tree, 'received'),
-        'accepted': get_event_date(xml_tree, 'accepted'),
-        'ecollection': dates.ArticleDates(xml_tree).collection_date
+        "received": get_event_date(xml_tree, "received"),
+        "accepted": get_event_date(xml_tree, "accepted"),
+        "ecollection": dates.ArticleDates(xml_tree).collection_date,
     }
 
-    history = ET.Element('History')
+    history = ET.Element("History")
     for event, date in history_dates.items():
         if history_dates[event] is not None:
-            el = ET.Element('PubDate')
-            el.set('PubStatus', event)
+            el = ET.Element("PubDate")
+            el.set("PubStatus", event)
             add_date(el, date)
             history.append(el)
 
@@ -541,14 +545,14 @@ def xml_pubmed_object_list(xml_pubmed, xml_tree):
     kwd_list = get_keywords(xml_tree)
     if not kwd_list:
         return
-    obj_list = ET.Element('ObjectList')
+    obj_list = ET.Element("ObjectList")
     for kwd in kwd_list:
-        if kwd.get('lang') == 'en':
-            obj = ET.Element('Object')
-            obj.set('Type', 'keyword')
-            param = ET.Element('Param')
-            param.set('Name', 'value')
-            param.text = kwd.get('text')
+        if kwd.get("lang") == "en":
+            obj = ET.Element("Object")
+            obj.set("Type", "keyword")
+            param = ET.Element("Param")
+            param.set("Name", "value")
+            param.text = kwd.get("text")
             obj.append(param)
             obj_list.append(obj)
     xml_pubmed.append(obj_list)
@@ -565,7 +569,7 @@ def xml_pubmed_reference_list(xml_pubmed):
     """
     <ReferenceList/>
     """
-    xml_pubmed.append(ET.Element('ReferenceList'))
+    xml_pubmed.append(ET.Element("ReferenceList"))
 
 
 def xml_pubmed_title_reference_list(xml_pubmed, xml_tree):
@@ -575,20 +579,20 @@ def xml_pubmed_title_reference_list(xml_pubmed, xml_tree):
     </ReferenceList>
     """
     try:
-        title = xml_tree.find('./back/ref-list/title').text
-        title_el = ET.Element('Title')
+        title = xml_tree.find("./back/ref-list/title").text
+        title_el = ET.Element("Title")
         title_el.text = title
-        xml_pubmed.find('./ReferenceList').append(title_el)
+        xml_pubmed.find("./ReferenceList").append(title_el)
     except AttributeError:
         pass
 
 
 def add_element_citation_id(ids):
-    article_id_list = ET.Element('ArticleIdList')
+    article_id_list = ET.Element("ArticleIdList")
     for key, value in ids.items():
-        article_id = ET.Element('ArticleId')
-        key = 'pubmed' if key == 'pmid' else key
-        article_id.set('IdType', key)
+        article_id = ET.Element("ArticleId")
+        key = "pubmed" if key == "pmid" else key
+        article_id.set("IdType", key)
         article_id.text = value
         article_id_list.append(article_id)
     return article_id_list
@@ -619,13 +623,13 @@ def xml_pubmed_citations(xml_pubmed, xml_tree):
      </ReferenceList>
     """
     refs = article_citations.ArticleCitations(xml_tree).article_citations
-    xml = xml_pubmed.find('./ReferenceList')
+    xml = xml_pubmed.find("./ReferenceList")
     for ref in refs:
-        ref_el = ET.Element('Reference')
-        citation = ET.Element('Citation')
-        citation.text = ref.get('mixed_citation')
+        ref_el = ET.Element("Reference")
+        citation = ET.Element("Citation")
+        citation.text = ref.get("mixed_citation")
         ref_el.append(citation)
-        ids = ref.get('citation_ids')
+        ids = ref.get("citation_ids")
         if ids != {}:
             ref_el.append(add_element_citation_id(ids))
         xml.append(ref_el)
@@ -637,26 +641,23 @@ def get_abstracts(xml_tree):
     abstract_without_tag = article_abstracts.abstracts_without_tags
     for abstract in article_abstracts.abstracts_with_tags:
         try:
-            lang = abstract.get('lang')
-            structured = abstract.get('sections')
+            lang = abstract.get("lang")
+            structured = abstract.get("sections")
             if structured == {}:
                 abstracts[lang] = {
-                    'text': abstract_without_tag.get(abstract.get('lang')),
-                    'structured': False
+                    "text": abstract_without_tag.get(abstract.get("lang")),
+                    "structured": False,
                 }
             else:
-                abstracts[lang] = {
-                    'text': structured,
-                    'structured': True
-                }
+                abstracts[lang] = {"text": structured, "structured": True}
         except AttributeError:
             pass
     return abstracts
 
 
 def add_abstract_text(label, text):
-    abstract_text = ET.Element('AbstractText')
-    abstract_text.set('Label', label.upper()[:-1])
+    abstract_text = ET.Element("AbstractText")
+    abstract_text.set("Label", label.upper()[:-1])
     abstract_text.text = text
     return abstract_text
 
@@ -678,13 +679,13 @@ def xml_pubmed_abstract(xml_pubmed, xml_tree):
     </Abstract>
     """
 
-    abstract_el = ET.Element('Abstract')
-    abstract = get_abstracts(xml_tree).get('en')
+    abstract_el = ET.Element("Abstract")
+    abstract = get_abstracts(xml_tree).get("en")
     try:
-        if not abstract['structured']:
-            abstract_el.text = abstract.get('text')
+        if not abstract["structured"]:
+            abstract_el.text = abstract.get("text")
         else:
-            for label, text in abstract.get('text').items():
+            for label, text in abstract.get("text").items():
                 abstract_el.append(add_abstract_text(label, text))
         xml_pubmed.append(abstract_el)
     except TypeError:
@@ -701,14 +702,13 @@ def xml_pubmed_other_abstract(xml_pubmed, xml_tree):
       <AbstractText Label="CONCLUSION">Une meilleure estimation du fardeau économique global des facteurs de risque multiples au sein d’une population peut faciliter l’établissement des priorités et améliorer le soutien aux initiatives de prevention primaire. </AbstractText>
     </OtherAbstract>
     """
-    abstract_el = ET.Element('OtherAbstract')
+    abstract_el = ET.Element("OtherAbstract")
     for lang, abstract in get_abstracts(xml_tree).items():
-        if lang != 'en':
-            abstract_el.set('Language', lang)
-            if not abstract['structured']:
-                abstract_el.text = abstract.get('text')
+        if lang != "en":
+            abstract_el.set("Language", lang)
+            if not abstract["structured"]:
+                abstract_el.text = abstract.get("text")
             else:
-                for label, text in abstract.get('text').items():
+                for label, text in abstract.get("text").items():
                     abstract_el.append(add_abstract_text(label, text))
             xml_pubmed.append(abstract_el)
-  

--- a/packtools/sps/formats/pubmed_generator.py
+++ b/packtools/sps/formats/pubmed_generator.py
@@ -1,7 +1,4 @@
 import argparse
-import xml.dom.minidom as minidom
-
-from lxml import etree as ET
 
 from packtools.sps.formats import pubmed
 from packtools.sps.utils import xml_utils
@@ -30,12 +27,9 @@ def main():
     arguments = parser.parse_args()
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
-    xml_pubmed = ET.ElementTree(pubmed.pipeline_pubmed(xml_tree))
-    xml_string = ET.tostring(xml_pubmed, encoding="utf-8")
-    xml_pubmed_formated = minidom.parseString(xml_string).toprettyxml(indent="  ")
-
+    xml_pubmed = pubmed.pipeline_pubmed(xml_tree)
     with open(arguments.path_to_write, "w", encoding="utf-8") as file:
-        file.write(xml_pubmed_formated)
+        file.write(xml_pubmed)
         print(f"Arquivo criado em: {arguments.path_to_write}")
 
 

--- a/packtools/sps/formats/pubmed_generator.py
+++ b/packtools/sps/formats/pubmed_generator.py
@@ -8,11 +8,25 @@ from packtools.sps.utils import xml_utils
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Convert XML file from SciELO format to Pubmed format.')
-    parser.add_argument('-i', '--xml_scielo', action='store', dest='path_to_read', required=True,
-                        help='Path for reading the SciELO XML file.')
-    parser.add_argument('-o', '--xml_pubmed', action='store', dest='path_to_write', required=True,
-                        help='Path for writing the PubMed XML file.')
+    parser = argparse.ArgumentParser(
+        description="Convert XML file from SciELO format to Pubmed format."
+    )
+    parser.add_argument(
+        "-i",
+        "--xml_scielo",
+        action="store",
+        dest="path_to_read",
+        required=True,
+        help="Path for reading the SciELO XML file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--xml_pubmed",
+        action="store",
+        dest="path_to_write",
+        required=True,
+        help="Path for writing the PubMed XML file.",
+    )
     arguments = parser.parse_args()
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
@@ -25,5 +39,5 @@ def main():
         print(f"Arquivo criado em: {arguments.path_to_write}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
#### O que esse PR faz?
Modifica pmc_pipeline, pubmed_pipeline e crossref_pipeline para retornar str no lugar de xmltree, para facilitar o uso da função, para que a função cliente não tenha que lidar com a árvore de XML.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando os scripts de packtools/sps/formats: crossref_generator.py, pmc_generator.py, pubmed_generator.py

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
