### PR TITLE
Feat: alternatives validation

### DIFF
--- a/packtools/sps/models/alternatives.py
+++ b/packtools/sps/models/alternatives.py
@@ -33,11 +33,13 @@ class ArticleAlternatives:
         self.xmltree = xmltree
 
     def article_alternatives(self):
+        article_type = self.xmltree.find(".").get("article-type")
         for article_node in self.xmltree.xpath("./front | ./body | ./back"):
             for alternative in Alternatives(article_node).alternatives():
                 alternative_data = alternative.data
                 alternative_data["parent"] = "article"
                 alternative_data["parent_id"] = None
+                alternative_data["parent_article_type"] = article_type
                 yield alternative_data
 
     def sub_article_alternatives(self):
@@ -46,6 +48,7 @@ class ArticleAlternatives:
                 alternative_data = alternative.data
                 alternative_data["parent"] = "sub-article"
                 alternative_data["parent_id"] = sub_article_node.get("id")
+                alternative_data["parent_article_type"] = sub_article_node.get("article-type")
                 yield alternative_data
 
     def alternatives(self):

--- a/packtools/sps/models/alternatives.py
+++ b/packtools/sps/models/alternatives.py
@@ -33,11 +33,12 @@ class ArticleAlternatives:
         self.xmltree = xmltree
 
     def article_alternatives(self):
-        for alternative in Alternatives(self.article_body).alternatives():
-            alternative_data = alternative.data
-            alternative_data["parent"] = "article"
-            alternative_data["parent_id"] = None
-            yield alternative_data
+        for article_node in self.xmltree.xpath("./front | ./body | ./back"):
+            for alternative in Alternatives(article_node).alternatives():
+                alternative_data = alternative.data
+                alternative_data["parent"] = "article"
+                alternative_data["parent_id"] = None
+                yield alternative_data
 
     def sub_article_alternatives(self):
         for sub_article, parent_id in self.sub_article_bodies():

--- a/packtools/sps/models/alternatives.py
+++ b/packtools/sps/models/alternatives.py
@@ -32,14 +32,6 @@ class ArticleAlternatives:
     def __init__(self, xmltree):
         self.xmltree = xmltree
 
-    @property
-    def article_body(self):
-        return self.xmltree.xpath(".//body")[0]
-
-    def sub_article_bodies(self):
-        for sub_article in self.xmltree.xpath(".//sub-article"):
-            yield sub_article.xpath(".//body")[0], sub_article.get("id")
-
     def article_alternatives(self):
         for alternative in Alternatives(self.article_body).alternatives():
             alternative_data = alternative.data

--- a/packtools/sps/models/alternatives.py
+++ b/packtools/sps/models/alternatives.py
@@ -1,0 +1,43 @@
+class Alternative:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def parent(self):
+        return self.node.getparent().tag
+
+    @property
+    def children(self):
+        for children in self.node.getchildren():
+            yield children.tag
+
+    @property
+    def data(self):
+        yield {
+            "alternative_parent": self.parent,
+            "alternative_childrens": list(self.children)
+        }
+
+
+class Alternatives:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+
+    @property
+    def alternatives(self):
+        for alternative in self.xmltree.xpath(".//alternatives"):
+            for ancestor in alternative.iterancestors():
+                if ancestor.tag == "sub-article":
+                    parent = ancestor.tag
+                    parent_id = ancestor.get("id")
+                    break
+            else:
+                parent = "article"
+                parent_id = None
+            alternative_data = Alternative(alternative)
+            yield {
+                "parent": parent,
+                "parent_id": parent_id,
+                "alternative_parent": alternative_data.parent,
+                "alternative_children": list(alternative_data.children)
+            }

--- a/packtools/sps/models/alternatives.py
+++ b/packtools/sps/models/alternatives.py
@@ -41,11 +41,11 @@ class ArticleAlternatives:
                 yield alternative_data
 
     def sub_article_alternatives(self):
-        for sub_article, parent_id in self.sub_article_bodies():
-            for alternative in Alternatives(sub_article).alternatives():
+        for sub_article_node in self.xmltree.xpath(".//sub-article"):
+            for alternative in Alternatives(sub_article_node).alternatives():
                 alternative_data = alternative.data
                 alternative_data["parent"] = "sub-article"
-                alternative_data["parent_id"] = parent_id
+                alternative_data["parent_id"] = sub_article_node.get("id")
                 yield alternative_data
 
     def alternatives(self):

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -81,20 +81,6 @@ class AlternativeValidation:
                     advice=f"Provide child tags according to the list: {self.parent_children_dict.get(self.obtained_parent)}"
                 )
 
-    def create_validation_response(self, expected, obtained, advice):
-        return format_response(
-            title="Alternatives validation",
-            parent=self.alternative.get("parent"),
-            parent_id=self.alternative.get("parent_id"),
-            item=self.obtained_parent,
-            sub_item="alternatives",
-            validation_type="value in list",
-            is_valid=False,
-            expected=expected,
-            obtained=obtained,
-            advice=advice,
-            data=self.alternative
-        )
 
 class AlternativesValidation:
     def __init__(self, xmltree, parent_children_dict=None):

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -4,11 +4,10 @@ from packtools.sps.validation.exceptions import ValidationAlternativesException
 
 
 class AlternativeValidation:
-    def __init__(self, alternative, parent_children_dict):
+    def __init__(self, alternative, children_list):
         self.alternative = alternative
-        self.obtained_parent = alternative.get("alternative_parent")
         self.obtained_children = alternative.get("alternative_children")
-        self.parent_children_dict = parent_children_dict
+        self.children_list = children_list
 
 
     def validate_children(self):

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -9,6 +9,7 @@ class AlternativeValidation:
         self.obtained_children = alternative.get("alternative_children")
         self.children_list = children_list
 
+    def validation(self):
         """
             Check whether the alternatives match the tag that contains them.
 
@@ -74,11 +75,19 @@ class AlternativeValidation:
                 ]
         """
         for tag in self.obtained_children:
-            if tag not in (self.parent_children_dict.get(self.obtained_parent) or []):
-                yield self.create_validation_response(
-                    expected=self.parent_children_dict.get(self.obtained_parent),
+            if tag not in (self.children_list or []):
+                yield format_response(
+                    title="Alternatives validation",
+                    parent=self.alternative.get("parent"),
+                    parent_id=self.alternative.get("parent_id"),
+                    item=self.alternative.get("alternative_parent"),
+                    sub_item="alternatives",
+                    validation_type="value in list",
+                    is_valid=False,
+                    expected=self.children_list,
                     obtained=self.obtained_children,
-                    advice=f"Provide child tags according to the list: {self.parent_children_dict.get(self.obtained_parent)}"
+                    advice=f"Provide child tags according to the list: {self.children_list}",
+                    data=self.alternative
                 )
 
 

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -10,13 +10,6 @@ class AlternativeValidation:
         self.obtained_children = alternative.get("alternative_children")
         self.parent_children_dict = parent_children_dict
 
-    def validate_parent(self):
-        if self.obtained_parent not in self.parent_children_dict:
-            yield self.create_validation_response(
-                expected=list(self.parent_children_dict.keys()),
-                obtained=self.obtained_parent,
-                advice=f"Provide parent tag according to the list: {list(self.parent_children_dict.keys())}"
-            )
 
     def validate_children(self):
         for tag in self.obtained_children:
@@ -58,6 +51,10 @@ class AlternativesValidation:
         if not parent_children_dict:
             raise ValidationAlternativesException("Function requires dict of parent tag (key) and child tags list (value)")
         for alternative in self.alternatives:
-            yield from AlternativeValidation(alternative, parent_children_dict).validation()
+            parent = alternative.get("alternative_parent")
+            children_list = parent_children_dict.get(parent)
+            if children_list is None:
+                raise ValidationAlternativesException(f"Tag {parent} is not provided in the function parameters")
+            yield from AlternativeValidation(alternative, children_list).validation()
 
 

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -1,0 +1,30 @@
+from packtools.sps.models.alternatives import Alternatives
+from packtools.sps.validation.utils import ALTERNATIVES, format_response
+
+
+class AlternativesValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.alternatives = list(Alternatives(xmltree).alternatives)
+
+    def validation(self):
+        for alternative in self.alternatives:
+            alternative_parent = alternative.get("alternative_parent")
+            alternative_children = alternative.get("alternative_children")
+            for tag in alternative_children:
+                if tag not in ALTERNATIVES.get(alternative_parent):
+                    yield format_response(
+                        title="Alternatives validation",
+                        parent=alternative.get("parent"),
+                        parent_id=alternative.get("parent_id"),
+                        item=alternative_parent,
+                        sub_item="alternative",
+                        validation_type="match",
+                        is_valid=False,
+                        expected=ALTERNATIVES.get(alternative_parent),
+                        obtained=alternative_children,
+                        advice=f"Provide child tags according to the list: {ALTERNATIVES.get(alternative_parent)}",
+                        data=alternative
+                    )
+
+

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -9,7 +9,70 @@ class AlternativeValidation:
         self.obtained_children = alternative.get("alternative_children")
         self.children_list = children_list
 
+        """
+            Check whether the alternatives match the tag that contains them.
 
+            XML input
+            ---------
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+                <body>
+                    <table-wrap>
+                        <alternatives>
+                            <p />
+                        </alternatives>
+                    </table-wrap>
+                </body>
+                <sub-article article-type="translation" xml:lang="en" id="TRen">
+                    <body>
+                        <fig>
+                            <alternatives>
+                                <title />
+                                <abstract />
+                            </alternatives>
+                        </fig>
+                    </body>
+                </sub-article>
+            </article>
+
+            Params
+            ------
+            alternative : dict, such as:
+                {
+                    'alternative_children': ['graphic', 'table'],
+                    'alternative_parent': 'table-wrap',
+                    'parent': 'article',
+                    'parent_id': None
+                }
+
+            children_list : list, such as:
+                ["graphic", "table"]
+
+            Returns
+            -------
+            list[dict], such as:
+                [
+                    {
+                        'title': 'Alternatives validation',
+                        'parent': 'article',
+                        'parent_id': None,
+                        'item': 'table-wrap',
+                        'sub_item': 'alternatives',
+                        'validation_type': 'value in list',
+                        'expected_value': ['graphic', 'table'],
+                        'got_value': ['p'],
+                        'response': 'ERROR',
+                        'message': "Got ['p'], expected ['graphic', 'table']",
+                        'advice': "Provide child tags according to the list: ['graphic', 'table']",
+                        'data': {
+                            'alternative_children': ['p'],
+                            'alternative_parent': 'table-wrap',
+                            'parent': 'article',
+                            'parent_id': None
+                        }
+                    },
+                ]
+        """
         for tag in self.obtained_children:
             if tag not in (self.parent_children_dict.get(self.obtained_parent) or []):
                 yield self.create_validation_response(

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -76,17 +76,18 @@ class AlternativeValidation:
         """
         for tag in self.obtained_children:
             if tag not in (self.children_list or []):
+                parent = self.alternative.get("alternative_parent")
                 yield format_response(
                     title="Alternatives validation",
                     parent=self.alternative.get("parent"),
                     parent_id=self.alternative.get("parent_id"),
-                    item=self.alternative.get("alternative_parent"),
+                    item=parent,
                     sub_item="alternatives",
                     validation_type="value in list",
                     is_valid=False,
                     expected=self.children_list,
                     obtained=self.obtained_children,
-                    advice=f"Provide child tags according to the list: {self.children_list}",
+                    advice=f'Add {self.children_list} as sub-elements of {parent}/alternatives',
                     data=self.alternative
                 )
 
@@ -99,13 +100,15 @@ class AlternativesValidation:
 
     def validation(self, parent_children_dict=None):
         parent_children_dict = parent_children_dict or self.parent_children_dict
-        if not parent_children_dict:
-            raise ValidationAlternativesException("Function requires dict of parent tag (key) and child tags list (value)")
         for alternative in self.alternatives:
             parent = alternative.get("alternative_parent")
+            if not parent_children_dict:
+                raise ValidationAlternativesException(f"The element '{parent}' is not configured to use 'alternatives'."
+                                                      " Provide alternatives parent and children")
             children_list = parent_children_dict.get(parent)
             if children_list is None:
-                raise ValidationAlternativesException(f"Tag {parent} is not provided in the function parameters")
+                raise ValidationAlternativesException(f"The element '{parent}' is not configured to use 'alternatives'."
+                                                      " Provide alternatives parent and children")
             yield from AlternativeValidation(alternative, children_list).validation()
 
 

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -1,30 +1,63 @@
-from packtools.sps.models.alternatives import Alternatives
-from packtools.sps.validation.utils import ALTERNATIVES, format_response
+from packtools.sps.models.alternatives import ArticleAlternatives
+from packtools.sps.validation.utils import format_response
+from packtools.sps.validation.exceptions import ValidationAlternativesException
+
+
+class AlternativeValidation:
+    def __init__(self, alternative, parent_children_dict):
+        self.alternative = alternative
+        self.obtained_parent = alternative.get("alternative_parent")
+        self.obtained_children = alternative.get("alternative_children")
+        self.parent_children_dict = parent_children_dict
+
+    def validate_parent(self):
+        if self.obtained_parent not in self.parent_children_dict:
+            yield self.create_validation_response(
+                expected=list(self.parent_children_dict.keys()),
+                obtained=self.obtained_parent,
+                advice=f"Provide parent tag according to the list: {list(self.parent_children_dict.keys())}"
+            )
+
+    def validate_children(self):
+        for tag in self.obtained_children:
+            if tag not in (self.parent_children_dict.get(self.obtained_parent) or []):
+                yield self.create_validation_response(
+                    expected=self.parent_children_dict.get(self.obtained_parent),
+                    obtained=self.obtained_children,
+                    advice=f"Provide child tags according to the list: {self.parent_children_dict.get(self.obtained_parent)}"
+                )
+
+    def create_validation_response(self, expected, obtained, advice):
+        return format_response(
+            title="Alternatives validation",
+            parent=self.alternative.get("parent"),
+            parent_id=self.alternative.get("parent_id"),
+            item=self.obtained_parent,
+            sub_item="alternatives",
+            validation_type="value in list",
+            is_valid=False,
+            expected=expected,
+            obtained=obtained,
+            advice=advice,
+            data=self.alternative
+        )
+
+    def validation(self):
+        yield from self.validate_parent()
+        yield from self.validate_children()
 
 
 class AlternativesValidation:
-    def __init__(self, xmltree):
+    def __init__(self, xmltree, parent_children_dict=None):
         self.xmltree = xmltree
-        self.alternatives = list(Alternatives(xmltree).alternatives)
+        self.parent_children_dict = parent_children_dict
+        self.alternatives = ArticleAlternatives(xmltree).alternatives()
 
-    def validation(self):
+    def validation(self, parent_children_dict=None):
+        parent_children_dict = parent_children_dict or self.parent_children_dict
+        if not parent_children_dict:
+            raise ValidationAlternativesException("Function requires dict of parent tag (key) and child tags list (value)")
         for alternative in self.alternatives:
-            alternative_parent = alternative.get("alternative_parent")
-            alternative_children = alternative.get("alternative_children")
-            for tag in alternative_children:
-                if tag not in ALTERNATIVES.get(alternative_parent):
-                    yield format_response(
-                        title="Alternatives validation",
-                        parent=alternative.get("parent"),
-                        parent_id=alternative.get("parent_id"),
-                        item=alternative_parent,
-                        sub_item="alternative",
-                        validation_type="match",
-                        is_valid=False,
-                        expected=ALTERNATIVES.get(alternative_parent),
-                        obtained=alternative_children,
-                        advice=f"Provide child tags according to the list: {ALTERNATIVES.get(alternative_parent)}",
-                        data=alternative
-                    )
+            yield from AlternativeValidation(alternative, parent_children_dict).validation()
 
 

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -10,7 +10,6 @@ class AlternativeValidation:
         self.children_list = children_list
 
 
-    def validate_children(self):
         for tag in self.obtained_children:
             if tag not in (self.parent_children_dict.get(self.obtained_parent) or []):
                 yield self.create_validation_response(
@@ -33,11 +32,6 @@ class AlternativeValidation:
             advice=advice,
             data=self.alternative
         )
-
-    def validation(self):
-        yield from self.validate_parent()
-        yield from self.validate_children()
-
 
 class AlternativesValidation:
     def __init__(self, xmltree, parent_children_dict=None):

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -78,3 +78,7 @@ class ValidationArticleCitationsException(Exception):
 
 class ValidationPeerReviewException(Exception):
     ...
+
+
+class ValidationAlternativesException(Exception):
+    ...

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -22,11 +22,3 @@ def format_response(
                 'message': f'Got {obtained}, expected {expected}',
                 'advice': None if is_valid else advice
             }
-
-
-ALTERNATIVES = {
-    "table-wrap": ["graphic", "table", "inline-graphic", "media", "supplementary-material"],
-    "fig": ["graphic", "inline-graphic", "media", "supplementary-material"],
-    "inline-formula": ["inline-graphic", "mml:math", "tex-math"],
-    "disp-formula": ["mml:math", "tex-math"],
-}

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -22,3 +22,11 @@ def format_response(
                 'message': f'Got {obtained}, expected {expected}',
                 'advice': None if is_valid else advice
             }
+
+
+ALTERNATIVES = {
+    "table-wrap": ["graphic", "table", "inline-graphic", "media", "supplementary-material"],
+    "fig": ["graphic", "inline-graphic", "media", "supplementary-material"],
+    "inline-formula": ["inline-graphic", "mml:math", "tex-math"],
+    "disp-formula": ["mml:math", "tex-math"],
+}

--- a/tests/sps/models/test_alternatives.py
+++ b/tests/sps/models/test_alternatives.py
@@ -10,22 +10,38 @@ class AlternativesTest(unittest.TestCase):
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
+                <front>
+                    <table-wrap id="t5">
+                        <alternatives>
+                            <alt_1_front />
+                            <alt_2_front />
+                        </alternatives>
+                    </table-wrap>
+                </front>
                 <body>
                     <table-wrap id="t5">
                         <alternatives>
-                            <graphic xlink:href="nomedaimagemdatabela.svg"/>
-                            <table />
+                            <alt_1_body />
+                            <alt_2_body />
                         </alternatives>
                     </table-wrap>
                 </body>
+                <back>
+                    <table-wrap id="t5">
+                        <alternatives>
+                            <alt_1_back />
+                            <alt_2_back />
+                        </alternatives>
+                    </table-wrap>
+                </back>
                 <sub-article article-type="translation" xml:lang="en" id="TRen">
                     <body>
-                        <fig>
+                        <table-wrap id="t5">
                             <alternatives>
-                                <graphic xlink:href="nomedaimagemdatabela.svg"/>
-                                <media />
+                                <alt_1_sub-article />
+                                <alt_2_sub-article />
                             </alternatives>
-                        </fig>
+                        </table-wrap>
                     </body>
                 </sub-article>
             </article>
@@ -43,23 +59,39 @@ class AlternativesTest(unittest.TestCase):
         node = self.xmltree.xpath(".//alternatives")[0]
         alternative = Alternative(node)
         obtained = list(alternative.children)
-        expected = ["graphic", "table"]
+        expected = ['alt_1_front', 'alt_2_front']
         self.assertListEqual(obtained, expected)
 
     def test_alternatives(self):
         obtained = list(ArticleAlternatives(self.xmltree).alternatives())
         expected = [
             {
-                'alternative_children': ['graphic', 'table'],
+                'alternative_children': ['alt_1_front', 'alt_2_front'],
                 'alternative_parent': 'table-wrap',
                 'parent': 'article',
-                'parent_id': None
+                'parent_id': None,
+                'parent_article_type': 'research-article'
             },
             {
-                'alternative_children': ['graphic', 'media'],
-                'alternative_parent': 'fig',
+                'alternative_children': ['alt_1_body', 'alt_2_body'],
+                'alternative_parent': 'table-wrap',
+                'parent': 'article',
+                'parent_id': None,
+                'parent_article_type': 'research-article'
+            },
+            {
+                'alternative_children': ['alt_1_back', 'alt_2_back'],
+                'alternative_parent': 'table-wrap',
+                'parent': 'article',
+                'parent_id': None,
+                'parent_article_type': 'research-article'
+            },
+            {
+                'alternative_children': ['alt_1_sub-article', 'alt_2_sub-article'],
+                'alternative_parent': 'table-wrap',
                 'parent': 'sub-article',
-                'parent_id': 'TRen'
+                'parent_id': 'TRen',
+                'parent_article_type': 'translation'
             }
         ]
         for i, item in enumerate(expected):

--- a/tests/sps/models/test_alternatives.py
+++ b/tests/sps/models/test_alternatives.py
@@ -1,7 +1,7 @@
 import unittest
 from lxml import etree
 
-from packtools.sps.models.alternatives import Alternatives, Alternative
+from packtools.sps.models.alternatives import ArticleAlternatives, Alternative
 
 
 class AlternativesTest(unittest.TestCase):
@@ -10,96 +10,24 @@ class AlternativesTest(unittest.TestCase):
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <graphic xlink:href="nomedaimagemdatabela.svg"/>
-            <table>
-            <thead>
-            <tr>
-            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
-            </tr>
-            <tr>
-            <th>Receita Bruta em 12 Meses - em R$</th>
-            <th>Anexo I - Comércio</th>
-            <th>Anexo II Indústria</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
-            <td>4,00%</td>
-            <td>4,50%</td>
-            </tr>
-            <tr>
-            <td>De R$ 450.000,01 a R$ 900.000,00</td>
-            <td>8,25%</td>
-            <td>8,00%</td>
-            </tr>
-            <tr>
-            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
-            <td>11,25%</td>
-            <td>12,25%</td>
-            </tr>
-            </tbody>
-            </table>
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            <sub-article article-type="translation" xml:lang="en" id="TRen">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <graphic xlink:href="nomedaimagemdatabela.svg"/>
-            <table>
-            <thead>
-            <tr>
-            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
-            </tr>
-            <tr>
-            <th>Receita Bruta em 12 Meses - em R$</th>
-            <th>Anexo I - Comércio</th>
-            <th>Anexo II Indústria</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
-            <td>4,00%</td>
-            <td>4,50%</td>
-            </tr>
-            <tr>
-            <td>De R$ 450.000,01 a R$ 900.000,00</td>
-            <td>8,25%</td>
-            <td>8,00%</td>
-            </tr>
-            <tr>
-            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
-            <td>11,25%</td>
-            <td>12,25%</td>
-            </tr>
-            </tbody>
-            </table>
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            </sub-article>
+                <body>
+                    <table-wrap id="t5">
+                        <alternatives>
+                            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+                            <table />
+                        </alternatives>
+                    </table-wrap>
+                </body>
+                <sub-article article-type="translation" xml:lang="en" id="TRen">
+                    <body>
+                        <fig>
+                            <alternatives>
+                                <graphic xlink:href="nomedaimagemdatabela.svg"/>
+                                <media />
+                            </alternatives>
+                        </fig>
+                    </body>
+                </sub-article>
             </article>
             """
         )
@@ -119,7 +47,7 @@ class AlternativesTest(unittest.TestCase):
         self.assertListEqual(obtained, expected)
 
     def test_alternatives(self):
-        obtained = list(Alternatives(self.xmltree).alternatives)
+        obtained = list(ArticleAlternatives(self.xmltree).alternatives())
         expected = [
             {
                 'alternative_children': ['graphic', 'table'],
@@ -128,8 +56,8 @@ class AlternativesTest(unittest.TestCase):
                 'parent_id': None
             },
             {
-                'alternative_children': ['graphic', 'table'],
-                'alternative_parent': 'table-wrap',
+                'alternative_children': ['graphic', 'media'],
+                'alternative_parent': 'fig',
                 'parent': 'sub-article',
                 'parent_id': 'TRen'
             }

--- a/tests/sps/models/test_alternatives.py
+++ b/tests/sps/models/test_alternatives.py
@@ -1,0 +1,143 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.models.alternatives import Alternatives, Alternative
+
+
+class AlternativesTest(unittest.TestCase):
+    def setUp(self):
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+            <table>
+            <thead>
+            <tr>
+            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
+            </tr>
+            <tr>
+            <th>Receita Bruta em 12 Meses - em R$</th>
+            <th>Anexo I - Comércio</th>
+            <th>Anexo II Indústria</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
+            <td>4,00%</td>
+            <td>4,50%</td>
+            </tr>
+            <tr>
+            <td>De R$ 450.000,01 a R$ 900.000,00</td>
+            <td>8,25%</td>
+            <td>8,00%</td>
+            </tr>
+            <tr>
+            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
+            <td>11,25%</td>
+            <td>12,25%</td>
+            </tr>
+            </tbody>
+            </table>
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            <sub-article article-type="translation" xml:lang="en" id="TRen">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+            <table>
+            <thead>
+            <tr>
+            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
+            </tr>
+            <tr>
+            <th>Receita Bruta em 12 Meses - em R$</th>
+            <th>Anexo I - Comércio</th>
+            <th>Anexo II Indústria</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
+            <td>4,00%</td>
+            <td>4,50%</td>
+            </tr>
+            <tr>
+            <td>De R$ 450.000,01 a R$ 900.000,00</td>
+            <td>8,25%</td>
+            <td>8,00%</td>
+            </tr>
+            <tr>
+            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
+            <td>11,25%</td>
+            <td>12,25%</td>
+            </tr>
+            </tbody>
+            </table>
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            </sub-article>
+            </article>
+            """
+        )
+
+    def test_alternative_parent(self):
+        node = self.xmltree.xpath(".//alternatives")[0]
+        alternative = Alternative(node)
+        obtained = alternative.parent
+        expected = "table-wrap"
+        self.assertEqual(obtained, expected)
+
+    def test_alternative_children(self):
+        node = self.xmltree.xpath(".//alternatives")[0]
+        alternative = Alternative(node)
+        obtained = list(alternative.children)
+        expected = ["graphic", "table"]
+        self.assertListEqual(obtained, expected)
+
+    def test_alternatives(self):
+        obtained = list(Alternatives(self.xmltree).alternatives)
+        expected = [
+            {
+                'alternative_children': ['graphic', 'table'],
+                'alternative_parent': 'table-wrap',
+                'parent': 'article',
+                'parent_id': None
+            },
+            {
+                'alternative_children': ['graphic', 'table'],
+                'alternative_parent': 'table-wrap',
+                'parent': 'sub-article',
+                'parent_id': 'TRen'
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_alternatives.py
+++ b/tests/sps/validation/test_alternatives.py
@@ -1,173 +1,89 @@
 from lxml import etree
-import unittest
+from unittest import TestCase
 
 from packtools.sps.validation.alternatives import AlternativesValidation
 
 
-class AlternativesValidationTest(unittest.TestCase):
+class AlternativesValidationTest(TestCase):
     def test_validation_success(self):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <graphic xlink:href="nomedaimagemdatabela.svg"/>
-            <table>
-            <thead>
-            <tr>
-            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
-            </tr>
-            <tr>
-            <th>Receita Bruta em 12 Meses - em R$</th>
-            <th>Anexo I - Comércio</th>
-            <th>Anexo II Indústria</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
-            <td>4,00%</td>
-            <td>4,50%</td>
-            </tr>
-            <tr>
-            <td>De R$ 450.000,01 a R$ 900.000,00</td>
-            <td>8,25%</td>
-            <td>8,00%</td>
-            </tr>
-            <tr>
-            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
-            <td>11,25%</td>
-            <td>12,25%</td>
-            </tr>
-            </tbody>
-            </table>
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            <sub-article article-type="translation" xml:lang="en" id="TRen">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <graphic xlink:href="nomedaimagemdatabela.svg"/>
-            <table>
-            <thead>
-            <tr>
-            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
-            </tr>
-            <tr>
-            <th>Receita Bruta em 12 Meses - em R$</th>
-            <th>Anexo I - Comércio</th>
-            <th>Anexo II Indústria</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
-            <td>4,00%</td>
-            <td>4,50%</td>
-            </tr>
-            <tr>
-            <td>De R$ 450.000,01 a R$ 900.000,00</td>
-            <td>8,25%</td>
-            <td>8,00%</td>
-            </tr>
-            <tr>
-            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
-            <td>11,25%</td>
-            <td>12,25%</td>
-            </tr>
-            </tbody>
-            </table>
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            </sub-article>
+                <body>
+                    <table-wrap>
+                        <alternatives>
+                            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+                            <table />
+                        </alternatives>
+                    </table-wrap>
+                </body>
+                <sub-article article-type="translation" xml:lang="en" id="TRen">
+                    <body>
+                        <fig>
+                            <alternatives>
+                                <graphic xlink:href="nomedaimagemdatabela.svg"/>
+                                <media />
+                            </alternatives>
+                        </fig>
+                    </body>
+                </sub-article>
             </article>
             """
         )
-        obtained = list(AlternativesValidation(self.xmltree).validation())
+        params = {
+            "table-wrap": ["graphic", "table"],
+            "fig": ["graphic", "media"]
+        }
+        obtained = list(AlternativesValidation(self.xmltree, params).validation())
         expected = []
         self.assertListEqual(obtained, expected)
 
-    def test_validation_fail(self):
+    def test_validation_children_fail(self):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <p>
-            altenativa
-            </p>
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            <sub-article article-type="translation" xml:lang="en" id="TRen">
-            <body>
-            <table-wrap id="t5">
-            <label>Tabela 5</label>
-            <caption>
-            <title>Alíquota menor para prestadores</title>
-            </caption>
-            <alternatives>
-            <title />
-            <abstract />
-            </alternatives>
-            <table-wrap-foot>
-            <fn id="TFN1">
-            <p>A informação de alíquota do anexo II é significativa</p>
-            </fn>
-            </table-wrap-foot>
-            </table-wrap>
-            </body>
-            </sub-article>
+                <body>
+                    <table-wrap>
+                        <alternatives>
+                            <p />
+                        </alternatives>
+                    </table-wrap>
+                </body>
+                <sub-article article-type="translation" xml:lang="en" id="TRen">
+                    <body>
+                        <fig>
+                            <alternatives>
+                                <title />
+                                <abstract />
+                            </alternatives>
+                        </fig>
+                    </body>
+                </sub-article>
             </article>
             """
         )
-        obtained = list(AlternativesValidation(self.xmltree).validation())
+        params = {
+            "table-wrap": ["graphic", "table"],
+            "fig": ["graphic", "media"]
+        }
+        obtained = list(AlternativesValidation(self.xmltree, params).validation())
         expected = [
             {
                 'title': 'Alternatives validation',
                 'parent': 'article',
                 'parent_id': None,
                 'item': 'table-wrap',
-                'sub_item': 'alternative',
-                'validation_type': 'match',
-                'expected_value': ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material'],
+                'sub_item': 'alternatives',
+                'validation_type': 'value in list',
+                'expected_value': ['graphic', 'table'],
                 'got_value': ['p'],
                 'response': 'ERROR',
-                'message': "Got ['p'], expected ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
-                'advice': "Provide child tags according to the list: ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'message': "Got ['p'], expected ['graphic', 'table']",
+                'advice': "Provide child tags according to the list: ['graphic', 'table']",
                 'data': {
                     'alternative_children': ['p'],
                     'alternative_parent': 'table-wrap',
@@ -179,17 +95,17 @@ class AlternativesValidationTest(unittest.TestCase):
                 'title': 'Alternatives validation',
                 'parent': 'sub-article',
                 'parent_id': 'TRen',
-                'item': 'table-wrap',
-                'sub_item': 'alternative',
-                'validation_type': 'match',
-                'expected_value': ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material'],
+                'item': 'fig',
+                'sub_item': 'alternatives',
+                'validation_type': 'value in list',
+                'expected_value': ['graphic', 'media'],
                 'got_value': ['title', 'abstract'],
                 'response': 'ERROR',
-                'message': "Got ['title', 'abstract'], expected ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
-                'advice': "Provide child tags according to the list: ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'message': "Got ['title', 'abstract'], expected ['graphic', 'media']",
+                'advice': "Provide child tags according to the list: ['graphic', 'media']",
                 'data': {
                     'alternative_children': ['title', 'abstract'],
-                    'alternative_parent': 'table-wrap',
+                    'alternative_parent': 'fig',
                     'parent': 'sub-article',
                     'parent_id': 'TRen'
                 }
@@ -199,6 +115,78 @@ class AlternativesValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_validation_parent_fail(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+                dtd-version="1.0" article-type="research-article" xml:lang="pt">
+                    <body>
+                        <inline-formula>
+                            <alternatives>
+                                <mml:math />
+                                <tex-math />
+                            </alternatives>
+                        </inline-formula>
+                    </body>
+                    <sub-article article-type="translation" xml:lang="en" id="TRen">
+                        <body>
+                            <disp-formula>
+                                <alternatives>
+                                    <mml:math />
+                                    <tex-math />
+                                </alternatives>
+                            </disp-formula>
+                        </body>
+                    </sub-article>
+                </article>
+                """
+        )
+        params = {
+            "table-wrap": ["graphic", "table"],
+            "fig": ["graphic", "media"]
+        }
+        obtained = list(AlternativesValidation(self.xmltree, params).validation())
+        expected = [
+            {
+                'title': 'Alternatives validation',
+                'parent': 'article',
+                'parent_id': None,
+                'item': 'inline-formula',
+                'sub_item': 'alternatives',
+                'validation_type': 'value in list',
+                'expected_value': ['table-wrap', 'fig'],
+                'got_value': 'inline-formula',
+                'response': 'ERROR',
+                'message': "Got inline-formula, expected ['table-wrap', 'fig']",
+                'advice': "Provide parent tag according to the list: ['table-wrap', 'fig']",
+                'data': {
+                    'alternative_children': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
+                    'alternative_parent': 'inline-formula',
+                    'parent': 'article',
+                    'parent_id': None
+                }
+            },
+            {
+                'title': 'Alternatives validation',
+                'parent': 'article',
+                'parent_id': None,
+                'item': 'inline-formula',
+                'sub_item': 'alternatives',
+                'validation_type': 'value in list',
+                'expected_value': None,
+                'got_value': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
+                'response': 'ERROR',
+                'message': "Got ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'], expected None",
+                'advice': 'Provide child tags according to the list: None',
+                'data': {
+                    'alternative_children': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
+                    'alternative_parent': 'inline-formula',
+                    'parent': 'article',
+                    'parent_id': None
+                }
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])

--- a/tests/sps/validation/test_alternatives.py
+++ b/tests/sps/validation/test_alternatives.py
@@ -1,0 +1,204 @@
+from lxml import etree
+import unittest
+
+from packtools.sps.validation.alternatives import AlternativesValidation
+
+
+class AlternativesValidationTest(unittest.TestCase):
+    def test_validation_success(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+            <table>
+            <thead>
+            <tr>
+            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
+            </tr>
+            <tr>
+            <th>Receita Bruta em 12 Meses - em R$</th>
+            <th>Anexo I - Comércio</th>
+            <th>Anexo II Indústria</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
+            <td>4,00%</td>
+            <td>4,50%</td>
+            </tr>
+            <tr>
+            <td>De R$ 450.000,01 a R$ 900.000,00</td>
+            <td>8,25%</td>
+            <td>8,00%</td>
+            </tr>
+            <tr>
+            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
+            <td>11,25%</td>
+            <td>12,25%</td>
+            </tr>
+            </tbody>
+            </table>
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            <sub-article article-type="translation" xml:lang="en" id="TRen">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <graphic xlink:href="nomedaimagemdatabela.svg"/>
+            <table>
+            <thead>
+            <tr>
+            <th rowspan="3">Proposta de Novas Tabelas - 2016</th>
+            </tr>
+            <tr>
+            <th>Receita Bruta em 12 Meses - em R$</th>
+            <th>Anexo I - Comércio</th>
+            <th>Anexo II Indústria</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr><td>De R$ 225.000,01 a RS 450.000,00</td>
+            <td>4,00%</td>
+            <td>4,50%</td>
+            </tr>
+            <tr>
+            <td>De R$ 450.000,01 a R$ 900.000,00</td>
+            <td>8,25%</td>
+            <td>8,00%</td>
+            </tr>
+            <tr>
+            <td>De R$ 900.000,01 a R$ 1.800.000,00</td>
+            <td>11,25%</td>
+            <td>12,25%</td>
+            </tr>
+            </tbody>
+            </table>
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            </sub-article>
+            </article>
+            """
+        )
+        obtained = list(AlternativesValidation(self.xmltree).validation())
+        expected = []
+        self.assertListEqual(obtained, expected)
+
+    def test_validation_fail(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <p>
+            altenativa
+            </p>
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            <sub-article article-type="translation" xml:lang="en" id="TRen">
+            <body>
+            <table-wrap id="t5">
+            <label>Tabela 5</label>
+            <caption>
+            <title>Alíquota menor para prestadores</title>
+            </caption>
+            <alternatives>
+            <title />
+            <abstract />
+            </alternatives>
+            <table-wrap-foot>
+            <fn id="TFN1">
+            <p>A informação de alíquota do anexo II é significativa</p>
+            </fn>
+            </table-wrap-foot>
+            </table-wrap>
+            </body>
+            </sub-article>
+            </article>
+            """
+        )
+        obtained = list(AlternativesValidation(self.xmltree).validation())
+        expected = [
+            {
+                'title': 'Alternatives validation',
+                'parent': 'article',
+                'parent_id': None,
+                'item': 'table-wrap',
+                'sub_item': 'alternative',
+                'validation_type': 'match',
+                'expected_value': ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material'],
+                'got_value': ['p'],
+                'response': 'ERROR',
+                'message': "Got ['p'], expected ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'advice': "Provide child tags according to the list: ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'data': {
+                    'alternative_children': ['p'],
+                    'alternative_parent': 'table-wrap',
+                    'parent': 'article',
+                    'parent_id': None
+                }
+            },
+            {
+                'title': 'Alternatives validation',
+                'parent': 'sub-article',
+                'parent_id': 'TRen',
+                'item': 'table-wrap',
+                'sub_item': 'alternative',
+                'validation_type': 'match',
+                'expected_value': ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material'],
+                'got_value': ['title', 'abstract'],
+                'response': 'ERROR',
+                'message': "Got ['title', 'abstract'], expected ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'advice': "Provide child tags according to the list: ['graphic', 'table', 'inline-graphic', 'media', 'supplementary-material']",
+                'data': {
+                    'alternative_children': ['title', 'abstract'],
+                    'alternative_parent': 'table-wrap',
+                    'parent': 'sub-article',
+                    'parent_id': 'TRen'
+                }
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_alternatives.py
+++ b/tests/sps/validation/test_alternatives.py
@@ -2,6 +2,7 @@ from lxml import etree
 from unittest import TestCase
 
 from packtools.sps.validation.alternatives import AlternativesValidation
+from packtools.sps.validation.exceptions import ValidationAlternativesException
 
 
 class AlternativesValidationTest(TestCase):
@@ -129,16 +130,6 @@ class AlternativesValidationTest(TestCase):
                             </alternatives>
                         </inline-formula>
                     </body>
-                    <sub-article article-type="translation" xml:lang="en" id="TRen">
-                        <body>
-                            <disp-formula>
-                                <alternatives>
-                                    <mml:math />
-                                    <tex-math />
-                                </alternatives>
-                            </disp-formula>
-                        </body>
-                    </sub-article>
                 </article>
                 """
         )
@@ -146,47 +137,7 @@ class AlternativesValidationTest(TestCase):
             "table-wrap": ["graphic", "table"],
             "fig": ["graphic", "media"]
         }
-        obtained = list(AlternativesValidation(self.xmltree, params).validation())
-        expected = [
-            {
-                'title': 'Alternatives validation',
-                'parent': 'article',
-                'parent_id': None,
-                'item': 'inline-formula',
-                'sub_item': 'alternatives',
-                'validation_type': 'value in list',
-                'expected_value': ['table-wrap', 'fig'],
-                'got_value': 'inline-formula',
-                'response': 'ERROR',
-                'message': "Got inline-formula, expected ['table-wrap', 'fig']",
-                'advice': "Provide parent tag according to the list: ['table-wrap', 'fig']",
-                'data': {
-                    'alternative_children': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
-                    'alternative_parent': 'inline-formula',
-                    'parent': 'article',
-                    'parent_id': None
-                }
-            },
-            {
-                'title': 'Alternatives validation',
-                'parent': 'article',
-                'parent_id': None,
-                'item': 'inline-formula',
-                'sub_item': 'alternatives',
-                'validation_type': 'value in list',
-                'expected_value': None,
-                'got_value': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
-                'response': 'ERROR',
-                'message': "Got ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'], expected None",
-                'advice': 'Provide child tags according to the list: None',
-                'data': {
-                    'alternative_children': ['{http://www.w3.org/1998/Math/MathML}math', 'tex-math'],
-                    'alternative_parent': 'inline-formula',
-                    'parent': 'article',
-                    'parent_id': None
-                }
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        obtained = AlternativesValidation(self.xmltree, params)
+        with self.assertRaises(ValidationAlternativesException) as context:
+            next(obtained.validation())
+        self.assertEqual("Tag inline-formula is not provided in the function parameters", str(context.exception))

--- a/tests/sps/validation/test_alternatives.py
+++ b/tests/sps/validation/test_alternatives.py
@@ -89,7 +89,8 @@ class AlternativesValidationTest(TestCase):
                     'alternative_children': ['p'],
                     'alternative_parent': 'table-wrap',
                     'parent': 'article',
-                    'parent_id': None
+                    'parent_id': None,
+                    'parent_article_type': 'research-article'
                 }
             },
             {
@@ -108,7 +109,8 @@ class AlternativesValidationTest(TestCase):
                     'alternative_children': ['title', 'abstract'],
                     'alternative_parent': 'fig',
                     'parent': 'sub-article',
-                    'parent_id': 'TRen'
+                    'parent_id': 'TRen',
+                    'parent_article_type': 'translation'
                 }
             }
         ]

--- a/tests/sps/validation/test_alternatives.py
+++ b/tests/sps/validation/test_alternatives.py
@@ -84,7 +84,7 @@ class AlternativesValidationTest(TestCase):
                 'got_value': ['p'],
                 'response': 'ERROR',
                 'message': "Got ['p'], expected ['graphic', 'table']",
-                'advice': "Provide child tags according to the list: ['graphic', 'table']",
+                'advice': "Add ['graphic', 'table'] as sub-elements of table-wrap/alternatives",
                 'data': {
                     'alternative_children': ['p'],
                     'alternative_parent': 'table-wrap',
@@ -104,7 +104,7 @@ class AlternativesValidationTest(TestCase):
                 'got_value': ['title', 'abstract'],
                 'response': 'ERROR',
                 'message': "Got ['title', 'abstract'], expected ['graphic', 'media']",
-                'advice': "Provide child tags according to the list: ['graphic', 'media']",
+                'advice': "Add ['graphic', 'media'] as sub-elements of fig/alternatives",
                 'data': {
                     'alternative_children': ['title', 'abstract'],
                     'alternative_parent': 'fig',
@@ -142,4 +142,5 @@ class AlternativesValidationTest(TestCase):
         obtained = AlternativesValidation(self.xmltree, params)
         with self.assertRaises(ValidationAlternativesException) as context:
             next(obtained.validation())
-        self.assertEqual("Tag inline-formula is not provided in the function parameters", str(context.exception))
+        self.assertEqual("The element 'inline-formula' is not configured to use 'alternatives'. Provide alternatives "
+                         "parent and children", str(context.exception))


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona modelo e validação para `<alternatives>`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_alternatives.py`
`python3 -m unittest -v tests/sps/validation/test_alternatives.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #607 

### Referências
NA.
