### PR TITLE
Fix: abstract with subtags

### DIFF
--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -114,18 +114,18 @@ class Abstract:
             p = title = None
             node_title = node.find("title")
             if node_title is not None:
-                title = node_text(node_title)
+                title = get_node_without_subtag(node_title)
 
             node_p = node.find("p")
             if node_p is not None:
-                p = node_text(node_p)
+                p = get_node_without_subtag(node_p)
 
             out["sections"].append({"title": title, "p": p})
         else:
             # abstract/p
             node_p = abstract_node.find("p")
             if node_p is not None:
-                out["p"] = node_text(node_p).strip()
+                out["p"] = get_node_without_subtag(node_p).strip()
         return out
 
     def _format_abstract(self, abstract_node, style=None):

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -72,7 +72,7 @@ article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lan
 </sub-article>
 </article>
 """
-from packtools.sps.utils.xml_utils import node_text, get_node_without_subtag
+from packtools.sps.utils.xml_utils import node_text, get_node_without_subtag, convert_xml_to_html
 
 
 class Abstract:
@@ -80,7 +80,7 @@ class Abstract:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    def _get_structured_abstract(self, abstract_node):
+    def _get_structured_abstract(self, abstract_node, html=False, allowed_tags=None, xml_to_html=None):
         """
         Retorna o resumo estruturado
 
@@ -104,7 +104,8 @@ class Abstract:
         """
         out = dict()
 
-        out["title"] = abstract_node.findtext("title")
+        out["title"] = abstract_node.findtext("title") if not html else \
+            convert_xml_to_html(abstract_node.find("title"), allowed_tags, xml_to_html)
         out["lang"] = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
 
         for node in abstract_node.xpath("sec"):
@@ -114,41 +115,49 @@ class Abstract:
             p = title = None
             node_title = node.find("title")
             if node_title is not None:
-                title = get_node_without_subtag(node_title)
+                title = get_node_without_subtag(node_title) if not html else \
+                    convert_xml_to_html(node_title, allowed_tags, xml_to_html)
 
             node_p = node.find("p")
             if node_p is not None:
-                p = get_node_without_subtag(node_p)
+                p = get_node_without_subtag(node_p) if not html else \
+                    convert_xml_to_html(node_p, allowed_tags, xml_to_html)
 
             out["sections"].append({"title": title, "p": p})
         else:
             # abstract/p
             node_p = abstract_node.find("p")
             if node_p is not None:
-                out["p"] = get_node_without_subtag(node_p).strip()
+                out["p"] = get_node_without_subtag(node_p).strip() if not html else \
+                    convert_xml_to_html(node_p, allowed_tags, xml_to_html)
         return out
 
-    def _format_abstract(self, abstract_node, style=None):
+    def _format_abstract(self, abstract_node, style=None, html=False, allowed_tags=None, xml_to_html=None):
         if style == "xml":
             # formato xml
             return node_text(abstract_node)
 
         if style == "inline":
             # retorna o conteúdo do nó abstract como str
+            if html:
+                return convert_xml_to_html(abstract_node, allowed_tags, xml_to_html)
             return get_node_without_subtag(abstract_node, remove_extra_spaces=True)
 
         if style == "only_p":
             # retorna somente o conteúdo dos nós abstract//p como str
             texts = []
             for node_p in abstract_node.xpath(".//p"):
-                p_text = get_node_without_subtag(node_p)
+                if html:
+                    p_text = convert_xml_to_html(node_p, allowed_tags, xml_to_html)
+                else:
+                    p_text = get_node_without_subtag(node_p)
                 texts.append(p_text.strip())
             return " ".join(texts)
 
         # retorna abstract em formato de dicionário
-        return self._get_structured_abstract(abstract_node)
+        return self._get_structured_abstract(abstract_node, html, allowed_tags, xml_to_html)
 
-    def get_main_abstract(self, style=None):
+    def get_main_abstract(self, style=None, html=False, allowed_tags=None, xml_to_html=None):
         """
         Retorna o resumo principal no formato indicado.
         Formato padrão: inline
@@ -159,6 +168,9 @@ class Abstract:
             abstract = self._format_abstract(
                 abstract_node=abstract_node,
                 style=style,
+                html=html,
+                allowed_tags=allowed_tags,
+                xml_to_html=xml_to_html
             )
             article_lang = self.xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
             abstract_lang = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
@@ -170,7 +182,7 @@ class Abstract:
                 "abstract": abstract
             }
 
-    def _get_sub_article_abstracts(self, style=None):
+    def _get_sub_article_abstracts(self, style=None, html=False, allowed_tags=None, xml_to_html=None):
         """
         Retorna gerador de resumos em sub-article
         """
@@ -184,14 +196,17 @@ class Abstract:
                 item["lang"] = abstract_lang or sub_article_lang
                 item["abstract"] = self._format_abstract(
                     abstract_node=abstract_node,
-                    style=style
+                    style=style,
+                    html=html,
+                    allowed_tags=allowed_tags,
+                    xml_to_html=xml_to_html
                 )
                 if not style:
                     item["abstract"]["lang"] = item["lang"]
                 item['id'] = sub_article.get("id")
                 yield item
 
-    def _get_trans_abstracts(self, style=None):
+    def _get_trans_abstracts(self, style=None, html=False, allowed_tags=None, xml_to_html=None):
         """
         Retorna gerador de resumos trans-abstract
         """
@@ -201,7 +216,10 @@ class Abstract:
             item["lang"] = trans_abstract.get("{http://www.w3.org/XML/1998/namespace}lang")
             item["abstract"] = self._format_abstract(
                 abstract_node=trans_abstract,
-                style=style
+                style=style,
+                html=html,
+                allowed_tags=allowed_tags,
+                xml_to_html=xml_to_html
             )
             yield item
 

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -105,8 +105,10 @@ class Abstract:
         """
         out = dict()
 
-        out["title"] = process_subtags(abstract_node.find("title"), tags_to_keep, tags_to_remove_with_content,
-                                       tags_to_convert_to_html) if html else abstract_node.findtext("title")
+        node_title = abstract_node.find("title")
+
+        out["title"] = process_subtags(node_title, tags_to_keep, tags_to_remove_with_content,
+                                       tags_to_convert_to_html) if html else get_node_without_subtag(node_title)
 
         out["lang"] = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
 
@@ -195,7 +197,7 @@ class Abstract:
             False -> conteúdo de 'abstract' no formato indicado por 'style' (padrão)
         tags_to_keep : list
             Lista de 'tags' que serão mantidas no formato HTML, os valores em 'tags_to_keep' serão
-            complementados com as seguites 'tags': ['sup', 'sub', 'mml'] (padrão)
+            complementados com as seguites 'tags': ['sup', 'sub', 'mml:math', 'math'] (padrão)
         tags_to_remove_with_content : list
             Lista de 'tags' que serão removidas com o respectivo conteúdo no formato HTML,
             os valores em 'tags_to_remove_with_content' serão complementados com as seguites 'tags': ['xref'] (padrão)
@@ -263,7 +265,7 @@ class Abstract:
             False -> conteúdo de 'abstract' no formato indicado por 'style' (padrão)
         tags_to_keep : list
             Lista de 'tags' que serão mantidas no formato HTML, os valores em 'tags_to_keep' serão
-            complementados com as seguites 'tags': ['sup', 'sub', 'mml'] (padrão)
+            complementados com as seguites 'tags': ['sup', 'sub', 'mml:math', 'math'] (padrão)
         tags_to_remove_with_content : list
             Lista de 'tags' que serão removidas com o respectivo conteúdo no formato HTML,
             os valores em 'tags_to_remove_with_content' serão complementados com as seguites 'tags': ['xref'] (padrão)
@@ -334,7 +336,7 @@ class Abstract:
             False -> conteúdo de 'trans-abstract' no formato indicado por 'style' (padrão)
         tags_to_keep : list
             Lista de 'tags' que serão mantidas no formato HTML, os valores em 'tags_to_keep' serão
-            complementados com as seguites 'tags': ['sup', 'sub', 'mml'] (padrão)
+            complementados com as seguites 'tags': ['sup', 'sub', 'mml:math', 'math'] (padrão)
         tags_to_remove_with_content : list
             Lista de 'tags' que serão removidas com o respectivo conteúdo no formato HTML,
             os valores em 'tags_to_remove_with_content' serão complementados com as seguites 'tags': ['xref'] (padrão)

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -105,9 +105,9 @@ class Abstract:
         """
         out = dict()
 
-        out["title"] = abstract_node.findtext("title") if not html else \
-            process_subtags(abstract_node.find("title"), tags_to_keep, tags_to_remove_with_content,
-                            tags_to_convert_to_html)
+        out["title"] = process_subtags(abstract_node.find("title"), tags_to_keep, tags_to_remove_with_content,
+                                       tags_to_convert_to_html) if html else abstract_node.findtext("title")
+
         out["lang"] = abstract_node.get("{http://www.w3.org/XML/1998/namespace}lang")
 
         for node in abstract_node.xpath("sec"):
@@ -117,21 +117,22 @@ class Abstract:
             p = title = None
             node_title = node.find("title")
             if node_title is not None:
-                title = get_node_without_subtag(node_title) if not html else \
-                    process_subtags(node_title, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
+                title = process_subtags(node_title, tags_to_keep, tags_to_remove_with_content,
+                                        tags_to_convert_to_html) if html else get_node_without_subtag(node_title)
 
             node_p = node.find("p")
             if node_p is not None:
-                p = get_node_without_subtag(node_p) if not html else \
-                    process_subtags(node_p, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
+                p = process_subtags(node_p, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html) \
+                    if html else get_node_without_subtag(node_p)
 
             out["sections"].append({"title": title, "p": p})
         else:
             # abstract/p
             node_p = abstract_node.find("p")
             if node_p is not None:
-                out["p"] = get_node_without_subtag(node_p).strip() if not html else \
-                    process_subtags(node_p, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
+                out["p"] = process_subtags(node_p, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html) \
+                    if html else get_node_without_subtag(node_p).strip()
+
         return out
 
     def _format_abstract(self, abstract_node, style=None, html=False, tags_to_keep=None,

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -145,7 +145,7 @@ def get_node_without_subtag(node, remove_extra_spaces=False):
         Função que retorna nó sem subtags.
     """
     if remove_extra_spaces:
-        return " ".join([text.strip()for text in node.xpath(".//text()") if text.strip()])
+        return " ".join([text.strip() for text in node.xpath(".//text()") if text.strip()])
     return "".join(node.xpath(".//text()"))
 
 
@@ -317,3 +317,35 @@ def match_pubdate(node, pubdate_xpaths):
         pubdate = node.find(xpath)
         if pubdate is not None:
             return pubdate
+
+
+def remove_subtags(node, allowed_tags=None):
+    """
+    Remove as subtags de node que não estiverem especificadas em allowed_tags.
+
+    Exemplo:
+        Entrada: <bold><italic>São</italic> Paulo</bold> <i>Paulo</i>, ['italic']
+        Saída: <italic>São</italic> Paulo Paulo
+
+    Outros exemplos nos testes.
+    """
+    if allowed_tags is None:
+        allowed_tags = []
+    text = node.text if node.text is not None else ''
+    for child in node:
+        text += remove_subtags(child, allowed_tags)
+        if child.tail is not None:
+            text += child.tail
+    if node.tag in allowed_tags:
+        return f'<{node.tag}>{text}</{node.tag}>'
+    else:
+        return text
+
+
+def convert_xml_to_html(node, allowed_tags=None, xml_to_html=None):
+    text = remove_subtags(node, allowed_tags)
+    if xml_to_html is not None and isinstance(xml_to_html, dict):
+        for xml_tag, html_tag in xml_to_html.items():
+            text = text.replace(f'<{xml_tag}>', f'<{html_tag}>')
+            text = text.replace(f'</{xml_tag}>', f'</{html_tag}>')
+    return text

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -339,13 +339,14 @@ def remove_subtags(node, allowed_tags=None):
     if node.tag in allowed_tags:
         return f'<{node.tag}>{text}</{node.tag}>'
     else:
-        return text
+        return ' '.join(text.split())
 
 
 def convert_xml_to_html(node, allowed_tags=None, xml_to_html=None):
     text = remove_subtags(node, allowed_tags)
     if xml_to_html is not None and isinstance(xml_to_html, dict):
         for xml_tag, html_tag in xml_to_html.items():
+            text = text.replace(f'<{xml_tag}', f'<{html_tag}')
             text = text.replace(f'<{xml_tag}>', f'<{html_tag}>')
             text = text.replace(f'</{xml_tag}>', f'</{html_tag}>')
     return text

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -355,15 +355,34 @@ def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, ta
     return text
 
 
+def process_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, tags_to_convert_to_html=None):
+    std_to_keep = ['sup', 'sub', 'mml']
+    std_to_remove_content = ['xref']
+    std_to_convert = {'italic': 'i'}
+
+    # garante que as tags em std_to_keep serão mantidas
+    if tags_to_keep is None:
+        tags_to_keep = std_to_keep
     else:
-        return ' '.join(text.split())
+        tags_to_keep = list(set(tags_to_keep + std_to_keep))
 
+    # garante que as tags em std_to_remove_content serão removidas
+    if tags_to_remove_with_content is None:
+        tags_to_remove_with_content = std_to_remove_content
+    else:
+        tags_to_remove_with_content = list(set(tags_to_remove_with_content + std_to_remove_content))
 
-def convert_xml_to_html(node, allowed_tags=None, xml_to_html=None):
-    text = remove_subtags(node, allowed_tags)
-    if xml_to_html is not None and isinstance(xml_to_html, dict):
-        for xml_tag, html_tag in xml_to_html.items():
-            text = text.replace(f'<{xml_tag}', f'<{html_tag}')
-            text = text.replace(f'<{xml_tag}>', f'<{html_tag}>')
-            text = text.replace(f'</{xml_tag}>', f'</{html_tag}>')
+    # garante que as tags em std_to_convert serão convertidas em html
+    if tags_to_convert_to_html is None or not isinstance(tags_to_convert_to_html, dict):
+        tags_to_convert_to_html = std_to_convert
+    else:
+        tags_to_convert_to_html.update(std_to_convert)
+
+    text = remove_subtags(node, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
+
+    for xml_tag, html_tag in tags_to_convert_to_html.items():
+        text = text.replace(f'<{xml_tag}', f'<{html_tag}')
+        text = text.replace(f'<{xml_tag}>', f'<{html_tag}>')
+        text = text.replace(f'</{xml_tag}>', f'</{html_tag}>')
+
     return text

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -319,11 +319,11 @@ def match_pubdate(node, pubdate_xpaths):
             return pubdate
 
 
-def remove_subtags(node, allowed_tags=None):
 def _generate_tag_list(tags_to_keep, tags_to_convert_to_html):
     return list(tags_to_keep or []) + list(tags_to_convert_to_html and tags_to_convert_to_html.keys() or [])
 
 
+def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, tags_to_convert_to_html=None):
     """
     Remove as subtags de node que não estiverem especificadas em allowed_tags.
 

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -356,7 +356,7 @@ def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, ta
 
 
 def process_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, tags_to_convert_to_html=None):
-    std_to_keep = ['sup', 'sub', 'mml']
+    std_to_keep = ['sup', 'sub', 'mml:math', 'math']
     std_to_remove_content = ['xref']
     std_to_convert = {'italic': 'i'}
 
@@ -367,21 +367,16 @@ def process_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, t
         tags_to_keep = list(set(tags_to_keep + std_to_keep))
 
     # garante que as tags em std_to_remove_content serão removidas
-    if tags_to_remove_with_content is None:
-        tags_to_remove_with_content = std_to_remove_content
-    else:
-        tags_to_remove_with_content = list(set(tags_to_remove_with_content + std_to_remove_content))
+    tags_to_remove_with_content = std_to_remove_content + (tags_to_remove_with_content or [])
+    tags_to_remove_with_content = list(set(tags_to_remove_with_content))
 
     # garante que as tags em std_to_convert serão convertidas em html
-    if tags_to_convert_to_html is None or not isinstance(tags_to_convert_to_html, dict):
-        tags_to_convert_to_html = std_to_convert
-    else:
-        tags_to_convert_to_html.update(std_to_convert)
+    std_to_convert.update(tags_to_convert_to_html or {})
 
-    text = remove_subtags(node, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
+    text = remove_subtags(node, tags_to_keep, tags_to_remove_with_content, std_to_convert)
 
-    for xml_tag, html_tag in tags_to_convert_to_html.items():
-        text = text.replace(f'<{xml_tag}', f'<{html_tag}')
+    for xml_tag, html_tag in std_to_convert.items():
+        text = text.replace(f'<{xml_tag} ', f'<{html_tag} ')
         text = text.replace(f'<{xml_tag}>', f'<{html_tag}>')
         text = text.replace(f'</{xml_tag}>', f'</{html_tag}>')
 

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -333,15 +333,28 @@ def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, ta
 
     Outros exemplos nos testes.
     """
-    if allowed_tags is None:
-        allowed_tags = []
+    # verifica se é o caso de remoção do conteúdo da tag
+    if node.tag in (tags_to_remove_with_content or []):
+        return ''
+
+    # obtem o conteúdo da tag
     text = node.text if node.text is not None else ''
+
+    # processa as tags internas
     for child in node:
-        text += remove_subtags(child, allowed_tags)
+        text += remove_subtags(child, tags_to_keep, tags_to_remove_with_content, tags_to_convert_to_html)
         if child.tail is not None:
             text += child.tail
-    if node.tag in allowed_tags:
+
+    # gera uma lista com as tags que serão mantidas
+    all_tags_to_keep = _generate_tag_list(tags_to_keep, tags_to_convert_to_html)
+
+    text = ' '.join(text.split())
+    if node.tag in all_tags_to_keep:
         return f'<{node.tag}>{text}</{node.tag}>'
+    return text
+
+
     else:
         return ' '.join(text.split())
 

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -320,6 +320,10 @@ def match_pubdate(node, pubdate_xpaths):
 
 
 def remove_subtags(node, allowed_tags=None):
+def _generate_tag_list(tags_to_keep, tags_to_convert_to_html):
+    return list(tags_to_keep or []) + list(tags_to_convert_to_html and tags_to_convert_to_html.keys() or [])
+
+
     """
     Remove as subtags de node que não estiverem especificadas em allowed_tags.
 

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -166,8 +166,7 @@ class AbstractWithSectionsTest(TestCase):
         }
         result = self.abstract.get_main_abstract(
             html=True,
-            allowed_tags=['title', 'italic'],
-            xml_to_html={'title': 't', 'italic': 'i'}
+            tags_to_convert_to_html={'title': 't', 'italic': 'i'}
         )
         self.assertDictEqual(expected, result)
 
@@ -215,9 +214,7 @@ class AbstractWithSectionsTest(TestCase):
         }
         result = self.abstract.get_main_abstract(
             style="inline",
-            html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
+            html=True
         )
         self.assertDictEqual(expected, result)
 
@@ -297,8 +294,6 @@ class AbstractWithSectionsTest(TestCase):
         result = self.abstract.get_main_abstract(
             style="only_p",
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         self.assertDictEqual(expected, result)
 
@@ -471,8 +466,7 @@ class AbstractWithSectionsTest(TestCase):
         )
         result = self.abstract._get_sub_article_abstracts(
             html=True,
-            allowed_tags=['italic', 'bold'],
-            xml_to_html={'italic': 'i', 'bold': 'b'}
+            tags_to_convert_to_html={'bold': 'b'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(res["lang"]):
@@ -550,8 +544,6 @@ class AbstractWithSectionsTest(TestCase):
         )
         result = self.abstract._get_trans_abstracts(
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):
@@ -643,7 +635,7 @@ class AbstractWithoutSectionsTest(TestCase):
             'parent_name': 'article',
             "abstract": {
                 "lang": "en",
-                "title": "<t>Abstract</t>",
+                "title": "<title>Abstract</title>",
                 "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
                      "elderly people. Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) "
                      "comparing day hospital care with comprehensive care (five trials), domiciliary care "
@@ -652,8 +644,7 @@ class AbstractWithoutSectionsTest(TestCase):
         }
         result = self.abstract.get_main_abstract(
             html=True,
-            allowed_tags=['title', 'italic'],
-            xml_to_html={'title': 't', 'italic': 'i'}
+            tags_to_keep=['title'],
         )
         self.assertDictEqual(expected, result)
 
@@ -677,8 +668,6 @@ class AbstractWithoutSectionsTest(TestCase):
         result = self.abstract.get_main_abstract(
             style="inline",
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         self.assertDictEqual(expected, result)
 
@@ -717,8 +706,6 @@ class AbstractWithoutSectionsTest(TestCase):
         result = self.abstract.get_main_abstract(
             style="only_p",
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         self.assertDictEqual(expected, result)
 
@@ -837,8 +824,6 @@ class AbstractWithoutSectionsTest(TestCase):
         )
         result = self.abstract._get_sub_article_abstracts(
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(res["lang"]):
@@ -886,8 +871,6 @@ class AbstractWithoutSectionsTest(TestCase):
         )
         result = self.abstract._get_trans_abstracts(
             html=True,
-            allowed_tags=['italic'],
-            xml_to_html={'italic': 'i'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):
@@ -1053,30 +1036,30 @@ class AbstractWithStylesTest(TestCase):
             'parent_name': 'article',
             "abstract": {
                 "lang": "en",
-                "title": "<t>Abstract</t>",
+                "title": "<title>Abstract</title>",
                 "sections": [{
-                    "title": "<t>inicio</t>",
+                    "title": "<title>inicio</title>",
                     "p": "<b>conteúdo de bold</b> text",
                 },
                     {
-                        "title": "<t>meio</t>",
+                        "title": "<title>meio</title>",
                         "p": "text <b>conteúdo de bold</b> text",
                     },
                     {
-                        "title": "<t>fim</t>",
+                        "title": "<title>fim</title>",
                         "p": "text <b>conteúdo de bold</b>",
                     },
                     {
-                        "title": "<t>aninhado</t>",
-                        "p": "text <b>conteúdo de bold</b>",
+                        "title": "<title>aninhado</title>",
+                        "p": "text <b>conteúdo <i>de</i> bold</b>",
 
                     }],
             }
         }
         result = self.abstract.get_main_abstract(
             html=True,
-            allowed_tags=['title', 'bold'],
-            xml_to_html={'title': 't', 'bold': 'b'}
+            tags_to_keep=['title'],
+            tags_to_convert_to_html={'bold': 'b'}
         )
         self.assertDictEqual(expected, result)
 
@@ -1144,8 +1127,7 @@ class AbstractWithStylesTest(TestCase):
         result = self.abstract.get_main_abstract(
             style="inline",
             html=True,
-            allowed_tags=['italic', 'bold'],
-            xml_to_html={'italic': 'i', 'bold': 'b'}
+            tags_to_convert_to_html={'bold': 'b'}
         )
         self.assertDictEqual(expected, result)
 
@@ -1239,8 +1221,7 @@ class AbstractWithStylesTest(TestCase):
         result = self.abstract.get_main_abstract(
             style="only_p",
             html=True,
-            allowed_tags=['italic', 'bold'],
-            xml_to_html={'italic': 'i', 'bold': 'b'}
+            tags_to_convert_to_html={'italic': 'i', 'bold': 'b'}
         )
         self.assertDictEqual(expected, result)
 
@@ -1365,8 +1346,7 @@ class AbstractWithStylesTest(TestCase):
         )
         result = self.abstract._get_sub_article_abstracts(
             html=True,
-            allowed_tags=['italic', 'bold'],
-            xml_to_html={'italic': 'i', 'bold': 'b'}
+            tags_to_convert_to_html={'italic': 'i', 'bold': 'b'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(res["lang"]):
@@ -1425,8 +1405,7 @@ class AbstractWithStylesTest(TestCase):
         )
         result = self.abstract._get_trans_abstracts(
             html=True,
-            allowed_tags=['italic', 'bold'],
-            xml_to_html={'italic': 'i', 'bold': 'b'}
+            tags_to_convert_to_html={'italic': 'i', 'bold': 'b'}
         )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -112,21 +112,63 @@ class AbstractWithSectionsTest(TestCase):
             "abstract": {
                 "lang": "en",
                 "title": "Abstract",
-                "sections": [{
-                    "title": "Objective",
-                    "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
-                         "elderly people.",
-                },
-                {
-                    "title": "Design",
-                    "p": "Systematic review of 12 controlled clinical trials (available by January 1997) comparing day "
-                         "hospital care with comprehensive care (five trials), domiciliary care (four trials), "
-                         "or no comprehensive care (three trials).",
+                "sections": [
+                    {
+                        "title": "Objective",
+                        "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
+                             "elderly people.",
+                    },
+                    {
+                        "title": "Design",
+                        "p": "Systematic review of 12 controlled clinical trials (available by January 1997) comparing day "
+                             "hospital care with comprehensive care (five trials), domiciliary care (four trials), "
+                             "or no comprehensive care (three trials).",
 
-                }],
+                    }],
             }
         }
         result = self.abstract.get_main_abstract()
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_default_style_html(self):
+        self.maxDiff = None
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": {
+                "lang": "en",
+                "title": "<t>Abstract</t>",
+                "sections": [
+                    {
+                        "title": "<t>Objective</t>",
+                        "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
+                             "elderly people.",
+                    },
+                    {
+                        "title": "<t>Design</t>",
+                        "p": "Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) comparing day "
+                             "hospital care with comprehensive care (five trials), domiciliary care (four trials), "
+                             "or no comprehensive care (three trials).",
+
+                    }],
+            }
+        }
+        result = self.abstract.get_main_abstract(
+            html=True,
+            allowed_tags=['title', 'italic'],
+            xml_to_html={'title': 't', 'italic': 'i'}
+        )
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_inline(self):
@@ -147,6 +189,36 @@ class AbstractWithSectionsTest(TestCase):
             "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Design Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="inline")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_inline_html(self):
+        self.maxDiff = None
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": "Abstract Objective To examine the effectiveness of day hospital attendance in prolonging "
+                        "independent living for elderly people. Design Systematic review of 12 controlled "
+                        "<i>clinical trials</i> (available by January 1997) comparing day hospital care with "
+                        "comprehensive care (five trials), domiciliary care (four trials), or no comprehensive "
+                        "care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(
+            style="inline",
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_xml(self):
@@ -180,7 +252,9 @@ class AbstractWithSectionsTest(TestCase):
         self.assertIn("<italic>clinical trials</italic>", result["abstract"])
         self.assertIn("<title>Objective</title>", result["abstract"])
         self.assertIn("<title>Design</title>", result["abstract"])
-        self.assertIn("<p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>", result["abstract"])
+        self.assertIn(
+            "<p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>",
+            result["abstract"])
 
     def test_get_main_abstract_only_p(self):
         """
@@ -200,6 +274,32 @@ class AbstractWithSectionsTest(TestCase):
             "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_only_p_html(self):
+        self.maxDiff = None
+        """
+        <title>Abstract</title>
+        <sec>
+            <title>Objective</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.</p>
+        </sec>
+        <sec>
+            <title>Design</title>
+            <p>Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(
+            style="only_p",
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         self.assertDictEqual(expected, result)
 
     def test__get_sub_article_abstracts(self):
@@ -288,6 +388,96 @@ class AbstractWithSectionsTest(TestCase):
             with self.subTest(res["lang"]):
                 self.assertDictEqual(exp, res)
 
+    def test__get_sub_article_abstracts_html(self):
+        """
+        <sub-article article-type="translation" xml:lang="es">
+            <front-stub>
+                <abstract>
+                    <title>Resumen</title>
+                    <sec>
+                      <title>Objetivo: </title>
+                      <p>evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. </p>
+                    </sec>
+                    <sec>
+                      <title>Método: </title>
+                      <p>Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. </p>
+                    </sec>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        <sub-article article-type="translation" xml:lang="de">
+            <front-stub>
+                <abstract>
+                    <title>Zusammenfassung</title>
+                    <sec>
+                      <title>Ziel: </title>
+                      <p>Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung.</p>
+                    </sec>
+                    <sec>
+                      <title>Methode: </title>
+                      <p>Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben.</p>
+                    </sec>
+                  </abstract>
+            </front-stub>
+        </sub-article>
+        """
+        self.maxDiff = None
+        expected = (
+            {
+                "lang": "es",
+                'parent_name': 'sub-article',
+                "abstract": {
+                    "lang": "es",
+                    "title": "Resumen",
+                    "sections": [
+                        {
+                            "title": "Objetivo:",
+                            "p": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la "
+                                 "calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de "
+                                 "accidentes cerebrovasculares."
+                        },
+                        {
+                            "title": "Método:",
+                            "p": "Ensayo Clínico Aleatorizado ... <i>World Health Organization Quality of Life "
+                                 "Assessment</i> (WHOQOL-BREF) y el módulo <i>Old</i>(WHOQOL-OLD) "
+                                 "1semana, 2meses y 1año después del alta."
+                        },
+                    ]
+                },
+                "id": "01"
+            },
+            {
+                "lang": "de",
+                'parent_name': 'sub-article',
+                "abstract": {
+                    "lang": "de",
+                    "title": "Zusammenfassung",
+                    "sections": [
+                        {
+                            "title": "Ziel:",
+                            "p": "Randomisierte klinische Studie... Modul <i>Alt</i> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 "
+                                 "Jahr nach der Entlassung."
+                        },
+                        {
+                            "title": "Methode:",
+                            "p": "Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die "
+                                 "Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre "
+                                 "Unfälle überlebt haben."
+                        },
+                    ]
+                },
+                "id": "02"
+            },
+        )
+        result = self.abstract._get_sub_article_abstracts(
+            html=True,
+            allowed_tags=['italic', 'bold'],
+            xml_to_html={'italic': 'i', 'bold': 'b'}
+        )
+        for res, exp in zip(result, expected):
+            with self.subTest(res["lang"]):
+                self.assertDictEqual(exp, res)
+
     def test__get_trans_abstracts(self):
         """
         <trans-abstract xml:lang="pt">
@@ -324,15 +514,15 @@ class AbstractWithSectionsTest(TestCase):
                     "title": "Resumo",
                     "sections": [
                         {
-                            "title": "Objetivo: ",
+                            "title": "Objetivo:",
                             "p": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de "
                                  "vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral "
-                                 "(AVC). "
+                                 "(AVC)."
                         },
                         {
-                            "title": "Método: ",
-                            "p": "Ensaio Clínico Randomizado... Módulo Old (WHOQOL-OLD) em 1 semana, "
-                                 "2 meses e 1 ano após a alta. "
+                            "title": "Método:",
+                            "p": "Ensaio Clínico Randomizado... Módulo <i>Old</i> (WHOQOL-OLD) em 1 semana, "
+                                 "2 meses e 1 ano após a alta."
                         },
                     ]
                 }
@@ -345,20 +535,24 @@ class AbstractWithSectionsTest(TestCase):
                     "title": "Résumé",
                     "sections": [
                         {
-                            "title": "Objectif: ",
+                            "title": "Objectif:",
                             "p": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de "
                                  "vie des aidants familiaux de personnes âgées ayant survécu à un AVC."
                         },
                         {
-                            "title": "Méthode: ",
-                            "p": "Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 "
+                            "title": "Méthode:",
+                            "p": "Essai clinique randomisé... Module <i>Old</i> (WHOQOL-OLD) à 1 semaine, 2 "
                                  "mois et 1 an après la sortie."
                         },
                     ]
                 }
             },
         )
-        result = self.abstract._get_trans_abstracts()
+        result = self.abstract._get_trans_abstracts(
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):
                 self.assertDictEqual(exp, res)
@@ -436,13 +630,56 @@ class AbstractWithoutSectionsTest(TestCase):
         result = self.abstract.get_main_abstract()
         self.assertDictEqual(expected, result)
 
+    def test_get_main_abstract_default_style_html(self):
+        '''
+        <abstract>
+            <title>Abstract</title>
+            <p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>
+        </abstract>
+        '''
+        self.maxDiff = None
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": {
+                "lang": "en",
+                "title": "<t>Abstract</t>",
+                "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
+                     "elderly people. Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) "
+                     "comparing day hospital care with comprehensive care (five trials), domiciliary care "
+                     "(four trials), or no comprehensive care (three trials).",
+            }
+        }
+        result = self.abstract.get_main_abstract(
+            html=True,
+            allowed_tags=['title', 'italic'],
+            xml_to_html={'title': 't', 'italic': 'i'}
+        )
+        self.assertDictEqual(expected, result)
+
     def test_get_main_abstract_inline(self):
+        self.maxDiff = None
         expected = {
             "lang": "en",
             'parent_name': 'article',
             "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="inline")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_inline_html(self):
+        self.maxDiff = None
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": "Abstract To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(
+            style="inline",
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_xml(self):
@@ -456,7 +693,9 @@ class AbstractWithoutSectionsTest(TestCase):
         self.assertEqual(expected["lang"], result["lang"])
         self.assertIn("<title>Abstract</title>", result["abstract"])
         self.assertIn("<italic>clinical trials</italic>", result["abstract"])
-        self.assertIn("<p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>", result["abstract"])
+        self.assertIn(
+            "<p>To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).</p>",
+            result["abstract"])
 
     def test_get_main_abstract_only_p(self):
         self.maxDiff = None
@@ -466,6 +705,21 @@ class AbstractWithoutSectionsTest(TestCase):
             "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
         }
         result = self.abstract.get_main_abstract(style="only_p")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_only_p_html(self):
+        self.maxDiff = None
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <i>clinical trials</i> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials)."
+        }
+        result = self.abstract.get_main_abstract(
+            style="only_p",
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         self.assertDictEqual(expected, result)
 
     def test__get_sub_article_abstracts(self):
@@ -527,6 +781,69 @@ class AbstractWithoutSectionsTest(TestCase):
             with self.subTest(res["lang"]):
                 self.assertDictEqual(exp, res)
 
+    def test__get_sub_article_abstracts_html(self):
+        """
+        <article>
+        <sub-article article-type="translation" id="01" xml:lang="es">
+        <front-stub>
+        <abstract>
+        <title>Resumen</title>
+        <p>
+        Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).</p>
+        </abstract>
+        </front-stub>
+        </sub-article>
+        <sub-article article-type="translation" id="02" xml:lang="it">
+        <front-stub>
+        <abstract>
+        <title>Riepilogo</title>
+        <p>
+        Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).</p>
+        </abstract>
+        </front-stub>
+        </sub-article>
+        </article>
+        """
+        self.maxDiff = None
+        expected = (
+            {
+                "lang": "es",
+                'parent_name': 'sub-article',
+                "abstract": {
+                    "lang": "es",
+                    "title": "Resumen",
+                    "p": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida "
+                         "independiente de las personas mayores. Revisión sistemática de 12 <i>ensayos clínicos</i> "
+                         "controlados (disponibles en enero de 1997) que compararon la atención hospitalaria "
+                         "de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) "
+                         "o ninguna atención integral (tres ensayos).",
+                },
+                "id": "01"
+            },
+            {
+                "lang": "it",
+                'parent_name': 'sub-article',
+                "abstract": {
+                    "lang": "it",
+                    "title": "Riepilogo",
+                    "p": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita "
+                         "autonoma delle persone anziane. Revisione sistematica di 12 <i>studi clinici</i> controllati "
+                         "(disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con "
+                         "l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna "
+                         "assistenza completa (tre studi).",
+                },
+                "id": "02"
+            },
+        )
+        result = self.abstract._get_sub_article_abstracts(
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
+        for res, exp in zip(result, expected):
+            with self.subTest(res["lang"]):
+                self.assertDictEqual(exp, res)
+
     def test__get_trans_abstracts(self):
         self.maxDiff = None
         """
@@ -547,7 +864,7 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "pt",
                     "title": "Resumo",
                     "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de "
-                         "idosos. Revisão sistemática de 12 estudos clínicos controlados (disponível "
+                         "idosos. Revisão sistemática de 12 <i>estudos clínicos</i> controlados (disponível "
                          "em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente "
                          "(cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente "
                          "(três ensaios).",
@@ -560,14 +877,18 @@ class AbstractWithoutSectionsTest(TestCase):
                     "lang": "fr",
                     "title": "Résumé",
                     "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie "
-                         "autonome des personnes âgées. Revue systématique de 12 essais cliniques "
+                         "autonome des personnes âgées. Revue systématique de 12 <i>essais cliniques</i> "
                          "contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins "
                          "complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins "
                          "complets (trois essais).",
                 }
             },
         )
-        result = self.abstract._get_trans_abstracts()
+        result = self.abstract._get_trans_abstracts(
+            html=True,
+            allowed_tags=['italic'],
+            xml_to_html={'italic': 'i'}
+        )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):
                 self.assertDictEqual(exp, res)
@@ -689,22 +1010,74 @@ class AbstractWithStylesTest(TestCase):
                     "title": "inicio",
                     "p": "conteúdo de bold text ",
                 },
-                {
-                    "title": "meio",
-                    "p": "text conteúdo de bold text ",
-                },
-                {
-                    "title": "fim",
-                    "p": "text conteúdo de bold",
-                },
-                {
-                    "title": "aninhado",
-                    "p": "text conteúdo de bold",
+                    {
+                        "title": "meio",
+                        "p": "text conteúdo de bold text ",
+                    },
+                    {
+                        "title": "fim",
+                        "p": "text conteúdo de bold",
+                    },
+                    {
+                        "title": "aninhado",
+                        "p": "text conteúdo de bold",
 
-                }],
+                    }],
             }
         }
         result = self.abstract.get_main_abstract()
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_default_style_html(self):
+        self.maxDiff = None
+        """
+        <sec>
+            <title>inicio</title>
+            <p><bold>conteúdo de bold</bold> text </p>
+        </sec>
+        <sec>
+            <title>meio</title>
+            <p>text <bold>conteúdo de bold</bold> text </p>
+        </sec>
+        <sec>
+            <title>fim</title>
+            <p>text <bold>conteúdo de bold</bold></p>
+        </sec>
+        <sec>
+            <title>aninhado</title>
+            <p>text <bold>conteúdo <italic>de</italic> bold</bold></p>
+        </sec>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": {
+                "lang": "en",
+                "title": "<t>Abstract</t>",
+                "sections": [{
+                    "title": "<t>inicio</t>",
+                    "p": "<b>conteúdo de bold</b> text",
+                },
+                    {
+                        "title": "<t>meio</t>",
+                        "p": "text <b>conteúdo de bold</b> text",
+                    },
+                    {
+                        "title": "<t>fim</t>",
+                        "p": "text <b>conteúdo de bold</b>",
+                    },
+                    {
+                        "title": "<t>aninhado</t>",
+                        "p": "text <b>conteúdo de bold</b>",
+
+                    }],
+            }
+        }
+        result = self.abstract.get_main_abstract(
+            html=True,
+            allowed_tags=['title', 'bold'],
+            xml_to_html={'title': 't', 'bold': 'b'}
+        )
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_inline(self):
@@ -737,6 +1110,43 @@ class AbstractWithStylesTest(TestCase):
                         'text fim text conteúdo de bold aninhado text conteúdo de bold',
         }
         result = self.abstract.get_main_abstract(style="inline")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_inline_html(self):
+        self.maxDiff = None
+        """
+        <abstract>
+                <title>Abstract</title>
+                <sec>
+                    <title>inicio</title>
+                    <p><bold>conteúdo de bold</bold> text </p>
+                </sec>
+                <sec>
+                    <title>meio</title>
+                    <p>text <bold>conteúdo de bold</bold> text </p>
+                </sec>
+                <sec>
+                    <title>fim</title>
+                    <p>text <bold>conteúdo de bold</bold></p>
+                </sec>
+                <sec>
+                    <title>aninhado</title>
+                    <p>text <bold>conteúdo <italic>de</italic> bold</bold></p>
+                </sec>
+            </abstract>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": 'Abstract inicio <b>conteúdo de bold</b> text meio text <b>conteúdo de bold</b> '
+                        'text fim text <b>conteúdo de bold</b> aninhado text <b>conteúdo <i>de</i> bold</b>',
+        }
+        result = self.abstract.get_main_abstract(
+            style="inline",
+            html=True,
+            allowed_tags=['italic', 'bold'],
+            xml_to_html={'italic': 'i', 'bold': 'b'}
+        )
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_xml(self):
@@ -796,6 +1206,42 @@ class AbstractWithStylesTest(TestCase):
             "abstract": 'conteúdo de bold text text conteúdo de bold text text conteúdo de bold text conteúdo de bold',
         }
         result = self.abstract.get_main_abstract(style="only_p")
+        self.assertDictEqual(expected, result)
+
+    def test_get_main_abstract_only_p_html(self):
+        """
+        <abstract>
+                <title>Abstract</title>
+                <sec>
+                    <title>inicio</title>
+                    <p><bold>conteúdo de bold</bold> text </p>
+                </sec>
+                <sec>
+                    <title>meio</title>
+                    <p>text <bold>conteúdo de bold</bold> text </p>
+                </sec>
+                <sec>
+                    <title>fim</title>
+                    <p>text <bold>conteúdo de bold</bold></p>
+                </sec>
+                <sec>
+                    <title>aninhado</title>
+                    <p>text <bold>conteúdo <italic>de</italic> bold</bold></p>
+                </sec>
+            </abstract>
+        """
+        expected = {
+            "lang": "en",
+            'parent_name': 'article',
+            "abstract": '<b>conteúdo de bold</b> text text <b>conteúdo de bold</b> text text <b>conteúdo de bold</b> '
+                        'text <b>conteúdo <i>de</i> bold</b>',
+        }
+        result = self.abstract.get_main_abstract(
+            style="only_p",
+            html=True,
+            allowed_tags=['italic', 'bold'],
+            xml_to_html={'italic': 'i', 'bold': 'b'}
+        )
         self.assertDictEqual(expected, result)
 
     def test__get_sub_article_abstracts(self):
@@ -860,6 +1306,72 @@ class AbstractWithStylesTest(TestCase):
             with self.subTest(res["lang"]):
                 self.assertDictEqual(exp, res)
 
+    def test__get_sub_article_abstracts_html(self):
+        self.maxDiff = None
+        """
+        <sub-article article-type="translation" id="01" xml:lang="es">
+            <front-stub>
+                <abstract>
+                    <title>Abstract</title>
+                    <sec>
+                        <title>inicio</title>
+                        <p><bold>conteúdo de bold</bold> text </p>
+                    </sec>
+                    <sec>
+                        <title>meio</title>
+                        <p>text <bold>conteúdo de bold</bold> text </p>
+                    </sec>
+                    <sec>
+                        <title>fim</title>
+                        <p>text <bold>conteúdo de bold</bold></p>
+                    </sec>
+                    <sec>
+                        <title>aninhado</title>
+                        <p>text <bold>conteúdo <italic>de</italic> bold</bold></p>
+                    </sec>
+                </abstract>
+            </front-stub>
+        </sub-article>
+        """
+        self.maxDiff = None
+        expected = (
+            {
+                "lang": "es",
+                'parent_name': 'sub-article',
+                "abstract": {
+                    "lang": "es",
+                    "title": "Abstract",
+                    "sections": [
+                        {
+                            "title": "inicio",
+                            "p": "<b>conteúdo de bold</b> text"
+                        },
+                        {
+                            "title": "meio",
+                            "p": "text <b>conteúdo de bold</b> text"
+                        },
+                        {
+                            "title": "fim",
+                            "p": "text <b>conteúdo de bold</b>"
+                        },
+                        {
+                            "title": "aninhado",
+                            "p": "text <b>conteúdo <i>de</i> bold</b>"
+                        },
+                    ]
+                },
+                "id": "01"
+            },
+        )
+        result = self.abstract._get_sub_article_abstracts(
+            html=True,
+            allowed_tags=['italic', 'bold'],
+            xml_to_html={'italic': 'i', 'bold': 'b'}
+        )
+        for res, exp in zip(result, expected):
+            with self.subTest(res["lang"]):
+                self.assertDictEqual(exp, res)
+
     def test__get_trans_abstracts(self):
         """
         <trans-abstract xml:lang="pt">
@@ -893,25 +1405,29 @@ class AbstractWithStylesTest(TestCase):
                     "sections": [
                         {
                             "title": "inicio",
-                            "p": "conteúdo de bold text "
+                            "p": "<b>conteúdo de bold</b> text"
                         },
                         {
                             "title": "meio",
-                            "p": "text conteúdo de bold text "
+                            "p": "text <b>conteúdo de bold</b> text"
                         },
                         {
                             "title": "fim",
-                            "p": "text conteúdo de bold"
+                            "p": "text <b>conteúdo de bold</b>"
                         },
                         {
                             "title": "aninhado",
-                            "p": "text conteúdo de bold"
+                            "p": "text <b>conteúdo <i>de</i> bold</b>"
                         },
                     ]
                 }
             },
         )
-        result = self.abstract._get_trans_abstracts()
+        result = self.abstract._get_trans_abstracts(
+            html=True,
+            allowed_tags=['italic', 'bold'],
+            xml_to_html={'italic': 'i', 'bold': 'b'}
+        )
         for res, exp in zip(result, expected):
             with self.subTest(exp["lang"]):
                 self.assertDictEqual(exp, res)

--- a/tests/sps/models/test_article_abstract.py
+++ b/tests/sps/models/test_article_abstract.py
@@ -114,11 +114,14 @@ class AbstractWithSectionsTest(TestCase):
                 "title": "Abstract",
                 "sections": [{
                     "title": "Objective",
-                    "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people.",
+                    "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
+                         "elderly people.",
                 },
                 {
                     "title": "Design",
-                    "p": "Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+                    "p": "Systematic review of 12 controlled clinical trials (available by January 1997) comparing day "
+                         "hospital care with comprehensive care (five trials), domiciliary care (four trials), "
+                         "or no comprehensive care (three trials).",
 
                 }],
             }
@@ -243,11 +246,15 @@ class AbstractWithSectionsTest(TestCase):
                     "sections": [
                         {
                             "title": "Objetivo: ",
-                            "p": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de accidentes cerebrovasculares. "
+                            "p": "evaluar el efecto de intervenciones de atención domiciliaria de enfermería sobre la "
+                                 "calidad de vida en cuidadores familiares de adultos mayores sobrevivientes de "
+                                 "accidentes cerebrovasculares. "
                         },
                         {
                             "title": "Método: ",
-                            "p": "Ensayo Clínico Aleatorizado ... <italic>World Health Organization Quality of Life Assessment</italic> (WHOQOL-BREF) y el módulo <italic>Old</italic>(WHOQOL-OLD) 1semana, 2meses y 1año después del alta. "
+                            "p": "Ensayo Clínico Aleatorizado ... World Health Organization Quality of Life "
+                                 "Assessment (WHOQOL-BREF) y el módulo Old(WHOQOL-OLD) "
+                                 "1semana, 2meses y 1año después del alta. "
                         },
                     ]
                 },
@@ -262,11 +269,14 @@ class AbstractWithSectionsTest(TestCase):
                     "sections": [
                         {
                             "title": "Ziel: ",
-                            "p": "Randomisierte klinische Studie... Modul <italic>Alt</italic> (WHOQOL-OLD) 1 Woche, 2 Monate und 1 Jahr nach der Entlassung."
+                            "p": "Randomisierte klinische Studie... Modul Alt (WHOQOL-OLD) 1 Woche, 2 Monate und 1 "
+                                 "Jahr nach der Entlassung."
                         },
                         {
                             "title": "Methode: ",
-                            "p": "Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre Unfälle überlebt haben."
+                            "p": "Bewertung der Auswirkungen von Pflegeeinsätzen in Pflegeheimen auf die "
+                                 "Lebensqualität von Familienbetreuern älterer Erwachsener, die zerebrovaskuläre "
+                                 "Unfälle überlebt haben."
                         },
                     ]
                 },
@@ -304,6 +314,7 @@ class AbstractWithSectionsTest(TestCase):
             </sec>
         </trans-abstract>
         """
+        self.maxDiff = None
         expected = (
             {
                 "lang": "pt",
@@ -314,11 +325,14 @@ class AbstractWithSectionsTest(TestCase):
                     "sections": [
                         {
                             "title": "Objetivo: ",
-                            "p": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral (AVC). "
+                            "p": "avaliar o efeito de intervenção educativa domiciliar de enfermagem na qualidade de "
+                                 "vida de cuidadores familiares de idosos sobreviventes de acidente vascular cerebral "
+                                 "(AVC). "
                         },
                         {
                             "title": "Método: ",
-                            "p": "Ensaio Clínico Randomizado... Módulo <italic>Old</italic> (WHOQOL-OLD) em 1 semana, 2 meses e 1 ano após a alta. "
+                            "p": "Ensaio Clínico Randomizado... Módulo Old (WHOQOL-OLD) em 1 semana, "
+                                 "2 meses e 1 ano após a alta. "
                         },
                     ]
                 }
@@ -332,11 +346,13 @@ class AbstractWithSectionsTest(TestCase):
                     "sections": [
                         {
                             "title": "Objectif: ",
-                            "p": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de vie des aidants familiaux de personnes âgées ayant survécu à un AVC."
+                            "p": "évaluer l'effet d'une intervention éducative en maison de retraite sur la qualité de "
+                                 "vie des aidants familiaux de personnes âgées ayant survécu à un AVC."
                         },
                         {
                             "title": "Méthode: ",
-                            "p": "Essai clinique randomisé... Module <italic>Old</italic> (WHOQOL-OLD) à 1 semaine, 2 mois et 1 an après la sortie."
+                            "p": "Essai clinique randomisé... Module Old (WHOQOL-OLD) à 1 semaine, 2 "
+                                 "mois et 1 an après la sortie."
                         },
                     ]
                 }
@@ -404,13 +420,17 @@ class AbstractWithoutSectionsTest(TestCase):
         self.assertDictEqual(expected, result)
 
     def test_get_main_abstract_default_style(self):
+        self.maxDiff = None
         expected = {
             "lang": "en",
             'parent_name': 'article',
             "abstract": {
                 "lang": "en",
                 "title": "Abstract",
-                "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for elderly people. Systematic review of 12 controlled <italic>clinical trials</italic> (available by January 1997) comparing day hospital care with comprehensive care (five trials), domiciliary care (four trials), or no comprehensive care (three trials).",
+                "p": "To examine the effectiveness of day hospital attendance in prolonging independent living for "
+                     "elderly people. Systematic review of 12 controlled clinical trials (available by January 1997) "
+                     "comparing day hospital care with comprehensive care (five trials), domiciliary care "
+                     "(four trials), or no comprehensive care (three trials).",
             }
         }
         result = self.abstract.get_main_abstract()
@@ -479,7 +499,11 @@ class AbstractWithoutSectionsTest(TestCase):
                 "abstract": {
                     "lang": "es",
                     "title": "Resumen",
-                    "p": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida independiente de las personas mayores. Revisión sistemática de 12 <italic>ensayos clínicos</italic> controlados (disponibles en enero de 1997) que compararon la atención hospitalaria de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) o ninguna atención integral (tres ensayos).",
+                    "p": "Examinar la efectividad de la asistencia al hospital de día para prolongar la vida "
+                         "independiente de las personas mayores. Revisión sistemática de 12 ensayos clínicos "
+                         "controlados (disponibles en enero de 1997) que compararon la atención hospitalaria "
+                         "de día con atención integral (cinco ensayos), atención domiciliaria (cuatro ensayos) "
+                         "o ninguna atención integral (tres ensayos).",
                 },
                 "id": "01"
             },
@@ -489,7 +513,11 @@ class AbstractWithoutSectionsTest(TestCase):
                 "abstract": {
                     "lang": "it",
                     "title": "Riepilogo",
-                    "p": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita autonoma delle persone anziane. Revisione sistematica di 12 <italic>studi clinici</italic> controllati (disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna assistenza completa (tre studi).",
+                    "p": "Esaminare l'efficacia della frequenza del day hospital nel prolungamento della vita "
+                         "autonoma delle persone anziane. Revisione sistematica di 12 studi clinici controllati "
+                         "(disponibili entro gennaio 1997) che confrontano l'assistenza in day hospital con "
+                         "l'assistenza completa (cinque studi), l'assistenza domiciliare (quattro studi) o nessuna "
+                         "assistenza completa (tre studi).",
                 },
                 "id": "02"
             },
@@ -518,7 +546,11 @@ class AbstractWithoutSectionsTest(TestCase):
                 "abstract": {
                     "lang": "pt",
                     "title": "Resumo",
-                    "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de idosos. Revisão sistemática de 12 <italic>estudos clínicos</italic> controlados (disponível em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente (cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente (três ensaios).",
+                    "p": "Examinar a eficácia do atendimento em hospital-dia no prolongamento da vida independente de "
+                         "idosos. Revisão sistemática de 12 estudos clínicos controlados (disponível "
+                         "em janeiro de 1997) comparando o atendimento em hospital-dia com atendimento abrangente "
+                         "(cinco ensaios), atendimento domiciliar (quatro ensaios) ou nenhum atendimento abrangente "
+                         "(três ensaios).",
                 }
             },
             {
@@ -527,7 +559,20 @@ class AbstractWithoutSectionsTest(TestCase):
                 "abstract": {
                     "lang": "fr",
                     "title": "Résumé",
-                    "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie autonome des personnes âgées. Revue systématique de 12 <italic>essais cliniques</italic> contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins complets (trois essais).",
+                    "p": "Examiner l'efficacité de la fréquentation d'un hôpital de jour pour prolonger la vie "
+                         "autonome des personnes âgées. Revue systématique de 12 essais cliniques "
+                         "contrôlés (disponibles en janvier 1997) comparant les soins hospitaliers de jour aux soins "
+                         "complets (cinq essais), aux soins à domicile (quatre essais) ou à l'absence de soins "
+                         "complets (trois essais).",
+                }
+            },
+        )
+        result = self.abstract._get_trans_abstracts()
+        for res, exp in zip(result, expected):
+            with self.subTest(exp["lang"]):
+                self.assertDictEqual(exp, res)
+
+
                 }
             },
         )

--- a/tests/sps/models/test_xml_utils.py
+++ b/tests/sps/models/test_xml_utils.py
@@ -47,6 +47,143 @@ class NodeTextTest(TestCase):
         result = xml_utils.node_text(xmltree.find(".//city"))
         self.assertEqual(expected, result)
 
+    def test_remove_subtags_keeps_i(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "São Paulo <i>Paulo</i>"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['i'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_bold(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<bold>São Paulo</bold> Paulo"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['bold'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_italic(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<italic>São</italic> Paulo Paulo"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['italic'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_bold_and_italic(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<bold><italic>São</italic> Paulo</bold> Paulo"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['bold', 'italic'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_bold_and_i(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<bold>São Paulo</bold> <i>Paulo</i>"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['bold', 'i'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_italic_and_i(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<italic>São</italic> Paulo <i>Paulo</i>"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['italic', 'i'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_keeps_all(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<bold><italic>São</italic> Paulo</bold> <i>Paulo</i>"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"), ['bold', 'italic', 'i'])
+        self.assertEqual(expected, obtained)
+
+    def test_remove_subtags_remove_all(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "São Paulo Paulo"
+        obtained = xml_utils.remove_subtags(xmltree.find(".//city"))
+        self.assertEqual(expected, obtained)
+
+    def test_convert_xml_to_html(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<b><i>São</i> Paulo</b> Paulo"
+        obtained = xml_utils.convert_xml_to_html(
+            xmltree.find(".//city"),
+            ['italic', 'bold'],
+            {'italic': 'i', 'bold': 'b'}
+        )
+        self.assertEqual(expected, obtained)
+
+    def test_convert_xml_to_html_without_dict(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <root>
+            <city><bold><italic>São</italic> Paulo</bold> <i>Paulo</i></city>
+            </root>
+            """
+        )
+        expected = "<bold><italic>São</italic> Paulo</bold> Paulo"
+        obtained = xml_utils.convert_xml_to_html(
+            xmltree.find(".//city"),
+            ['italic', 'bold']
+        )
+        self.assertEqual(expected, obtained)
+
 
 class NodeTextWithoutXrefTest(TestCase):
 


### PR DESCRIPTION
#### O que esse PR faz?
Modifica a obtenção de textos para desconsiderar `subtags.`

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_article_abstract.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #556 

### Referências
NA.

