### PR TITLE
Fix: fig validation

### DIFF
--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -5,10 +5,7 @@ class Fig:
     """
     Represents a figure element within an XML document.
 
-    **Attributes:**
-        element (xml.etree.ElementTree.Element): The XML element representing the figure.
-
-    **Parameters:**
+    Parameters:
         element (xml.etree.ElementTree.Element): The XML element representing the figure.
     """
 
@@ -16,7 +13,7 @@ class Fig:
         """
         Initializes a Fig object.
 
-        **Parameters:**
+        Parameters:
             element (xml.etree.ElementTree.Element): The XML element representing the figure.
         """
         self.element = element
@@ -124,50 +121,50 @@ class Fig:
         }
 
 
+class Figs:
+    def __init__(self, fig_node):
+        self.fig_node = fig_node
+
+    def figs(self):
+        for fig in self.fig_node.xpath(".//fig"):
+            yield Fig(fig)
+
+
 class ArticleFigs:
     """
     Represents an article with its associated figures, grouped by language.
 
-    **Parameters:**
-        xmltree (lxml.etree._ElementTree): The parsed XML document representing the article.
-
-    **Attributes:**
-        xmltree (lxml.etree._ElementTree): The internal representation of the parsed XML document.
+    Parameters:
+        xml_tree (lxml.etree._ElementTree): The parsed XML document representing the article.
     """
 
-    def __init__(self, xmltree):
+    def __init__(self, xml_tree):
         """
         Initializes an ArticleFigs object.
 
-        **Parameters:**
-            xmltree (lxml.etree._ElementTree or xml.etree.ElementTree.ElementTree or lxml.etree.Element): The parsed XML document representing the article.
+        Parameters:
+            xml_tree (lxml.etree._ElementTree or xml.etree.ElementTree.ElementTree or lxml.etree.Element):
+            The parsed XML document representing the article.
         """
-        self.xmltree = xmltree
+        self.xml_tree = xml_tree
 
     @property
-    def items_by_lang(self):
+    def article_figs(self):
         """
-        Returns a dictionary containing information about figures grouped by language.
+        Generates information about figures grouped by language within the article.
 
-        Iterates through parent contexts (article or sub-article elements) in the XML document
+        Iterates through parent contexts (article or sub-article elements) in the XML document,
         and creates `Parent` objects. For each parent context, it yields data for associated figures
         using the `parent.items` generator.
 
-        Returns:
-            dict: A dictionary where keys are languages and values are generators that yield dictionaries
-                  containing information about figures within that language context.
+        Yields:
+            dict: A dictionary containing information about figures within the given language context,
+                  including language, article type, parent, parent ID, and figure data.
         """
-        langs = {}
         for node, lang, article_type, parent, parent_id in get_parent_context(
-            self.xmltree
+            self.xml_tree
         ):
-            for item in node.xpath(".//fig"):
-                figure = Fig(item)
+            for figure in Figs(node).figs():
                 data = figure.data
                 data["node"] = figure
-                langs.setdefault(lang, [])
-                langs[lang].append(
-                    put_parent_context(data, lang, article_type, parent, parent_id)
-                )
-        if langs:
-            return langs
+                yield put_parent_context(data, lang, article_type, parent, parent_id)

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -75,7 +75,6 @@ class Figs:
             The XML node (element) that contains one or more <fig> elements.
             This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
-        self.node = node
         self.node = node.find(".") if node.tag == "article" else node
         self.parent = self.node.tag
         self.parent_id = self.node.get("id")

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -164,6 +164,7 @@ class ArticleFigs:
             for item in node.xpath(".//fig"):
                 figure = Fig(item)
                 data = figure.data
+                data["node"] = figure
                 langs.setdefault(lang, [])
                 langs[lang].append(
                     put_parent_context(data, lang, article_type, parent, parent_id)

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -1,62 +1,33 @@
-from packtools.sps.utils.xml_utils import put_parent_context
+from packtools.sps.utils.xml_utils import put_parent_context, tostring
 
 
 class Fig:
-    """
-    Represents a figure element within an XML document.
-
-    Attributes:
-        element (xml.etree.ElementTree.Element): The XML element representing the figure.
-    """
-
     def __init__(self, element):
-        """
-        Initializes a Fig object.
-
-        Parameters:
-            element (xml.etree.ElementTree.Element): The XML element representing the figure.
-        """
         self.element = element
+
+    def str_main_tag(self):
+        return f'<fig fig-type="{self.fig_type}" id="{self.fig_id}">'
+
+    def __str__(self):
+        return tostring(self.element)
+
+    def xml(self):
+        return tostring(node=self.element, doctype=None, pretty_print=True, xml_declaration=True)
 
     @property
     def fig_id(self):
-        """
-        Returns the ID of the figure from the 'id' attribute of the element.
-
-        Returns:
-            str: The ID of the figure, or None if the 'id' attribute is not found.
-        """
         return self.element.get("id")
 
     @property
     def fig_type(self):
-        """
-        Returns the type of the figure from the 'fig-type' attribute of the element.
-
-        Returns:
-            str: The type of the figure, or None if the 'fig-type' attribute is not found.
-        """
         return self.element.get("fig-type")
 
     @property
     def label(self):
-        """
-        Returns the label of the figure.
-
-        Returns:
-            str: The text content of the <label> element, or None if the element is not found.
-        """
         return self.element.findtext("label")
 
     @property
     def graphic_href(self):
-        """
-        Returns the href of the graphic element within the figure.
-
-        Returns:
-            str: The value of the 'xlink:href' attribute of the <graphic> element,
-                 or None if the element or attribute is not found.
-        """
         graphic_element = self.element.find(".//graphic")
         if graphic_element is not None:
             return graphic_element.get("{http://www.w3.org/1999/xlink}href")
@@ -64,13 +35,6 @@ class Fig:
 
     @property
     def caption_text(self):
-        """
-        Returns the text content of the caption element within the figure.
-
-        Returns:
-            str: The concatenated text content of the <caption> element,
-                 or an empty string if the element is not found.
-        """
         caption_element = self.element.find(".//caption")
         if caption_element is not None:
             return caption_element.xpath("string()").strip()
@@ -78,23 +42,10 @@ class Fig:
 
     @property
     def source_attrib(self):
-        """
-        Returns the text content of the attrib element within the figure.
-
-        Returns:
-            str: The text content of the <attrib> element, or None if the element is not found.
-        """
         return self.element.findtext("attrib")
 
     @property
     def alternative_elements(self):
-        """
-        Returns a list of tags within the alternatives element.
-
-        Returns:
-            list of str: A list of tag names of the elements within the <alternatives> element,
-                         or an empty list if the element is not found.
-        """
         alternative_elements = self.element.find(".//alternatives")
         if alternative_elements is not None:
             return [child.tag for child in alternative_elements]
@@ -102,14 +53,6 @@ class Fig:
 
     @property
     def data(self):
-        """
-        Returns a dictionary containing the figure's data.
-
-        Returns:
-            dict: A dictionary with keys 'fig_id', 'fig_type', 'label', 'graphic_href',
-                  'caption_text', 'source_attrib', and 'alternative_elements',
-                  containing the respective data of the figure.
-        """
         return {
             "alternative_parent": "fig",
             "fig_id": self.fig_id,
@@ -123,29 +66,18 @@ class Fig:
 
 
 class Figs:
-    """
-    Handles the extraction of figure data from an XML node and its context.
-
-    Attributes:
-        node (xml.etree.ElementTree.Element): The XML node containing figures.
-    """
-
     def __init__(self, node):
         """
-        Initializes a Figs object.
+        Initializes the Figs class with an XML node.
 
         Parameters:
-            node (xml.etree.ElementTree.Element): The XML node containing figures.
+        node : lxml.etree._Element
+            The XML node (element) that contains one or more <fig> elements.
+            This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
         self.node = node
 
     def figs(self):
-        """
-        Generates data for each figure found within the node.
-
-        Yields:
-            dict: A dictionary containing figure data, along with context from the parent node.
-        """
         parent = self.node.tag
         parent_id = self.node.get("id")
 
@@ -165,68 +97,25 @@ class Figs:
 
 
 class ArticleFigs:
-    """
-    Represents an article with its associated figures, grouped by language.
-
-    Attributes:
-        xml_tree (lxml.etree._ElementTree or xml.etree.ElementTree.ElementTree or lxml.etree.Element):
-        The parsed XML document representing the article.
-    """
-
     def __init__(self, xml_tree):
-        """
-        Initializes an ArticleFigs object.
-
-        Parameters:
-            xml_tree (lxml.etree._ElementTree or xml.etree.ElementTree.ElementTree or lxml.etree.Element):
-            The parsed XML document representing the article.
-        """
         self.xml_tree = xml_tree
 
     @property
     def get_all_figs(self):
-        """
-        Generates information about figures grouped by language within the article.
-
-        Iterates through parent contexts (article or sub-article elements) in the XML document,
-        and generates data for associated figures using the `Figs` class.
-
-        Yields:
-            dict: A dictionary containing information about figures within the given language context,
-                  including language, article type, parent, parent ID, and figure data.
-        """
         yield from self.get_article_figs
         yield from self.get_sub_article_translation_figs
         yield from self.get_sub_article_non_translation_figs
 
     @property
     def get_article_figs(self):
-        """
-        Generates information about figures associated directly with the main article.
-
-        Yields:
-            dict: A dictionary containing figure data where the parent context is the main article.
-        """
         yield from Figs(self.xml_tree).figs()
 
     @property
     def get_sub_article_translation_figs(self):
-        """
-        Generates information about figures within sub-articles of type 'translation'.
-
-        Yields:
-            dict: A dictionary containing figure data where the parent context is a sub-article of type 'translation'.
-        """
         for node in self.xml_tree.xpath(".//sub-article[@article-type='translation']"):
             yield from Figs(node).figs()
 
     @property
     def get_sub_article_non_translation_figs(self):
-        """
-        Generates information about figures within sub-articles that are not of type 'translation'.
-
-        Yields:
-            dict: A dictionary containing figure data where the parent context is a sub-article that is not of type 'translation'.
-        """
         for node in self.xml_tree.xpath(".//sub-article[@article-type!='translation']"):
             yield from Figs(node).figs()

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -1,5 +1,3 @@
-import xml.etree.ElementTree as ET
-
 from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
 
 
@@ -78,7 +76,7 @@ class Fig:
         """
         caption_element = self.element.find(".//caption")
         if caption_element is not None:
-            return ET.tostring(caption_element, encoding='unicode', method='text').strip()
+            return caption_element.xpath("string()").strip()
         return ""
 
     @property
@@ -100,7 +98,7 @@ class Fig:
             list: A list of tag names of the elements within the <alternatives> element,
                   or an empty list if the element is not found.
         """
-        alternative_elements = self.element.find('.//alternatives')
+        alternative_elements = self.element.find(".//alternatives")
         if alternative_elements is not None:
             return [child.tag for child in alternative_elements]
         return []
@@ -122,7 +120,7 @@ class Fig:
             "graphic_href": self.graphic_href,
             "caption_text": self.caption_text,
             "source_attrib": self.source_attrib,
-            "alternative_elements": self.alternative_elements
+            "alternative_elements": self.alternative_elements,
         }
 
 
@@ -131,10 +129,10 @@ class ArticleFigs:
     Represents an article with its associated figures, grouped by language.
 
     **Parameters:**
-        xmltree (xml.etree.ElementTree.ElementTree): The parsed XML document representing the article.
+        xmltree (lxml.etree._ElementTree): The parsed XML document representing the article.
 
     **Attributes:**
-        xmltree (xml.etree.ElementTree.ElementTree): The internal representation of the parsed XML document.
+        xmltree (lxml.etree._ElementTree): The internal representation of the parsed XML document.
     """
 
     def __init__(self, xmltree):
@@ -142,7 +140,7 @@ class ArticleFigs:
         Initializes an ArticleFigs object.
 
         **Parameters:**
-            xmltree (xml.etree.ElementTree.ElementTree): The parsed XML document representing the article.
+            xmltree (lxml.etree._ElementTree or xml.etree.ElementTree.ElementTree or lxml.etree.Element): The parsed XML document representing the article.
         """
         self.xmltree = xmltree
 
@@ -160,7 +158,9 @@ class ArticleFigs:
                   containing information about figures within that language context.
         """
         langs = {}
-        for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xmltree
+        ):
             for item in node.xpath(".//fig"):
                 figure = Fig(item)
                 data = figure.data

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -75,7 +75,7 @@ class Figs:
             The XML node (element) that contains one or more <fig> elements.
             This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
-        self.node = node.find(".") if node.tag == "article" else node
+        self.node = node
         self.parent = self.node.tag
         self.parent_id = self.node.get("id")
         self.lang = self.node.get("{http://www.w3.org/XML/1998/namespace}lang")
@@ -104,7 +104,7 @@ class ArticleFigs:
 
     @property
     def get_article_figs(self):
-        yield from Figs(self.xml_tree).figs()
+        yield from Figs(self.xml_tree.find(".")).figs()
 
     @property
     def get_sub_article_translation_figs(self):

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -164,7 +164,9 @@ class ArticleFigs:
             for item in node.xpath(".//fig"):
                 figure = Fig(item)
                 data = figure.data
-                parent = put_parent_context(data, lang, article_type, parent, parent_id)
-                langs[lang] = parent
+                langs.setdefault(lang, [])
+                langs[lang].append(
+                    put_parent_context(data, lang, article_type, parent, parent_id)
+                )
         if langs:
             return langs

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -122,12 +122,35 @@ class Fig:
 
 
 class Figs:
-    def __init__(self, fig_node):
+    """
+    Handles the extraction of figure data from an XML node and its context.
+
+    Parameters:
+        fig_node (xml.etree.ElementTree.Element): The XML node containing figures.
+        lang (str): The language of the article or sub-article.
+        article_type (str): The type of the article (e.g., "research-article").
+        parent (str): The parent element type (e.g., "article", "sub-article").
+        parent_id (str): The ID of the parent element.
+    """
+
+    def __init__(self, fig_node, lang, article_type, parent, parent_id):
         self.fig_node = fig_node
+        self.lang = lang
+        self.article_type = article_type
+        self.parent = parent
+        self.parent_id = parent_id
 
     def figs(self):
+        """
+        Generates data for each figure found within the node.
+
+        Yields:
+            dict: A dictionary containing figure data, along with context from the parent node.
+        """
         for fig in self.fig_node.xpath(".//fig"):
-            yield Fig(fig)
+            data = Fig(fig).data
+            data["node"] = fig
+            yield put_parent_context(data, self.lang, self.article_type, self.parent, self.parent_id)
 
 
 class ArticleFigs:

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -9,10 +9,10 @@ class Fig:
         return f'<fig fig-type="{self.fig_type}" id="{self.fig_id}">'
 
     def __str__(self):
-        return tostring(self.element)
+        return tostring(self.element, xml_declaration=False)
 
-    def xml(self):
-        return tostring(node=self.element, doctype=None, pretty_print=True, xml_declaration=True)
+    def xml(self, pretty_print=True):
+        return tostring(node=self.element, doctype=None, pretty_print=pretty_print, xml_declaration=False)
 
     @property
     def fig_id(self):
@@ -76,24 +76,21 @@ class Figs:
             This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
         self.node = node
+        self.node = node.find(".") if node.tag == "article" else node
+        self.parent = self.node.tag
+        self.parent_id = self.node.get("id")
+        self.lang = self.node.get("{http://www.w3.org/XML/1998/namespace}lang")
+        self.article_type = self.node.get("article-type")
 
     def figs(self):
-        parent = self.node.tag
-        parent_id = self.node.get("id")
-
-        if parent == "article":
-            root = self.node.xpath(".")[0]
+        if self.parent == "article":
             path = "./front//fig | ./body//fig | ./back//fig"
         else:
-            root = self.node
             path = ".//fig"
 
-        lang = root.get("{http://www.w3.org/XML/1998/namespace}lang")
-        article_type = root.get("article-type")
-
-        for fig in root.xpath(path):
+        for fig in self.node.xpath(path):
             data = Fig(fig).data
-            yield put_parent_context(data, lang, article_type, parent, parent_id)
+            yield put_parent_context(data, self.lang, self.article_type, self.parent, self.parent_id)
 
 
 class ArticleFigs:

--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -1,11 +1,10 @@
 from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
 
-
 class Fig:
     """
     Represents a figure element within an XML document.
 
-    Parameters:
+    Attributes:
         element (xml.etree.ElementTree.Element): The XML element representing the figure.
     """
 
@@ -106,7 +105,8 @@ class Fig:
         Returns a dictionary containing the figure's data.
 
         Returns:
-            dict: A dictionary with keys 'fig_id', 'fig_type', 'label', 'graphic_href', 'caption_text', 'source_attrib', and 'alternative_tags',
+            dict: A dictionary with keys 'fig_id', 'fig_type', 'label', 'graphic_href',
+                  'caption_text', 'source_attrib', and 'alternative_elements',
                   containing the respective data of the figure.
         """
         return {

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -27,11 +27,11 @@ class FigValidation:
 
         Parameters
         ----------
-        xmltree : lxml.etree._ElementTree
+        xml_tree : lxml.etree._ElementTree
             The parsed XML document representing the article.
         """
         self.xml_tree = xml_tree
-        self.figures = list(ArticleFigs(xml_tree).article_figs)
+        self.figures = list(ArticleFigs(xml_tree).get_all_figs)
 
     def validate_fig_existence(self, error_level="WARNING"):
         """
@@ -52,7 +52,7 @@ class FigValidation:
         """
         if self.figures:
             for figure in self.figures:
-                figure_node = figure.get("node").element
+                figure_node = figure.get("node")
                 yield format_response(
                     title="fig presence",
                     parent=figure.get("parent"),

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -1,3 +1,5 @@
+from lxml import etree
+
 from packtools.sps.models.fig import ArticleFigs
 from packtools.sps.validation.utils import format_response
 
@@ -51,8 +53,9 @@ class FigValidation:
         if self.figures_by_language:
             for lang, figure_data_list in self.figures_by_language.items():
                 for figure_data in figure_data_list:
+                    figure_node = figure_data.get("node").element
                     yield format_response(
-                        title="validation of <fig> elements",
+                        title="fig presence",
                         parent=figure_data.get("parent"),
                         parent_id=figure_data.get("parent_id"),
                         parent_article_type=figure_data.get("parent_article_type"),
@@ -62,14 +65,14 @@ class FigValidation:
                         validation_type="exist",
                         is_valid=True,
                         expected="<fig> element",
-                        obtained="<fig> present",
+                        obtained=etree.tostring(figure_node, encoding='unicode'),
                         advice=None,
                         data=figure_data,
                         error_level="OK",
                     )
         else:
             yield format_response(
-                title="validation of <fig> elements",
+                title="fig presence",
                 parent="article",
                 parent_id=None,
                 parent_article_type=self.xmltree.get("article-type"),

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -1,5 +1,3 @@
-from lxml import etree
-
 from packtools.sps.models.fig import ArticleFigs
 from packtools.sps.validation.utils import format_response
 
@@ -10,10 +8,10 @@ class FigValidation:
 
     Attributes
     ----------
-    xmltree : lxml.etree._ElementTree
+    xml_tree : lxml.etree._ElementTree
         The parsed XML document representing the article.
-    figures_by_language : dict
-        A dictionary containing information about figures grouped by language.
+    figures : list
+        A list of dictionaries containing information about figures extracted from the XML.
 
     Methods
     -------
@@ -22,14 +20,6 @@ class FigValidation:
     """
 
     def __init__(self, xml_tree):
-        """
-        Initializes a FigValidation object.
-
-        Parameters
-        ----------
-        xml_tree : lxml.etree._ElementTree
-            The parsed XML document representing the article.
-        """
         self.xml_tree = xml_tree
         self.figures = list(ArticleFigs(xml_tree).get_all_figs)
 
@@ -48,7 +38,7 @@ class FigValidation:
         Yields
         ------
         dict
-            A dictionary containing the validation response.
+            A dictionary containing the validation response for each <fig> element, or a single response indicating no figures were found.
         """
         if self.figures:
             for figure in self.figures:
@@ -63,7 +53,7 @@ class FigValidation:
                     validation_type="exist",
                     is_valid=True,
                     expected="<fig> element",
-                    obtained=f"<fig fig-type=\"{figure.get('fig_type')}\" id=\"{figure.get('fig_id')}\">",
+                    obtained=f'<fig fig-type="{figure.get("fig_type")}" id="{figure.get("fig_id")}">',
                     advice=None,
                     data=figure,
                     error_level="OK",

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -1,5 +1,5 @@
-from ..models.fig import ArticleFigs
-from ..validation.utils import format_response
+from packtools.sps.models.fig import ArticleFigs
+from packtools.sps.validation.utils import format_response
 
 
 class FigValidation:

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -9,23 +9,24 @@ class FigValidation:
 
     def validate_fig_existence(self, error_level="WARNING"):
         if self.figures_by_language:
-            for lang, figure_data in self.figures_by_language.items():
-                yield format_response(
-                    title="validation of <fig> elements",
-                    parent=figure_data.get("parent"),
-                    parent_id=figure_data.get("parent_id"),
-                    parent_article_type=figure_data.get("parent_article_type"),
-                    parent_lang=figure_data.get("parent_lang"),
-                    item="fig",
-                    sub_item=None,
-                    validation_type="exist",
-                    is_valid=True,
-                    expected=figure_data.get("fig_id"),
-                    obtained=figure_data.get("fig_id"),
-                    advice=None,
-                    data=figure_data,
-                    error_level="OK",
-                )
+            for lang, figure_data_list in self.figures_by_language.items():
+                for figure_data in figure_data_list:
+                    yield format_response(
+                        title="validation of <fig> elements",
+                        parent=figure_data.get("parent"),
+                        parent_id=figure_data.get("parent_id"),
+                        parent_article_type=figure_data.get("parent_article_type"),
+                        parent_lang=figure_data.get("parent_lang"),
+                        item="fig",
+                        sub_item=None,
+                        validation_type="exist",
+                        is_valid=True,
+                        expected="<fig> element",
+                        obtained="<fig> present",
+                        advice=None,
+                        data=figure_data,
+                        error_level="OK",
+                    )
         else:
             yield format_response(
                 title="validation of <fig> elements",

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -21,7 +21,7 @@ class FigValidation:
         Validates the existence of <fig> elements within the XML document and yields formatted responses.
     """
 
-    def __init__(self, xmltree):
+    def __init__(self, xml_tree):
         """
         Initializes a FigValidation object.
 
@@ -30,8 +30,8 @@ class FigValidation:
         xmltree : lxml.etree._ElementTree
             The parsed XML document representing the article.
         """
-        self.xmltree = xmltree
-        self.figures_by_language = ArticleFigs(xmltree).items_by_lang
+        self.xml_tree = xml_tree
+        self.figures = list(ArticleFigs(xml_tree).article_figs)
 
     def validate_fig_existence(self, error_level="WARNING"):
         """
@@ -50,33 +50,32 @@ class FigValidation:
         dict
             A dictionary containing the validation response.
         """
-        if self.figures_by_language:
-            for lang, figure_data_list in self.figures_by_language.items():
-                for figure_data in figure_data_list:
-                    figure_node = figure_data.get("node").element
-                    yield format_response(
-                        title="fig presence",
-                        parent=figure_data.get("parent"),
-                        parent_id=figure_data.get("parent_id"),
-                        parent_article_type=figure_data.get("parent_article_type"),
-                        parent_lang=figure_data.get("parent_lang"),
-                        item="fig",
-                        sub_item=None,
-                        validation_type="exist",
-                        is_valid=True,
-                        expected="<fig> element",
-                        obtained=etree.tostring(figure_node, encoding='unicode'),
-                        advice=None,
-                        data=figure_data,
-                        error_level="OK",
-                    )
+        if self.figures:
+            for figure in self.figures:
+                figure_node = figure.get("node").element
+                yield format_response(
+                    title="fig presence",
+                    parent=figure.get("parent"),
+                    parent_id=figure.get("parent_id"),
+                    parent_article_type=figure.get("parent_article_type"),
+                    parent_lang=figure.get("parent_lang"),
+                    item="fig",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=True,
+                    expected="<fig> element",
+                    obtained=etree.tostring(figure_node, encoding='unicode'),
+                    advice=None,
+                    data=figure,
+                    error_level="OK",
+                )
         else:
             yield format_response(
                 title="fig presence",
                 parent="article",
                 parent_id=None,
-                parent_article_type=self.xmltree.get("article-type"),
-                parent_lang=self.xmltree.get(
+                parent_article_type=self.xml_tree.get("article-type"),
+                parent_lang=self.xml_tree.get(
                     "{http://www.w3.org/XML/1998/namespace}lang"
                 ),
                 item="fig",

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -3,11 +3,51 @@ from packtools.sps.validation.utils import format_response
 
 
 class FigValidation:
+    """
+    A class used to validate the existence of <fig> elements within an XML document.
+
+    Attributes
+    ----------
+    xmltree : lxml.etree._ElementTree
+        The parsed XML document representing the article.
+    figures_by_language : dict
+        A dictionary containing information about figures grouped by language.
+
+    Methods
+    -------
+    validate_fig_existence(error_level="WARNING")
+        Validates the existence of <fig> elements within the XML document and yields formatted responses.
+    """
+
     def __init__(self, xmltree):
+        """
+        Initializes a FigValidation object.
+
+        Parameters
+        ----------
+        xmltree : lxml.etree._ElementTree
+            The parsed XML document representing the article.
+        """
         self.xmltree = xmltree
         self.figures_by_language = ArticleFigs(xmltree).items_by_lang
 
     def validate_fig_existence(self, error_level="WARNING"):
+        """
+        Validates the existence of <fig> elements within the XML document.
+
+        If <fig> elements are found, yields a formatted response for each figure.
+        If no <fig> elements are found, yields a single formatted response indicating their absence.
+
+        Parameters
+        ----------
+        error_level : str, optional
+            The level of the error to be reported (default is "WARNING").
+
+        Yields
+        ------
+        dict
+            A dictionary containing the validation response.
+        """
         if self.figures_by_language:
             for lang, figure_data_list in self.figures_by_language.items():
                 for figure_data in figure_data_list:

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -52,7 +52,6 @@ class FigValidation:
         """
         if self.figures:
             for figure in self.figures:
-                figure_node = figure.get("node")
                 yield format_response(
                     title="fig presence",
                     parent=figure.get("parent"),
@@ -64,7 +63,7 @@ class FigValidation:
                     validation_type="exist",
                     is_valid=True,
                     expected="<fig> element",
-                    obtained=etree.tostring(figure_node, encoding='unicode'),
+                    obtained=f"<fig fig-type=\"{figure.get('fig_type')}\" id=\"{figure.get('fig_id')}\">",
                     advice=None,
                     data=figure,
                     error_level="OK",

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -81,40 +81,71 @@ class FigTest(unittest.TestCase):
 class ArticleFigsTest(unittest.TestCase):
     def setUp(self):
         xml = (
-            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            "<body>"
-            "<p>"
-            '<fig fig-type="map" id="f02">'
-            "<label>FIGURE 2</label>"
-            "<caption>"
-            "<title>Título da figura</title>"
-            "</caption>"
-            '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>'
-            "<attrib>Fonte: IBGE (2018)</attrib>"
-            "<alternatives>"
-            '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-lowres.tif" mime-subtype="low-resolution"/>'
-            '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-highres.tif" mime-subtype="high-resolution"/>'
-            "<textual-alternative>"
-            "<p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>"
-            "</textual-alternative>"
-            '<media xlink:href="1234-5678-zwy-12-04-0123-gf02.mp4" mime-subtype="video"/>'
-            "</alternatives>"
-            "</fig>"
-            "</p>"
-            "</body>"
-            '<sub-article article-type="translation" id="TRen" xml:lang="en">'
-            "<body>"
-            '<fig fig-type="map" id="f01">'
-            "<label>Map 1</label>"
-            "<caption>"
-            "<title>Título do Mapa</title>"
-            "</caption>"
-            '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf01.tif"/>'
-            "</fig>"
-            "</body>"
-            "</sub-article>"
-            "</article>"
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+                     dtd-version="1.0" article-type="research-article" xml:lang="pt">
+                <body>
+                    <p>
+                        <fig fig-type="map" id="f02">
+                            <label>FIGURE 2</label>
+                            <caption>
+                                <title>Título da figura 1 em Português</title>
+                            </caption>
+                            <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>
+                            <attrib>Fonte: IBGE (2018)</attrib>
+                            <alternatives>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-lowres.tif" mime-subtype="low-resolution"/>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-highres.tif" mime-subtype="high-resolution"/>
+                                <textual-alternative>
+                                    <p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>
+                                </textual-alternative>
+                                <media xlink:href="1234-5678-zwy-12-04-0123-gf02.mp4" mime-subtype="video"/>
+                            </alternatives>
+                        </fig>
+                    </p>
+                    <p>
+                        <fig fig-type="map" id="f03">
+                            <label>FIGURE 3</label>
+                            <caption>
+                                <title>Título da figura 2 em Português</title>
+                            </caption>
+                            <graphic xlink:href="1234-5678-zwy-12-04-0123-gf03.tif"/>
+                            <attrib>Fonte: IBGE (2019)</attrib>
+                            <alternatives>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf03-lowres.tif" mime-subtype="low-resolution"/>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf03-highres.tif" mime-subtype="high-resolution"/>
+                                <textual-alternative>
+                                    <p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>
+                                </textual-alternative>
+                                <media xlink:href="1234-5678-zwy-12-04-0123-gf03.mp4" mime-subtype="video"/>
+                            </alternatives>
+                        </fig>
+                    </p>
+                </body>
+                <sub-article article-type="translation" id="TRen" xml:lang="en">
+                    <body>
+                        <p>
+                            <fig fig-type="map" id="f01">
+                                <label>FIGURE 1</label>
+                                <caption>
+                                    <title>Title of Map 1</title>
+                                </caption>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf01.tif"/>
+                            </fig>
+                        </p>
+                        <p>
+                            <fig fig-type="map" id="f04">
+                                <label>FIGURE 4</label>
+                                <caption>
+                                    <title>Title of Map 2</title>
+                                </caption>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-gf04.tif"/>
+                            </fig>
+                        </p>
+                    </body>
+                </sub-article>
+            </article>
+            """
         )
         self.xmltree = etree.fromstring(xml)
 
@@ -130,8 +161,27 @@ class ArticleFigsTest(unittest.TestCase):
                     "fig_type": "map",
                     "label": "FIGURE 2",
                     "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
-                    "caption_text": "Título da figura",
+                    "caption_text": "Título da figura 1 em Português",
                     "source_attrib": "Fonte: IBGE (2018)",
+                    "alternative_elements": [
+                        "graphic",
+                        "graphic",
+                        "textual-alternative",
+                        "media",
+                    ],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_lang": "pt",
+                    "parent_article_type": "research-article",
+                },
+                {
+                    "alternative_parent": "fig",
+                    "fig_id": "f03",
+                    "fig_type": "map",
+                    "label": "FIGURE 3",
+                    "graphic_href": "1234-5678-zwy-12-04-0123-gf03.tif",
+                    "caption_text": "Título da figura 2 em Português",
+                    "source_attrib": "Fonte: IBGE (2019)",
                     "alternative_elements": [
                         "graphic",
                         "graphic",
@@ -149,9 +199,23 @@ class ArticleFigsTest(unittest.TestCase):
                     "alternative_parent": "fig",
                     "fig_id": "f01",
                     "fig_type": "map",
-                    "label": "Map 1",
+                    "label": "FIGURE 1",
                     "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
-                    "caption_text": "Título do Mapa",
+                    "caption_text": "Title of Map 1",
+                    "source_attrib": None,
+                    "alternative_elements": [],
+                    "parent": "sub-article",
+                    "parent_id": "TRen",
+                    "parent_lang": "en",
+                    "parent_article_type": "translation",
+                },
+                {
+                    "alternative_parent": "fig",
+                    "fig_id": "f04",
+                    "fig_type": "map",
+                    "label": "FIGURE 4",
+                    "graphic_href": "1234-5678-zwy-12-04-0123-gf04.tif",
+                    "caption_text": "Title of Map 2",
                     "source_attrib": None,
                     "alternative_elements": [],
                     "parent": "sub-article",
@@ -162,10 +226,16 @@ class ArticleFigsTest(unittest.TestCase):
             ],
         }
 
-        for lang, item in expected.items():
+        for lang, items in expected.items():
             with self.subTest(lang):
-                for i, data in enumerate(item):
-                    self.assertDictEqual(data, obtained[lang][i])
+                for i, expected_data in enumerate(items):
+                    obtained_data = obtained[lang][i].copy()
+
+                    # Remover a chave "node" antes de comparar
+                    obtained_data.pop("node", None)
+                    expected_data_copy = expected_data.copy()
+
+                    self.assertDictEqual(expected_data_copy, obtained_data)
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -42,9 +42,10 @@ class FigTest(unittest.TestCase):
         )
 
     def test_str(self):
+        self.maxDiff = None
         self.assertEqual(
             str(self.fig_obj),
-            "<?xml version='1.0' encoding='utf-8'?>\n<fig xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
+            "<fig xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
             "xmlns:mml=\"http://www.w3.org/1998/Math/MathML\" fig-type=\"map\" id=\"f02\"><label>FIGURE "
             "2</label><caption><title>Título da figura</title></caption><graphic "
             "xlink:href=\"1234-5678-zwy-12-04-0123-gf02.tif\"/><attrib>Fonte: IBGE ("
@@ -59,8 +60,7 @@ class FigTest(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(
             self.fig_obj.xml(),
-            """<?xml version='1.0' encoding='utf-8'?>
-<fig xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" fig-type="map" id="f02">
+            """<fig xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" fig-type="map" id="f02">
   <label>FIGURE 2</label>
   <caption>
     <title>Título da figura</title>

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -9,27 +9,27 @@ class FigTest(unittest.TestCase):
         xml = (
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            '<body>'
-            '<p>'
+            "<body>"
+            "<p>"
             '<fig fig-type="map" id="f02">'
-            '<label>FIGURE 2</label>'
-            '<caption>'
-            '<title>Título da figura</title>'
-            '</caption>'
+            "<label>FIGURE 2</label>"
+            "<caption>"
+            "<title>Título da figura</title>"
+            "</caption>"
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>'
-            '<attrib>Fonte: IBGE (2018)</attrib>'
-            '<alternatives>'
+            "<attrib>Fonte: IBGE (2018)</attrib>"
+            "<alternatives>"
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-lowres.tif" mime-subtype="low-resolution"/>'
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-highres.tif" mime-subtype="high-resolution"/>'
-            '<textual-alternative>'
-            '<p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>'
-            '</textual-alternative>'
+            "<textual-alternative>"
+            "<p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>"
+            "</textual-alternative>"
             '<media xlink:href="1234-5678-zwy-12-04-0123-gf02.mp4" mime-subtype="video"/>'
-            '</alternatives>'
-            '</fig>'
-            '</p>'
-            '</body>'
-            '</article>'
+            "</alternatives>"
+            "</fig>"
+            "</p>"
+            "</body>"
+            "</article>"
         )
         self.xmltree = etree.fromstring(xml)
         self.fig_element = self.xmltree.xpath("//fig")[0]
@@ -54,7 +54,10 @@ class FigTest(unittest.TestCase):
         self.assertEqual(self.fig_obj.source_attrib, "Fonte: IBGE (2018)")
 
     def test_alternative_elements(self):
-        self.assertListEqual(self.fig_obj.alternative_elements, ['graphic', 'graphic', 'textual-alternative', 'media'])
+        self.assertListEqual(
+            self.fig_obj.alternative_elements,
+            ["graphic", "graphic", "textual-alternative", "media"],
+        )
 
     def test_data(self):
         expected_data = {
@@ -65,7 +68,12 @@ class FigTest(unittest.TestCase):
             "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
             "caption_text": "Título da figura",
             "source_attrib": "Fonte: IBGE (2018)",
-            "alternative_elements": ['graphic', 'graphic', 'textual-alternative', 'media']
+            "alternative_elements": [
+                "graphic",
+                "graphic",
+                "textual-alternative",
+                "media",
+            ],
         }
         self.assertDictEqual(self.fig_obj.data, expected_data)
 
@@ -75,38 +83,38 @@ class ArticleFigsTest(unittest.TestCase):
         xml = (
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            '<body>'
-            '<p>'
+            "<body>"
+            "<p>"
             '<fig fig-type="map" id="f02">'
-            '<label>FIGURE 2</label>'
-            '<caption>'
-            '<title>Título da figura</title>'
-            '</caption>'
+            "<label>FIGURE 2</label>"
+            "<caption>"
+            "<title>Título da figura</title>"
+            "</caption>"
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>'
-            '<attrib>Fonte: IBGE (2018)</attrib>'
-            '<alternatives>'
+            "<attrib>Fonte: IBGE (2018)</attrib>"
+            "<alternatives>"
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-lowres.tif" mime-subtype="low-resolution"/>'
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-highres.tif" mime-subtype="high-resolution"/>'
-            '<textual-alternative>'
-            '<p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>'
-            '</textual-alternative>'
+            "<textual-alternative>"
+            "<p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>"
+            "</textual-alternative>"
             '<media xlink:href="1234-5678-zwy-12-04-0123-gf02.mp4" mime-subtype="video"/>'
-            '</alternatives>'
-            '</fig>'
-            '</p>'
-            '</body>'
+            "</alternatives>"
+            "</fig>"
+            "</p>"
+            "</body>"
             '<sub-article article-type="translation" id="TRen" xml:lang="en">'
-		    '<body>'
+            "<body>"
             '<fig fig-type="map" id="f01">'
-            '<label>Map 1</label>'
-            '<caption>'
-            '<title>Título do Mapa</title>'
-            '</caption>'
+            "<label>Map 1</label>"
+            "<caption>"
+            "<title>Título do Mapa</title>"
+            "</caption>"
             '<graphic xlink:href="1234-5678-zwy-12-04-0123-gf01.tif"/>'
-            '</fig>'
-            '</body>'
-            '</sub-article>'
-            '</article>'
+            "</fig>"
+            "</body>"
+            "</sub-article>"
+            "</article>"
         )
         self.xmltree = etree.fromstring(xml)
 
@@ -156,8 +164,9 @@ class ArticleFigsTest(unittest.TestCase):
 
         for lang, item in expected.items():
             with self.subTest(lang):
-                self.assertDictEqual(item, obtained[lang])
+                for i, data in enumerate(item):
+                    self.assertDictEqual(data, obtained[lang][i])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -35,6 +35,50 @@ class FigTest(unittest.TestCase):
         self.fig_element = self.xml_tree.xpath("//fig")[0]
         self.fig_obj = Fig(self.fig_element)
 
+    def test_str_main_tag(self):
+        self.assertEqual(
+            self.fig_obj.str_main_tag(),
+            '<fig fig-type="map" id="f02">'
+        )
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.fig_obj),
+            "<?xml version='1.0' encoding='utf-8'?>\n<fig xmlns:xlink=\"http://www.w3.org/1999/xlink\" "
+            "xmlns:mml=\"http://www.w3.org/1998/Math/MathML\" fig-type=\"map\" id=\"f02\"><label>FIGURE "
+            "2</label><caption><title>Título da figura</title></caption><graphic "
+            "xlink:href=\"1234-5678-zwy-12-04-0123-gf02.tif\"/><attrib>Fonte: IBGE ("
+            "2018)</attrib><alternatives><graphic xlink:href=\"1234-5678-zwy-12-04-0123-gf02-lowres.tif\" "
+            "mime-subtype=\"low-resolution\"/><graphic xlink:href=\"1234-5678-zwy-12-04-0123-gf02-highres.tif\" "
+            "mime-subtype=\"high-resolution\"/><textual-alternative><p>Texto alternativo que descreve a figura em "
+            "detalhes para acessibilidade.</p></textual-alternative><media "
+            "xlink:href=\"1234-5678-zwy-12-04-0123-gf02.mp4\" mime-subtype=\"video\"/></alternatives></fig>"
+        )
+
+    def test_xml(self):
+        self.maxDiff = None
+        self.assertEqual(
+            self.fig_obj.xml(),
+            """<?xml version='1.0' encoding='utf-8'?>
+<fig xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" fig-type="map" id="f02">
+  <label>FIGURE 2</label>
+  <caption>
+    <title>Título da figura</title>
+  </caption>
+  <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>
+  <attrib>Fonte: IBGE (2018)</attrib>
+  <alternatives>
+    <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-lowres.tif" mime-subtype="low-resolution"/>
+    <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02-highres.tif" mime-subtype="high-resolution"/>
+    <textual-alternative>
+      <p>Texto alternativo que descreve a figura em detalhes para acessibilidade.</p>
+    </textual-alternative>
+    <media xlink:href="1234-5678-zwy-12-04-0123-gf02.mp4" mime-subtype="video"/>
+  </alternatives>
+</fig>
+"""
+        )
+
     def test_fig_id(self):
         self.assertEqual(self.fig_obj.fig_id, "f02")
 

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -302,9 +302,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 5)
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(item, expected[i])
+                self.assertDictEqual(item, obtained[i])
 
     def test_get_article_figs(self):
         self.maxDiff = None
@@ -352,9 +352,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(item, expected[i])
+                self.assertDictEqual(item, obtained[i])
 
     def test_get_sub_article_translation_figs(self):
         self.maxDiff = None
@@ -418,9 +418,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 1)
-        for i, item in enumerate(obtained):
+        for i, item in enumerate(expected):
             with self.subTest(i):
-                self.assertDictEqual(item, expected[i])
+                self.assertDictEqual(item, obtained[i])
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -31,8 +31,8 @@ class FigTest(unittest.TestCase):
             "</body>"
             "</article>"
         )
-        self.xmltree = etree.fromstring(xml)
-        self.fig_element = self.xmltree.xpath("//fig")[0]
+        self.xml_tree = etree.fromstring(xml)
+        self.fig_element = self.xml_tree.xpath("//fig")[0]
         self.fig_obj = Fig(self.fig_element)
 
     def test_fig_id(self):
@@ -147,95 +147,88 @@ class ArticleFigsTest(unittest.TestCase):
             </article>
             """
         )
-        self.xmltree = etree.fromstring(xml)
+        self.xml_tree = etree.fromstring(xml)
 
-    def test_items_by_lang(self):
+    def test_article_figs(self):
         self.maxDiff = None
-        obtained = ArticleFigs(self.xmltree).items_by_lang
+        obtained = list(ArticleFigs(self.xml_tree).article_figs)
 
-        expected = {
-            "pt": [
-                {
-                    "alternative_parent": "fig",
-                    "fig_id": "f02",
-                    "fig_type": "map",
-                    "label": "FIGURE 2",
-                    "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
-                    "caption_text": "Título da figura 1 em Português",
-                    "source_attrib": "Fonte: IBGE (2018)",
-                    "alternative_elements": [
-                        "graphic",
-                        "graphic",
-                        "textual-alternative",
-                        "media",
-                    ],
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "parent_article_type": "research-article",
-                },
-                {
-                    "alternative_parent": "fig",
-                    "fig_id": "f03",
-                    "fig_type": "map",
-                    "label": "FIGURE 3",
-                    "graphic_href": "1234-5678-zwy-12-04-0123-gf03.tif",
-                    "caption_text": "Título da figura 2 em Português",
-                    "source_attrib": "Fonte: IBGE (2019)",
-                    "alternative_elements": [
-                        "graphic",
-                        "graphic",
-                        "textual-alternative",
-                        "media",
-                    ],
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "parent_article_type": "research-article",
-                }
-            ],
-            "en": [
-                {
-                    "alternative_parent": "fig",
-                    "fig_id": "f01",
-                    "fig_type": "map",
-                    "label": "FIGURE 1",
-                    "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
-                    "caption_text": "Title of Map 1",
-                    "source_attrib": None,
-                    "alternative_elements": [],
-                    "parent": "sub-article",
-                    "parent_id": "TRen",
-                    "parent_lang": "en",
-                    "parent_article_type": "translation",
-                },
-                {
-                    "alternative_parent": "fig",
-                    "fig_id": "f04",
-                    "fig_type": "map",
-                    "label": "FIGURE 4",
-                    "graphic_href": "1234-5678-zwy-12-04-0123-gf04.tif",
-                    "caption_text": "Title of Map 2",
-                    "source_attrib": None,
-                    "alternative_elements": [],
-                    "parent": "sub-article",
-                    "parent_id": "TRen",
-                    "parent_lang": "en",
-                    "parent_article_type": "translation",
-                }
-            ],
-        }
+        expected = [
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f02",
+                "fig_type": "map",
+                "label": "FIGURE 2",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
+                "caption_text": "Título da figura 1 em Português",
+                "source_attrib": "Fonte: IBGE (2018)",
+                "alternative_elements": [
+                    "graphic",
+                    "graphic",
+                    "textual-alternative",
+                    "media",
+                ],
+                "parent": "article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "parent_article_type": "research-article",
+            },
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f03",
+                "fig_type": "map",
+                "label": "FIGURE 3",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf03.tif",
+                "caption_text": "Título da figura 2 em Português",
+                "source_attrib": "Fonte: IBGE (2019)",
+                "alternative_elements": [
+                    "graphic",
+                    "graphic",
+                    "textual-alternative",
+                    "media",
+                ],
+                "parent": "article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "parent_article_type": "research-article",
+            },
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f01",
+                "fig_type": "map",
+                "label": "FIGURE 1",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
+                "caption_text": "Title of Map 1",
+                "source_attrib": None,
+                "alternative_elements": [],
+                "parent": "sub-article",
+                "parent_id": "TRen",
+                "parent_lang": "en",
+                "parent_article_type": "translation",
+            },
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f04",
+                "fig_type": "map",
+                "label": "FIGURE 4",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf04.tif",
+                "caption_text": "Title of Map 2",
+                "source_attrib": None,
+                "alternative_elements": [],
+                "parent": "sub-article",
+                "parent_id": "TRen",
+                "parent_lang": "en",
+                "parent_article_type": "translation",
+            }
+        ]
 
-        for lang, items in expected.items():
-            with self.subTest(lang):
-                for i, expected_data in enumerate(items):
-                    obtained_data = obtained[lang][i].copy()
-
-                    # Remover a chave "node" antes de comparar
-                    obtained_data.pop("node", None)
-                    expected_data_copy = expected_data.copy()
-
-                    self.assertDictEqual(expected_data_copy, obtained_data)
+        self.assertEqual(len(obtained), 4)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                # Remove "node" antes da verificação
+                obtained_copy = obtained[i].copy()
+                obtained_copy.pop("node")
+                self.assertDictEqual(item, obtained_copy)
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -302,9 +302,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 5)
-        for i, item in enumerate(expected):
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertDictEqual(item, expected[i])
 
     def test_get_article_figs(self):
         self.maxDiff = None
@@ -352,9 +352,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertDictEqual(item, expected[i])
 
     def test_get_sub_article_translation_figs(self):
         self.maxDiff = None
@@ -392,9 +392,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertDictEqual(item, expected[i])
 
     def test_get_sub_article_non_translation_figs(self):
         self.maxDiff = None
@@ -418,9 +418,9 @@ class ArticleFigsTest(unittest.TestCase):
         ]
 
         self.assertEqual(len(obtained), 1)
-        for i, item in enumerate(expected):
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertDictEqual(item, expected[i])
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -144,14 +144,61 @@ class ArticleFigsTest(unittest.TestCase):
                         </p>
                     </body>
                 </sub-article>
+                <sub-article article-type="supplementary-material" id="SM1" xml:lang="en">
+                    <front-stub>
+                        <title-group>
+                            <article-title>Supplementary Material: Detailed Methodology</article-title>
+                        </title-group>
+                    </front-stub>
+                    <body>
+                        <sec>
+                            <title>Supplementary Figures</title>
+                            <fig fig-type="chart" id="sf1">
+                                <label>SUPPLEMENTARY FIGURE 1</label>
+                                <caption>
+                                    <title>Chart Showing Additional Data</title>
+                                </caption>
+                                <graphic xlink:href="1234-5678-zwy-12-04-0123-sf01.tif"/>
+                                <attrib>Data Source: Experimental Data 2020</attrib>
+                            </fig>
+                        </sec>
+                        <sec>
+                            <title>Supplementary Tables</title>
+                            <table-wrap id="st1">
+                                <label>SUPPLEMENTARY TABLE 1</label>
+                                <caption>
+                                    <title>Table of Experimental Results</title>
+                                </caption>
+                                <table>
+                                    <thead>
+                                        <tr>
+                                            <th>Experiment</th>
+                                            <th>Result</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>Exp 1</td>
+                                            <td>Positive</td>
+                                        </tr>
+                                        <tr>
+                                            <td>Exp 2</td>
+                                            <td>Negative</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </table-wrap>
+                        </sec>
+                    </body>
+                </sub-article>
             </article>
             """
         )
         self.xml_tree = etree.fromstring(xml)
 
-    def test_article_figs(self):
+    def test_get_all_figs(self):
         self.maxDiff = None
-        obtained = list(ArticleFigs(self.xml_tree).article_figs)
+        obtained = list(ArticleFigs(self.xml_tree).get_all_figs)
 
         expected = [
             {
@@ -219,10 +266,150 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": "TRen",
                 "parent_lang": "en",
                 "parent_article_type": "translation",
+            },
+            {
+                'alternative_elements': [],
+                'alternative_parent': 'fig',
+                'caption_text': 'Chart Showing Additional Data',
+                'fig_id': 'sf1',
+                'fig_type': 'chart',
+                'graphic_href': '1234-5678-zwy-12-04-0123-sf01.tif',
+                'label': 'SUPPLEMENTARY FIGURE 1',
+                'parent': 'sub-article',
+                'parent_article_type': 'supplementary-material',
+                'parent_id': 'SM1',
+                'parent_lang': 'en',
+                'source_attrib': 'Data Source: Experimental Data 2020'
+            }
+
+        ]
+
+        self.assertEqual(len(obtained), 5)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                # Remove "node" antes da verificação
+                obtained_copy = obtained[i].copy()
+                obtained_copy.pop("node")
+                self.assertDictEqual(item, obtained_copy)
+
+    def test_get_article_figs(self):
+        self.maxDiff = None
+        obtained = list(ArticleFigs(self.xml_tree).get_article_figs)
+
+        expected = [
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f02",
+                "fig_type": "map",
+                "label": "FIGURE 2",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
+                "caption_text": "Título da figura 1 em Português",
+                "source_attrib": "Fonte: IBGE (2018)",
+                "alternative_elements": [
+                    "graphic",
+                    "graphic",
+                    "textual-alternative",
+                    "media",
+                ],
+                "parent": "article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "parent_article_type": "research-article",
+            },
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f03",
+                "fig_type": "map",
+                "label": "FIGURE 3",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf03.tif",
+                "caption_text": "Título da figura 2 em Português",
+                "source_attrib": "Fonte: IBGE (2019)",
+                "alternative_elements": [
+                    "graphic",
+                    "graphic",
+                    "textual-alternative",
+                    "media",
+                ],
+                "parent": "article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "parent_article_type": "research-article",
             }
         ]
 
-        self.assertEqual(len(obtained), 4)
+        self.assertEqual(len(obtained), 2)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                # Remove "node" antes da verificação
+                obtained_copy = obtained[i].copy()
+                obtained_copy.pop("node")
+                self.assertDictEqual(item, obtained_copy)
+
+    def test_get_sub_article_translation_figs(self):
+        self.maxDiff = None
+        obtained = list(ArticleFigs(self.xml_tree).get_sub_article_translation_figs)
+
+        expected = [
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f01",
+                "fig_type": "map",
+                "label": "FIGURE 1",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
+                "caption_text": "Title of Map 1",
+                "source_attrib": None,
+                "alternative_elements": [],
+                "parent": "sub-article",
+                "parent_id": "TRen",
+                "parent_lang": "en",
+                "parent_article_type": "translation",
+            },
+            {
+                "alternative_parent": "fig",
+                "fig_id": "f04",
+                "fig_type": "map",
+                "label": "FIGURE 4",
+                "graphic_href": "1234-5678-zwy-12-04-0123-gf04.tif",
+                "caption_text": "Title of Map 2",
+                "source_attrib": None,
+                "alternative_elements": [],
+                "parent": "sub-article",
+                "parent_id": "TRen",
+                "parent_lang": "en",
+                "parent_article_type": "translation",
+            }
+        ]
+
+        self.assertEqual(len(obtained), 2)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                # Remove "node" antes da verificação
+                obtained_copy = obtained[i].copy()
+                obtained_copy.pop("node")
+                self.assertDictEqual(item, obtained_copy)
+
+    def test_get_sub_article_non_translation_figs(self):
+        self.maxDiff = None
+        obtained = list(ArticleFigs(self.xml_tree).get_sub_article_non_translation_figs)
+
+        expected = [
+            {
+                'alternative_elements': [],
+                'alternative_parent': 'fig',
+                'caption_text': 'Chart Showing Additional Data',
+                'fig_id': 'sf1',
+                'fig_type': 'chart',
+                'graphic_href': '1234-5678-zwy-12-04-0123-sf01.tif',
+                'label': 'SUPPLEMENTARY FIGURE 1',
+                'parent': 'sub-article',
+                'parent_article_type': 'supplementary-material',
+                'parent_id': 'SM1',
+                'parent_lang': 'en',
+                'source_attrib': 'Data Source: Experimental Data 2020'
+            }
+        ]
+
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 # Remove "node" antes da verificação

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -115,34 +115,43 @@ class ArticleFigsTest(unittest.TestCase):
         obtained = ArticleFigs(self.xmltree).items_by_lang
 
         expected = {
-            "pt": {
-                "alternative_parent": "fig",
-                "fig_id": "f02",
-                "fig_type": "map",
-                "label": "FIGURE 2",
-                "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
-                "caption_text": "Título da figura",
-                "source_attrib": "Fonte: IBGE (2018)",
-                "alternative_elements": ['graphic', 'graphic', 'textual-alternative', 'media'],
-                "parent": "article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "parent_article_type": "research-article",
-            },
-            "en": {
-                "alternative_parent": "fig",
-                "fig_id": "f01",
-                "fig_type": "map",
-                "label": "Map 1",
-                "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
-                "caption_text": "Título do Mapa",
-                "source_attrib": None,
-                "alternative_elements": [],
-                "parent": "sub-article",
-                "parent_id": "TRen",
-                "parent_lang": "en",
-                "parent_article_type": "translation",
-            },
+            "pt": [
+                {
+                    "alternative_parent": "fig",
+                    "fig_id": "f02",
+                    "fig_type": "map",
+                    "label": "FIGURE 2",
+                    "graphic_href": "1234-5678-zwy-12-04-0123-gf02.tif",
+                    "caption_text": "Título da figura",
+                    "source_attrib": "Fonte: IBGE (2018)",
+                    "alternative_elements": [
+                        "graphic",
+                        "graphic",
+                        "textual-alternative",
+                        "media",
+                    ],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_lang": "pt",
+                    "parent_article_type": "research-article",
+                }
+            ],
+            "en": [
+                {
+                    "alternative_parent": "fig",
+                    "fig_id": "f01",
+                    "fig_type": "map",
+                    "label": "Map 1",
+                    "graphic_href": "1234-5678-zwy-12-04-0123-gf01.tif",
+                    "caption_text": "Título do Mapa",
+                    "source_attrib": None,
+                    "alternative_elements": [],
+                    "parent": "sub-article",
+                    "parent_id": "TRen",
+                    "parent_lang": "en",
+                    "parent_article_type": "translation",
+                }
+            ],
         }
 
         for lang, item in expected.items():

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -162,33 +162,6 @@ class ArticleFigsTest(unittest.TestCase):
                                 <attrib>Data Source: Experimental Data 2020</attrib>
                             </fig>
                         </sec>
-                        <sec>
-                            <title>Supplementary Tables</title>
-                            <table-wrap id="st1">
-                                <label>SUPPLEMENTARY TABLE 1</label>
-                                <caption>
-                                    <title>Table of Experimental Results</title>
-                                </caption>
-                                <table>
-                                    <thead>
-                                        <tr>
-                                            <th>Experiment</th>
-                                            <th>Result</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr>
-                                            <td>Exp 1</td>
-                                            <td>Positive</td>
-                                        </tr>
-                                        <tr>
-                                            <td>Exp 2</td>
-                                            <td>Negative</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </table-wrap>
-                        </sec>
                     </body>
                 </sub-article>
             </article>
@@ -287,10 +260,7 @@ class ArticleFigsTest(unittest.TestCase):
         self.assertEqual(len(obtained), 5)
         for i, item in enumerate(expected):
             with self.subTest(i):
-                # Remove "node" antes da verificação
-                obtained_copy = obtained[i].copy()
-                obtained_copy.pop("node")
-                self.assertDictEqual(item, obtained_copy)
+                self.assertDictEqual(item, obtained[i])
 
     def test_get_article_figs(self):
         self.maxDiff = None
@@ -340,10 +310,7 @@ class ArticleFigsTest(unittest.TestCase):
         self.assertEqual(len(obtained), 2)
         for i, item in enumerate(expected):
             with self.subTest(i):
-                # Remove "node" antes da verificação
-                obtained_copy = obtained[i].copy()
-                obtained_copy.pop("node")
-                self.assertDictEqual(item, obtained_copy)
+                self.assertDictEqual(item, obtained[i])
 
     def test_get_sub_article_translation_figs(self):
         self.maxDiff = None
@@ -383,10 +350,7 @@ class ArticleFigsTest(unittest.TestCase):
         self.assertEqual(len(obtained), 2)
         for i, item in enumerate(expected):
             with self.subTest(i):
-                # Remove "node" antes da verificação
-                obtained_copy = obtained[i].copy()
-                obtained_copy.pop("node")
-                self.assertDictEqual(item, obtained_copy)
+                self.assertDictEqual(item, obtained[i])
 
     def test_get_sub_article_non_translation_figs(self):
         self.maxDiff = None
@@ -412,10 +376,7 @@ class ArticleFigsTest(unittest.TestCase):
         self.assertEqual(len(obtained), 1)
         for i, item in enumerate(expected):
             with self.subTest(i):
-                # Remove "node" antes da verificação
-                obtained_copy = obtained[i].copy()
-                obtained_copy.pop("node")
-                self.assertDictEqual(item, obtained_copy)
+                self.assertDictEqual(item, obtained[i])
 
 
 if __name__ == "__main__":

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -2,6 +2,7 @@ import unittest
 from lxml import etree
 
 from packtools.sps.validation.fig import FigValidation
+from packtools.sps.utils import xml_utils
 
 
 class FigValidationTest(unittest.TestCase):
@@ -70,9 +71,9 @@ class FigValidationTest(unittest.TestCase):
                 "sub_item": None,
                 "validation_type": "exist",
                 "response": "OK",
-                "expected_value": "f01",
-                "got_value": "f01",
-                "message": "Got f01, expected f01",
+                "expected_value": "<fig> element",
+                "got_value": "<fig> present",
+                "message": "Got <fig> present, expected <fig> element",
                 "advice": None,
                 "data": {
                     "alternative_parent": "fig",

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -8,7 +8,7 @@ from packtools.sps.utils import xml_utils
 class FigValidationTest(unittest.TestCase):
     def test_fig_validation_no_fig_elements(self):
         self.maxDiff = None
-        xmltree = etree.fromstring(
+        xml_tree = etree.fromstring(
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
             "<body>"
@@ -16,7 +16,7 @@ class FigValidationTest(unittest.TestCase):
             "</body>"
             "</article>"
         )
-        obtained = list(FigValidation(xmltree).validate_fig_existence())
+        obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
         # Remover a chave "node" dos dados obtidos
         for item in obtained:
@@ -48,7 +48,7 @@ class FigValidationTest(unittest.TestCase):
 
     def test_fig_validation_with_fig_elements(self):
         self.maxDiff = None
-        xmltree = etree.fromstring(
+        xml_tree = etree.fromstring(
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
             "<body>"
@@ -63,7 +63,7 @@ class FigValidationTest(unittest.TestCase):
             "</body>"
             "</article>"
         )
-        obtained = list(FigValidation(xmltree).validate_fig_existence())
+        obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
         # Remover a chave "node" dos dados obtidos
         for item in obtained:
@@ -123,11 +123,11 @@ class FigValidationTest(unittest.TestCase):
 
     def test_fig_validation_with_fig_elements_fix_bug(self):
         self.maxDiff = None
-        xmltree = xml_utils.get_xml_tree(
+        xml_tree = xml_utils.get_xml_tree(
             "tests/fixtures/htmlgenerator/table_wrap_group_and_fig_group/2236-8906"
             "-hoehnea-49-e1082020/2236-8906-hoehnea-49-e1082020.xml"
         )
-        obtained = list(FigValidation(xmltree).validate_fig_existence())
+        obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
         # Remover a chave "node" dos dados obtidos
         for item in obtained:
@@ -174,12 +174,53 @@ class FigValidationTest(unittest.TestCase):
                     "parent_lang": "pt",
                     "source_attrib": None,
                 },
+            },
+            {
+                'title': 'fig presence',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'fig',
+                'sub_item': None,
+                'validation_type': 'exist',
+                'expected_value': '<fig> element',
+                'got_value': '<fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                             'xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en"><label>Figure '
+                             '14</label><caption><title>Axes 1 and 3 of the ordering analyses by the CA method of the '
+                             'three study areas, Parque Estadual da Cantareira, São Paulo, São Paulo State, '
+                             'Brasil.</title></caption><graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+                             'xlink:href="2236-8906-hoehnea-49-e1082020-gf14.tif"/></fig>',
+                'response': 'OK',
+                'message': 'Got <fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                           'xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en"><label>Figure '
+                           '14</label><caption><title>Axes 1 and 3 of the ordering analyses by the CA method of the '
+                           'three study areas, Parque Estadual da Cantareira, São Paulo, São Paulo State, '
+                           'Brasil.</title></caption><graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+                           'xlink:href="2236-8906-hoehnea-49-e1082020-gf14.tif"/></fig>, expected <fig> element',
+                'advice': None,
+                'data': {
+                    'alternative_elements': [],
+                    'alternative_parent': 'fig',
+                    'caption_text': 'Axes 1 and 3 of the ordering analyses by the CA method of the three study areas, '
+                                    'Parque Estadual da Cantareira, São Paulo, São Paulo State, Brasil.',
+                    'fig_id': None,
+                    'fig_type': None,
+                    'graphic_href': '2236-8906-hoehnea-49-e1082020-gf14.tif',
+                    'label': 'Figure 14',
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'pt',
+                    'source_attrib': None
+                }
             }
         ]
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        self.assertEqual(len(obtained), 28)
+        # showing only the first and last record for the figure
+        self.assertDictEqual(expected[0], obtained[0])
+        self.assertDictEqual(expected[1], obtained[27])
 
 
 if __name__ == "__main__":

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -18,11 +18,6 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
-        # Remover a chave "node" dos dados obtidos
-        for item in obtained:
-            if item.get("data"):
-                item["data"].pop("node", None)
-
         expected = [
             {
                 "title": "fig presence",
@@ -65,11 +60,6 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
-        # Remover a chave "node" dos dados obtidos
-        for item in obtained:
-            if item.get("data"):
-                item["data"].pop("node", None)
-
         expected = [
             {
                 "title": "fig presence",
@@ -82,23 +72,8 @@ class FigValidationTest(unittest.TestCase):
                 "validation_type": "exist",
                 "response": "OK",
                 "expected_value": "<fig> element",
-                'got_value': '<fig xmlns:xlink="http://www.w3.org/1999/xlink" '
-                             'xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                             'id="f01"><label>Figure 1</label><graphic '
-                             'xlink:href="image1.png"/><alternatives><graphic '
-                             'xlink:href="image1-lowres.png" '
-                             'mime-subtype="low-resolution"/><graphic '
-                             'xlink:href="image1-highres.png" '
-                             'mime-subtype="high-resolution"/></alternatives></fig>',
-                'message': 'Got <fig xmlns:xlink="http://www.w3.org/1999/xlink" '
-                           'xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                           'id="f01"><label>Figure 1</label><graphic '
-                           'xlink:href="image1.png"/><alternatives><graphic '
-                           'xlink:href="image1-lowres.png" '
-                           'mime-subtype="low-resolution"/><graphic '
-                           'xlink:href="image1-highres.png" '
-                           'mime-subtype="high-resolution"/></alternatives></fig>, expected '
-                           '<fig> element',
+                'got_value': '<fig fig-type="None" id="f01">',
+                'message': 'Got <fig fig-type="None" id="f01">, expected <fig> element',
                 "advice": None,
                 "data": {
                     "alternative_parent": "fig",
@@ -129,11 +104,6 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xml_tree).validate_fig_existence())
 
-        # Remover a chave "node" dos dados obtidos
-        for item in obtained:
-            if item.get("data"):
-                item["data"].pop("node", None)
-
         expected = [
             {
                 "title": "fig presence",
@@ -145,19 +115,9 @@ class FigValidationTest(unittest.TestCase):
                 "sub_item": None,
                 "validation_type": "exist",
                 "expected_value": "<fig> element",
-                "got_value": '<fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                             'xmlns:xlink="http://www.w3.org/1999/xlink" '
-                             'xml:lang="pt"><label>Figura 1</label><caption><title>Mapa com a '
-                             'localização das três áreas de estudo, Parque Estadual da '
-                             'Cantareira, São Paulo, SP, Brasil. Elaborado por Marina '
-                             'Kanashiro, 2019.</title></caption></fig>',
+                'got_value': '<fig fig-type="None" id="None">',
                 "response": "OK",
-                'message': 'Got <fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                           'xmlns:xlink="http://www.w3.org/1999/xlink" '
-                           'xml:lang="pt"><label>Figura 1</label><caption><title>Mapa com a '
-                           'localização das três áreas de estudo, Parque Estadual da '
-                           'Cantareira, São Paulo, SP, Brasil. Elaborado por Marina '
-                           'Kanashiro, 2019.</title></caption></fig>, expected <fig> element',
+                'message': 'Got <fig fig-type="None" id="None">, expected <fig> element',
                 "advice": None,
                 "data": {
                     "alternative_elements": [],
@@ -185,19 +145,9 @@ class FigValidationTest(unittest.TestCase):
                 'sub_item': None,
                 'validation_type': 'exist',
                 'expected_value': '<fig> element',
-                'got_value': '<fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                             'xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en"><label>Figure '
-                             '14</label><caption><title>Axes 1 and 3 of the ordering analyses by the CA method of the '
-                             'three study areas, Parque Estadual da Cantareira, São Paulo, São Paulo State, '
-                             'Brasil.</title></caption><graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
-                             'xlink:href="2236-8906-hoehnea-49-e1082020-gf14.tif"/></fig>',
+                'got_value': '<fig fig-type="None" id="None">',
                 'response': 'OK',
-                'message': 'Got <fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-                           'xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en"><label>Figure '
-                           '14</label><caption><title>Axes 1 and 3 of the ordering analyses by the CA method of the '
-                           'three study areas, Parque Estadual da Cantareira, São Paulo, São Paulo State, '
-                           'Brasil.</title></caption><graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
-                           'xlink:href="2236-8906-hoehnea-49-e1082020-gf14.tif"/></fig>, expected <fig> element',
+                'message': 'Got <fig fig-type="None" id="None">, expected <fig> element',
                 'advice': None,
                 'data': {
                     'alternative_elements': [],

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -18,9 +18,14 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xmltree).validate_fig_existence())
 
+        # Remover a chave "node" dos dados obtidos
+        for item in obtained:
+            if item.get("data"):
+                item["data"].pop("node", None)
+
         expected = [
             {
-                "title": "validation of <fig> elements",
+                "title": "fig presence",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -30,8 +35,8 @@ class FigValidationTest(unittest.TestCase):
                 "validation_type": "exist",
                 "response": "WARNING",
                 "expected_value": "<fig> element",
-                "got_value": None,
-                "message": "Got None, expected <fig> element",
+                'got_value': None,
+                'message': 'Got None, expected <fig> element',
                 "advice": "Add <fig> element to illustrate the content.",
                 "data": None,
             }
@@ -60,9 +65,14 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xmltree).validate_fig_existence())
 
+        # Remover a chave "node" dos dados obtidos
+        for item in obtained:
+            if item.get("data"):
+                item["data"].pop("node", None)
+
         expected = [
             {
-                "title": "validation of <fig> elements",
+                "title": "fig presence",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -72,8 +82,23 @@ class FigValidationTest(unittest.TestCase):
                 "validation_type": "exist",
                 "response": "OK",
                 "expected_value": "<fig> element",
-                "got_value": "<fig> present",
-                "message": "Got <fig> present, expected <fig> element",
+                'got_value': '<fig xmlns:xlink="http://www.w3.org/1999/xlink" '
+                             'xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                             'id="f01"><label>Figure 1</label><graphic '
+                             'xlink:href="image1.png"/><alternatives><graphic '
+                             'xlink:href="image1-lowres.png" '
+                             'mime-subtype="low-resolution"/><graphic '
+                             'xlink:href="image1-highres.png" '
+                             'mime-subtype="high-resolution"/></alternatives></fig>',
+                'message': 'Got <fig xmlns:xlink="http://www.w3.org/1999/xlink" '
+                           'xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                           'id="f01"><label>Figure 1</label><graphic '
+                           'xlink:href="image1.png"/><alternatives><graphic '
+                           'xlink:href="image1-lowres.png" '
+                           'mime-subtype="low-resolution"/><graphic '
+                           'xlink:href="image1-highres.png" '
+                           'mime-subtype="high-resolution"/></alternatives></fig>, expected '
+                           '<fig> element',
                 "advice": None,
                 "data": {
                     "alternative_parent": "fig",
@@ -104,9 +129,14 @@ class FigValidationTest(unittest.TestCase):
         )
         obtained = list(FigValidation(xmltree).validate_fig_existence())
 
+        # Remover a chave "node" dos dados obtidos
+        for item in obtained:
+            if item.get("data"):
+                item["data"].pop("node", None)
+
         expected = [
             {
-                "title": "validation of <fig> elements",
+                "title": "fig presence",
                 "parent": "article",
                 "parent_article_type": "research-article",
                 "parent_id": None,
@@ -115,9 +145,19 @@ class FigValidationTest(unittest.TestCase):
                 "sub_item": None,
                 "validation_type": "exist",
                 "expected_value": "<fig> element",
-                "got_value": "<fig> present",
+                "got_value": '<fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                             'xmlns:xlink="http://www.w3.org/1999/xlink" '
+                             'xml:lang="pt"><label>Figura 1</label><caption><title>Mapa com a '
+                             'localização das três áreas de estudo, Parque Estadual da '
+                             'Cantareira, São Paulo, SP, Brasil. Elaborado por Marina '
+                             'Kanashiro, 2019.</title></caption></fig>',
                 "response": "OK",
-                "message": "Got <fig> present, expected <fig> element",
+                'message': 'Got <fig xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                           'xmlns:xlink="http://www.w3.org/1999/xlink" '
+                           'xml:lang="pt"><label>Figura 1</label><caption><title>Mapa com a '
+                           'localização das três áreas de estudo, Parque Estadual da '
+                           'Cantareira, São Paulo, SP, Brasil. Elaborado por Marina '
+                           'Kanashiro, 2019.</title></caption></fig>, expected <fig> element',
                 "advice": None,
                 "data": {
                     "alternative_elements": [],

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -96,6 +96,51 @@ class FigValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
 
+    def test_fig_validation_with_fig_elements_fix_bug(self):
+        self.maxDiff = None
+        xmltree = xml_utils.get_xml_tree(
+            "tests/fixtures/htmlgenerator/table_wrap_group_and_fig_group/2236-8906"
+            "-hoehnea-49-e1082020/2236-8906-hoehnea-49-e1082020.xml"
+        )
+        obtained = list(FigValidation(xmltree).validate_fig_existence())
+
+        expected = [
+            {
+                "title": "validation of <fig> elements",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "item": "fig",
+                "sub_item": None,
+                "validation_type": "exist",
+                "expected_value": "<fig> element",
+                "got_value": "<fig> present",
+                "response": "OK",
+                "message": "Got <fig> present, expected <fig> element",
+                "advice": None,
+                "data": {
+                    "alternative_elements": [],
+                    "alternative_parent": "fig",
+                    "caption_text": "Mapa com a localização das três áreas de estudo, Parque Estadual da Cantareira, "
+                    "São Paulo, SP, Brasil. Elaborado por Marina Kanashiro, 2019.",
+                    "fig_id": None,
+                    "fig_type": None,
+                    "graphic_href": None,
+                    "label": "Figura 1",
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": "pt",
+                    "source_attrib": None,
+                },
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este Pull Request adiciona a validação da existência de elementos `<fig> `em documentos XML, além de incluir docstrings detalhadas para a classe `FigValidation` e seus métodos. Especificamente, ele:

- Introduz a classe `FigValidation` para validar a presença de elementos `<fig>` em documentos XML.
- Implementa o método `validate_fig_existence`, que gera respostas formatadas para a presença ou ausência de elementos `<fig>.`
- Adiciona docstrings detalhadas para a classe e seus métodos, fornecendo uma descrição clara de seus atributos e funcionalidades.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
python3 -m unittest -v tests/sps/models/test_fig.py
python3 -m unittest -v tests/sps/validation/test_fig.py

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
TK #657 

### Referências
NA

