### PR TITLE
Refactor: padroniza funções como geradoras (aff)

### DIFF
--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -13,18 +13,14 @@ class AffiliationsListValidation:
         country_codes_list = country_codes_list or self.country_codes_list
         if not country_codes_list:
             raise AffiliationValidationValidateCountryCodeException("Function requires list of country codes")
-        validations = []
         for affiliation in self.affiliations_list:
-            validations.extend(AffiliationValidation(affiliation, country_codes_list).validate_affiliation())
-        return validations
+            yield from AffiliationValidation(affiliation, country_codes_list).validate_affiliation()
 
     def validate(self, data):
         country_codes_list = data['country_codes_list'] or self.country_codes_list
         if not country_codes_list:
             raise AffiliationValidationValidateCountryCodeException("Function requires list of country codes")
-        return {
-            'affiliations_validation': self.validade_affiliations_list(country_codes_list)
-        }
+        yield from self.validade_affiliations_list(country_codes_list)
 
 
 class AffiliationValidation:
@@ -34,7 +30,7 @@ class AffiliationValidation:
 
     def validate_original(self):
         original = self.affiliation.get('original')
-        return {
+        yield {
             'title': 'aff/institution element original attribute validation',
             'xpath': './/aff/institution[@content-type="original"]',
             'validation_type': 'exist',
@@ -47,7 +43,7 @@ class AffiliationValidation:
 
     def validate_orgname(self):
         orgname = self.affiliation.get('orgname')
-        return {
+        yield {
             'title': 'aff/institution element orgname attribute validation',
             'xpath': './/aff/institution[@content-type="orgname"]',
             'validation_type': 'exist',
@@ -60,7 +56,7 @@ class AffiliationValidation:
 
     def validate_country(self):
         country = self.affiliation.get('country_name')
-        return {
+        yield {
             'title': 'aff element country attribute validation',
             'xpath': './/aff/country',
             'validation_type': 'exist',
@@ -78,7 +74,7 @@ class AffiliationValidation:
                 "Function requires list of country codes"
             )
         country_code = self.affiliation.get('country_code')
-        return {
+        yield {
             'title': 'aff element @country attribute validation',
             'xpath': './/aff/@country',
             'validation_type': 'value in list',
@@ -91,7 +87,7 @@ class AffiliationValidation:
 
     def validate_state(self):
         state = self.affiliation.get('state')
-        return {
+        yield {
             'title': 'aff/addr-line element state attribute validation',
             'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
             'validation_type': 'exist',
@@ -104,7 +100,7 @@ class AffiliationValidation:
 
     def validate_city(self):
         city = self.affiliation.get('city')
-        return {
+        yield {
             'title': 'aff/addr-line element city attribute validation',
             'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
             'validation_type': 'exist',
@@ -116,11 +112,9 @@ class AffiliationValidation:
         }
 
     def validate_affiliation(self):
-        return [
-            self.validate_original(),
-            self.validate_orgname(),
-            self.validate_country(),
-            self.validate_country_code(),
-            self.validate_state(),
-            self.validate_city()
-        ]
+        yield from self.validate_original()
+        yield from self.validate_orgname()
+        yield from self.validate_country()
+        yield from self.validate_country_code()
+        yield from self.validate_state()
+        yield from self.validate_city()

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -43,9 +43,9 @@ class AffiliationValidationTest(TestCase):
         """)
 
         xml_tree = etree.fromstring(xml)
-        message = AffiliationsListValidation(xml_tree, ['BR']).validade_affiliations_list()
+        obtained = list(AffiliationsListValidation(xml_tree, ['BR']).validade_affiliations_list())
 
-        expected_output = [
+        expected = [
                 {
                     'title': 'aff/institution element original attribute validation',
                     'xpath': './/aff/institution[@content-type="original"]',
@@ -174,7 +174,7 @@ class AffiliationValidationTest(TestCase):
                 }
             ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliation_without_original(self):
         self.maxDiff = None
@@ -198,20 +198,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0]).validate_original()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_original())
 
-        expected_output = {
-                    'title': 'aff/institution element original attribute validation',
-                    'xpath': './/aff/institution[@content-type="original"]',
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': 'original affiliation',
-                    'got_value': None,
-                    'message': 'Got None, expected original affiliation',
-                    'advice': 'provide the original affiliation'
-        }
+        expected = [
+            {
+                'title': 'aff/institution element original attribute validation',
+                'xpath': './/aff/institution[@content-type="original"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'original affiliation',
+                'got_value': None,
+                'message': 'Got None, expected original affiliation',
+                'advice': 'provide the original affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliations_without_orgname(self):
         self.maxDiff = None
@@ -234,20 +236,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0]).validate_orgname()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_orgname())
 
-        expected_output = {
-                    'title': 'aff/institution element orgname attribute validation',
-                    'xpath': './/aff/institution[@content-type="orgname"]',
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': 'orgname affiliation',
-                    'got_value': None,
-                    'message': 'Got None, expected orgname affiliation',
-                    'advice': 'provide the orgname affiliation'
-                }
+        expected = [
+            {
+                'title': 'aff/institution element orgname attribute validation',
+                'xpath': './/aff/institution[@content-type="orgname"]',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'orgname affiliation',
+                'got_value': None,
+                'message': 'Got None, expected orgname affiliation',
+                'advice': 'provide the orgname affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliations_without_country(self):
         self.maxDiff = None
@@ -271,20 +275,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0]).validate_country()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_country())
 
-        expected_output = {
-                    'title': 'aff element country attribute validation',
-                    'xpath': './/aff/country',
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': 'country affiliation',
-                    'got_value': None,
-                    'message': 'Got None, expected country affiliation',
-                    'advice': 'provide the country affiliation'
-                }
+        expected = [
+            {
+                'title': 'aff element country attribute validation',
+                'xpath': './/aff/country',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'country affiliation',
+                'got_value': None,
+                'message': 'Got None, expected country affiliation',
+                'advice': 'provide the country affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliations_without_country_code(self):
         self.maxDiff = None
@@ -309,20 +315,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0], ['BR']).validate_country_code()
+        obtained = list(AffiliationValidation(affiliations_list[0], ['BR']).validate_country_code())
 
-        expected_output = {
-                    'title': 'aff element @country attribute validation',
-                    'xpath': './/aff/@country',
-                    'validation_type': 'value in list',
-                    'response': 'ERROR',
-                    'expected_value': ['BR'],
-                    'got_value': None,
-                    'message': "Got None, expected one item of this list: ['BR']",
-                    'advice': 'provide a valid @country affiliation'
-                }
+        expected = [
+            {
+                'title': 'aff element @country attribute validation',
+                'xpath': './/aff/@country',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['BR'],
+                'got_value': None,
+                'message': "Got None, expected one item of this list: ['BR']",
+                'advice': 'provide a valid @country affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliations_without_state(self):
         self.maxDiff = None
@@ -346,20 +354,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0]).validate_state()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_state())
 
-        expected_output = {
-                    'title': 'aff/addr-line element state attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': 'state affiliation',
-                    'got_value': None,
-                    'message': 'Got None, expected state affiliation',
-                    'advice': 'provide the state affiliation'
-                }
+        expected = [
+            {
+                'title': 'aff/addr-line element state attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'state affiliation',
+                'got_value': None,
+                'message': 'Got None, expected state affiliation',
+                'advice': 'provide the state affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_affiliations_without_city(self):
         self.maxDiff = None
@@ -383,20 +393,22 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = Affiliation(xml_tree).affiliation_list
-        message = AffiliationValidation(affiliations_list[0]).validate_city()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_city())
 
-        expected_output = {
-                    'title': 'aff/addr-line element city attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': 'city affiliation',
-                    'got_value': None,
-                    'message': 'Got None, expected city affiliation',
-                    'advice': 'provide the city affiliation'
-                }
+        expected = [
+            {
+                'title': 'aff/addr-line element city attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': 'city affiliation',
+                'got_value': None,
+                'message': 'Got None, expected city affiliation',
+                'advice': 'provide the city affiliation'
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)
 
     def test_validate(self):
         self.maxDiff = None
@@ -434,137 +446,135 @@ class AffiliationValidationTest(TestCase):
         data = {
             'country_codes_list':  ['BR']
         }
-        message = AffiliationsListValidation(xml_tree).validate(data)
+        obtained = list(AffiliationsListValidation(xml_tree).validate(data))
 
-        expected_output = {
-            'affiliations_validation': [
-                {
-                    'title': 'aff/institution element original attribute validation',
-                    'xpath': './/aff/institution[@content-type="original"]',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'original affiliation',
-                    'got_value': 'Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil',
-                    'message': 'Got Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil, expected original affiliation',
-                    'advice': None
+        expected = [
+            {
+                'title': 'aff/institution element original attribute validation',
+                'xpath': './/aff/institution[@content-type="original"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'original affiliation',
+                'got_value': 'Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil',
+                'message': 'Got Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil, expected original affiliation',
+                'advice': None
 
-                },
-                {
-                    'title': 'aff/institution element orgname attribute validation',
-                    'xpath': './/aff/institution[@content-type="orgname"]',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'orgname affiliation',
-                    'got_value': 'Secretaria Municipal de Saúde de Belo Horizonte',
-                    'message': 'Got Secretaria Municipal de Saúde de Belo Horizonte, expected orgname affiliation',
-                    'advice': None
+            },
+            {
+                'title': 'aff/institution element orgname attribute validation',
+                'xpath': './/aff/institution[@content-type="orgname"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'orgname affiliation',
+                'got_value': 'Secretaria Municipal de Saúde de Belo Horizonte',
+                'message': 'Got Secretaria Municipal de Saúde de Belo Horizonte, expected orgname affiliation',
+                'advice': None
 
-                },
-                {
-                    'title': 'aff element country attribute validation',
-                    'xpath': './/aff/country',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'country affiliation',
-                    'got_value': 'Brasil',
-                    'message': 'Got Brasil, expected country affiliation',
-                    'advice': None
-                },
-                {
-                    'title': 'aff element @country attribute validation',
-                    'xpath': './/aff/@country',
-                    'validation_type': 'value in list',
-                    'response': 'OK',
-                    'expected_value': ['BR'],
-                    'got_value': 'BR',
-                    'message': "Got BR, expected one item of this list: ['BR']",
-                    'advice': None
-                },
-                {
-                    'title': 'aff/addr-line element state attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'state affiliation',
-                    'got_value': 'MG',
-                    'message': 'Got MG, expected state affiliation',
-                    'advice': None
-                },
-                {
-                    'title': 'aff/addr-line element city attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'city affiliation',
-                    'got_value': 'Belo Horizonte',
-                    'message': 'Got Belo Horizonte, expected city affiliation',
-                    'advice': None
-                },
-                {
-                    'title': 'aff/institution element original attribute validation',
-                    'xpath': './/aff/institution[@content-type="original"]',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'original affiliation',
-                    'got_value': 'Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. '
-                                 'Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil',
-                    'message': 'Got Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. '
-                                 'Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil, expected original affiliation',
-                    'advice': None
+            },
+            {
+                'title': 'aff element country attribute validation',
+                'xpath': './/aff/country',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'country affiliation',
+                'got_value': 'Brasil',
+                'message': 'Got Brasil, expected country affiliation',
+                'advice': None
+            },
+            {
+                'title': 'aff element @country attribute validation',
+                'xpath': './/aff/@country',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['BR'],
+                'got_value': 'BR',
+                'message': "Got BR, expected one item of this list: ['BR']",
+                'advice': None
+            },
+            {
+                'title': 'aff/addr-line element state attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'state affiliation',
+                'got_value': 'MG',
+                'message': 'Got MG, expected state affiliation',
+                'advice': None
+            },
+            {
+                'title': 'aff/addr-line element city attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'city affiliation',
+                'got_value': 'Belo Horizonte',
+                'message': 'Got Belo Horizonte, expected city affiliation',
+                'advice': None
+            },
+            {
+                'title': 'aff/institution element original attribute validation',
+                'xpath': './/aff/institution[@content-type="original"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'original affiliation',
+                'got_value': 'Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. '
+                             'Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil',
+                'message': 'Got Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. '
+                           'Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil, expected original affiliation',
+                'advice': None
 
-                },
-                {
-                    'title': 'aff/institution element orgname attribute validation',
-                    'xpath': './/aff/institution[@content-type="orgname"]',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'orgname affiliation',
-                    'got_value': 'Universidade Federal de Minas Gerais',
-                    'message': 'Got Universidade Federal de Minas Gerais, expected orgname affiliation',
-                    'advice': None
+            },
+            {
+                'title': 'aff/institution element orgname attribute validation',
+                'xpath': './/aff/institution[@content-type="orgname"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'orgname affiliation',
+                'got_value': 'Universidade Federal de Minas Gerais',
+                'message': 'Got Universidade Federal de Minas Gerais, expected orgname affiliation',
+                'advice': None
 
-                },
-                {
-                    'title': 'aff element country attribute validation',
-                    'xpath': './/aff/country',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'country affiliation',
-                    'got_value': 'Brasil',
-                    'message': 'Got Brasil, expected country affiliation',
-                    'advice': None
-                },
-                {
-                    'title': 'aff element @country attribute validation',
-                    'xpath': './/aff/@country',
-                    'validation_type': 'value in list',
-                    'response': 'OK',
-                    'expected_value': ['BR'],
-                    'got_value': 'BR',
-                    'message': "Got BR, expected one item of this list: ['BR']",
-                    'advice': None
-                },
-                {
-                    'title': 'aff/addr-line element state attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'state affiliation',
-                    'got_value': 'MG',
-                    'message': 'Got MG, expected state affiliation',
-                    'advice': None
-                },
-                {
-                    'title': 'aff/addr-line element city attribute validation',
-                    'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': 'city affiliation',
-                    'got_value': 'Belo Horizonte',
-                    'message': 'Got Belo Horizonte, expected city affiliation',
-                    'advice': None
-                }
-            ]
-        }
+            },
+            {
+                'title': 'aff element country attribute validation',
+                'xpath': './/aff/country',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'country affiliation',
+                'got_value': 'Brasil',
+                'message': 'Got Brasil, expected country affiliation',
+                'advice': None
+            },
+            {
+                'title': 'aff element @country attribute validation',
+                'xpath': './/aff/@country',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['BR'],
+                'got_value': 'BR',
+                'message': "Got BR, expected one item of this list: ['BR']",
+                'advice': None
+            },
+            {
+                'title': 'aff/addr-line element state attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="state"] or .//aff/addr-line/state',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'state affiliation',
+                'got_value': 'MG',
+                'message': 'Got MG, expected state affiliation',
+                'advice': None
+            },
+            {
+                'title': 'aff/addr-line element city attribute validation',
+                'xpath': './/aff/addr-line/named-content[@content-type="city"] or .//aff/addr-line/city',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': 'city affiliation',
+                'got_value': 'Belo Horizonte',
+                'message': 'Got Belo Horizonte, expected city affiliation',
+                'advice': None
+            }
+        ]
 
-        self.assertEqual(message, expected_output)
+        self.assertEqual(obtained, expected)


### PR DESCRIPTION
#### O que esse PR faz?
Padroniza o retorno das funções de validação de afiliações para funcionarem como geradoras.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_aff.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #568 

### Referências
NA.

