### PR TITLE
Feat: adds validation tablewrap

### DIFF
--- a/packtools/sps/validation/tablewrap.py
+++ b/packtools/sps/validation/tablewrap.py
@@ -1,0 +1,45 @@
+from ..models.tablewrap import ArticleTableWraps
+from ..validation.utils import format_response
+
+
+class TableWrapValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.table_wraps_by_language = ArticleTableWraps(xmltree).items_by_lang
+
+    def validate_tablewrap_existence(self, error_level="WARNING"):
+        if self.table_wraps_by_language:
+            for lang, table_wrap_data in self.table_wraps_by_language.items():
+                yield format_response(
+                    title="validation of <table-wrap> elements",
+                    parent=table_wrap_data.get("parent"),
+                    parent_id=table_wrap_data.get("parent_id"),
+                    parent_article_type=table_wrap_data.get("parent_article_type"),
+                    parent_lang=table_wrap_data.get("parent_lang"),
+                    item="table-wrap",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=True,
+                    expected=table_wrap_data.get("table_wrap_id"),
+                    obtained=table_wrap_data.get("table_wrap_id"),
+                    advice=None,
+                    data=table_wrap_data,
+                    error_level="OK",
+                )
+        else:
+            yield format_response(
+                title="validation of <table-wrap> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get("{http://www.w3.org/XML/1998/namespace}lang"),
+                item="table-wrap",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=False,
+                expected="<table-wrap> element",
+                obtained=None,
+                advice="Add <table-wrap> element to properly illustrate the content.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/validation/test_tablewrap.py
+++ b/tests/sps/validation/test_tablewrap.py
@@ -1,0 +1,100 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.tablewrap import TableWrapValidation
+
+
+class TableWrapValidationTest(unittest.TestCase):
+    def test_tablewrap_validation_no_tablewrap_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without table wraps.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(TableWrapValidation(xmltree).validate_tablewrap_existence())
+
+        expected = [
+            {
+                "title": "validation of <table-wrap> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "table-wrap",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<table-wrap> element",
+                "got_value": None,
+                "message": "Got None, expected <table-wrap> element",
+                "advice": "Add <table-wrap> element to properly illustrate the content.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_tablewrap_validation_with_tablewrap_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<table-wrap id="t01">'
+            "<label>Table 1</label>"
+            '<caption>Table caption</caption>'
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</table-wrap>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(TableWrapValidation(xmltree).validate_tablewrap_existence())
+
+        expected = [
+            {
+                "title": "validation of <table-wrap> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "table-wrap",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "t01",
+                "got_value": "t01",
+                "message": "Got t01, expected t01",
+                "advice": None,
+                "data": {
+                    "alternative_parent": "table-wrap",
+                    "table_wrap_id": "t01",
+                    "label": "Table 1",
+                    "caption": "Table caption",
+                    "footnote": "",
+                    "footnote_id": None,
+                    "footnote_label": None,
+                    "alternative_elements": ["graphic", "graphic"],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona validação para a existência de elementos `<table-wrap>` em um documento XML. Ele introduz a classe `TableWrapValidation` para verificar se os elementos `<table-wrap>` estão presentes no XML fornecido e produz mensagens de validação apropriadas.

#### Onde a revisão poderia começar?
O revisor deve começar pela classe `TableWrapValidation` no arquivo `packtools/sps/validation/tablewrap.py`. Em seguida, prosseguir para revisar os casos de teste no arquivo `tests/sps/validation/test_tablewrap.py`.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_tablewrap.py
`
#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

