### PR TITLE
Refactor: adiciona classe 'Contrib' para analisar informações de autores em XML

### DIFF
--- a/packtools/sps/models/article_contribs.py
+++ b/packtools/sps/models/article_contribs.py
@@ -30,6 +30,7 @@ class Contrib:
 
     @property
     def contrib_ids(self):
+        # os valores de @contrib-id-type podem ser: lattes, orcid, researchid e scopus
         return {
             item.get("contrib-id-type"): item.text for item in self.node.xpath(".//contrib-id")
         }

--- a/packtools/sps/models/article_contribs.py
+++ b/packtools/sps/models/article_contribs.py
@@ -1,0 +1,87 @@
+"""
+<contrib contrib-type="author">
+    <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+    <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+    <collab>The MARS Group</collab>
+    <name>
+        <surname>Einstein</surname>
+        <given-names>Albert</given-names>
+        <prefix>Prof</prefix>
+        <suffix>Nieto</suffix>
+    </name>
+    <xref ref-type="aff" rid="aff1">1</xref>
+    <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+    <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+    <role specific-use="reviewer">Reviewer</role>
+</contrib>
+"""
+
+
+class Contrib:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def contrib_type(self):
+        return self.node.get("contrib-type")
+
+    @property
+    def contrib_ids(self):
+        return {
+            item.get("contrib-id-type"): item.text for item in self.node.xpath(".//contrib-id")
+        }
+
+    @property
+    def contrib_name(self):
+        name = self.node.find("name")
+        if name is not None:
+            return {
+                item.tag: item.text for item in name
+            }
+
+    @property
+    def collab(self):
+        return self.node.findtext("collab")
+
+    @property
+    def contrib_xref(self):
+        for item in self.node.xpath(".//xref"):
+            yield {
+                "rid": item.get("rid"),
+                "ref_type": item.get("ref-type"),
+                "text": item.text
+            }
+
+    @property
+    def contrib_role(self):
+        for item in self.node.xpath(".//role"):
+            yield {
+                "text": item.text,
+                "content-type": item.get("content-type"),
+                "specific-use": item.get("specific-use")
+            }
+
+    @property
+    def data(self):
+        data = {}
+        for key, value in zip(
+            (
+                "contrib_type",
+                "contrib_ids",
+                "contrib_name",
+                "collab",
+                "contrib_xref",
+                "contrib_role"
+            ),
+            (
+                self.contrib_type,
+                self.contrib_ids,
+                self.contrib_name,
+                self.collab,
+                list(self.contrib_xref),
+                list(self.contrib_role)
+            )
+        ):
+            if value:
+                data[key] = value
+        return data

--- a/packtools/sps/models/article_contribs.py
+++ b/packtools/sps/models/article_contribs.py
@@ -1,3 +1,6 @@
+from packtools.sps.models.aff import Affiliation
+from packtools.sps.utils.xml_utils import node_plain_text
+
 """
 <contrib contrib-type="author">
     <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
@@ -41,7 +44,7 @@ class Contrib:
 
     @property
     def collab(self):
-        return self.node.findtext("collab")
+        return node_plain_text(self.node.find("collab"))
 
     @property
     def contrib_xref(self):
@@ -65,23 +68,81 @@ class Contrib:
     def data(self):
         data = {}
         for key, value in zip(
-            (
-                "contrib_type",
-                "contrib_ids",
-                "contrib_name",
-                "collab",
-                "contrib_xref",
-                "contrib_role"
-            ),
-            (
-                self.contrib_type,
-                self.contrib_ids,
-                self.contrib_name,
-                self.collab,
-                list(self.contrib_xref),
-                list(self.contrib_role)
-            )
+                (
+                        "contrib_type",
+                        "contrib_ids",
+                        "contrib_name",
+                        "collab",
+                        "contrib_xref",
+                        "contrib_role"
+                ),
+                (
+                        self.contrib_type,
+                        self.contrib_ids,
+                        self.contrib_name,
+                        self.collab,
+                        list(self.contrib_xref),
+                        list(self.contrib_role)
+                )
         ):
             if value:
                 data[key] = value
         return data
+
+
+class ContribGroup:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def contribs(self):
+        for contribs in self.node.xpath(".//contrib"):
+            contrib = Contrib(contribs)
+            yield contrib.data
+
+
+class ArticleContribs:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.aff = Affiliation(xmltree).affiliation_by_id
+
+    @property
+    def contribs(self):
+        for node, lang, article_type, parent, parent_id in _get_parent_context(self.xmltree):
+            for contrib_group in node.xpath(".//contrib-group"):
+                for contrib in ContribGroup(contrib_group).contribs:
+                    affs = list(_get_affs(self.aff, contrib))
+                    if affs:
+                        contrib['affs'] = affs
+                    yield _put_parent_context(contrib, lang, article_type, parent, parent_id)
+
+
+def _get_parent_context(xmltree):
+    main = xmltree.xpath(".")[0]
+    main_lang = main.get("{http://www.w3.org/XML/1998/namespace}lang")
+    main_article_type = main.get("article-type")
+    for node in xmltree.xpath(".//article-meta | .//sub-article"):
+        parent = "sub-article" if node.tag == "sub-article" else "article"
+        parent_id = node.get("id")
+        lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or main_lang
+        article_type = node.get("article-type") or main_article_type
+        yield node, lang, article_type, parent, parent_id
+
+
+def _put_parent_context(data, lang, article_type, parent, parent_id):
+    data.update(
+        {
+            "parent": parent,
+            "parent_id": parent_id,
+            "parent_lang": lang,
+            "parent_article_type": article_type,
+        }
+    )
+    return data
+
+
+def _get_affs(affs, contrib):
+    for xref in contrib.get('contrib_xref'):
+        aff = affs.get(xref.get('rid'))
+        if aff:
+            yield aff

--- a/packtools/sps/models/article_contribs.py
+++ b/packtools/sps/models/article_contribs.py
@@ -69,22 +69,22 @@ class Contrib:
     def data(self):
         data = {}
         for key, value in zip(
-                (
-                        "contrib_type",
-                        "contrib_ids",
-                        "contrib_name",
-                        "collab",
-                        "contrib_xref",
-                        "contrib_role"
-                ),
-                (
-                        self.contrib_type,
-                        self.contrib_ids,
-                        self.contrib_name,
-                        self.collab,
-                        list(self.contrib_xref),
-                        list(self.contrib_role)
-                )
+            (
+                "contrib_type",
+                "contrib_ids",
+                "contrib_name",
+                "collab",
+                "contrib_xref",
+                "contrib_role"
+            ),
+            (
+                self.contrib_type,
+                self.contrib_ids,
+                self.contrib_name,
+                self.collab,
+                list(self.contrib_xref),
+                list(self.contrib_role)
+            )
         ):
             if value:
                 data[key] = value

--- a/tests/sps/models/test_article_contribs.py
+++ b/tests/sps/models/test_article_contribs.py
@@ -1,0 +1,555 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from packtools.sps.models.article_contribs import Contrib
+
+
+class ContribTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_contrib_type(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).contrib_type
+
+        self.assertEqual(obtained, "author")
+
+    def test_contrib_ids(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).contrib_ids
+        expected = {
+            'orcid': '0000-0001-8528-2091',
+            'scopus': '24771926600'
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+    def test_contrib_name(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).contrib_name
+        expected = {
+            'given-names': 'Albert',
+            'surname': 'Einstein',
+            'prefix': 'Prof',
+            'suffix': 'Nieto',
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+    def test_collab(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).collab
+
+        self.assertEqual(obtained, "The MARS Group")
+
+    def test_contrib_xref(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = list(Contrib(contrib).contrib_xref)
+        expected = [
+            {
+                'rid': 'aff1',
+                'ref_type': 'aff',
+                'text': '1'
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_contrib_role(self):
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = list(Contrib(contrib).contrib_role)
+        expected = [
+            {
+                "text": 'Data curation',
+                "content-type": "https://credit.niso.org/contributor-roles/data-curation/",
+                "specific-use": None,
+            },
+            {
+                "text": 'Conceptualization',
+                "content-type": "https://credit.niso.org/contributor-roles/conceptualization/",
+                "specific-use": None,
+            },
+            {
+                "text": "Reviewer",
+                "content-type": None,
+                "specific-use": "reviewer",
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'collab': 'The MARS Group',
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ],
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutContribTypeTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib>
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'collab': 'The MARS Group',
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ],
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutContribIdTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'collab': 'The MARS Group',
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ],
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutCollabTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ],
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutNameTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'collab': 'The MARS Group',
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ],
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutXrefTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <role content-type="https://credit.niso.org/contributor-roles/data-curation/">Data curation</role>
+                                <role content-type="https://credit.niso.org/contributor-roles/conceptualization/">Conceptualization</role>
+                                <role specific-use="reviewer">Reviewer</role>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'collab': 'The MARS Group',
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_role': [
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/data-curation/',
+                    'specific-use': None,
+                    'text': 'Data curation'
+                },
+                {
+                    'content-type': 'https://credit.niso.org/contributor-roles/conceptualization/',
+                    'specific-use': None,
+                    'text': 'Conceptualization'
+                },
+                {
+                    'content-type': None,
+                    'specific-use': 'reviewer',
+                    'text': 'Reviewer'
+                }
+            ],
+        }
+
+        self.assertDictEqual(obtained, expected)
+
+
+class ContribWithoutRoleTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib = self.xmltree.xpath(".//contrib")[0]
+        obtained = Contrib(contrib).data
+        expected = {
+            'contrib_type': 'author',
+            'contrib_ids': {
+                'orcid': '0000-0001-8528-2091',
+                'scopus': '24771926600'
+            },
+            'collab': 'The MARS Group',
+            'contrib_name': {
+                'given-names': 'Albert',
+                'surname': 'Einstein',
+                'prefix': 'Prof',
+                'suffix': 'Nieto'
+            },
+            'contrib_xref': [
+                {
+                    'ref_type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
+            ]
+        }
+
+        self.assertDictEqual(obtained, expected)

--- a/tests/sps/models/test_article_contribs.py
+++ b/tests/sps/models/test_article_contribs.py
@@ -2,7 +2,8 @@ from unittest import TestCase
 
 from lxml import etree
 
-from packtools.sps.models.article_contribs import Contrib
+from packtools.sps.models.article_contribs import Contrib, ContribGroup, ArticleContribs
+from packtools.sps.utils import xml_utils
 
 
 class ContribTest(TestCase):
@@ -553,3 +554,209 @@ class ContribWithoutRoleTest(TestCase):
         }
 
         self.assertDictEqual(obtained, expected)
+
+
+class ContribGroupTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <collab collab-type="committee">Technical Committee ISO/TC 108, Subcommittee SC 2</collab>
+                                <xref ref-type="aff" rid="aff1"/>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <collab>
+                                    <named-content content-type="program">Joint United
+                                    Nations Program on HIV/AIDS (UNAIDS)</named-content>,
+                                    <institution>World Health Organization</institution>,
+                                    Geneva, <country>Switzerland</country>
+                                </collab>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <collab>
+                                    <named-content content-type="program">Nonoccupational HIV
+                                    PEP Task Force, Brown University AIDS Program</named-content>
+                                    and the <institution>Rhode Island Department of
+                                    Health</institution>, Providence, Rhode Island
+                                </collab>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>VENEGAS-MARTÍNEZ</surname>
+                                    <given-names>FRANCISCO</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1"/>
+                                <xref ref-type="aff" rid="aff2"/>
+                            </contrib>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        contrib_group = self.xmltree.xpath(".//contrib-group")[0]
+        obtained = list(ContribGroup(contrib_group).contribs)
+        expected = [
+            {
+                'collab': 'Technical Committee ISO/TC 108, Subcommittee SC 2',
+                'contrib_type': 'author',
+                'contrib_xref': [{'ref_type': 'aff', 'rid': 'aff1', 'text': None}]
+            },
+            {
+                'collab': 'Joint United Nations Program on HIV/AIDS (UNAIDS) , World Health Organization , Geneva, '
+                          'Switzerland',
+                'contrib_type': 'author'
+            },
+            {
+                'collab': 'Nonoccupational HIV PEP Task Force, Brown University AIDS Program and the Rhode Island '
+                          'Department of Health , Providence, Rhode Island',
+                'contrib_type': 'author'
+            },
+            {
+                'contrib_name': {
+                    'given-names': 'FRANCISCO',
+                    'prefix': 'Prof',
+                    'suffix': 'Nieto',
+                    'surname': 'VENEGAS-MARTÍNEZ'
+                },
+                'contrib_type': 'author',
+                'contrib_xref': [
+                    {'ref_type': 'aff', 'rid': 'aff1', 'text': None},
+                    {'ref_type': 'aff', 'rid': 'aff2', 'text': None}
+                ]
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+class ArticleContribTest(TestCase):
+    def setUp(self):
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+               <front>
+                  <article-meta>
+                     <contrib-group>
+                        <contrib contrib-type="author">
+                           <contrib-id contrib-id-type="orcid">0000-0003-2243-0821</contrib-id>
+                           <name>
+                              <surname>Castro</surname>
+                              <given-names>Silvana de</given-names>
+                           </name>
+                           <xref ref-type="aff" rid="aff1">a</xref>
+                           <xref ref-type="corresp" rid="c1">*</xref>
+                        </contrib>
+                        <aff id="aff1">
+                           <label>a</label>
+                           <institution content-type="orgname">Universidade Federal do Rio de Janeiro (UFRJ)</institution>
+                           <addr-line>
+                              <named-content content-type="city">Rio de Janeiro</named-content>
+                              <named-content content-type="state">RJ</named-content>
+                           </addr-line>
+                           <country country="BR">Brazil</country>
+                           <institution content-type="original">Universidade Federal do Rio de Janeiro (UFRJ)</institution>
+                        </aff>
+                     </contrib-group>
+                  </article-meta>
+               </front>
+               <sub-article article-type="translation" id="SA1" xml:lang="pt">
+                  <front-stub>
+                     <article-id pub-id-type="doi">10.1016/j.bjan.2019.01.002</article-id>
+                     <contrib-group>
+                        <contrib contrib-type="author">
+                           <contrib-id contrib-id-type="orcid">0000-0003-2243-0821</contrib-id>
+                           <name>
+                              <surname>Castro</surname>
+                              <given-names>Silvana de</given-names>
+                           </name>
+                           <xref ref-type="aff" rid="aff4">a</xref>
+                           <xref ref-type="corresp" rid="c2">*</xref>
+                        </contrib>
+                     </contrib-group>
+                     <aff id="aff4">
+                        <label>a</label>
+                        <institution content-type="original">Universidade Federal do Rio de Janeiro (UFRJ)</institution>
+                     </aff>
+                  </front-stub>
+               </sub-article>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_data(self):
+        self.maxDiff = None
+        obtained = list(ArticleContribs(self.xmltree).contribs)
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'contrib_ids': {'orcid': '0000-0003-2243-0821'},
+                'contrib_name': {'given-names': 'Silvana de', 'surname': 'Castro'},
+                'contrib_type': 'author',
+                'contrib_xref': [
+                    {'ref_type': 'aff', 'rid': 'aff1', 'text': 'a'},
+                    {'ref_type': 'corresp', 'rid': 'c1', 'text': '*'}
+                ],
+                'affs': [
+                    {
+                        'city': 'Rio de Janeiro',
+                        'country_code': 'BR',
+                        'country_name': 'Brazil',
+                        'email': None,
+                        'id': 'aff1',
+                        'label': 'a',
+                        'orgdiv1': None,
+                        'orgdiv2': None,
+                        'orgname': 'Universidade Federal do Rio de Janeiro (UFRJ)',
+                        'original': 'Universidade Federal do Rio de Janeiro (UFRJ)',
+                        'state': 'RJ'
+                    }
+                ]
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 'SA1',
+                'parent_lang': 'pt',
+                'contrib_ids': {'orcid': '0000-0003-2243-0821'},
+                'contrib_name': {'given-names': 'Silvana de', 'surname': 'Castro'},
+                'contrib_type': 'author',
+                'contrib_xref': [
+                    {'ref_type': 'aff', 'rid': 'aff4', 'text': 'a'},
+                    {'ref_type': 'corresp', 'rid': 'c2', 'text': '*'}
+                ],
+                'affs': [
+                    {
+                        'city': None,
+                        'country_name': None,
+                        'email': None,
+                        'id': 'aff4',
+                        'label': 'a',
+                        'orgdiv1': None,
+                        'orgdiv2': None,
+                        'orgname': None,
+                        'original': 'Universidade Federal do Rio de Janeiro (UFRJ)',
+                        'state': None
+                    }
+                ]
+            }
+
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona uma nova classe `Contrib` que permite a análise e extração de informações detalhadas de autores a partir de dados XML estruturados. A classe `Contrib` oferece várias propriedades e métodos que facilitam o acesso a diversos elementos de contribuição, tais como identificadores, nome, colaboração, referências cruzadas e papéis dos autores.

Funcionalidades incluídas:

- Tipo de Contribuição (`contrib_type`): Obtém o atributo `contrib-type` do elemento `<contrib>`.

- Identificadores de Contribuição (`contrib_ids`): Extrai todos os identificadores de contribuição (`contrib-id`) e seus respectivos tipos.

- Nome do Contribuidor (`contrib_name`): Obtém as partes do nome do contribuidor, incluindo `surname`, `given-names`, `prefix` e `suffix`.

- Autoria Institucional (`collab`): Extrai o nome da instituição ou grupo que colaborou no trabalho a partir do elemento `<collab>`.

- Referências Cruzadas (`contrib_xref`): Itera e extrai informações sobre referências cruzadas (`xref`), incluindo `rid`, `ref-type` e texto associado.

- Papéis de Contribuição (`contrib_role`): Itera e extrai detalhes sobre os papéis de contribuição (`role`), incluindo texto associado, `content-type` e `specific-use`.

- Dados Completos (`data`): Método que retorna todos os dados extraídos de um elemento `<contrib>` em um dicionário organizado.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_article_contribs.py`

#### Algum cenário de contexto que queira dar?
Esse PR substitui o PR #597 

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

