### PR TITLE
Chore: standardize article doi

### DIFF
--- a/packtools/sps/models/article_doi_with_lang.py
+++ b/packtools/sps/models/article_doi_with_lang.py
@@ -43,13 +43,25 @@ class DoiWithLang:
 
     @property
     def data(self):
-        _data = []
-        if self.main_doi:
-            _data.append({"lang": self.main_lang, "value": self.main_doi})
+        _data = [{
+            "lang": self.main_lang,
+            "value": self.main_doi,
+            "parent": "article",
+            "parent_article_type": self._xmltree.get("article-type")
+        }]
 
         for sub_article in self._xmltree.xpath(".//sub-article[@article-type='translation']"):
             lang = sub_article.get("{http://www.w3.org/XML/1998/namespace}lang")
             value = self._get_node_text('.//article-id[@pub-id-type="doi"]', sub_article)
-            if value:
-                _data.append({"lang": lang, "value": value})
+            # Obs.: este módulo foi mantido por não haver modificação na resposta
+            # houve apenas adição de valores no dicionário que não compromete outras utilizações
+            _data.append(
+                {
+                    "lang": lang,
+                    "value": value,
+                    "parent": "sub-article",
+                    "parent_article_type": "translation",
+                    "parent_id": sub_article.get("id")
+                }
+            )
         return _data

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -82,7 +82,7 @@ class ArticleDoiValidation:
         """
         for doi in self.doi.data:
             yield format_response(
-                title=f'{doi.get("parent")} DOI element',
+                title='Article DOI element exists',
                 parent=doi.get("parent"),
                 parent_id=doi.get("parent_id"),
                 parent_article_type=doi.get("parent_article_type"),
@@ -184,7 +184,7 @@ class ArticleDoiValidation:
             parent_lang=self.articles.main_lang,
             item="article-id",
             sub_item='@pub-id-type="doi"',
-            validation_type='exist/verification',
+            validation_type='unique',
             is_valid=validated,
             expected='Unique DOI values',
             obtained=list(dois.keys()),

--- a/tests/sps/models/test_article_doi_with_lang.py
+++ b/tests/sps/models/test_article_doi_with_lang.py
@@ -16,18 +16,18 @@ def _get_xmltree(doi=None, doi1=None, doi2=None):
         )
     if doi1:
         doi1 = (
-            """<sub-article xml:lang='es' article-type='translation'><front-stub>"""
+            """<sub-article xml:lang='es' id="01" article-type='translation'><front-stub>"""
             f"""<article-id pub-id-type="doi">{doi1}</article-id>"""
             """</front-stub></sub-article>"""
         )
     if doi2:
         doi2 = (
-            """<sub-article xml:lang='en' article-type='translation'><front-stub>"""
+            """<sub-article xml:lang='en' id="02" article-type='translation'><front-stub>"""
             f"""<article-id pub-id-type="doi">{doi2}</article-id>"""
             """</front-stub></sub-article>"""
         )
     s = (
-        "<article xml:lang='pt'>"
+        "<article xml:lang='pt' article-type='research-article'>"
         "<front>"
         "    <article-meta>"
         f"{doi}"
@@ -56,9 +56,27 @@ class TestDoiWithLang(TestCase):
         self.assertIsNone(article_doi_with_lang.main_doi)
 
     def test_data(self):
+        self.maxDiff = None
         expected = [
-            {"lang": "pt", "value": "10.1590/1678-69712003/administracao.v4n1p108-123"},
-            {"lang": "es", "value": "10.1590/1678-69712003/administracao.v4n1p108-123.es"},
-            {"lang": "en", "value": "10.1590/1678-69712003/administracao.v4n1p108-123.en"},
+            {
+                "lang": "pt",
+                "value": "10.1590/1678-69712003/administracao.v4n1p108-123",
+                "parent": "article",
+                "parent_article_type": "research-article",
+            },
+            {
+                "lang": "es",
+                "value": "10.1590/1678-69712003/administracao.v4n1p108-123.es",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": "01",
+            },
+            {
+                "lang": "en",
+                "value": "10.1590/1678-69712003/administracao.v4n1p108-123.en",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": "02",
+            },
         ]
         self.assertEqual(expected, self.article_doi_with_lang.data)

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -85,7 +85,7 @@ class ArticleDoiTest(unittest.TestCase):
         obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -115,7 +115,7 @@ class ArticleDoiTest(unittest.TestCase):
                 ],
             },
             {
-                'title': 'sub-article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': 's1',
@@ -170,7 +170,7 @@ class ArticleDoiTest(unittest.TestCase):
         obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -201,7 +201,7 @@ class ArticleDoiTest(unittest.TestCase):
                 ],
             },
             {
-                'title': 'sub-article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': 's1',
@@ -257,7 +257,7 @@ class ArticleDoiTest(unittest.TestCase):
         obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -287,7 +287,7 @@ class ArticleDoiTest(unittest.TestCase):
                 ],
             },
             {
-                'title': 'sub-article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': 's1',
@@ -344,7 +344,7 @@ class ArticleDoiTest(unittest.TestCase):
         obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -375,7 +375,7 @@ class ArticleDoiTest(unittest.TestCase):
                 ],
             },
             {
-                'title': 'sub-article DOI element',
+                'title': 'Article DOI element exists',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': 's1',
@@ -442,7 +442,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'parent_lang': 'pt',
                 'item': 'article-id',
                 'sub_item': '@pub-id-type="doi"',
-                'validation_type': 'exist/verification',
+                'validation_type': 'unique',
                 'response': 'OK',
                 'expected_value': 'Unique DOI values',
                 'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],
@@ -509,7 +509,7 @@ class ArticleDoiTest(unittest.TestCase):
                 'parent_lang': 'pt',
                 'item': 'article-id',
                 'sub_item': '@pub-id-type="doi"',
-                'validation_type': 'exist/verification',
+                'validation_type': 'unique',
                 'response': 'CRITICAL',
                 'expected_value': 'Unique DOI values',
                 'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -63,7 +63,7 @@ def callable_get_data_missing_authors(doi):
 
 
 class ArticleDoiTest(unittest.TestCase):
-    def test_validate_article_has_doi(self):
+    def test_validate_doi_exists_success(self):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -74,27 +74,82 @@ class ArticleDoiTest(unittest.TestCase):
             <article-id pub-id-type="doi">10.1590/1518-8345.2927.3231</article-id>
             <article-id pub-id-type="other">00303</article-id>
             </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                </front-stub>
+            </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_main_article_doi_exists()
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'Article DOI element',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'article DOI element',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/1518-8345.2927.3231',
                 'got_value': '10.1590/1518-8345.2927.3231',
-                'message': 'Got 10.1590/1518-8345.2927.3231 expected 10.1590/1518-8345.2927.3231',
-                'advice': None
+                'message': 'Got 10.1590/1518-8345.2927.3231, expected 10.1590/1518-8345.2927.3231',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/1518-8345.2927.3231'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
+            },
+            {
+                'title': 'sub-article DOI element',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
+                'validation_type': 'exist',
+                'response': 'OK',
+                'expected_value': '10.1590/2176-4573e59270',
+                'got_value': '10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/1518-8345.2927.3231'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
-    def test_validate_article_has_no_doi(self):
+    def test_validate_doi_exists_without_article_doi_fail(self):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -104,178 +159,256 @@ class ArticleDoiTest(unittest.TestCase):
             <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
             <article-id pub-id-type="other">00303</article-id>
             </front>
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                </front-stub>
+            </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_main_article_doi_exists()
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'Article DOI element',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'article DOI element',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'article DOI',
                 'got_value': None,
-                'message': 'Got None expected a DOI',
-                'advice': 'Provide a valid DOI for the research-article'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_translation_subarticle_has_one_translation_and_one_doi(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
-            <front>
-                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
-                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
-                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
-                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
-            </front>
-            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
-            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
-            <sub-article article-type="translation" id="s1" xml:lang="en">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
-                </front-stub>
-            </sub-article>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_translations_doi_exists()
-
-        expected = [
+                'message': 'Got None, expected article DOI',
+                'advice': 'Provide a valid DOI for the article represented by the following tag: '
+                          '<article article-type="research-article" id="None" xml:lang="en">',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': None
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
+            },
             {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
+                'title': 'sub-article DOI element',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': None
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
-    def test_validate_translation_subarticle_has_two_translations_and_one_doi(self):
+    def test_validate_doi_exists_without_sub_article_doi_fail(self):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
-                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
-                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
-                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
-                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            <article-id pub-id-type="doi">10.1590/1518-8345.2927.3231</article-id>
+            <article-id pub-id-type="other">00303</article-id>
             </front>
-            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
-            <sub-article article-type="translation" id="s3" xml:lang="es" />
-            <sub-article article-type="translation" id="s1" xml:lang="en">
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
                 <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                    
                 </front-stub>
             </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_translations_doi_exists()
-
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
+                'title': 'article DOI element',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'sub-article DOI',
+                'response': 'OK',
+                'expected_value': '10.1590/1518-8345.2927.3231',
+                'got_value': '10.1590/1518-8345.2927.3231',
+                'message': 'Got 10.1590/1518-8345.2927.3231, expected 10.1590/1518-8345.2927.3231',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/1518-8345.2927.3231'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': None
+                    }
+                ],
+            },
+            {
+                'title': 'sub-article DOI element',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': 'article DOI',
                 'got_value': None,
-                'message': 'Got None expected sub-article DOI',
-                'advice': 'Provide a valid DOI for the sub-article represented by the following '
-                          'tag: <sub-article article-type="translation" id="s3" xml:lang="es">'
-            },
-            {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573e59270',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got None, expected article DOI',
+                'advice': 'Provide a valid DOI for the sub-article represented by the following tag: '
+                          '<sub-article article-type="translation" id="s1" xml:lang="pt">',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/1518-8345.2927.3231'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': None
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
-    def test_validate_translation_subarticle_has_three_translations_and_two_doi(self):
+    def test_validate_doi_exists_fail(self):
         self.maxDiff = None
         xml_str = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
-                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
-                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
-                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
-                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+            
+            <article-id pub-id-type="other">00303</article-id>
             </front>
-            <sub-article article-type="translation" id="s2" xml:lang="fr" />
-            <sub-article article-type="translation" id="s3" xml:lang="es">
+            <sub-article article-type="translation" id="s1" xml:lang="pt">
                 <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
-                </front-stub>
-            </sub-article>
-            <sub-article article-type="translation" id="s1" xml:lang="en">
-                <front-stub>
-                    <article-id pub-id-type="doi">10.1590/2176-4573e59270</article-id>
+                    
                 </front-stub>
             </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_translations_doi_exists()
-
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_exists())
         expected = [
             {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
+                'title': 'article DOI element',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'sub-article DOI',
+                'response': 'CRITICAL',
+                'expected_value': 'article DOI',
                 'got_value': None,
-                'message': 'Got None expected sub-article DOI',
-                'advice': 'Provide a valid DOI for the sub-article represented by the following '
-                          'tag: <sub-article article-type="translation" id="s2" xml:lang="fr">'
+                'message': 'Got None, expected article DOI',
+                'advice': 'Provide a valid DOI for the article represented by the following tag: '
+                          '<article article-type="research-article" id="None" xml:lang="en">',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': None
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': None
+                    }
+                ],
             },
             {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
+                'title': 'sub-article DOI element',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573e59270',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
-            },
-            {
-                'title': 'Sub-article translation DOI element',
-                'xpath': './sub-article[@article-type="translation"]',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/2176-4573e59270',
-                'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'response': 'CRITICAL',
+                'expected_value': 'article DOI',
+                'got_value': None,
+                'message': 'Got None, expected article DOI',
+                'advice': 'Provide a valid DOI for the sub-article represented by the following tag: '
+                          '<sub-article article-type="translation" id="s1" xml:lang="pt">',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': None
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': None
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_all_dois_are_unique(self):
         self.maxDiff = None
@@ -298,23 +431,43 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_all_dois_are_unique()
+        obtained = list(ArticleDoiValidation(xml_tree).validate_all_dois_are_unique())
 
         expected = [
             {
                 'title': 'Article DOI element is unique',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist/verification',
                 'response': 'OK',
                 'expected_value': 'Unique DOI values',
                 'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],
-                'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 1)",
-                'advice': None
+                'message': "Got ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'], expected Unique DOI values",
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'pt',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/2176-4573p59270'
+                    },
+                    {
+                        'lang': 'en',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_all_dois_are_not_unique(self):
         self.maxDiff = None
@@ -345,23 +498,55 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_all_dois_are_unique()
+        obtained = list(ArticleDoiValidation(xml_tree).validate_all_dois_are_unique())
 
         expected = [
             {
                 'title': 'Article DOI element is unique',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist/verification',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Unique DOI values',
                 'got_value': ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'],
-                'message': "Got DOIs and frequencies ('10.1590/2176-4573p59270', 1) | ('10.1590/2176-4573e59270', 3)",
-                'advice': 'Consider replacing the following DOIs that are not unique: 10.1590/2176-4573e59270'
+                'message': "Got ['10.1590/2176-4573p59270', '10.1590/2176-4573e59270'], expected Unique DOI values",
+                'advice': 'Consider replacing the following DOIs that are not unique: 10.1590/2176-4573e59270',
+                'data': [
+                    {
+                        'lang': 'pt',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/2176-4573p59270'
+                    },
+                    {
+                        'lang': 'fr',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's2',
+                        'value': '10.1590/2176-4573e59270'},
+                    {
+                        'lang': 'es',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's3',
+                        'value': '10.1590/2176-4573e59270'},
+                    {
+                        'lang': 'en',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_success(self):
         self.maxDiff = None
@@ -410,100 +595,260 @@ class ArticleDoiTest(unittest.TestCase):
                             </contrib>
                         </contrib-group>
                 </front-stub>
-            </sub-article>      
+            </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_ok
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Title in English',
                 'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title in English',
-                'advice': None
+                'message': 'Got Title in English, expected Title in English',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
                 'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
+                'message': 'Got Martínez-Momblán, Maria Antonia, expected Martínez-Momblán, Maria Antonia',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
+                'message': 'Got Colina-Torralva, Javier, expected Colina-Torralva, Javier',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573p59270',
                 'got_value': '10.1590/2176-4573p59270',
-                'message': 'Got 10.1590/2176-4573p59270 expected 10.1590/2176-4573p59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573p59270, expected 10.1590/2176-4573p59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Título em Português',
                 'got_value': 'Título em Português',
-                'message': 'Got Título em Português expected Título em Português',
-                'advice': None
+                'message': 'Got Título em Português, expected Título em Português',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
                 'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Martínez-Momblán, Maria Antonia',
-                'advice': None
+                'message': 'Got Martínez-Momblán, Maria Antonia, expected Martínez-Momblán, Maria Antonia',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: pt, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
+                'message': 'Got Colina-Torralva, Javier, expected Colina-Torralva, Javier',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             }
 
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_doi_is_not_registered(self):
         self.maxDiff = None
@@ -552,39 +897,79 @@ class ArticleDoiTest(unittest.TestCase):
                             </contrib>
                         </contrib-group>
                 </front-stub>
-            </sub-article>      
+            </sub-article>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_not_registered
-        )
+        ))
 
         expected = [
             {
                 'title': 'Article DOI is registered',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Data registered to the DOI 10.1590/2176-4573e59270',
                 'got_value': None,
-                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573e59270',
-                'advice': 'Consult again after DOI has been registered'
+                'message': 'Got None, expected Data registered to the DOI 10.1590/2176-4573e59270',
+                'advice': 'Consult again after DOI has been registered',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             },
             {
                 'title': 'Article DOI is registered',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'pt',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Data registered to the DOI 10.1590/2176-4573p59270',
                 'got_value': None,
-                'message': 'Got None expected data registered to the DOI 10.1590/2176-4573p59270',
-                'advice': 'Consult again after DOI has been registered'
+                'message': 'Got None, expected Data registered to the DOI 10.1590/2176-4573p59270',
+                'advice': 'Consult again after DOI has been registered',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    },
+                    {
+                        'lang': 'pt',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_only_doi_is_correct(self):
         self.maxDiff = None
@@ -615,58 +1000,110 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_ok
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Title in English',
                 'got_value': 'Title English',
-                'message': 'Got Title English expected Title in English',
+                'message': 'Got Title English, expected Title in English',
                 'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
                 'got_value': 'Martínez, Maria Antonia',
-                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia, expected Martínez-Momblán, Maria Antonia',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Colina, Javier',
-                'message': 'Got Colina, Javier expected Colina-Torralva, Javier',
+                'message': 'Got Colina, Javier, expected Colina-Torralva, Javier',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_only_title_is_correct(self):
         self.maxDiff = None
@@ -697,58 +1134,110 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_ok
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59271',
-                'message': 'Got 10.1590/2176-4573e59271 expected 10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59271, expected 10.1590/2176-4573e59270',
                 'advice': 'DOI not registered or validator not found, provide a value for doi element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Title in English',
                 'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title in English',
-                'advice': None
+                'message': 'Got Title in English, expected Title in English',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
                 'got_value': 'Martínez, Maria Antonia',
-                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia, expected Martínez-Momblán, Maria Antonia',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Colina, Javier',
-                'message': 'Got Colina, Javier expected Colina-Torralva, Javier',
+                'message': 'Got Colina, Javier, expected Colina-Torralva, Javier',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_only_one_author_is_correct(self):
         self.maxDiff = None
@@ -779,58 +1268,110 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_ok
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59271',
-                'message': 'Got 10.1590/2176-4573e59271 expected 10.1590/2176-4573e59270',
+                'message': 'Got 10.1590/2176-4573e59271, expected 10.1590/2176-4573e59270',
                 'advice': 'DOI not registered or validator not found, provide a value for doi element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Title in English',
                 'got_value': 'Title English',
-                'message': 'Got Title English expected Title in English',
+                'message': 'Got Title English, expected Title in English',
                 'advice': 'DOI not registered or validator not found, provide a value for title element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Martínez-Momblán, Maria Antonia',
                 'got_value': 'Martínez, Maria Antonia',
-                'message': 'Got Martínez, Maria Antonia expected Martínez-Momblán, Maria Antonia',
+                'message': 'Got Martínez, Maria Antonia, expected Martínez-Momblán, Maria Antonia',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
-                          'matches the record for DOI.'
+                          'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Colina-Torralva, Javier',
-                'message': 'Got Colina-Torralva, Javier expected Colina-Torralva, Javier',
-                'advice': None
+                'message': 'Got Colina-Torralva, Javier, expected Colina-Torralva, Javier',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59271'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_no_expected_authors(self):
         self.maxDiff = None
@@ -861,45 +1402,84 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_missing_authors
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Title in English',
                 'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title in English',
-                'advice': None
+                'message': 'Got Title in English, expected Title in English',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: authors)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': [],
                 'got_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
                 'message': 'The following items are surplus in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
                 'advice': 'Remove the following items from the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_no_obtained_authors(self):
         self.maxDiff = None
@@ -916,45 +1496,84 @@ class ArticleDoiTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_ok
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Title in English',
                 'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title in English',
-                'advice': None
+                'message': 'Got Title in English, expected Title in English',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: authors)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
                 'got_value': [],
                 'message': 'The following items are not found in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
                 'advice': 'Complete the following items in the XML: Martínez-Momblán, Maria Antonia | Colina-Torralva, Javier',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
     def test_validate_doi_registered_expected_one_author_obtained_two_authors(self):
         self.maxDiff = None
@@ -981,60 +1600,112 @@ class ArticleDoiTest(unittest.TestCase):
                     </contrib>
                 </contrib-group>
                 </article-meta>
-            </front>  
+            </front>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = ArticleDoiValidation(xml_tree).validate_doi_registered(
+        obtained = list(ArticleDoiValidation(xml_tree).validate_doi_registered(
             callable_get_data_one_author
-        )
+        ))
 
         expected = [
             {
-                'title': 'Article DOI is registered (lang: en, element: doi)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': '10.1590/2176-4573e59270',
                 'got_value': '10.1590/2176-4573e59270',
-                'message': 'Got 10.1590/2176-4573e59270 expected 10.1590/2176-4573e59270',
-                'advice': None
+                'message': 'Got 10.1590/2176-4573e59270, expected 10.1590/2176-4573e59270',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: title)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
                 'response': 'OK',
                 'expected_value': 'Title in English',
                 'got_value': 'Title in English',
-                'message': 'Got Title in English expected Title in English',
-                'advice': None
+                'message': 'Got Title in English, expected Title in English',
+                'advice': None,
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: author)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': 'Colina-Torralva, Javier',
                 'got_value': 'Martínez-Momblán, Maria Antonia',
-                'message': 'Got Martínez-Momblán, Maria Antonia expected Colina-Torralva, Javier',
+                'message': 'Got Martínez-Momblán, Maria Antonia, expected Colina-Torralva, Javier',
                 'advice': 'DOI not registered or validator not found, provide a value for author element that '
                           'matches the record for DOI.',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             },
             {
-                'title': 'Article DOI is registered (lang: en, element: authors)',
-                'xpath': './article-id[@pub-id-type="doi"]',
+                'title': 'Article DOI is registered',
+                'parent': 'article',
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
                 'validation_type': 'exist',
-                'response': 'ERROR',
+                'response': 'CRITICAL',
                 'expected_value': ['Colina-Torralva, Javier'],
                 'got_value': ['Martínez-Momblán, Maria Antonia', 'Colina-Torralva, Javier'],
                 'message': 'The following items are surplus in the XML: Colina-Torralva, Javier',
                 'advice': 'Remove the following items from the XML: Colina-Torralva, Javier',
+                'data': [
+                    {
+                        'lang': 'en',
+                        'parent': 'article',
+                        'parent_article_type': None,
+                        'value': '10.1590/2176-4573e59270'
+                    }
+                ],
             }
         ]
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
+                self.assertDictEqual(obtained[i], item)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### O que esse PR faz?
Este Pull Request implementa uma nova funcionalidade para validação de DOIs em artigos XML. Ele adiciona métodos para:

- Verificar a existência de DOIs.
- Garantir que todos os DOIs sejam únicos.
- Validar que os DOIs estejam registrados e correspondam aos metadados esperados (título, autores).


Essas funcionalidades visam solucionar problemas relacionados à inconsistência e duplicidade de DOIs, garantindo a integridade dos dados nos artigos XML.

#### Onde a revisão poderia começar?
Sugiro iniciar pela avaliação dos testes:

- `tests/sps/models/test_article_doi_with_lang.py`
- `tests/sps/models/test_article_doi_with_lang.py`

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_doi.py
`
#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

