### PR TITLE
Feat: adds validation formula

### DIFF
--- a/packtools/sps/validation/formula.py
+++ b/packtools/sps/validation/formula.py
@@ -1,0 +1,47 @@
+from ..models.formula import ArticleFormulas
+from ..validation.utils import format_response
+
+
+class FormulaValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.formulas_by_language = ArticleFormulas(xmltree).items_by_lang
+
+    def validate_formula_existence(self, error_level="WARNING"):
+        if self.formulas_by_language:
+            for lang, formula_data in self.formulas_by_language.items():
+                yield format_response(
+                    title="validation of <formula> elements",
+                    parent=formula_data.get("parent"),
+                    parent_id=formula_data.get("parent_id"),
+                    parent_article_type=formula_data.get("parent_article_type"),
+                    parent_lang=formula_data.get("parent_lang"),
+                    item=formula_data.get("alternative_parent"),
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=True,
+                    expected=formula_data.get("formula_id"),
+                    obtained=formula_data.get("formula_id"),
+                    advice=None,
+                    data=formula_data,
+                    error_level="OK",
+                )
+        else:
+            yield format_response(
+                title="validation of <formula> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                item="formula",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=False,
+                expected="<formula> element",
+                obtained=None,
+                advice="Include <formula> elements to properly represent mathematical expressions in the content.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/validation/test_formula.py
+++ b/tests/sps/validation/test_formula.py
@@ -1,0 +1,145 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.formula import FormulaValidation
+
+
+class FormulaValidationTest(unittest.TestCase):
+    def test_formula_validation_no_formula_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without formulas.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(FormulaValidation(xmltree).validate_formula_existence())
+
+        expected = [
+            {
+                "title": "validation of <formula> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "formula",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<formula> element",
+                "got_value": None,
+                "message": "Got None, expected <formula> element",
+                "advice": "Include <formula> elements to properly represent mathematical expressions in the content.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_formula_validation_with_disp_formula_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<disp-formula id="d01">'
+            "<label>Formula 1</label>"
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</disp-formula>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(FormulaValidation(xmltree).validate_formula_existence())
+
+        expected = [
+            {
+                "title": "validation of <formula> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "disp-formula",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "d01",
+                "got_value": "d01",
+                "message": "Got d01, expected d01",
+                "advice": None,
+                "data": {
+                    "alternative_parent": "disp-formula",
+                    "formula_id": "d01",
+                    "formula_label": "Formula 1",
+                    "alternative_elements": ["graphic", "graphic"],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_formula_validation_with_inline_formula_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<inline-formula id="i01">'
+            "<label>Formula 1</label>"
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</inline-formula>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(FormulaValidation(xmltree).validate_formula_existence())
+
+        expected = [
+            {
+                "title": "validation of <formula> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "inline-formula",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "i01",
+                "got_value": "i01",
+                "message": "Got i01, expected i01",
+                "advice": None,
+                "data": {
+                    "alternative_parent": "inline-formula",
+                    "formula_id": "i01",
+                    "formula_label": "Formula 1",
+                    "alternative_elements": ["graphic", "graphic"],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona validação para a existência de elementos `<disp-formula>` e `<inline-formula>` em um documento XML. Ele introduz a classe `FormulaValidation` para verificar se os elementos `<disp-formula>` e `<inline-formula>` estão presentes no XML fornecido e produz mensagens de validação apropriadas.

#### Onde a revisão poderia começar?
O revisor deve começar pela classe `FormulaValidation `no arquivo `packtools/sps/validation/formula.py`. Em seguida, prosseguir para revisar os casos de teste no arquivo `tests/sps/validation/test_formula.py.`

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_formula.py`

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

