### PR TITLE
Feat: get doi information

### DIFF
--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -1,6 +1,8 @@
 import requests
 from langdetect import detect
 
+from packtools.sps.libs.requester import fetch_data
+
 
 def format_response(
     title,
@@ -38,12 +40,8 @@ def format_response(
 
 def get_doi_information(doi):
     url = f"https://api.crossref.org/works/{doi}"
-    response = requests.get(url)
-    if response.status_code != 200:
-        raise Exception(f"Error fetching DOI information: {response.status_code}")
-
-    data = response.json()
-    item = data['message']
+    response = fetch_data(url=url, json=True)
+    item = response['message']
 
     result = {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tox==4.11.4
 langcodes==3.3.0
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 ipdb==0.13.13
+langdetect~=1.0.9

--- a/tests/sps/validation/test_utils.py
+++ b/tests/sps/validation/test_utils.py
@@ -1,0 +1,48 @@
+import unittest
+
+from packtools.sps.validation.utils import get_doi_information
+
+
+class MyTestCase(unittest.TestCase):
+    def test_get_doi_information(self):
+        self.maxDiff = None
+        expected = [
+            {
+                'authors': [
+                    'Rossi, Luciano',
+                    'Damaceno, Rafael J.P.',
+                    'Freire, Igor L.',
+                    'Bechara, Etelvino J.H.',
+                    'Mena-Chalco, Jesús P.'
+                ],
+                'en': {
+                    'doi': '10.1016/j.joi.2018.08.004',
+                    'title': 'Topological metrics in academic genealogy graphs'
+                }
+            },
+            {
+                'authors': [
+                    'Carlos de Carvalho, João'
+                ],
+                'en': {
+                    'doi': '10.1590/2176-4573p59270',
+                    'title': 'The Jewish Amazon by Moacyr Scliar: The Word of the Other as Affirmation of the '
+                             'Noncoincidence of the Other in Oneself'},
+                'pt': {
+                    'doi': '10.1590/2176-4573p59270',
+                    'title': 'A Amazônia judaica de Moacyr Scliar: a palavra alheia como afirmação da '
+                             'não-coincidência do outro em si'
+                }
+            }
+            ]
+
+        dois = ["10.1016/j.joi.2018.08.004", "10.1590/2176-4573p59270"]
+
+        for i, doi in enumerate(dois):
+            with self.subTest(i):
+                obtained = get_doi_information(doi)
+                self.assertDictEqual(expected[i], obtained)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este Pull Request adiciona uma nova função `get_doi_information` que consulta a API da CrossRef para obter informações detalhadas sobre um DOI, incluindo títulos e autores. A função detecta o idioma dos títulos e estrutura os dados de forma organizada. Também foram incluídos testes unitários para garantir o correto funcionamento da função.

#### Onde a revisão poderia começar?
O revisor deve iniciar a leitura do código a partir dos seguintes arquivos:

- `packtools/sps/validation/utils.py (contendo a função get_doi_information)`
- `tests/test_doi_information.py (contendo os testes unitários)`

#### Como este poderia ser testado manualmente?
Para testar manualmente esta funcionalidade, siga os passos abaixo:

1. Garanta que as dependências listadas no arquivo requirements.txt estejam instaladas.
2. Utilize a função get_doi_information com um DOI válido e verifique se a resposta contém os títulos e autores organizados por idioma.
3. Execute os testes unitários com unittest para confirmar que os casos de teste fornecidos são bem-sucedidos: `python3 -m unittest -v tests/sps/validation/test_utils.py`

#### Algum cenário de contexto que queira dar?
Este Pull Request trata de uma proposta inicial para integrar a funcionalidade de obtenção e estruturação de informações de DOIs. É importante considerar que esta implementação pode ser ajustada ou modificada conforme necessário para atender melhor às necessidades do projeto. A abordagem apresentada serve como ponto de partida para futuras melhorias e adaptações.

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
Referências utilizadas para a elaboração deste Pull Request:

- Documentação da API da CrossRef.
- Bibliotecas utilizadas: requests, langdetect, unittest.

