### PR TITLE
Troca http para https nos links para orcid, lattes e researcherid

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-contrib.xsl
@@ -253,13 +253,13 @@
 
     <xsl:template match="contrib-id" mode="url"/>
     <xsl:template match="contrib-id[@contrib-id-type='orcid']" mode="url"
-        >http://orcid.org/</xsl:template>
+        >https://orcid.org/</xsl:template>
     <xsl:template match="contrib-id[@contrib-id-type='lattes']" mode="url"
-        >http://lattes.cnpq.br/</xsl:template>
+        >https://lattes.cnpq.br/</xsl:template>
     <xsl:template match="contrib-id[@contrib-id-type='scopus']" mode="url"
         >https://www.scopus.com/authid/detail.uri?authorId=</xsl:template>
     <xsl:template match="contrib-id[@contrib-id-type='researchid']" mode="url"
-        >http://www.researcherid.com/rid/</xsl:template>
+        >https://www.researcherid.com/rid/</xsl:template>
 
     <xsl:template match="aff" mode="insert-separator">
         <xsl:apply-templates select="institution" mode="insert-separator"/>


### PR DESCRIPTION
#### O que esse PR faz?
Troca http para https nos links de orcid, lattes e researchid

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando o comando htmlgenerator

```console
python packtools/htmlgenerator.py --nonetwork --nochecks --loglevel DEBUG  path_de_xml.xml
```

Observe o link para o orcid após clicar no botão Autoria ou Authorship abaixo do título do artigo. Observe que o link é montado com https no lugar de http.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

