### PR TITLE
Refactor: padroniza funções como geradoras (article doi)

### DIFF
--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -69,7 +69,7 @@ class ArticleLangValidation:
             else:
                 msg = '<sub-article article-type={} id={} xml:lang={}>'.format(article_type, article_id, article_lang)
 
-            item = {
+            yield {
                 'title': 'Article element lang attribute validation',
                 'xpath': './article/@xml:lang' if article_id == 'main' else './/sub-article/@xml:lang',
                 'validation_type': 'value in list',
@@ -82,7 +82,6 @@ class ArticleLangValidation:
                                                                                                                     " | ".join(
                                                                                                                         language_codes_list))
             }
-            yield item
 
 
 class ArticleAttribsValidation:
@@ -133,7 +132,7 @@ class ArticleAttribsValidation:
         article_specific_use = self.articles.main_specific_use
         validated = article_specific_use in specific_use_list
 
-        return {
+        yield {
             'title': 'Article element specific-use attribute validation',
             'xpath': './article/@specific-use',
             'validation_type': 'value in list',
@@ -187,7 +186,7 @@ class ArticleAttribsValidation:
         article_dtd_version = self.articles.main_dtd_version
         validated = article_dtd_version in dtd_version_list
 
-        return {
+        yield {
             'title': 'Article element dtd-version attribute validation',
             'xpath': './article/@dtd-version',
             'validation_type': 'value in list',
@@ -250,7 +249,7 @@ class ArticleTypeValidation:
         article_type_list = [tp.lower() for tp in article_type_list]
 
         validated = article_type in article_type_list
-        return {
+        yield {
             'title': 'Article type validation',
             'xpath': './article/@article-type',
             'validation_type': 'value in list',
@@ -322,7 +321,7 @@ class ArticleSubjectsValidation:
 
         validated = len(declared_subjects) == 0
         got_value = None if validated else ", ".join(declared_subjects)
-        return {
+        yield {
             'title': 'Article type vs subjects validation',
             'xpath': './article/@article-type .//subject',
             'validation_type': 'value in list',
@@ -408,15 +407,13 @@ class ArticleSubjectsValidation:
             raise ValidationArticleAndSubArticlesSubjectsException("Function requires list of subjects")
 
         subjects_list = [f"{item['subject']} ({item['lang']})" for item in subjects_list]
-        result = []
 
         for article in self.articles.data:
             article_subject = f"{article['subject']} ({article['lang']})"
             article_id = article['article_id']
             calculated_similarity, subject = most_similar(similarity(subjects_list, article_subject))
             validated = calculated_similarity >= expected_similarity
-            result.append(
-                {
+            yield {
                     'title': 'Article type vs subjects validation',
                     'xpath': './article/@article-type .//subject',
                     'validation_type': 'similarity',
@@ -427,9 +424,6 @@ class ArticleSubjectsValidation:
                     'advice': None if validated else 'The subject {} does not match the items provided in the list: {}'
                     .format(article_subject, " | ".join(subjects_list))
                 }
-            )
-
-        return result
 
     def validate(self, data):
         """
@@ -439,7 +433,7 @@ class ArticleSubjectsValidation:
             dict: Um dicionário contendo os resultados das validações realizadas.
 
         """
-        return {
+        yield {
             'article_lang_validation': self.validate_language(data['language_codes_list']),
             'article_specific_use_validation': self.validate_specific_use(data['specific_use_list'])
         }
@@ -483,7 +477,7 @@ class ArticleIdValidation:
         """
         is_valid = self.other_id.isnumeric() and len(self.other_id) <= 5
         expected_value = self.other_id if is_valid else 'A numeric value with up to five digits'
-        return {
+        yield {
             'title': 'Article id other validation',
             'xpath': './/article-id[@pub-id-type="other"]',
             'validation_type': 'format',

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -50,8 +50,7 @@ class ArticleDoiValidation:
                 }
             ]
         """
-        return [
-            {
+        yield {
                 'title': 'Article DOI element',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist',
@@ -61,7 +60,6 @@ class ArticleDoiValidation:
                 'message': 'Got {} expected {}'.format(self.doi, self.doi if self.doi else 'a DOI'),
                 'advice': None if self.doi else 'Provide a valid DOI for the {}'.format(self.articles.main_article_type)
             }
-        ]
 
     def validate_translations_doi_exists(self):
         """
@@ -178,8 +176,7 @@ class ArticleDoiValidation:
         if not validated:
             diff = [doi for doi, freq in dois.items() if freq > 1]
 
-        return [
-            {
+        yield {
                 'title': 'Article DOI element is unique',
                 'xpath': './article-id[@pub-id-type="doi"]',
                 'validation_type': 'exist/verification',
@@ -191,7 +188,6 @@ class ArticleDoiValidation:
                 'advice': None if validated else 'Consider replacing the following DOIs that are not unique: {}'.format(
                     " | ".join(diff))
             }
-        ]
 
     def validate_doi_registered(self, callable_get_data=None):
         """

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -379,20 +379,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue']))
 
-        expected = {
-            'title': 'Article element specific-use attribute validation',
-            'xpath': './article/@specific-use',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
-            'got_value': 'sps-1.9',
-            'message': 'Got sps-1.9 expected one item of this list: sps-1.9 | preprint | special-issue',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article element specific-use attribute validation',
+                'xpath': './article/@specific-use',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
+                'got_value': 'sps-1.9',
+                'message': 'Got sps-1.9 expected one item of this list: sps-1.9 | preprint | special-issue',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_without_specific_use(self):
         self.maxDiff = None
@@ -406,20 +408,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_specific_use(specific_use_list=['sps-1.9', 'preprint', 'special-issue']))
 
-        expected = {
-            'title': 'Article element specific-use attribute validation',
-            'xpath': './article/@specific-use',
-            'validation_type': 'value in list',
-            'response': 'ERROR',
-            'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
-            'got_value': None,
-            'message': 'Got None expected one item of this list: sps-1.9 | preprint | special-issue',
-            'advice': 'XML research-article has None as specific-use, expected one item of this list: sps-1.9 | preprint | special-issue'
-        }
+        expected = [
+            {
+                'title': 'Article element specific-use attribute validation',
+                'xpath': './article/@specific-use',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['sps-1.9', 'preprint', 'special-issue'],
+                'got_value': None,
+                'message': 'Got None expected one item of this list: sps-1.9 | preprint | special-issue',
+                'advice': 'XML research-article has None as specific-use, expected one item of this list: sps-1.9 | preprint | special-issue'
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_dtd_version(self):
         self.maxDiff = None
@@ -433,20 +437,22 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleAttribsValidation(xml_tree).validate_dtd_version(dtd_version_list=['1.1', '1.2', '1.3'])
+        obtained = list(ArticleAttribsValidation(xml_tree).validate_dtd_version(dtd_version_list=['1.1', '1.2', '1.3']))
 
-        expected = {
-            'title': 'Article element dtd-version attribute validation',
-            'xpath': './article/@dtd-version',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['1.1', '1.2', '1.3'],
-            'got_value': '1.1',
-            'message': 'Got 1.1 expected one item of this list: 1.1 | 1.2 | 1.3',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article element dtd-version attribute validation',
+                'xpath': './article/@dtd-version',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['1.1', '1.2', '1.3'],
+                'got_value': '1.1',
+                'message': 'Got 1.1 expected one item of this list: 1.1 | 1.2 | 1.3',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_is_valid(self):
         self.maxDiff = None
@@ -460,22 +466,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleTypeValidation(xml_tree).validate_article_type(
+        obtained = list(ArticleTypeValidation(xml_tree).validate_article_type(
             article_type_list=['research-article']
-        )
+        ))
 
-        expected = {
-            'title': 'Article type validation',
-            'xpath': './article/@article-type',
-            'validation_type': 'value in list',
-            'response': 'OK',
-            'expected_value': ['research-article'],
-            'got_value': 'research-article',
-            'message': 'Got research-article expected one item of this list: research-article',
-            'advice': None
-        }
+        expected = [
+            {
+                'title': 'Article type validation',
+                'xpath': './article/@article-type',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': ['research-article'],
+                'got_value': 'research-article',
+                'message': 'Got research-article expected one item of this list: research-article',
+                'advice': None
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_is_not_valid(self):
         self.maxDiff = None
@@ -489,22 +497,24 @@ class ArticleAndSubarticlesTest(TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleTypeValidation(xml_tree).validate_article_type(
+        obtained = list(ArticleTypeValidation(xml_tree).validate_article_type(
             article_type_list=['research-article']
-        )
+        ))
 
-        expected = {
-            'title': 'Article type validation',
-            'xpath': './article/@article-type',
-            'validation_type': 'value in list',
-            'response': 'ERROR',
-            'expected_value': ['research-article'],
-            'got_value': 'main',
-            'message': 'Got main expected one item of this list: research-article',
-            'advice': 'XML has main as article-type, expected one item of this list: research-article'
-        }
+        expected = [
+            {
+                'title': 'Article type validation',
+                'xpath': './article/@article-type',
+                'validation_type': 'value in list',
+                'response': 'ERROR',
+                'expected_value': ['research-article'],
+                'got_value': 'main',
+                'message': 'Got main expected one item of this list: research-article',
+                'advice': 'XML has main as article-type, expected one item of this list: research-article'
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_there_is_subject_there_should_be_no_subject(self):
         self.maxDiff = None
@@ -537,9 +547,10 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
                 """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleSubjectsValidation(xml_tree).validate_without_subjects()
+        obtained = list(ArticleSubjectsValidation(xml_tree).validate_without_subjects())
 
-        expected = {
+        expected = [
+            {
                 'title': 'Article type vs subjects validation',
                 'xpath': './article/@article-type .//subject',
                 'validation_type': 'value in list',
@@ -549,9 +560,10 @@ class ArticleAndSubarticlesTest(TestCase):
                 'message': 'Got scientific article, artigo científico, artículo científico expected no subject',
                 'advice': 'XML has scientific article, artigo científico, artículo científico as subjects, expected '
                           'no subjects'
-        }
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_there_is_no_subject_there_should_be_no_subject(self):
         self.maxDiff = None
@@ -569,9 +581,10 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleSubjectsValidation(xml_tree).validate_without_subjects()
+        obtained = list(ArticleSubjectsValidation(xml_tree).validate_without_subjects())
 
-        expected = {
+        expected = [
+            {
                 'title': 'Article type vs subjects validation',
                 'xpath': './article/@article-type .//subject',
                 'validation_type': 'value in list',
@@ -580,9 +593,10 @@ class ArticleAndSubarticlesTest(TestCase):
                 'got_value': None,
                 'message': 'Got None expected no subject',
                 'advice': 'XML has None as subjects, expected no subjects'
-        }
+            }
+        ]
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(obtained, expected)
 
     def test_article_and_subarticles_article_type_vs_subject_similarity(self):
         self.maxDiff = None
@@ -687,19 +701,21 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'OK',
-            'expected_value': '123',
-            'got_value': '123',
-            'message': 'Got 123 expected 123',
-            'advice': None
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'OK',
+                'expected_value': '123',
+                'got_value': '123',
+                'message': 'Got 123 expected 123',
+                'advice': None
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)
 
     def test_article_and_subarticles_validate_article_id_other_non_numeric_digit(self):
         self.maxDiff = None
@@ -716,19 +732,21 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'ERROR',
-            'expected_value': 'A numeric value with up to five digits',
-            'got_value': 'x23',
-            'message': 'Got x23 expected a numeric value with up to five digits',
-            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'A numeric value with up to five digits',
+                'got_value': 'x23',
+                'message': 'Got x23 expected a numeric value with up to five digits',
+                'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)
 
     def test_article_and_subarticles_validate_article_id_other_with_more_than_five_digits(self):
         self.maxDiff = None
@@ -745,16 +763,18 @@ class ArticleAndSubarticlesTest(TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleIdValidation(xml_tree).validate_article_id_other()
+        obtained = list(ArticleIdValidation(xml_tree).validate_article_id_other())
 
-        expected = {
-            'title': 'Article id other validation',
-            'xpath': './/article-id[@pub-id-type="other"]',
-            'validation_type': 'format',
-            'response': 'ERROR',
-            'expected_value': 'A numeric value with up to five digits',
-            'got_value': '123456',
-            'message': 'Got 123456 expected a numeric value with up to five digits',
-            'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
+        expected = [
+            {
+                'title': 'Article id other validation',
+                'xpath': './/article-id[@pub-id-type="other"]',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'A numeric value with up to five digits',
+                'got_value': '123456',
+                'message': 'Got 123456 expected a numeric value with up to five digits',
+                'advice': 'Provide a numeric value for <article-id pub-id-type="other"> with up to five digits'
             }
-        self.assertDictEqual(expected, obtained)
+        ]
+        self.assertEqual(expected, obtained)


### PR DESCRIPTION
#### O que esse PR faz?
Padroniza o retorno das funções de validação de DOI para funcionarem como geradoras.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_doi.py
`
#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #568 

### Referências
NA.

