### PR TITLE
[página artigo v2.0] Corrige links do menu esquerdo

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-meta-abstract.xsl
@@ -129,6 +129,7 @@
 
     <xsl:template match="article" mode="create-anchor-and-title-for-abstracts-without-title-div-h-number">
         <xsl:param name="title"/>
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <div class="articleSection" data-anchor="{$title}">
             <h1 class="articleSectionTitle"><xsl:value-of select="$title"/></h1>
         </div>
@@ -191,6 +192,7 @@
         <!-- Apresenta a âncora e o título, ou seja, Abstract, Resumo, ou Resumen -->
 
         <!-- âncora -->
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <xsl:attribute name="class">articleSection</xsl:attribute>
         <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="title"/></xsl:attribute>
         <xsl:if test="@xml:lang='ar'">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
@@ -85,6 +85,7 @@
 
     <xsl:template match="*" mode="back-section-menu">
         <xsl:if test="title or label">
+            <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
             <xsl:attribute name="class">articleSection</xsl:attribute>
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select="label"/>
@@ -98,6 +99,7 @@
         <xsl:variable name="name" select="name()"/>
         <!-- cria menu somente para o primeiro ref-list (há casos de série de ref-list) -->
         <xsl:if test="not(preceding-sibling::node()) or preceding-sibling::*[1][name()!=$name]">
+            <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
             <xsl:attribute name="class">articleSection</xsl:attribute>
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select="." mode="text-labels">

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
@@ -85,6 +85,7 @@
 
     <xsl:template match="*" mode="back-section-menu">
         <xsl:if test="title or label">
+            <xsl:attribute name="class">articleSection</xsl:attribute>
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select="label"/>
                 <xsl:if test="label and title">&#160;</xsl:if>
@@ -97,6 +98,7 @@
         <xsl:variable name="name" select="name()"/>
         <!-- cria menu somente para o primeiro ref-list (há casos de série de ref-list) -->
         <xsl:if test="not(preceding-sibling::node()) or preceding-sibling::*[1][name()!=$name]">
+            <xsl:attribute name="class">articleSection</xsl:attribute>
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select="." mode="text-labels">
                     <xsl:with-param name="text">ref-list</xsl:with-param>
@@ -116,7 +118,7 @@
     </xsl:template>
         
     <xsl:template match="*" mode="back-section">
-        <div class="articleSection">
+        <div>
             <xsl:apply-templates select="." mode="back-section-menu"/>
             <xsl:apply-templates select="." mode="back-section-h"/>
             <xsl:apply-templates select="." mode="back-section-content"/>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-fn.xsl
@@ -121,6 +121,8 @@
         Evita que no menu apareça o mesmo título mais de uma vez 
         -->
         <xsl:if test="not(preceding-sibling::node()) or preceding-sibling::*[1][not(@fn-type)] or preceding-sibling::*[1][@fn-type!=$name]">
+            <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
+            <xsl:attribute name="class">articleSection</xsl:attribute>
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select="." mode="text-labels">
                     <xsl:with-param name="text"><xsl:value-of select="@fn-type"/></xsl:with-param>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
@@ -41,6 +41,7 @@
                 <xsl:with-param name="text">Data availability</xsl:with-param>
             </xsl:apply-templates>
         </xsl:variable>
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <div class="articleSection">
             <xsl:attribute name="data-anchor"><xsl:value-of select="$title"/></xsl:attribute>
             <h1 class="articleSectionTitle"><xsl:value-of select="$title"/></h1>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-sub-article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-sub-article.xsl
@@ -77,6 +77,7 @@
 
     <xsl:template match="title-group" mode="sub-article-not-translation-component">
         <!-- Apresentação padrão de um compontente do Bloco do sub-article (not translation) ou response -->
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <div class="articleSection">
             <xsl:attribute name="data-anchor">
                 <xsl:apply-templates select=".//article-title"/>

--- a/packtools/catalogs/htmlgenerator/v2.0/article-text.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text.xsl
@@ -40,6 +40,7 @@
         <xsl:param name="alt_title"></xsl:param>
         <div>
             <xsl:if test="$alt_title!=''">
+                <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
                 <xsl:attribute name="class">articleSection</xsl:attribute>
                 <xsl:attribute name="data-anchor"><xsl:value-of select="$alt_title"/></xsl:attribute>
             </xsl:if>

--- a/packtools/catalogs/htmlgenerator/v2.0/generic-history.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/generic-history.xsl
@@ -19,6 +19,7 @@
     </xsl:template>
 
     <xsl:template match="history" mode="history-section">
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <div class="articleSection">
             <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="text-labels">
                 <xsl:with-param name="text">History</xsl:with-param>

--- a/packtools/catalogs/htmlgenerator/v2.0/generic-pub-date.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/generic-pub-date.xsl
@@ -4,6 +4,7 @@
 
     <xsl:template match="article-meta | sub-article | response" mode="generic-pub-date">
        <xsl:if test=".//pub-date">
+        <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
         <div class="articleSection">
              <xsl:attribute name="data-anchor"><xsl:apply-templates select="." mode="text-labels">
                  <xsl:with-param name="text">Publication Dates</xsl:with-param>


### PR DESCRIPTION
#### O que esse PR faz?
Às vezes o menu esquerdo não é gerado adequadamente. Foi identificado que é necessário que existe no `div` os dois atributos juntos: `class="articleSection" e data-anchor="título da seção no menu"`. Havia casos de `class="articleSection"` sem o correspondente `data-anchor="título da seção no menu"`, então o link era levado a uma âncora incorreta.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python packtools/htmlgenerator.py --nonetwork --nochecks --loglevel DEBUG  arquivo.xml
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#614 

### Referências
n/a
