### PR TITLE
Fix: adiciona obtenção de `collab` no modelo

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -1,4 +1,12 @@
 from packtools.sps.models.aff import Affiliation
+from packtools.sps.utils.xml_utils import node_plain_text
+
+
+def _get_collab(node):
+    try:
+        return {"collab": node_plain_text(node.xpath(".//collab")[0])}
+    except IndexError:
+        return {}
 
 
 class Authors:

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -24,7 +24,7 @@ class Authors:
     def contribs(self):
         _data = []
         for node in self.xmltree.xpath(".//front//contrib"):
-            _author = {}
+            _author = _get_collab(node)
             for tag in ("surname", "prefix", "suffix"):
                 data = node.findtext(f".//{tag}")
                 if data:

--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -29,7 +29,8 @@ class Authors:
                 data = node.findtext(f".//{tag}")
                 if data:
                     _author[tag] = data
-            _author["given_names"] = node.findtext(".//given-names")
+            if data := node.findtext(".//given-names"):
+                _author["given_names"] = data
 
             try:
                 _author["orcid"] = node.xpath("contrib-id[@contrib-id-type='orcid']")[

--- a/tests/sps/models/test_article_authors.py
+++ b/tests/sps/models/test_article_authors.py
@@ -323,6 +323,26 @@ class AuthorsWithAffTest(TestCase):
                 <article-meta>
                     <contrib-group>
                         <contrib contrib-type="author">
+                            <collab collab-type="committee">Technical Committee ISO/TC 108, Subcommittee SC 2</collab>
+                            <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                        <contrib contrib-type="author">
+                            <collab>
+                                <named-content content-type="program">Joint United
+                                Nations Program on HIV/AIDS (UNAIDS)</named-content>,
+                                <institution>World Health Organization</institution>,
+                                Geneva, <country>Switzerland</country>
+                            </collab>
+                        </contrib>
+                        <contrib contrib-type="author">
+                            <collab>
+                                <named-content content-type="program">Nonoccupational HIV
+                                PEP Task Force, Brown University AIDS Program</named-content>
+                                and the <institution>Rhode Island Department of
+                                Health</institution>, Providence, Rhode Island
+                            </collab>
+                        </contrib>
+                        <contrib contrib-type="author">
                           <name>
                             <surname>VENEGAS-MARTÍNEZ</surname>
                             <given-names>FRANCISCO</given-names>
@@ -362,7 +382,42 @@ class AuthorsWithAffTest(TestCase):
         self.authors = Authors(xmltree)
 
     def test_contribs(self):
+        self.maxDiff = None
         expected = [
+            {
+                'collab': 'Technical Committee ISO/TC 108, Subcommittee SC 2',
+                "rid": ["aff1"],
+                "rid-aff": ["aff1"],
+                "aff_rids": ["aff1"],
+                "contrib-type": "author",
+                "affs": [
+                    {
+                        "id": "aff1",
+                        "label": "I",
+                        "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
+                        "orgdiv1": None,
+                        "orgdiv2": None,
+                        "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
+                        "city": "Belo Horizonte",
+                        "state": "MG",
+                        "country_code": None,
+                        "country_name": "Brasil",
+                        "email": None,
+                    },
+                ],
+            },
+            {
+                'collab': 'Joint United Nations Program on HIV/AIDS (UNAIDS), World Health Organization, Geneva, '
+                          'Switzerland',
+                'aff_rids': None,
+                'contrib-type': 'author',
+            },
+            {
+                'collab': 'Nonoccupational HIV PEP Task Force, Brown University AIDS Program and the Rhode Island '
+                          'Department of Health, Providence, Rhode Island',
+                'aff_rids': None,
+                'contrib-type': 'author',
+            },
             {
                 "surname": "VENEGAS-MARTÍNEZ",
                 "prefix": "Prof",


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a obtenção de `collab` ao modelo `Authors`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_article_authors.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.
