### PR TITLE
Fix: corrige problemas identificados pelos testes

### DIFF
--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -321,6 +321,17 @@ def match_pubdate(node, pubdate_xpaths):
             return pubdate
 
 
+def _handles_namespace(node):
+    # converte de <{http://www.w3.org/1998/Math/MathML}mrow> para <mml:mrow>
+    ns = {'{http://www.w3.org/1998/Math/MathML}': 'mml:'}
+
+    tag = str(node.tag)
+    for key, value in ns.items():
+        tag = tag.replace(key, value)
+
+    return tag
+
+
 def _generate_tag_list(tags_to_keep, tags_to_convert_to_html):
     return list(tags_to_keep or []) + list(tags_to_convert_to_html and tags_to_convert_to_html.keys() or [])
 

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -346,12 +346,15 @@ def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, ta
 
     Outros exemplos nos testes.
     """
-    # verifica se é o caso de remoção do conteúdo da tag
-    if node.tag in (tags_to_remove_with_content or []):
-        return ''
 
-    # obtem o conteúdo da tag
+    # obtem a tag, seu conteúdo e seus atributos
+    tag = _handles_namespace(node) # trata possíves namespaces
     text = node.text if node.text is not None else ''
+    attribs = ' '.join(f'{key}="{value}"' for key, value in node.attrib.items())
+
+    # verifica se é o caso de remoção do conteúdo da tag
+    if tag in (tags_to_remove_with_content or []):
+        return ''
 
     # processa as tags internas
     for child in node:
@@ -363,13 +366,15 @@ def remove_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, ta
     all_tags_to_keep = _generate_tag_list(tags_to_keep, tags_to_convert_to_html)
 
     text = ' '.join(text.split())
-    if node.tag in all_tags_to_keep:
-        return f'<{node.tag}>{text}</{node.tag}>'
+    if tag in all_tags_to_keep:
+        if attribs:
+            return f'<{tag} {attribs}>{text}</{tag}>'
+        return f'<{tag}>{text}</{tag}>'
     return text
 
 
 def process_subtags(node, tags_to_keep=None, tags_to_remove_with_content=None, tags_to_convert_to_html=None):
-    std_to_keep = ['sup', 'sub', 'mml:math', 'math']
+    std_to_keep = ['sup', 'sub', 'mml:math', 'mml:mrow', 'mml:msqrt', 'mml:mn', 'math']
     std_to_remove_content = ['xref']
     std_to_convert = {'italic': 'i'}
 

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -144,6 +144,8 @@ def get_node_without_subtag(node, remove_extra_spaces=False):
     """
         Função que retorna nó sem subtags.
     """
+    if node is None:
+        return
     if remove_extra_spaces:
         return " ".join([text.strip() for text in node.xpath(".//text()") if text.strip()])
     return "".join(node.xpath(".//text()"))

--- a/tests/sps/models/test_xml_utils.py
+++ b/tests/sps/models/test_xml_utils.py
@@ -152,15 +152,17 @@ class NodeTextTest(TestCase):
     def test_process_subtags_keeps_math(self):
         self.maxDiff = None
         xmltree = etree.fromstring(
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML">
-            <article-title>Uma Reflexão de Professores sobre Demonstrações Relativas à Irracionalidade de 
-            <inline-formula><mml:math display="inline" id="m1"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>
-            </mml:mrow></mml:math></inline-formula> </article-title>
-            </article>
-            """
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            '<article-title xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            'Uma Reflexão de Professores sobre Demonstrações Relativas à Irracionalidade de ' 
+            '<inline-formula><mml:math display="inline" id="m1"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt>'
+            '</mml:mrow></mml:math></inline-formula> </article-title>'
+            '</article>'
         )
-        expected = 'Uma Reflexão de Professores sobre Demonstrações Relativas à Irracionalidade de <mml:math display="inline" id="m1"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt></mml:mrow></mml:math>'
+        expected = ('Uma Reflexão de Professores sobre Demonstrações Relativas à Irracionalidade de '
+                    '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" display="inline" '
+                    'id="m1"><mml:mrow><mml:msqrt><mml:mn>2</mml:mn></mml:msqrt></mml:mrow></mml:math>')
+
         obtained = xml_utils.process_subtags(xmltree.find(".//article-title"))
         self.assertEqual(expected, obtained)
 
@@ -284,12 +286,16 @@ class NodeTextTest(TestCase):
             </article>
             """
         )
-        expected = '<journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id> ' \
-                   'Revista de Saúde Pública ' \
-                   '<abbrev-journal-title abbrev-type="publisher">Rev. Saúde Pública</abbrev-journal-title> ' \
-                   '<issn pub-type="ppub">0034-8910</issn> ' \
-                   '<issn pub-type="epub">1518-8787</issn> ' \
-                   'Faculdade de Saúde Pública da Universidade de São Paulo'
+
+        expected = (
+            '<journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id> '
+            'Revista de Saúde Pública '
+            '<abbrev-journal-title abbrev-type="publisher">Rev. Saúde Pública</abbrev-journal-title> '
+            '<issn pub-type="ppub">0034-8910</issn> '
+            '<issn pub-type="epub">1518-8787</issn> '
+            'Faculdade de Saúde Pública da Universidade de São Paulo'
+        )
+
         obtained = xml_utils.process_subtags(
             xmltree.find(".//front"),
             tags_to_keep=['journal-id', 'abbrev-journal-title', 'issn']

--- a/tests/sps/models/test_xml_utils.py
+++ b/tests/sps/models/test_xml_utils.py
@@ -262,6 +262,40 @@ class NodeTextTest(TestCase):
         )
         self.assertEqual(expected, obtained)
 
+    def test_convert_xml_to_html_with_attribs(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <article>
+                <front>
+                <journal-meta>
+                    <journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>
+                    <journal-title-group>
+                        <journal-title>Revista de Saúde Pública</journal-title>
+                        <abbrev-journal-title abbrev-type="publisher">Rev. Saúde Pública</abbrev-journal-title>
+                    </journal-title-group>
+                    <issn pub-type="ppub">0034-8910</issn>
+                    <issn pub-type="epub">1518-8787</issn>
+                    <publisher>
+                        <publisher-name>Faculdade de Saúde Pública da Universidade de São Paulo</publisher-name>
+                    </publisher>
+                </journal-meta>
+                </front>
+            </article>
+            """
+        )
+        expected = '<journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id> ' \
+                   'Revista de Saúde Pública ' \
+                   '<abbrev-journal-title abbrev-type="publisher">Rev. Saúde Pública</abbrev-journal-title> ' \
+                   '<issn pub-type="ppub">0034-8910</issn> ' \
+                   '<issn pub-type="epub">1518-8787</issn> ' \
+                   'Faculdade de Saúde Pública da Universidade de São Paulo'
+        obtained = xml_utils.process_subtags(
+            xmltree.find(".//front"),
+            tags_to_keep=['journal-id', 'abbrev-journal-title', 'issn']
+        )
+        self.assertEqual(expected, obtained)
+
 
 class NodeTextWithoutXrefTest(TestCase):
 

--- a/tests/sps/models/test_xml_utils.py
+++ b/tests/sps/models/test_xml_utils.py
@@ -166,6 +166,19 @@ class NodeTextTest(TestCase):
         obtained = xml_utils.process_subtags(xmltree.find(".//article-title"))
         self.assertEqual(expected, obtained)
 
+    def test_process_subtags_keeps_math_tex_math(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<p>... Selected as described for Acc-29'
+            '<disp-formula>'
+            '<tex-math id="M1"><![CDATA[xxxxxxxxxx]]></tex-math>'
+            '</disp-formula> TER1/ter1-Acc: Acc-29 crossed with ...</p>'
+        )
+        expected = ('... Selected as described for Acc-29xxxxxxxxxx TER1/ter1-Acc: Acc-29 crossed with ...')
+
+        obtained = xml_utils.process_subtags(xmltree.find("."))
+        self.assertEqual(expected, obtained)
+
     def test_process_subtags_remove_italic_content(self):
         self.maxDiff = None
         xmltree = etree.fromstring(


### PR DESCRIPTION
#### O que esse PR faz?
Corrige problemas identificados pelos testes:

1. Nó é `None` em `get_node_without_subtag`;
2. Tratamento de `namespaces`, ex.: de `<{http://www.w3.org/1998/Math/MathML}mrow>` para `<mml:mrow>`;
3. Manutenção dos atributos de um **nó**, quando este **nó** não for removido.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Avaliar os testes.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

