### PR TITLE
Feat: validate element citation

### DIFF
--- a/packtools/sps/models/article_citations.py
+++ b/packtools/sps/models/article_citations.py
@@ -10,6 +10,10 @@ def get_label(node):
     return text
 
 
+def get_publication_type(node):
+    return node.find('./element-citation').get('publication-type')
+
+
 def get_source(node):
     return xml_utils.node_plain_text(node.find('./element-citation/source'))
 
@@ -96,6 +100,7 @@ class ArticleCitations:
             tags = [
                 ('ref_id', get_ref_id(node)),
                 ('label', get_label(node)),
+                ('publication_type', get_publication_type(node)),
                 ('source', get_source(node)),
                 ('main_author', get_main_author(node)),
                 ('all_authors', get_all_authors(node)),

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -211,3 +211,13 @@ class ArticleCitationsValidation:
                                                 f"is missing or is invalid, provide one value from the list: {' | '.join(publication_type_list)}"
             }
 
+    def validate_article_citation(self, publication_type_list=None):
+        yield from self.validate_article_citation_year()
+        yield from self.validate_article_citation_source()
+        yield from self.validate_article_citation_article_title()
+        yield from self.validate_article_citation_authors()
+        yield from self.validate_article_citation_publication_type(publication_type_list)
+
+
+
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -50,3 +50,41 @@ class ArticleCitationsValidation:
                                                 f"or is invalid, provide a valid value to year"
             }
 
+    def validate_article_citation_source(self):
+        """
+        Checks whether the source in an article citation exists.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'source',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': 'Drug Alcohol Depend.',
+                    'got_value': 'Drug Alcohol Depend.',
+                    'message': 'Got Drug Alcohol Depend. expected Drug Alcohol Depend.',
+                    'advice': None
+                },...
+            ]
+        """
+        for citation in self.article_citations:
+            source = citation.get('source')
+            is_valid = source is not None
+            yield {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'source',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': source if is_valid else 'a valid value to source',
+                'got_value': source,
+                'message': f'Got {source} expected {source if is_valid else "a valid value to source"}',
+                'advice': None if is_valid else f"The source in reference (ref-id: {citation.get('ref_id')}) is missing "
+                                                f"provide a valid value to source"
+            }
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -8,3 +8,45 @@ class ArticleCitationsValidation:
         self.article_citations = list(ArticleCitations(self._xmltree).article_citations)
         self.publication_type_list = publication_type_list
 
+    def validate_article_citation_year(self):
+        """
+        Checks whether the year in an article citation exists and is valid.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'year',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': '2015',
+                    'got_value': '2015',
+                    'message': f'Got 2015 expected 2015',
+                    'advice': None
+                },...
+            ]
+        """
+        for citation in self.article_citations:
+            if citation.get('year'):
+                year = str(citation['year'])
+                is_valid = year.isdigit() and len(year) == 4
+            else:
+                year = None
+                is_valid = False
+            yield {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'year',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': year if is_valid else 'a valid value to year',
+                'got_value': year,
+                'message': f'Got {year} expected {year if is_valid else "a valid value to year"}',
+                'advice': None if is_valid else f"The year in reference (ref-id: {citation.get('ref_id')}) is missing "
+                                                f"or is invalid, provide a valid value to year"
+            }
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -35,7 +35,7 @@ class ArticleCitationValidation:
             start_year = 0
         if end_year is None:
             try:
-                end_year = int(ArticleDates(self.xmltree).collection_date['year'])
+                end_year = int(ArticleDates(self.xmltree).article_date['year'])
             except TypeError:
                 raise ValidationArticleCitationsException('Article publication date not found and is required')
         year = self.citation.get('year')

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -2,10 +2,9 @@ from packtools.sps.models.article_citations import ArticleCitations
 from packtools.sps.validation.exceptions import ValidationArticleCitationsException
 
 
-class ArticleCitationsValidation:
-    def __init__(self, xmltree, publication_type_list=None):
-        self._xmltree = xmltree
-        self.article_citations = list(ArticleCitations(self._xmltree).article_citations)
+class ArticleCitationValidation:
+    def __init__(self, citation, publication_type_list=None):
+        self.citation = citation
         self.publication_type_list = publication_type_list
 
     def validate_article_citation_year(self):
@@ -30,25 +29,24 @@ class ArticleCitationsValidation:
                 },...
             ]
         """
-        for citation in self.article_citations:
-            if citation.get('year'):
-                year = str(citation['year'])
-                is_valid = year.isdigit() and len(year) == 4
-            else:
-                year = None
-                is_valid = False
-            yield {
-                'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'year',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': year if is_valid else 'a valid value to year',
-                'got_value': year,
-                'message': f'Got {year} expected {year if is_valid else "a valid value to year"}',
-                'advice': None if is_valid else f"The year in reference (ref-id: {citation.get('ref_id')}) is missing "
-                                                f"or is invalid, provide a valid value to year"
-            }
+        if self.citation.get('year'):
+            year = str(self.citation['year'])
+            is_valid = year.isdigit() and len(year) == 4
+        else:
+            year = None
+            is_valid = False
+        yield {
+            'title': 'element citation validation',
+            'element': 'element-citation',
+            'sub-element': 'year',
+            'validation_type': 'exist',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': year if is_valid else 'a valid value to year',
+            'got_value': year,
+            'message': f'Got {year} expected {year if is_valid else "a valid value to year"}',
+            'advice': None if is_valid else f"The year in reference (ref-id: {self.citation.get('ref_id')}) is missing "
+                                            f"or is invalid, provide a valid value to year"
+        }
 
     def validate_article_citation_source(self):
         """
@@ -72,21 +70,20 @@ class ArticleCitationsValidation:
                 },...
             ]
         """
-        for citation in self.article_citations:
-            source = citation.get('source')
-            is_valid = source is not None
-            yield {
-                'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'source',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': source if is_valid else 'a valid value to source',
-                'got_value': source,
-                'message': f'Got {source} expected {source if is_valid else "a valid value to source"}',
-                'advice': None if is_valid else f"The source in reference (ref-id: {citation.get('ref_id')}) is missing "
-                                                f"provide a valid value to source"
-            }
+        source = self.citation.get('source')
+        is_valid = source is not None
+        yield {
+            'title': 'element citation validation',
+            'element': 'element-citation',
+            'sub-element': 'source',
+            'validation_type': 'exist',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': source if is_valid else 'a valid value to source',
+            'got_value': source,
+            'message': f'Got {source} expected {source if is_valid else "a valid value to source"}',
+            'advice': None if is_valid else f"The source in reference (ref-id: {self.citation.get('ref_id')}) is missing "
+                                            f"provide a valid value to source"
+        }
 
     def validate_article_citation_article_title(self):
         """
@@ -114,23 +111,22 @@ class ArticleCitationsValidation:
                 },...
             ]
         """
-        for citation in self.article_citations:
-            publication_type = citation.get('publication_type')
-            if publication_type == 'journal':
-                article_title = citation.get('article_title')
-                is_valid = article_title is not None
-                yield {
-                    'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'article-title',
-                    'validation_type': 'exist',
-                    'response': 'OK' if is_valid else 'ERROR',
-                    'expected_value': article_title if is_valid else 'a valid value to article-title',
-                    'got_value': article_title,
-                    'message': f'Got {article_title} expected {article_title if is_valid else "a valid value to article-title"}',
-                    'advice': None if is_valid else f"The article-title in reference (ref-id: {citation.get('ref_id')}) is missing "
-                                                    f"provide a valid value to article-title"
-                }
+        publication_type = self.citation.get('publication_type')
+        if publication_type == 'journal':
+            article_title = self.citation.get('article_title')
+            is_valid = article_title is not None
+            yield {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'article-title',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': article_title if is_valid else 'a valid value to article-title',
+                'got_value': article_title,
+                'message': f'Got {article_title} expected {article_title if is_valid else "a valid value to article-title"}',
+                'advice': None if is_valid else f"The article-title in reference (ref-id: {self.citation.get('ref_id')}) is missing "
+                                                f"provide a valid value to article-title"
+            }
 
     def validate_article_citation_authors(self):
         """
@@ -154,21 +150,20 @@ class ArticleCitationsValidation:
                 },...
             ]
         """
-        for citation in self.article_citations:
-            number_authors = len(citation.get('all_authors')) if citation.get('all_authors') else 0
-            is_valid = number_authors > 0
-            yield {
-                'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'person-group//name or person-group//colab',
-                'validation_type': 'exist',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': 'at least 1 author in each element-citation',
-                'got_value': f'{number_authors} authors',
-                'message': f'Got {number_authors} authors expected at least 1 author in each element-citation',
-                'advice': None if is_valid else f"There are no authors for the reference (ref-id: {citation.get('ref_id')}) "
-                                                f"provide at least 1 author"
-            }
+        number_authors = len(self.citation.get('all_authors')) if self.citation.get('all_authors') else 0
+        is_valid = number_authors > 0
+        yield {
+            'title': 'element citation validation',
+            'element': 'element-citation',
+            'sub-element': 'person-group//name or person-group//colab',
+            'validation_type': 'exist',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': 'at least 1 author in each element-citation',
+            'got_value': f'{number_authors} authors',
+            'message': f'Got {number_authors} authors expected at least 1 author in each element-citation',
+            'advice': None if is_valid else f"There are no authors for the reference (ref-id: {self.citation.get('ref_id')}) "
+                                            f"provide at least 1 author"
+        }
 
     def validate_article_citation_publication_type(self, publication_type_list=None):
         """
@@ -195,28 +190,36 @@ class ArticleCitationsValidation:
         publication_type_list = publication_type_list or self.publication_type_list
         if publication_type_list is None:
             raise ValidationArticleCitationsException('Function requires list of publications type')
-        for citation in self.article_citations:
-            publication_type = citation.get('publication_type')
-            is_valid = publication_type in publication_type_list
-            yield {
-                'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'publication-type',
-                'validation_type': 'value in list',
-                'response': 'OK' if is_valid else 'ERROR',
-                'expected_value': publication_type_list,
-                'got_value': publication_type,
-                'message': f'Got {publication_type} expected one item of this list: {" | ".join(publication_type_list)}',
-                'advice': None if is_valid else f"publication-type for the reference (ref-id: {citation.get('ref_id')}) "
-                                                f"is missing or is invalid, provide one value from the list: {' | '.join(publication_type_list)}"
-            }
+        publication_type = self.citation.get('publication_type')
+        is_valid = publication_type in publication_type_list
+        yield {
+            'title': 'element citation validation',
+            'element': 'element-citation',
+            'sub-element': 'publication-type',
+            'validation_type': 'value in list',
+            'response': 'OK' if is_valid else 'ERROR',
+            'expected_value': publication_type_list,
+            'got_value': publication_type,
+            'message': f'Got {publication_type} expected one item of this list: {" | ".join(publication_type_list)}',
+            'advice': None if is_valid else f"publication-type for the reference (ref-id: {self.citation.get('ref_id')}) "
+                                            f"is missing or is invalid, provide one value from the list: {' | '.join(publication_type_list)}"
+        }
 
-    def validate_article_citation(self, publication_type_list=None):
-        yield from self.validate_article_citation_year()
-        yield from self.validate_article_citation_source()
-        yield from self.validate_article_citation_article_title()
-        yield from self.validate_article_citation_authors()
-        yield from self.validate_article_citation_publication_type(publication_type_list)
+
+class ArticleCitationsValidation:
+    def __init__(self, xmltree, publication_type_list=None):
+        self._xmltree = xmltree
+        self.article_citations = ArticleCitations(self._xmltree).article_citations
+        self.publication_type_list = publication_type_list
+
+    def validate_article_citations(self, publication_type_list=None):
+        for article_citation in self.article_citations:
+            citation = ArticleCitationValidation(article_citation, publication_type_list)
+            yield from citation.validate_article_citation_year()
+            yield from citation.validate_article_citation_source()
+            yield from citation.validate_article_citation_article_title()
+            yield from citation.validate_article_citation_authors()
+            yield from citation.validate_article_citation_publication_type(publication_type_list)
 
 
 

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -170,3 +170,44 @@ class ArticleCitationsValidation:
                                                 f"provide at least 1 author"
             }
 
+    def validate_article_citation_publication_type(self, publication_type_list=None):
+        """
+        Checks if the publication type is present in the list of default values.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'publication-type',
+                    'validation_type': 'value in list',
+                    'response': 'OK',
+                    'expected_value': ['journal', 'book'],
+                    'got_value': 'journal',
+                    'message': 'Got journal expected one item of this list: journal | book',
+                    'advice': None
+                },...
+            ]
+        """
+        publication_type_list = publication_type_list or self.publication_type_list
+        if publication_type_list is None:
+            raise ValidationArticleCitationsException('Function requires list of publications type')
+        for citation in self.article_citations:
+            publication_type = citation.get('publication_type')
+            is_valid = publication_type in publication_type_list
+            yield {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'publication-type',
+                'validation_type': 'value in list',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': publication_type_list,
+                'got_value': publication_type,
+                'message': f'Got {publication_type} expected one item of this list: {" | ".join(publication_type_list)}',
+                'advice': None if is_valid else f"publication-type for the reference (ref-id: {citation.get('ref_id')}) "
+                                                f"is missing or is invalid, provide one value from the list: {' | '.join(publication_type_list)}"
+            }
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -132,3 +132,41 @@ class ArticleCitationsValidation:
                                                     f"provide a valid value to article-title"
                 }
 
+    def validate_article_citation_authors(self):
+        """
+        Checks if there are authors for the article citation.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'person-group//name or person-group//colab',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': 'at least 1 author in each element-citation',
+                    'got_value': '5 authors',
+                    'message': f'Got 5 authors expected at least 1 author in each element-citation',
+                    'advice': None
+                },...
+            ]
+        """
+        for citation in self.article_citations:
+            number_authors = len(citation.get('all_authors')) if citation.get('all_authors') else 0
+            is_valid = number_authors > 0
+            yield {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'person-group//name or person-group//colab',
+                'validation_type': 'exist',
+                'response': 'OK' if is_valid else 'ERROR',
+                'expected_value': 'at least 1 author in each element-citation',
+                'got_value': f'{number_authors} authors',
+                'message': f'Got {number_authors} authors expected at least 1 author in each element-citation',
+                'advice': None if is_valid else f"There are no authors for the reference (ref-id: {citation.get('ref_id')}) "
+                                                f"provide at least 1 author"
+            }
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -18,8 +18,8 @@ class ArticleCitationValidation:
             [
                 {
                     'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'year',
+                    'item': 'element-citation',
+                    'sub-item': 'year',
                     'validation_type': 'exist',
                     'response': 'OK',
                     'expected_value': '2015',
@@ -29,16 +29,16 @@ class ArticleCitationValidation:
                 },...
             ]
         """
-        if self.citation.get('year'):
+        try:
             year = str(self.citation['year'])
             is_valid = year.isdigit() and len(year) == 4
-        else:
+        except KeyError:
             year = None
             is_valid = False
         yield {
             'title': 'element citation validation',
-            'element': 'element-citation',
-            'sub-element': 'year',
+            'item': 'element-citation',
+            'sub-item': 'year',
             'validation_type': 'exist',
             'response': 'OK' if is_valid else 'ERROR',
             'expected_value': year if is_valid else 'a valid value to year',
@@ -59,8 +59,8 @@ class ArticleCitationValidation:
             [
                 {
                     'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'source',
+                    'item': 'element-citation',
+                    'sub-item': 'source',
                     'validation_type': 'exist',
                     'response': 'OK',
                     'expected_value': 'Drug Alcohol Depend.',
@@ -74,8 +74,8 @@ class ArticleCitationValidation:
         is_valid = source is not None
         yield {
             'title': 'element citation validation',
-            'element': 'element-citation',
-            'sub-element': 'source',
+            'item': 'element-citation',
+            'sub-item': 'source',
             'validation_type': 'exist',
             'response': 'OK' if is_valid else 'ERROR',
             'expected_value': source if is_valid else 'a valid value to source',
@@ -96,8 +96,8 @@ class ArticleCitationValidation:
             [
                 {
                     'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'article-title',
+                    'item': 'element-citation',
+                    'sub-item': 'article-title',
                     'validation_type': 'exist',
                     'response': 'OK',
                     'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
@@ -117,8 +117,8 @@ class ArticleCitationValidation:
             is_valid = article_title is not None
             yield {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'article-title',
+                'item': 'element-citation',
+                'sub-item': 'article-title',
                 'validation_type': 'exist',
                 'response': 'OK' if is_valid else 'ERROR',
                 'expected_value': article_title if is_valid else 'a valid value to article-title',
@@ -139,8 +139,8 @@ class ArticleCitationValidation:
             [
                 {
                     'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'person-group//name or person-group//colab',
+                    'item': 'element-citation',
+                    'sub-item': 'person-group//name or person-group//colab',
                     'validation_type': 'exist',
                     'response': 'OK',
                     'expected_value': 'at least 1 author in each element-citation',
@@ -154,8 +154,8 @@ class ArticleCitationValidation:
         is_valid = number_authors > 0
         yield {
             'title': 'element citation validation',
-            'element': 'element-citation',
-            'sub-element': 'person-group//name or person-group//colab',
+            'item': 'element-citation',
+            'sub-item': 'person-group//name or person-group//colab',
             'validation_type': 'exist',
             'response': 'OK' if is_valid else 'ERROR',
             'expected_value': 'at least 1 author in each element-citation',
@@ -176,8 +176,8 @@ class ArticleCitationValidation:
             [
                 {
                     'title': 'element citation validation',
-                    'element': 'element-citation',
-                    'sub-element': 'publication-type',
+                    'item': 'element-citation',
+                    'sub-item': 'publication-type',
                     'validation_type': 'value in list',
                     'response': 'OK',
                     'expected_value': ['journal', 'book'],
@@ -194,8 +194,8 @@ class ArticleCitationValidation:
         is_valid = publication_type in publication_type_list
         yield {
             'title': 'element citation validation',
-            'element': 'element-citation',
-            'sub-element': 'publication-type',
+            'item': 'element-citation',
+            'sub-item': 'publication-type',
             'validation_type': 'value in list',
             'response': 'OK' if is_valid else 'ERROR',
             'expected_value': publication_type_list,

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -88,3 +88,47 @@ class ArticleCitationsValidation:
                                                 f"provide a valid value to source"
             }
 
+    def validate_article_citation_article_title(self):
+        """
+        Checks whether the article title in an article citation exists.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, such as:
+            [
+                {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'article-title',
+                    'validation_type': 'exist',
+                    'response': 'OK',
+                    'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
+                                      'cessation in older ages',
+                    'got_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                                 'in older ages',
+                    'message': 'Got Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                               'in older ages expected Smoking and potentially preventable hospitalisation: the benefit '
+                               'of smoking cessation in older ages',
+                    'advice': None
+                },...
+            ]
+        """
+        for citation in self.article_citations:
+            publication_type = citation.get('publication_type')
+            if publication_type == 'journal':
+                article_title = citation.get('article_title')
+                is_valid = article_title is not None
+                yield {
+                    'title': 'element citation validation',
+                    'element': 'element-citation',
+                    'sub-element': 'article-title',
+                    'validation_type': 'exist',
+                    'response': 'OK' if is_valid else 'ERROR',
+                    'expected_value': article_title if is_valid else 'a valid value to article-title',
+                    'got_value': article_title,
+                    'message': f'Got {article_title} expected {article_title if is_valid else "a valid value to article-title"}',
+                    'advice': None if is_valid else f"The article-title in reference (ref-id: {citation.get('ref_id')}) is missing "
+                                                    f"provide a valid value to article-title"
+                }
+

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -1,0 +1,10 @@
+from packtools.sps.models.article_citations import ArticleCitations
+from packtools.sps.validation.exceptions import ValidationArticleCitationsException
+
+
+class ArticleCitationsValidation:
+    def __init__(self, xmltree, publication_type_list=None):
+        self._xmltree = xmltree
+        self.article_citations = list(ArticleCitations(self._xmltree).article_citations)
+        self.publication_type_list = publication_type_list
+

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -1,6 +1,7 @@
 class ValidationArticleDataError(Exception):
     """ The root of Article data exceptions.
     """
+
     def __init__(self, *args: object, message, line):
         super().__init__(*args)
         self.message = message
@@ -58,12 +59,18 @@ class ValidationLicenseException(Exception):
 class ValidationLicenseCodeException(Exception):
     ...
 
-  
+
 class ValidationDataAvailabilityException(Exception):
     ...
+
 
 class ValidationIssueMissingValue(Exception):
     ...
 
+
 class ValidationJournalMetaException(Exception):
+    ...
+
+
+class ValidationArticleCitationsException(Exception):
     ...

--- a/tests/sps/models/test_article_citations.py
+++ b/tests/sps/models/test_article_citations.py
@@ -68,6 +68,7 @@ class AuthorsTest(TestCase):
             {
                 'ref_id': 'B1',
                 'label': '1',
+                'publication_type': 'journal',
                 'author_type': 'person',
                 'mixed_citation': '1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially '
                                   'preventable hospitalisation: the benefit of smoking cessation in older ages. Drug '
@@ -130,6 +131,7 @@ class AuthorsTest(TestCase):
         expected = [
             {
                 'ref_id': 'B2',
+                'publication_type': 'book',
                 'author_type': 'person',
                 'mixed_citation': 'BARTHES, Roland. Aula. São Pulo: Cultrix, 1987.',
                 'source': 'Aula',
@@ -182,6 +184,7 @@ class AuthorsTest(TestCase):
         expected = [
             {
                 'ref_id': 'B2',
+                'publication_type': 'other',
                 'author_type': 'institutional',
                 'mixed_citation': '2. Brasil. Lei n. o 10.332, de 19/12/2001. Instituiu '
                                   'mecanismo de financiamento para o programa de ciência e '

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -71,8 +71,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'year',
+                'item': 'element-citation',
+                'sub-item': 'year',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '2015',
@@ -150,8 +150,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'year',
+                'item': 'element-citation',
+                'sub-item': 'year',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'a valid value to year',
@@ -228,8 +228,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'year',
+                'item': 'element-citation',
+                'sub-item': 'year',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'a valid value to year',
@@ -307,8 +307,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'source',
+                'item': 'element-citation',
+                'sub-item': 'source',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Drug Alcohol Depend.',
@@ -385,8 +385,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'source',
+                'item': 'element-citation',
+                'sub-item': 'source',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'a valid value to source',
@@ -464,8 +464,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'article-title',
+                'item': 'element-citation',
+                'sub-item': 'article-title',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
@@ -546,8 +546,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'article-title',
+                'item': 'element-citation',
+                'sub-item': 'article-title',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'a valid value to article-title',
@@ -625,8 +625,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'person-group//name or person-group//colab',
+                'item': 'element-citation',
+                'sub-item': 'person-group//name or person-group//colab',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'at least 1 author in each element-citation',
@@ -680,8 +680,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'person-group//name or person-group//colab',
+                'item': 'element-citation',
+                'sub-item': 'person-group//name or person-group//colab',
                 'validation_type': 'exist',
                 'response': 'ERROR',
                 'expected_value': 'at least 1 author in each element-citation',
@@ -760,8 +760,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'publication-type',
+                'item': 'element-citation',
+                'sub-item': 'publication-type',
                 'validation_type': 'value in list',
                 'response': 'OK',
                 'expected_value': ['journal', 'book'],
@@ -840,8 +840,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'publication-type',
+                'item': 'element-citation',
+                'sub-item': 'publication-type',
                 'validation_type': 'value in list',
                 'response': 'ERROR',
                 'expected_value': ['other', 'book'],
@@ -920,8 +920,8 @@ class ArticleCitationValidationTest(TestCase):
         expected = [
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'year',
+                'item': 'element-citation',
+                'sub-item': 'year',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '2015',
@@ -931,8 +931,8 @@ class ArticleCitationValidationTest(TestCase):
             },
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'source',
+                'item': 'element-citation',
+                'sub-item': 'source',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Drug Alcohol Depend.',
@@ -942,8 +942,8 @@ class ArticleCitationValidationTest(TestCase):
             },
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'article-title',
+                'item': 'element-citation',
+                'sub-item': 'article-title',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
@@ -957,8 +957,8 @@ class ArticleCitationValidationTest(TestCase):
             },
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'person-group//name or person-group//colab',
+                'item': 'element-citation',
+                'sub-item': 'person-group//name or person-group//colab',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'at least 1 author in each element-citation',
@@ -968,8 +968,8 @@ class ArticleCitationValidationTest(TestCase):
             },
             {
                 'title': 'element citation validation',
-                'element': 'element-citation',
-                'sub-element': 'publication-type',
+                'item': 'element-citation',
+                'sub-item': 'publication-type',
                 'validation_type': 'value in list',
                 'response': 'OK',
                 'expected_value': ['journal', 'book'],

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -1,0 +1,983 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from packtools.sps.validation.article_citations import ArticleCitationsValidation
+
+
+class ArticleCitationsValidationTest(TestCase):
+    def test_validate_article_citation_year_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'year',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '2015',
+                'got_value': '2015',
+                'message': f'Got 2015 expected 2015',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_year_fail_invalid(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>201a</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'year',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'a valid value to year',
+                'got_value': '201a',
+                'message': f'Got 201a expected a valid value to year',
+                'advice': 'The year in reference (ref-id: B1) is missing or is invalid, provide a valid value to year'
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_year_fail_missing(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'year',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'a valid value to year',
+                'got_value': None,
+                'message': f'Got None expected a valid value to year',
+                'advice': 'The year in reference (ref-id: B1) is missing or is invalid, provide a valid value to year'
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_source_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_source())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Drug Alcohol Depend.',
+                'got_value': 'Drug Alcohol Depend.',
+                'message': 'Got Drug Alcohol Depend. expected Drug Alcohol Depend.',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_source_fail(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_source())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'source',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'a valid value to source',
+                'got_value': None,
+                'message': 'Got None expected a valid value to source',
+                'advice': 'The source in reference (ref-id: B1) is missing provide a valid value to source'
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_article_title_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_article_title())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'article-title',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
+                                  'cessation in older ages',
+                'got_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                             'in older ages',
+                'message': 'Got Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                           'in older ages expected Smoking and potentially preventable hospitalisation: the benefit '
+                           'of smoking cessation in older ages',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_article_citation_article_title_fail(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_article_title())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'article-title',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'a valid value to article-title',
+                'got_value': None,
+                'message': 'Got None expected a valid value to article-title',
+                'advice': 'The article-title in reference (ref-id: B1) is missing provide a valid value to article-title'
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_authors_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_authors())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'person-group//name or person-group//colab',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 author in each element-citation',
+                'got_value': '5 authors',
+                'message': f'Got 5 authors expected at least 1 author in each element-citation',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_authors_fail(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation_authors())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'person-group//name or person-group//colab',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'at least 1 author in each element-citation',
+                'got_value': '0 authors',
+                'message': f'Got 0 authors expected at least 1 author in each element-citation',
+                'advice': 'There are no authors for the reference (ref-id: B1) provide at least 1 author'
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_publication_type_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = ArticleCitationsValidation(data).validate_article_citation_publication_type(
+            publication_type_list=['journal', 'book'])
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'publication-type',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['journal', 'book'],
+                'got_value': 'journal',
+                'message': 'Got journal expected one item of this list: journal | book',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_article_citation_publication_type_fail(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = ArticleCitationsValidation(data).validate_article_citation_publication_type(
+            publication_type_list=['other', 'book'])
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'publication-type',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['other', 'book'],
+                'got_value': 'journal',
+                'message': 'Got journal expected one item of this list: other | book',
+                'advice': 'publication-type for the reference (ref-id: B1) is missing or is invalid, '
+                          'provide one value from the list: other | book',
+            },
+        ]
+
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
+
+    def test_validate_article_citation_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <mixed-citation>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </mixed-citation>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+
+        data = etree.fromstring(xml)
+        obtained = list(ArticleCitationsValidation(data).validate_article_citation(publication_type_list=['journal', 'book']))
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'year',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '2015',
+                'got_value': '2015',
+                'message': f'Got 2015 expected 2015',
+                'advice': None
+            },
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'source',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Drug Alcohol Depend.',
+                'got_value': 'Drug Alcohol Depend.',
+                'message': 'Got Drug Alcohol Depend. expected Drug Alcohol Depend.',
+                'advice': None
+            },
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'article-title',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking '
+                                  'cessation in older ages',
+                'got_value': 'Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                             'in older ages',
+                'message': 'Got Smoking and potentially preventable hospitalisation: the benefit of smoking cessation '
+                           'in older ages expected Smoking and potentially preventable hospitalisation: the benefit '
+                           'of smoking cessation in older ages',
+                'advice': None
+            },
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'person-group//name or person-group//colab',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 author in each element-citation',
+                'got_value': '5 authors',
+                'message': f'Got 5 authors expected at least 1 author in each element-citation',
+                'advice': None
+            },
+            {
+                'title': 'element citation validation',
+                'element': 'element-citation',
+                'sub-element': 'publication-type',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['journal', 'book'],
+                'got_value': 'journal',
+                'message': 'Got journal expected one item of this list: journal | book',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -640,6 +640,61 @@ class ArticleCitationValidationTest(TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
+    def test_validate_article_citation_collab_success(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+                 <ref id="B2">
+                    <mixed-citation>
+                       2. Brasil. Lei n.
+                       <u>
+                          <sup>o</sup>
+                       </u>
+                       10.332, de 19/12/2001. Instituiu mecanismo de financiamento para o programa de ciência e tecnologia para o agronegócio, para o programa de fomento à pesquisa em saúde, para o programa de bioteconologia e recursos genéticos – Genoma, para o programa de ciência e tecnologia para o setor aeronáutico e para o programa de inovação para competitividade, e dá outras providências.
+                       <italic>Diário Oficial da União</italic>
+                       2001 dez 19.
+                    </mixed-citation>
+                    <element-citation publication-type="other">
+                       <person-group person-group-type="authors">
+                          <collab>Brasil</collab>
+                       </person-group>
+                       <article-title>Lei n.º 10.332, de 19/12/2001: Instituiu mecanismo de financiamento para o programa de ciência e tecnologia para o agronegócio, para o programa de fomento à pesquisa em saúde, para o programa de bioteconologia e recursos genéticos - Genoma, para o programa de ciência e tecnologia para o setor aeronáutico e para o programa de inovação para competitividade, e dá outras providências</article-title>
+                       <source>Diário Oficial da União</source>
+                       <date>
+                          <year>2001</year>
+                          <month>21</month>
+                       </date>
+                       <year>2001</year>
+                    </element-citation>
+                 </ref>
+                </ref-list>
+            </back>
+            </article>
+        """
+
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_authors())
+
+        expected = [
+            {
+                'title': 'element citation validation',
+                'item': 'element-citation',
+                'sub-item': 'person-group//name or person-group//colab',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'at least 1 author in each element-citation',
+                'got_value': '1 authors',
+                'message': f'Got 1 authors expected at least 1 author in each element-citation',
+                'advice': None
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
     def test_validate_article_citation_authors_fail(self):
         self.maxDiff = None
         xml = """

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -16,7 +16,7 @@ class ArticleCitationValidationTest(TestCase):
             <pub-date publication-format="electronic" date-type="pub">
             <day>20</day>
             <month>04</month>
-            <year>2022</year>
+            <year>2014</year>
             </pub-date>
             <pub-date publication-format="electronic" date-type="collection">
             <year>2003</year>
@@ -92,9 +92,9 @@ class ArticleCitationValidationTest(TestCase):
                 'sub-item': 'year',
                 'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'a value for year between 0 and 2003',
+                'expected_value': 'a value for year between 0 and 2014',
                 'got_value': '2015',
-                'message': f'Got 2015 expected a value for year between 0 and 2003',
+                'message': f'Got 2015 expected a value for year between 0 and 2014',
                 'advice': 'The year in reference (ref-id: B1) is missing or is invalid, provide a valid value for year'
             },
         ]

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -2,10 +2,11 @@ from unittest import TestCase
 
 from lxml import etree
 
-from packtools.sps.validation.article_citations import ArticleCitationsValidation
+from packtools.sps.models.article_citations import ArticleCitations
+from packtools.sps.validation.article_citations import ArticleCitationValidation, ArticleCitationsValidation
 
 
-class ArticleCitationsValidationTest(TestCase):
+class ArticleCitationValidationTest(TestCase):
     def test_validate_article_citation_year_success(self):
         self.maxDiff = None
         xml = """
@@ -64,8 +65,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_year())
 
         expected = [
             {
@@ -143,8 +144,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_year())
 
         expected = [
             {
@@ -221,8 +222,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_year())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_year())
 
         expected = [
             {
@@ -300,8 +301,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_source())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_source())
 
         expected = [
             {
@@ -378,8 +379,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_source())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_source())
 
         expected = [
             {
@@ -457,8 +458,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_article_title())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_article_title())
 
         expected = [
             {
@@ -539,8 +540,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_article_title())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_article_title())
 
         expected = [
             {
@@ -618,8 +619,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_authors())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_authors())
 
         expected = [
             {
@@ -673,8 +674,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation_authors())
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = list(ArticleCitationValidation(data).validate_article_citation_authors())
 
         expected = [
             {
@@ -752,8 +753,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = ArticleCitationsValidation(data).validate_article_citation_publication_type(
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = ArticleCitationValidation(data).validate_article_citation_publication_type(
             publication_type_list=['journal', 'book'])
 
         expected = [
@@ -832,8 +833,8 @@ class ArticleCitationsValidationTest(TestCase):
             </article>
         """
 
-        data = etree.fromstring(xml)
-        obtained = ArticleCitationsValidation(data).validate_article_citation_publication_type(
+        data = list(ArticleCitations(etree.fromstring(xml)).article_citations)[0]
+        obtained = ArticleCitationValidation(data).validate_article_citation_publication_type(
             publication_type_list=['other', 'book'])
 
         expected = [
@@ -914,7 +915,7 @@ class ArticleCitationsValidationTest(TestCase):
         """
 
         data = etree.fromstring(xml)
-        obtained = list(ArticleCitationsValidation(data).validate_article_citation(publication_type_list=['journal', 'book']))
+        obtained = list(ArticleCitationsValidation(data).validate_article_citations(publication_type_list=['journal', 'book']))
 
         expected = [
             {


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona classe de validação para referências, considerando: obrigatório `year`, `source`, `article-title` (se `publication-type=journal`), pelo menos um autor (institucional ou não), tipo da citação (valor)

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_citations.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.
