### PR TITLE
Add order (`article-id[@pub-id-type="other"]`) setter and getter

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_adapter.py
+++ b/packtools/sps/pid_provider/xml_sps_adapter.py
@@ -38,7 +38,13 @@ class PidProviderXMLAdapter:
 
     @property
     def v2_prefix(self):
+        # S + ISSN + YEAR ou 14 primeiros dígitos do pid clássico
         return self.xml_with_pre.v2_prefix
+
+    @property
+    def order(self):
+        # até 5 dígitos, em geral 5 últimos dígitos do pid v2
+        return self.xml_with_pre.order
 
     @property
     def volume(self):
@@ -111,6 +117,10 @@ class PidProviderXMLAdapter:
     @aop_pid.setter
     def aop_pid(self, value):
         self.xml_with_pre.aop_pid = value
+
+    @order.setter
+    def order(self, value):
+        self.xml_with_pre.order = value
 
     @property
     def z_links(self):

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -383,6 +383,34 @@ class XMLWithPre:
     def aop_pid(self):
         return self.article_ids.aop_pid
 
+    @property
+    def order(self):
+        return self.article_ids.other
+
+    @order.setter
+    def order(self, value):
+        try:
+            new_value = str(int(value)).zfill(5)
+        except (TypeError, ValueError, AttributeError):
+            new_value = None
+
+        if not new_value or len(new_value) > 5:
+            raise ValueError(
+                "can't set attribute XMLWithPre.order. "
+                "Expected value must a 5 characters digit. Got: %s" % value
+            )
+        try:
+            node = self.xmltree.xpath('.//article-id[@pub-id-type="other"]')[0]
+        except IndexError:
+            node = None
+
+        if node is None:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "other")
+            parent = self.article_id_parent
+            parent.insert(1, node)
+        node.text = new_value
+
     @v2.setter
     def v2(self, value):
         value = value and value.strip()


### PR DESCRIPTION
#### O que esse PR faz?
Add order (`article-id[@pub-id-type="other"]`) setter and getter

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```python
from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre

from packtools.sps.pid_provider.xml_sps_adapter import PidProviderXMLAdapter

from lxml import etree

for x in XMLWithPre.create(path="/Users/roberta.takenaka/github.com/scieloorg/packtools_/packtools_python3/packtools/tests/fixtures/htmlgenerator/table_wrap_group_and_fig_group/QMyWZTMgngWRCDtVJfJH9Cn/QMyWZTMgngWRCDtVJfJH9Cn.xml"):
       a = PidProviderXMLAdapter(x, x.sps_pkg_name)
       print(a.order)
       a.order = a.v2[-5:]

```
#### Algum cenário de contexto que queira dar?
Foi identificado ausência do article-id conforme esperado ao carregar XML no Upload dos países

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

