### PR TITLE
Feat: adds validation app

### DIFF
--- a/packtools/sps/models/app_group.py
+++ b/packtools/sps/models/app_group.py
@@ -1,0 +1,33 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class App:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def app_id(self):
+        return self.node.get("id")
+
+    @property
+    def app_label(self):
+        return self.node.findtext("label")
+
+    @property
+    def data(self):
+        return {"app_id": self.app_id, "app_label": self.app_label}
+
+
+class AppGroup:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def data(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            for app_node in node.xpath(".//app-group//app"):
+                app_data = App(app_node).data
+                yield put_parent_context(
+                    app_data, lang, article_type, parent, parent_id
+                )

--- a/packtools/sps/validation/app_group.py
+++ b/packtools/sps/validation/app_group.py
@@ -1,0 +1,46 @@
+from ..models.app_group import AppGroup
+from ..validation.utils import format_response
+
+
+class AppValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.apps = AppGroup(xmltree).data()
+
+    def validate_app_existence(self, error_level="WARNING"):
+        for app in self.apps:
+            yield format_response(
+                title="validation of <app> elements",
+                parent=app.get("parent"),
+                parent_id=app.get("parent_id"),
+                parent_article_type=app.get("parent_article_type"),
+                parent_lang=app.get("parent_lang"),
+                item="app-group",
+                sub_item="app",
+                validation_type="exist",
+                is_valid=True,
+                expected=app.get("app_id"),
+                obtained=app.get("app_id"),
+                advice=None,
+                data=app,
+                error_level="OK",
+            )
+        else:
+            yield format_response(
+                title="validation of <app> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                item="app-group",
+                sub_item="app",
+                validation_type="exist",
+                is_valid=False,
+                expected="<app> element",
+                obtained=None,
+                advice="Consider adding an <app> element to include additional content such as supplementary materials or appendices.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/models/test_app_group.py
+++ b/tests/sps/models/test_app_group.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from packtools.sps.models.app_group import App, AppGroup
+from packtools.sps.utils import xml_utils
+
+
+class AppTest(TestCase):
+    def setUp(self):
+        xml_tree = xml_utils.get_xml_tree('tests/fixtures/htmlgenerator/app_group_supplementary_material/0104-5970-hcsm-27-01-0275.xml')
+        self.app = App(xml_tree.xpath(".//app")[0])
+
+    def test_app_id(self):
+        self.assertEqual(self.app.app_id, "app01")
+
+    def test_app_label(self):
+        self.assertEqual(self.app.app_label, "FONTES")
+
+    def test_data(self):
+        expected = {
+            "app_id": "app01",
+            "app_label": "FONTES"
+        }
+        obtained = self.app.data
+        self.assertDictEqual(expected, obtained)
+
+
+class AppGroupTest(TestCase):
+    def setUp(self):
+        self.xml_tree = xml_utils.get_xml_tree('tests/fixtures/htmlgenerator/app_group_supplementary_material/0104-5970-hcsm-27-01-0275.xml')
+
+    def test_data(self):
+        obtained = list(AppGroup(self.xml_tree).data())
+        expected = [
+            {
+                'app_id': 'app01',
+                'app_label': 'FONTES',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt'
+            },
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])

--- a/tests/sps/validation/test_app_group.py
+++ b/tests/sps/validation/test_app_group.py
@@ -1,0 +1,97 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.app_group import AppValidation
+
+
+class AppValidationTest(unittest.TestCase):
+    def test_app_validation_no_app_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without apps.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(AppValidation(xmltree).validate_app_existence())
+
+        expected = [
+            {
+                "title": "validation of <app> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "app-group",
+                "sub_item": "app",
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<app> element",
+                "got_value": None,
+                "message": "Got None, expected <app> element",
+                "advice": "Consider adding an <app> element to include additional content such as supplementary materials or appendices.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_app_validation_with_app_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<app-group>"
+            '<app id="app1">'
+            "<label>Appendix 1</label>"
+            "<p>Some supplementary content.</p>"
+            "</app>"
+            "<alternatives>"
+            '<app id="app1-alt1">'
+            "<p>Alternative content for Appendix 1.</p>"
+            "</app>"
+            "</alternatives>"
+            "</app-group>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(AppValidation(xmltree).validate_app_existence())
+
+        expected = [
+            {
+                "title": "validation of <app> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "app-group",
+                "sub_item": "app",
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "app1",
+                "got_value": "app1",
+                "message": "Got app1, expected app1",
+                "advice": None,
+                "data": {
+                    "app_id": "app1",
+                    "app_label": "Appendix 1",
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a validação para a existência de elementos `<app>` dentro de um grupo `<app-group>` em documentos XML. A validação garante que todos os elementos `<app>` esperados estejam presentes e fornece feedback apropriado quando esses elementos estão ausentes. Além disso, foi introduzida a classe `AppGroup` para gerenciar e extrair dados dos elementos `<app-group>` e `<app>`.

#### Onde a revisão poderia começar?
O revisor deve começar pelos arquivos:

`packtools/sps/validation/app.py para ver a implementação da classe AppValidation.`
`packtools/sps/models/app_group.py para verificar a nova classe AppGroup`.
`tests/sps/validation/test_app.py para verificar os testes unitários da validação de <app>`.

#### Como este poderia ser testado manualmente?

1. Carregue um documento XML com a estrutura de artigo (<`article>`).
2. Assegure-se de que o documento XML tenha um grupo `<app-group>` com e sem elementos `<app>`.
3. Execute a validação usando a função `validate_app_existence()` da classe `AppValidation`.
4. Verifique os resultados de validação, assegurando-se de que a mensagem de validação é apropriada para ambos os cenários (presença e ausência de `<app>`).

#### Algum cenário de contexto que queira dar?
Esta funcionalidade é importante para garantir que os artigos XML que contêm conteúdo suplementar ou apêndices estejam devidamente estruturados e que todos os elementos esperados estejam presentes. A ausência de elementos `<app>` pode indicar que informações suplementares ou apêndices não foram incluídos corretamente no documento XML.

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA
