### PR TITLE
Fix: fixes future date validation

### DIFF
--- a/packtools/sps/validation/dates.py
+++ b/packtools/sps/validation/dates.py
@@ -360,7 +360,7 @@ class ArticleDatesValidation:
                 error_level=error_level,
             )
 
-    def validate_article_date(self, future_date, error_level=None):
+    def validate_article_date(self, future_date=None, error_level=None):
         """
         Checks if the publication date is valid and before a deadline.
 

--- a/packtools/sps/validation/dates.py
+++ b/packtools/sps/validation/dates.py
@@ -439,7 +439,7 @@ class ArticleDatesValidation:
             error_level=error_level,
         )
 
-    def validate_collection_date(self, future_date, error_level=None):
+    def validate_collection_date(self, future_date=None, error_level=None):
         """
         Checks if the collection date exists, is valid and before a deadline.
 

--- a/packtools/sps/validation/dates.py
+++ b/packtools/sps/validation/dates.py
@@ -505,7 +505,7 @@ class ArticleDatesValidation:
                 advice = 'Provide only numeric values for the collection year'
             elif len(obtained) != 4:
                 advice = 'Provide a four-digit numeric value for the year of collection'
-            elif obtained > future_date:
+            elif int(obtained) > int(future_date):
                 advice = 'Provide a numeric value less than or equal to {}'.format(future_date)
 
             is_valid = advice is None

--- a/tests/sps/validation/test_dates.py
+++ b/tests/sps/validation/test_dates.py
@@ -2007,3 +2007,48 @@ class ArticleDatesValidationTest(TestCase):
         }
 
         self.assertDictEqual(obtained, expected)
+
+    def test_validate_collection_date_without_future_date(self):
+        self.maxDiff = None
+        xml_str = """
+        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+        article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+                <article-meta>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v3">TPg77CCrGj4wcbLCh9vG8bS</article-id>
+                    <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0104-11692020000100303</article-id>
+                    <article-id pub-id-type="doi">10.1590/1518-8345.2927.3231</article-id>
+                    <article-id pub-id-type="other">00303</article-id>
+                    <pub-date date-type="pub" publication-format="electronic">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2023</year>
+                    </pub-date>
+                    <pub-date date-type="collection" publication-format="electronic">
+                        <year>2023</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>
+        """
+
+        xml_tree = get_xml_tree(xml_str)
+        obtained = dates.ArticleDatesValidation(xml_tree).validate_collection_date(future_date=None)
+        expected = {
+            'title': 'Collection pub-date validation',
+            'parent': 'article',
+            'parent_article_type': 'research-article',
+            'parent_id': None,
+            'parent_lang': 'en',
+            'item': 'pub-date',
+            'sub_item': "@date-type='collection'",
+            'validation_type': 'format',
+            'response': 'OK',
+            'expected_value': '2023',
+            'got_value': '2023',
+            'message': 'Got 2023, expected 2023',
+            'advice': None,
+            'data': {'type': 'collection', 'year': '2023'},
+        }
+
+        self.assertDictEqual(obtained, expected)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige a validação de datas futuras na verificação do campo "collection date". A modificação garante que o valor obtido para o ano de coleção seja corretamente convertido para um número inteiro antes de comparar com a data futura. Essa correção evita erros de comparação de tipos e assegura que a validação funcione conforme esperado.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_dates.py`

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
TK #658 

### Referências
NA

