### PR TITLE
Feat: adds supplementary material validation

### DIFF
--- a/packtools/sps/models/app_group.py
+++ b/packtools/sps/models/app_group.py
@@ -1,0 +1,33 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class App:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def app_id(self):
+        return self.node.get("id")
+
+    @property
+    def app_label(self):
+        return self.node.findtext("label")
+
+    @property
+    def data(self):
+        return {"app_id": self.app_id, "app_label": self.app_label}
+
+
+class AppGroup:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def data(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            for app_node in node.xpath(".//app-group//app"):
+                app_data = App(app_node).data
+                yield put_parent_context(
+                    app_data, lang, article_type, parent, parent_id
+                )

--- a/packtools/sps/models/supplementary_material.py
+++ b/packtools/sps/models/supplementary_material.py
@@ -1,0 +1,53 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class SupplementaryMaterial:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def supplementary_material_id(self):
+        return self.node.get("id")
+
+    @property
+    def supplementary_material_label(self):
+        return self.node.findtext("label")
+
+    @property
+    def mimetype(self):
+        return self.node.get("mimetype")
+
+    @property
+    def mime_subtype(self):
+        return self.node.get("mime-subtype")
+
+    @property
+    def xlink_href(self):
+        return self.node.get("{http://www.w3.org/1999/xlink}href")
+
+    @property
+    def data(self):
+        return {
+            "supplementary_material_id": self.supplementary_material_id,
+            "supplementary_material_label": self.supplementary_material_label,
+            "mimetype": self.mimetype,
+            "mime_subtype": self.mime_subtype,
+            "xlink_href": self.xlink_href,
+        }
+
+
+class ArticleSupplementaryMaterials:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def data(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            for supp_node in node.xpath(
+                ".//supplementary-material | .//inline-supplementary-material"
+            ):
+                supp_data = SupplementaryMaterial(supp_node).data
+                yield put_parent_context(
+                    supp_data, lang, article_type, parent, parent_id
+                )

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -1,0 +1,46 @@
+from ..models.supplementary_material import ArticleSupplementaryMaterials
+from ..validation.utils import format_response
+
+
+class SupplementaryMaterialValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.supplementary_materials = ArticleSupplementaryMaterials(xmltree).data()
+
+    def validate_supplementary_material_existence(self, error_level="WARNING"):
+        for supp in self.supplementary_materials:
+            yield format_response(
+                title="validation of <supplementary-material> elements",
+                parent=supp.get("parent"),
+                parent_id=supp.get("parent_id"),
+                parent_article_type=supp.get("parent_article_type"),
+                parent_lang=supp.get("parent_lang"),
+                item="supplementary-material",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=True,
+                expected=supp.get("supplementary_material_id"),
+                obtained=supp.get("supplementary_material_id"),
+                advice=None,
+                data=supp,
+                error_level="OK",
+            )
+        else:
+            yield format_response(
+                title="validation of <supplementary-material> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                item="supplementary-material",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=False,
+                expected="<supplementary-material> element",
+                obtained=None,
+                advice="Consider adding a <supplementary-material> element to provide additional data or materials related to the article.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/models/test_supplementary_material.py
+++ b/tests/sps/models/test_supplementary_material.py
@@ -1,0 +1,108 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.models.supplementary_material import (
+    SupplementaryMaterial,
+    ArticleSupplementaryMaterials,
+)
+
+
+class SupplementaryMaterialTest(unittest.TestCase):
+    def setUp(self):
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+                <supplementary-material id="supp01" mimetype="application" mime-subtype="pdf" xlink:href="supplementary1.pdf">
+                    <label>Supplementary Material 1</label>
+                </supplementary-material>
+            </body>
+        </article>
+        """
+        self.xml_tree = etree.fromstring(xml_str)
+        self.supplementary_material = SupplementaryMaterial(
+            self.xml_tree.xpath(".//supplementary-material")[0]
+        )
+
+    def test_supplementary_material_id(self):
+        self.assertEqual(
+            self.supplementary_material.supplementary_material_id, "supp01"
+        )
+
+    def test_supplementary_material_label(self):
+        self.assertEqual(
+            self.supplementary_material.supplementary_material_label,
+            "Supplementary Material 1",
+        )
+
+    def test_mimetype(self):
+        self.assertEqual(self.supplementary_material.mimetype, "application")
+
+    def test_mime_subtype(self):
+        self.assertEqual(self.supplementary_material.mime_subtype, "pdf")
+
+    def test_xlink_href(self):
+        self.assertEqual(self.supplementary_material.xlink_href, "supplementary1.pdf")
+
+    def test_data(self):
+        expected = {
+            "supplementary_material_id": "supp01",
+            "supplementary_material_label": "Supplementary Material 1",
+            "mimetype": "application",
+            "mime_subtype": "pdf",
+            "xlink_href": "supplementary1.pdf",
+        }
+        obtained = self.supplementary_material.data
+        self.assertDictEqual(expected, obtained)
+
+
+class ArticleSupplementaryMaterialsTest(unittest.TestCase):
+    def setUp(self):
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+                <supplementary-material id="supp01" mimetype="application" mime-subtype="pdf" xlink:href="supplementary1.pdf">
+                    <label>Supplementary Material 1</label>
+                </supplementary-material>
+                <inline-supplementary-material id="supp02" mimetype="text" mime-subtype="plain" xlink:href="inline-supplementary1.txt">
+                    <label>Inline Supplementary Material 1</label>
+                </inline-supplementary-material>
+            </body>
+        </article>
+        """
+        self.xml_tree = etree.fromstring(xml_str)
+
+    def test_data(self):
+        obtained = list(ArticleSupplementaryMaterials(self.xml_tree).data())
+        expected = [
+            {
+                "supplementary_material_id": "supp01",
+                "supplementary_material_label": "Supplementary Material 1",
+                "mimetype": "application",
+                "mime_subtype": "pdf",
+                "xlink_href": "supplementary1.pdf",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "pt",
+            },
+            {
+                "supplementary_material_id": "supp02",
+                "supplementary_material_label": "Inline Supplementary Material 1",
+                "mimetype": "text",
+                "mime_subtype": "plain",
+                "xlink_href": "inline-supplementary1.txt",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "pt",
+            },
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -1,0 +1,131 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.supplementary_material import (
+    SupplementaryMaterialValidation,
+)
+
+
+class SupplementaryMaterialValidationTest(unittest.TestCase):
+    def test_supplementary_material_validation_no_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without supplementary materials.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(
+            SupplementaryMaterialValidation(
+                xmltree
+            ).validate_supplementary_material_existence()
+        )
+
+        expected = [
+            {
+                "title": "validation of <supplementary-material> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "supplementary-material",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<supplementary-material> element",
+                "got_value": None,
+                "message": "Got None, expected <supplementary-material> element",
+                "advice": "Consider adding a <supplementary-material> element to provide additional data or materials related to the article.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_supplementary_material_validation_with_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<supplementary-material id="supp01" mimetype="application" mime-subtype="pdf" xlink:href="supplementary1.pdf">'
+            "<label>Supplementary Material 1</label>"
+            "</supplementary-material>"
+            '<inline-supplementary-material id="supp02" mimetype="text" mime-subtype="plain" xlink:href="inline-supplementary1.txt">'
+            "<label>Inline Supplementary Material 1</label>"
+            "</inline-supplementary-material>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(
+            SupplementaryMaterialValidation(
+                xmltree
+            ).validate_supplementary_material_existence()
+        )
+
+        expected = [
+            {
+                "title": "validation of <supplementary-material> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "supplementary-material",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "supp01",
+                "got_value": "supp01",
+                "message": "Got supp01, expected supp01",
+                "advice": None,
+                "data": {
+                    "supplementary_material_id": "supp01",
+                    "supplementary_material_label": "Supplementary Material 1",
+                    "mimetype": "application",
+                    "mime_subtype": "pdf",
+                    "xlink_href": "supplementary1.pdf",
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            },
+            {
+                "title": "validation of <supplementary-material> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "supplementary-material",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "supp02",
+                "got_value": "supp02",
+                "message": "Got supp02, expected supp02",
+                "advice": None,
+                "data": {
+                    "supplementary_material_id": "supp02",
+                    "supplementary_material_label": "Inline Supplementary Material 1",
+                    "mimetype": "text",
+                    "mime_subtype": "plain",
+                    "xlink_href": "inline-supplementary1.txt",
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a implementação do modelo e a validação para elementos `<supplementary-material>` e `<inline-supplementary-material>` em artigos XML. Inclui também a criação dos testes unitários para garantir a extração correta de atributos desses elementos e a validação de sua existência no documento XML.

#### Onde a revisão poderia começar?
Recomenda-se começar a revisão pelos arquivos:

- `models/supplementary_material.py`
- `validation/supplementary_material.py`
- `tests/models/test_supplementary_material.py`
- `tests/validation/test_supplementary_material.py`

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/test_supplementary_material.py`

#### Algum cenário de contexto que queira dar?
Essas modificações são importantes para garantir que materiais suplementares associados a artigos científicos sejam corretamente identificados e validados, assegurando a integridade dos dados e o cumprimento das normas de publicação.

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA
