### PR TITLE
Feat: adds media validation

### DIFF
--- a/packtools/sps/models/app_group.py
+++ b/packtools/sps/models/app_group.py
@@ -1,0 +1,33 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class App:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def app_id(self):
+        return self.node.get("id")
+
+    @property
+    def app_label(self):
+        return self.node.findtext("label")
+
+    @property
+    def data(self):
+        return {"app_id": self.app_id, "app_label": self.app_label}
+
+
+class AppGroup:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def data(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            for app_node in node.xpath(".//app-group//app"):
+                app_data = App(app_node).data
+                yield put_parent_context(
+                    app_data, lang, article_type, parent, parent_id
+                )

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -1,0 +1,41 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class Media:
+    def __init__(self, node):
+        self.node = node
+
+    @property
+    def mimetype(self):
+        return self.node.get("mimetype")
+
+    @property
+    def mime_subtype(self):
+        return self.node.get("mime-subtype")
+
+    @property
+    def xlink_href(self):
+        return self.node.get("{http://www.w3.org/1999/xlink}href")
+
+    @property
+    def data(self):
+        return {
+            "mimetype": self.mimetype,
+            "mime_subtype": self.mime_subtype,
+            "xlink_href": self.xlink_href,
+        }
+
+
+class ArticleMedias:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def data(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            for media_node in node.xpath(".//media"):
+                media_data = Media(media_node).data
+                yield put_parent_context(
+                    media_data, lang, article_type, parent, parent_id
+                )

--- a/packtools/sps/validation/media.py
+++ b/packtools/sps/validation/media.py
@@ -1,0 +1,46 @@
+from ..models.media import ArticleMedias
+from ..validation.utils import format_response
+
+
+class MediaValidation:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.medias = ArticleMedias(xmltree).data()
+
+    def validate_media_existence(self, error_level="WARNING"):
+        for media in self.medias:
+            yield format_response(
+                title="validation of <media> elements",
+                parent=media.get("parent"),
+                parent_id=media.get("parent_id"),
+                parent_article_type=media.get("parent_article_type"),
+                parent_lang=media.get("parent_lang"),
+                item="media",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=True,
+                expected="media element",
+                obtained="media element",
+                advice=None,
+                data=media,
+                error_level="OK",
+            )
+        else:
+            yield format_response(
+                title="validation of <media> elements",
+                parent="article",
+                parent_id=None,
+                parent_article_type=self.xmltree.get("article-type"),
+                parent_lang=self.xmltree.get(
+                    "{http://www.w3.org/XML/1998/namespace}lang"
+                ),
+                item="media",
+                sub_item=None,
+                validation_type="exist",
+                is_valid=False,
+                expected="<media> element",
+                obtained=None,
+                advice="Consider adding a <media> element to include multimedia content related to the article.",
+                data=None,
+                error_level=error_level,
+            )

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -1,0 +1,90 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.models.media import Media, ArticleMedias
+
+
+class MediaTest(unittest.TestCase):
+    def setUp(self):
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+                <media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">
+                    <label>Media 1</label>
+                </media>
+            </body>
+        </article>
+        """
+        self.xml_tree = etree.fromstring(xml_str)
+        self.media = Media(self.xml_tree.xpath(".//media")[0])
+
+    def test_mimetype(self):
+        self.assertEqual(self.media.mimetype, "video")
+
+    def test_mime_subtype(self):
+        self.assertEqual(self.media.mime_subtype, "mp4")
+
+    def test_xlink_href(self):
+        self.assertEqual(self.media.xlink_href, "media1.mp4")
+
+    def test_data(self):
+        expected = {
+            "mimetype": "video",
+            "mime_subtype": "mp4",
+            "xlink_href": "media1.mp4",
+        }
+        obtained = self.media.data
+        self.assertDictEqual(expected, obtained)
+
+
+class ArticleMediasTest(unittest.TestCase):
+    def setUp(self):
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+                <media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">
+                    <label>Media 1</label>
+                </media>
+            </body>
+            <sub-article article-type="translation" xml:lang="en">
+                <body>
+                    <media mimetype="audio" mime-subtype="mp3" xlink:href="media2.mp3">
+                        <label>Media 2</label>
+                    </media>
+                </body>
+            </sub-article>
+        </article>
+        """
+        self.xml_tree = etree.fromstring(xml_str)
+
+    def test_data(self):
+        obtained = list(ArticleMedias(self.xml_tree).data())
+        expected = [
+            {
+                "mimetype": "video",
+                "mime_subtype": "mp4",
+                "xlink_href": "media1.mp4",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "pt",
+            },
+            {
+                "mimetype": "audio",
+                "mime_subtype": "mp3",
+                "xlink_href": "media2.mp3",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "en",
+            },
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_media.py
+++ b/tests/sps/validation/test_media.py
@@ -1,0 +1,121 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.validation.media import MediaValidation
+
+
+class MediaValidationTest(unittest.TestCase):
+    def test_media_validation_no_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            "<p>Some text content without media.</p>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(MediaValidation(xmltree).validate_media_existence())
+
+        expected = [
+            {
+                "title": "validation of <media> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "media",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "WARNING",
+                "expected_value": "<media> element",
+                "got_value": None,
+                "message": "Got None, expected <media> element",
+                "advice": "Consider adding a <media> element to include multimedia content related to the article.",
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_media_validation_with_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">'
+            "<label>Media 1</label>"
+            "</media>"
+            "</body>"
+            '<sub-article article-type="translation" xml:lang="en">'
+            "<body>"
+            '<media mimetype="audio" mime-subtype="mp3" xlink:href="media2.mp3">'
+            "<label>Media 2</label>"
+            "</media>"
+            "</body>"
+            "</sub-article>"
+            "</article>"
+        )
+        obtained = list(MediaValidation(xmltree).validate_media_existence())
+
+        expected = [
+            {
+                "title": "validation of <media> elements",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "media",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "media element",
+                "got_value": "media element",
+                "message": "Got media element, expected media element",
+                "advice": None,
+                "data": {
+                    "mimetype": "video",
+                    "mime_subtype": "mp4",
+                    "xlink_href": "media1.mp4",
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                },
+            },
+            {
+                "title": "validation of <media> elements",
+                "parent": "sub-article",
+                "parent_id": None,
+                "parent_article_type": "translation",
+                "parent_lang": "en",
+                "item": "media",
+                "sub_item": None,
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "media element",
+                "got_value": "media element",
+                "message": "Got media element, expected media element",
+                "advice": None,
+                "data": {
+                    "mimetype": "audio",
+                    "mime_subtype": "mp3",
+                    "xlink_href": "media2.mp3",
+                    "parent": "sub-article",
+                    "parent_id": None,
+                    "parent_article_type": "translation",
+                    "parent_lang": "en",
+                },
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a validação para os elementos `<media>` em documentos XML no contexto SciELO. A validação garante que os elementos `<media>` estejam presentes no documento e extrai informações relevantes, como `mimetype`, `mime-subtype` e `xlink:href`. Também foram adicionados testes unitários para verificar a correta extração e validação desses elementos, incluindo a presença de elementos `<media>` em sub-artigos.

#### Onde a revisão poderia começar?
Os revisores podem começar pelos seguintes arquivos:

- `models/media.py`
- `validation/media.py`
- `tests/models/test_media.py`
- `tests/validation/test_media.py`

#### Como este poderia ser testado manualmente?
Execute os testes unitários para garantir que todas as validações e extrações estejam funcionando conforme o esperado:

`python3 -m unittest -v tests/sps/models/test_media.py`
`python3 -m unittest -v tests/sps/validation/test_media.py`

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

