### PR TITLE
Refactor: padroniza funções como geradoras (article authors)

### DIFF
--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -69,7 +69,7 @@ class ArticleLangValidation:
             else:
                 msg = '<sub-article article-type={} id={} xml:lang={}>'.format(article_type, article_id, article_lang)
 
-            item = {
+            yield {
                 'title': 'Article element lang attribute validation',
                 'xpath': './article/@xml:lang' if article_id == 'main' else './/sub-article/@xml:lang',
                 'validation_type': 'value in list',
@@ -82,7 +82,6 @@ class ArticleLangValidation:
                                                                                                                     " | ".join(
                                                                                                                         language_codes_list))
             }
-            yield item
 
 
 class ArticleAttribsValidation:
@@ -133,7 +132,7 @@ class ArticleAttribsValidation:
         article_specific_use = self.articles.main_specific_use
         validated = article_specific_use in specific_use_list
 
-        return {
+        yield {
             'title': 'Article element specific-use attribute validation',
             'xpath': './article/@specific-use',
             'validation_type': 'value in list',
@@ -187,7 +186,7 @@ class ArticleAttribsValidation:
         article_dtd_version = self.articles.main_dtd_version
         validated = article_dtd_version in dtd_version_list
 
-        return {
+        yield {
             'title': 'Article element dtd-version attribute validation',
             'xpath': './article/@dtd-version',
             'validation_type': 'value in list',
@@ -250,7 +249,7 @@ class ArticleTypeValidation:
         article_type_list = [tp.lower() for tp in article_type_list]
 
         validated = article_type in article_type_list
-        return {
+        yield {
             'title': 'Article type validation',
             'xpath': './article/@article-type',
             'validation_type': 'value in list',
@@ -322,7 +321,7 @@ class ArticleSubjectsValidation:
 
         validated = len(declared_subjects) == 0
         got_value = None if validated else ", ".join(declared_subjects)
-        return {
+        yield {
             'title': 'Article type vs subjects validation',
             'xpath': './article/@article-type .//subject',
             'validation_type': 'value in list',
@@ -408,15 +407,13 @@ class ArticleSubjectsValidation:
             raise ValidationArticleAndSubArticlesSubjectsException("Function requires list of subjects")
 
         subjects_list = [f"{item['subject']} ({item['lang']})" for item in subjects_list]
-        result = []
 
         for article in self.articles.data:
             article_subject = f"{article['subject']} ({article['lang']})"
             article_id = article['article_id']
             calculated_similarity, subject = most_similar(similarity(subjects_list, article_subject))
             validated = calculated_similarity >= expected_similarity
-            result.append(
-                {
+            yield {
                     'title': 'Article type vs subjects validation',
                     'xpath': './article/@article-type .//subject',
                     'validation_type': 'similarity',
@@ -427,9 +424,6 @@ class ArticleSubjectsValidation:
                     'advice': None if validated else 'The subject {} does not match the items provided in the list: {}'
                     .format(article_subject, " | ".join(subjects_list))
                 }
-            )
-
-        return result
 
     def validate(self, data):
         """
@@ -439,7 +433,7 @@ class ArticleSubjectsValidation:
             dict: Um dicionário contendo os resultados das validações realizadas.
 
         """
-        return {
+        yield {
             'article_lang_validation': self.validate_language(data['language_codes_list']),
             'article_specific_use_validation': self.validate_specific_use(data['specific_use_list'])
         }
@@ -483,7 +477,7 @@ class ArticleIdValidation:
         """
         is_valid = self.other_id.isnumeric() and len(self.other_id) <= 5
         expected_value = self.other_id if is_valid else 'A numeric value with up to five digits'
-        return {
+        yield {
             'title': 'Article id other validation',
             'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',

--- a/packtools/sps/validation/article_authors.py
+++ b/packtools/sps/validation/article_authors.py
@@ -228,8 +228,7 @@ class ArticleAuthorsValidation:
         if not is_valid:
             diff = [item for item, freq in orcid_freq.items() if freq > 1]
 
-        return [
-            {
+        yield {
                 'title': 'Author ORCID element is unique',
                 'xpath': './/contrib-id[@contrib-id-type="orcid"]',
                 'validation_type': 'exist/verification',
@@ -241,7 +240,6 @@ class ArticleAuthorsValidation:
                 'advice': None if is_valid else 'Consider replacing the following ORCIDs that are not unique: {}'.format(
                     " | ".join(diff))
             }
-        ]
 
     def validate_authors_orcid_is_registered(self, callable_get_validate=None):
         """
@@ -324,15 +322,8 @@ class ArticleAuthorsValidation:
         """
         Função que executa as validações da classe ArticleAuthorsValidation.
 
-        Returns:
-            dict: Um dicionário contendo os resultados das validações realizadas.
-        
         """
-        credit_terms_and_urls_results = {
-            'authors_credit_terms_and_urls_validation': self.validate_authors_role(data['credit_taxonomy_terms_and_urls'])
-            }
-        orcid_results = {
-            'authors_orcid_validation': self.validate_authors_orcid()
-            }
-        credit_terms_and_urls_results.update(orcid_results)
-        return credit_terms_and_urls_results
+        yield from self.validate_authors_role(data['credit_taxonomy_terms_and_urls'])
+        yield from self.validate_authors_orcid_format()
+        yield from self.validate_authors_orcid_is_unique()
+        yield from self.validate_authors_orcid_is_registered(callable_get_validate=data['callable_get_data'])

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -379,20 +379,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue']))
 
-        expected = {
-            'title': 'Article element specific-use attribute validation',
-            'xpath': './article/@specific-use',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
-            'got_value': 'sps-1.9',
-            'message': 'Got sps-1.9 expected one item of this list: sps-1.9 | preprint | special-issue',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article element specific-use attribute validation',
+                'xpath': './article/@specific-use',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
+                'got_value': 'sps-1.9',
+                'message': 'Got sps-1.9 expected one item of this list: sps-1.9 | preprint | special-issue',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_without_specific_use(self):
         self.maxDiff = None
@@ -406,20 +408,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue']))
 
-        expected = {
-            'title': 'Article element specific-use attribute validation',
-            'xpath': './article/@specific-use',
-            'validation_type': 'value in list',
-            'response': 'ERROR',
-            'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
-            'got_value': None,
-            'message': 'Got None expected one item of this list: sps-1.9 | preprint | special-issue',
-            'advice': 'XML research-article has None as specific-use, expected one item of this list: sps-1.9 | preprint | special-issue'
-        }
+        expected = [
+            {
+                'title': 'Article element specific-use attribute validation',
+                'xpath': './article/@specific-use',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
+                'got_value': None,
+                'message': 'Got None expected one item of this list: sps-1.9 | preprint | special-issue',
+                'advice': 'XML research-article has None as specific-use, expected one item of this list: sps-1.9 | preprint | special-issue'
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_dtd_version(self):
         self.maxDiff = None
@@ -433,20 +437,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_dtd_version(dtd_version_list=['1.1', '1.2', '1.3'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_dtd_version(dtd_version_list=['1.1', '1.2', '1.3']))
 
-        expected = {
-            'title': 'Article element dtd-version attribute validation',
-            'xpath': './article/@dtd-version',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['1.1', '1.2', '1.3'],
-            'got_value': '1.1',
-            'message': 'Got 1.1 expected one item of this list: 1.1 | 1.2 | 1.3',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article element dtd-version attribute validation',
+                'xpath': './article/@dtd-version',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['1.1', '1.2', '1.3'],
+                'got_value': '1.1',
+                'message': 'Got 1.1 expected one item of this list: 1.1 | 1.2 | 1.3',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_is_valid(self):
         self.maxDiff = None
@@ -460,22 +466,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleTypeValidation(xml_tree).validate_article_type(
+        obtained = list(ArticleTypeValidation(xml_tree).validate_article_type(
             article_type_list=['research-article']
-        )
+        ))
 
-        expected = {
-            'title': 'Article type validation',
-            'xpath': './article/@article-type',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['research-article'],
-            'got_value': 'research-article',
-            'message': 'Got research-article expected one item of this list: research-article',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article type validation',
+                'xpath': './article/@article-type',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['research-article'],
+                'got_value': 'research-article',
+                'message': 'Got research-article expected one item of this list: research-article',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_is_not_valid(self):
         self.maxDiff = None
@@ -489,22 +497,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleTypeValidation(xml_tree).validate_article_type(
+        obtained = list(ArticleTypeValidation(xml_tree).validate_article_type(
             article_type_list=['research-article']
-        )
+        ))
 
-        expected = {
-            'title': 'Article type validation',
-            'xpath': './article/@article-type',
-            'validation_type': 'value in list',
-            'response': 'ERROR',
-            'expected_value': ['research-article'],
-            'got_value': 'main',
-            'message': 'Got main expected one item of this list: research-article',
-            'advice': 'XML has main as article-type, expected one item of this list: research-article'
-        }
+        expected = [
+            {
+                'title': 'Article type validation',
+                'xpath': './article/@article-type',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['research-article'],
+                'got_value': 'main',
+                'message': 'Got main expected one item of this list: research-article',
+                'advice': 'XML has main as article-type, expected one item of this list: research-article'
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_there_is_subject_there_should_be_no_subject(self):
         self.maxDiff = None
@@ -537,9 +547,10 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
                 """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleSubjectsValidation(xml_tree).validate_without_subjects()
+        obtained = list(ArticleSubjectsValidation(xml_tree).validate_without_subjects())
 
-        expected = {
+        expected = [
+            {
                 'title': 'Article type vs subjects validation',
                 'xpath': './article/@article-type .//subject',
                 'validation_type': 'value in list',
@@ -549,9 +560,10 @@ class ArticleAndSubarticlesTest(TestCase):
                 'message': 'Got scientific article, artigo científico, artículo científico expected no subject',
                 'advice': 'XML has scientific article, artigo científico, artículo científico as subjects, expected '
                           'no subjects'
-        }
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_there_is_no_subject_there_should_be_no_subject(self):
         self.maxDiff = None
@@ -569,9 +581,10 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleSubjectsValidation(xml_tree).validate_without_subjects()
+        obtained = list(ArticleSubjectsValidation(xml_tree).validate_without_subjects())
 
-        expected = {
+        expected = [
+            {
                 'title': 'Article type vs subjects validation',
                 'xpath': './article/@article-type .//subject',
                 'validation_type': 'value in list',
@@ -580,9 +593,10 @@ class ArticleAndSubarticlesTest(TestCase):
                 'got_value': None,
                 'message': 'Got None expected no subject',
                 'advice': 'XML has None as subjects, expected no subjects'
-        }
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_vs_subject_similarity(self):
         self.maxDiff = None
@@ -687,19 +701,21 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'OK',
-            'expected_value': '123',
-            'got_value': '123',
-            'message': 'Got 123 expected 123',
-            'advice': None
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '123',
+                'got_value': '123',
+                'message': 'Got 123 expected 123',
+                'advice': None
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)
 
     def test_article_and_subarticles_validate_article_id_other_non_numeric_digit(self):
         self.maxDiff = None
@@ -716,19 +732,21 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'ERROR',
-            'expected_value': 'A numeric value with up to five digits',
-            'got_value': 'x23',
-            'message': 'Got x23 expected a numeric value with up to five digits',
-            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'A numeric value with up to five digits',
+                'got_value': 'x23',
+                'message': 'Got x23 expected a numeric value with up to five digits',
+                'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)
 
     def test_article_and_subarticles_validate_article_id_other_with_more_than_five_digits(self):
         self.maxDiff = None
@@ -745,16 +763,18 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'ERROR',
-            'expected_value': 'A numeric value with up to five digits',
-            'got_value': '123456',
-            'message': 'Got 123456 expected a numeric value with up to five digits',
-            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'A numeric value with up to five digits',
+                'got_value': '123456',
+                'message': 'Got 123456 expected a numeric value with up to five digits',
+                'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)

--- a/tests/sps/validation/test_article_authors.py
+++ b/tests/sps/validation/test_article_authors.py
@@ -969,3 +969,127 @@ class ArticleAuthorsValidationOrcidTest(TestCase):
         for i, item in enumerate(messages):
             with self.subTest(i):
                 self.assertDictEqual(expected_output[i], item)
+
+    def test_validate(self):
+        self.maxDiff = None
+        xml = """
+        <article>
+        <front>
+            <article-meta>
+              <contrib-group>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                  <name>
+                    <surname>VENEGAS-MARTÍNEZ</surname>
+                    <given-names>FRANCISCO</given-names>
+                    <prefix>Prof</prefix>
+                    <suffix>Nieto</suffix>
+                  </name>
+                  <xref ref-type="aff" rid="aff1"/>
+                </contrib>
+                <contrib contrib-type="author">
+                    <contrib-id contrib-id-type="orcid">0000-3333-1238-6873</contrib-id>
+                  <name>
+                    <surname>Higa</surname>
+                    <given-names>Vanessa M.</given-names>
+                  </name>
+                  <xref ref-type="aff" rid="aff1">a</xref>
+                </contrib>
+              </contrib-group>
+            </article-meta>
+          </front>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        messages = list(ArticleAuthorsValidation(xmltree=xmltree).validate(
+            {
+                'credit_taxonomy_terms_and_urls': credit_taxonomy_terms_and_urls,
+                'callable_get_data': callable_get_data
+            }
+        ))
+
+        expected_output = [
+            {
+                'title': 'CRediT taxonomy for contribs',
+                'xpath': './contrib-group//contrib//role[@content-type="https://credit.niso.org/contributor-roles/*"]',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': [
+                    '<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>',
+                    '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>'
+                ],
+                'got_value': None,
+                'message': '''Got None expected ['<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>', '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>']''',
+                'advice': '''The author FRANCISCO VENEGAS-MARTÍNEZ does not have a valid role. Provide a role from the list: ['<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>', '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>']'''
+            },
+            {
+                'title': 'CRediT taxonomy for contribs',
+                'xpath': './contrib-group//contrib//role[@content-type="https://credit.niso.org/contributor-roles/*"]',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': [
+                    '<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>',
+                    '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>'
+                ],
+                'got_value': None,
+                'message': '''Got None expected ['<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>', '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>']''',
+                'advice': '''The author Vanessa M. Higa does not have a valid role. Provide a role from the list: ['<role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>', '<role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>']'''
+            },
+            {
+                'title': 'Author ORCID',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '0990-0001-0058-4853',
+                'got_value': '0990-0001-0058-4853',
+                'message': f'Got 0990-0001-0058-4853 expected 0990-0001-0058-4853',
+                'advice': None
+            },
+            {
+                'title': 'Author ORCID',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '0000-3333-1238-6873',
+                'got_value': '0000-3333-1238-6873',
+                'message': f'Got 0000-3333-1238-6873 expected 0000-3333-1238-6873',
+                'advice': None
+            },
+            {
+                'title': 'Author ORCID element is unique',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist/verification',
+                'response': 'OK',
+                'expected_value': 'Unique ORCID values',
+                'got_value': ['0990-0001-0058-4853', '0000-3333-1238-6873'],
+                'message': 'Got ORCIDs and frequencies (\'0990-0001-0058-4853\', 1) | (\'0000-3333-1238-6873\', 1)',
+                'advice': None
+            },
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'got_value': ['0990-0001-0058-4853', 'FRANCISCO VENEGAS-MARTÍNEZ'],
+                'message': 'Got [\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\'] expected '
+                           '[\'0990-0001-0058-4853\', \'FRANCISCO VENEGAS-MARTÍNEZ\']',
+                'advice': None
+            },
+            {
+                'title': 'Author ORCID element is registered',
+                'xpath': './/contrib-id[@contrib-id-type="orcid"]',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': ['0000-3333-1238-6873', 'Vanessa M. Higa'],
+                'got_value': ['0000-3333-1238-6873', 'Vanessa M. Higa'],
+                'message': 'Got [\'0000-3333-1238-6873\', \'Vanessa M. Higa\'] expected '
+                           '[\'0000-3333-1238-6873\', \'Vanessa M. Higa\']',
+                'advice': None
+            }
+        ]
+
+        for i, item in enumerate(expected_output):
+            with self.subTest(i):
+                self.assertDictEqual(messages[i], item)


### PR DESCRIPTION
#### O que esse PR faz?
Padroniza o retorno das funções de validação de autores para funcionarem como geradoras.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_authors.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #568 

### Referências
NA.

