### PR TITLE
Adiciona em XMLWithPre, os atributos data e files

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -252,6 +252,17 @@ class XMLWithPre:
         self.pretty_print = pretty_print
         self.files = None
 
+    @property
+    def data(self):
+        return dict(
+            sps_pkg_name=self.sps_pkg_name,
+            pid_v3=self.v3,
+            pid_v2=self.v2,
+            aop_pid=self.aop_pid,
+            filename=self.filename,
+            files=self.files,
+        )
+
     @classmethod
     def create(cls, path=None, uri=None):
         """

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -110,6 +110,7 @@ def get_xml_items_from_zip_file(xml_sps_file_path, filenames=None):
                     yield {
                         "filename": item,
                         "xml_with_pre": get_xml_with_pre(zf.read(item).decode("utf-8")),
+                        "files": zf.namelist(),
                     }
             if not found:
                 raise TypeError(
@@ -249,6 +250,7 @@ class XMLWithPre:
         self.xmltree = xmltree
         self.filename = None
         self.pretty_print = pretty_print
+        self.files = None
 
     @classmethod
     def create(cls, path=None, uri=None):
@@ -263,6 +265,7 @@ class XMLWithPre:
         if path:
             for item in get_xml_items(path):
                 item["xml_with_pre"].filename = item["filename"]
+                item["xml_with_pre"].files = item["files"]
                 yield item["xml_with_pre"]
         if uri:
             yield get_xml_with_pre_from_uri(uri, timeout=30)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona em XMLWithPre, os atributos data e files

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Instanciando XMLWithPre e executando XMLWithPre.create e .data

```
>>> from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
>>> from lxml import etree
>>> x = XMLWithPre("", etree.fromstring("<article/>"))
>>> x.data
{'sps_pkg_name': '', 'pid_v3': None, 'pid_v2': None, 'aop_pid': None, 'filename': None, 'files': None}
```

```
from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
from lxml import etree
for x in XMLWithPre.create(path='/Users/roberta.takenaka/1519-9940-rbspa-25-0224.zip'):
    print(x.data)
```

```
{'sps_pkg_name': '2448-2455-jpe-34-e3440', 'pid_v3': None, 'pid_v2': None, 'aop_pid': None, 'filename': '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3440.xml', 'files': ['2448-2455-jpe-34-0223/', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gch1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gch2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gch3.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422-gf3.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3422.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423-gf1.png', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423-gf2.png', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423-gf3.png', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423-gf4.png', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3423.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3424-gf1.gif', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3424-gf2.gif', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3424-gf3.gif', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3424.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3424.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3425-gch1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3425-gch2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3425.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3425.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3426-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3426.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3426.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427-gch1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427-gch3.gif', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3427.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3428-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3428-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3428.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3428.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3429-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3429-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3429-gf3.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3429.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3429.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3430.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3430.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3432-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3432-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3432.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3432.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3433-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3433-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3433.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3433.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3434.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3434.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3435-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3435-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3435.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3435.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3437-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3437-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3437.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3437.xml', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3440-gf1.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3440-gf2.jpg', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3440.pdf', '2448-2455-jpe-34-0223/2448-2455-jpe-34-e3440.xml']}
```

#### Algum cenário de contexto que queira dar?
para uso do upload / módulo de ingresso

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
