### PR TITLE
Feat: adds validation fig

### DIFF
--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -1,0 +1,47 @@
+from ..models.fig import ArticleFigs
+from ..validation.utils import format_response
+
+
+class FigValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.figures_by_language = ArticleFigs(xmltree).items_by_lang
+
+    def validate_fig_existence(self, error_level="WARNING"):
+        if self.figures_by_language:
+            for lang, figure_data in self.figures_by_language.items():
+                yield format_response(
+                    title="validation of <fig> elements",
+                    parent=figure_data.get("parent"),
+                    parent_id=figure_data.get("parent_id"),
+                    parent_article_type=figure_data.get("parent_article_type"),
+                    parent_lang=figure_data.get("parent_lang"),
+                    item="fig",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=True,
+                    expected=figure_data.get("fig_id"),
+                    obtained=figure_data.get("fig_id"),
+                    advice=None,
+                    data=figure_data,
+                    error_level="OK",
+                )
+        else:
+            yield format_response(
+                title="validation of <fig> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                item="fig",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=False,
+                expected="<fig> element",
+                obtained=None,
+                advice="Add <fig> element to illustrate the content.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -1,0 +1,100 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.fig import FigValidation
+
+
+class FigValidationTest(unittest.TestCase):
+    def test_fig_validation_no_fig_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without figures.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(FigValidation(xmltree).validate_fig_existence())
+
+        expected = [
+            {
+                "title": "validation of <fig> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "fig",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<fig> element",
+                "got_value": None,
+                "message": "Got None, expected <fig> element",
+                "advice": "Add <fig> element to illustrate the content.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_fig_validation_with_fig_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<fig id="f01">'
+            "<label>Figure 1</label>"
+            '<graphic xlink:href="image1.png"/>'
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</fig>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(FigValidation(xmltree).validate_fig_existence())
+
+        expected = [
+            {
+                "title": "validation of <fig> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "fig",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "f01",
+                "got_value": "f01",
+                "message": "Got f01, expected f01",
+                "advice": None,
+                "data": {
+                    "alternative_parent": "fig",
+                    "fig_id": "f01",
+                    "fig_type": None,
+                    "label": "Figure 1",
+                    "graphic_href": "image1.png",
+                    "caption_text": "",
+                    "source_attrib": None,
+                    "alternative_elements": ["graphic", "graphic"],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona validação para a existência de elementos `<fig>` em um documento XML. Ele introduz a classe FigValidation para verificar se os elementos `<fig>` estão presentes no XML fornecido e produz mensagens de validação apropriadas.

#### Onde a revisão poderia começar?
O revisor deve começar pela classe `FigValidation` no arquivo `packtools/sps/validation/fig.py`. Em seguida, prosseguir para revisar os casos de teste no arquivo `tests/sps/validation/test_fig.py`.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_fig.py`

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA
