### PR TITLE
Fix: subject validation

### DIFF
--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -8,12 +8,17 @@ class ArticleTocSections:
 
     @property
     def sections(self):
-        for node, lang, article_type, parent, parent_id in get_parent_context(
-                self.xmltree
-        ):
+        for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
+            found = False
             for item in node.xpath(".//subj-group[@subj-group-type='heading']/subject"):
+                found = True
                 _section = {
                     "text": node_text_without_xref(item),
+                }
+                yield put_parent_context(_section, lang, article_type, parent, parent_id)
+            if not found:
+                _section = {
+                    "text": None,
                 }
                 yield put_parent_context(_section, lang, article_type, parent, parent_id)
 

--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -23,21 +23,3 @@ class ArticleTocSections:
             item['parent_lang']: item
             for item in self.sections
         }
-
-    @property
-    def sub_sections(self):
-        for node, lang, article_type, parent, parent_id in get_parent_context(
-                self.xmltree
-        ):
-            for item in node.xpath(".//subj-group[@subj-group-type='heading']/subj-group/subject"):
-                _section = {
-                    "text": node_text_without_xref(item),
-                }
-                yield put_parent_context(_section, lang, article_type, parent, parent_id)
-
-    @property
-    def sub_sections_dict(self):
-        return {
-            item['parent_lang']: item
-            for item in self.sub_sections
-        }

--- a/packtools/sps/validation/article_toc_sections.py
+++ b/packtools/sps/validation/article_toc_sections.py
@@ -97,6 +97,7 @@ class ArticleTocSectionsValidation:
             ]
         """
         obtained_toc_sections = self.article_toc_sections.sections_dict
+
         if obtained_toc_sections:
             obtained_langs = set(obtained_toc_sections)
             expected_langs = set(expected_toc_sections)
@@ -109,30 +110,30 @@ class ArticleTocSectionsValidation:
                 validation = "exist"
                 expected = expected_toc_sections.get(lang)
                 obtained = obtained_toc_sections.get(lang)
-                obtained_msg = obtained.get('text') if obtained else None
+                obtained_subject = obtained.get('text') if obtained else None
                 advice = 'Provide missing section for language: {}'.format(lang)
                 if lang in common_langs:
                     if obtained.get('text'):
                         # verifica se o título de seção está presente na lista esperada
-                        is_valid = obtained.get('text') in expected
+                        is_valid = obtained_subject in expected
                         if obtained.get("parent") == "sub-article":
                             title = f'Sub-article (id={obtained.get("parent_id")}) section title validation'
                         validation = 'value in list'
                 elif lang in obtained_langs:
-                    advice = 'Remove unexpected section for language: {}'.format(lang)
+                    advice = 'Check unexpected section {} for language: {}'.format(obtained_subject, lang)
 
                 yield format_response(
                     title=title,
-                    parent=obtained.get("parent"),
-                    parent_id=obtained.get("parent_id"),
-                    parent_article_type=obtained.get("parent_article_type"),
-                    parent_lang=obtained.get("parent_lang"),
+                    parent=obtained.get("parent") if obtained else None,
+                    parent_id=obtained.get("parent_id") if obtained else None,
+                    parent_article_type=obtained.get("parent_article_type") if obtained else None,
+                    parent_lang=obtained.get("parent_lang") if obtained else None,
                     item="subj-group",
                     sub_item="subject",
                     is_valid=is_valid,
                     validation_type=validation,
-                    expected=expected,
-                    obtained=obtained_msg,
+                    expected=expected if expected else "subject value",
+                    obtained=obtained_subject,
                     advice=advice,
                     data=obtained_toc_sections,
                     error_level=error_level,

--- a/tests/sps/models/test_article_toc_sections.py
+++ b/tests/sps/models/test_article_toc_sections.py
@@ -21,9 +21,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -32,9 +29,6 @@ class ArticleTocSectionsTest(TestCase):
                 <front-stub>
                     <subj-group subj-group-type="heading">
                         <subject>Ciências da Saúde</subject>
-                        <subj-group subj-group-type="sub-heading">
-                            <subject>Saúde Pública</subject>
-                        </subj-group>
                     </subj-group>
                     <title-group>
                         <article-title>Article title</article-title>
@@ -60,9 +54,11 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_id': '01',
                 'parent_lang': 'pt',
                 'text': 'Ciências da Saúde'
-            },
+            }
         ]
         obtained = list(self.article_toc_sections.sections)
+
+        self.assertEqual(len(obtained), 2)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -82,9 +78,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -94,9 +87,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                     <title-group>
@@ -130,11 +120,11 @@ class ArticleTocSectionsTest(TestCase):
 
         self.assertDictEqual(obtained, expected)
 
-    def test_sub_sections(self):
+    def test_article_section_empty_tag(self):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="en">
             <front>
                 <article-meta>
@@ -143,29 +133,21 @@ class ArticleTocSectionsTest(TestCase):
                     </title-group>
                     <article-categories>
                         <subj-group subj-group-type="heading">
-                            <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
+                            <subject></subject>
                         </subj-group>
                     </article-categories>
                 </article-meta>
             </front>
             <sub-article article-type="translation" id="01" xml:lang="pt">
                 <front-stub>
-                    <article-categories>
-                        <subj-group subj-group-type="heading">
-                            <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
-                        </subj-group>
-                    </article-categories>
+                    <subj-group subj-group-type="heading">
+                        <subject></subject>
+                    </subj-group>
                     <title-group>
                         <article-title>Article title</article-title>
                     </title-group>
                 </front-stub>
-            </sub-article>
+            </sub-article>        
             </article>
             """
         )
@@ -177,20 +159,29 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'en',
-                'text': 'Public Health'
+                'text': ''
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'text': ''
             }
         ]
-        obtained = list(self.article_toc_sections.sub_sections)
+        obtained = list(self.article_toc_sections.sections)
+
+        self.assertEqual(len(obtained), 2)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
-    def test_sub_sections_dict(self):
+    def test_article_section_missing_tag(self):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="en">
             <front>
                 <article-meta>
@@ -199,50 +190,46 @@ class ArticleTocSectionsTest(TestCase):
                     </title-group>
                     <article-categories>
                         <subj-group subj-group-type="heading">
-                            <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
+            
                         </subj-group>
                     </article-categories>
                 </article-meta>
             </front>
             <sub-article article-type="translation" id="01" xml:lang="pt">
                 <front-stub>
-                    <article-categories>
-                        <subj-group subj-group-type="heading">
-                            <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
-                        </subj-group>
-                    </article-categories>
+                    <subj-group subj-group-type="heading">
+
+                    </subj-group>
                     <title-group>
                         <article-title>Article title</article-title>
                     </title-group>
                 </front-stub>
-            </sub-article>
+            </sub-article>        
             </article>
             """
         )
         self.article_toc_sections = ArticleTocSections(self.xmltree)
 
-        expected = {
-            'en': {
+        expected = [
+            {
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'en',
-                'text': 'Public Health'
+                'text': None
             },
-            'pt': {
+            {
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
                 'parent_lang': 'pt',
-                'text': 'Saúde Pública'
+                'text': None
             }
-        }
-        obtained = self.article_toc_sections.sub_sections_dict
+        ]
+        obtained = list(self.article_toc_sections.sections)
 
-        self.assertDictEqual(obtained, expected)
+        self.assertEqual(len(obtained), 2)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -20,9 +20,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -32,9 +29,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                     <title-group>
@@ -116,6 +110,8 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
+        self.assertEqual(len(obtained), 2)
+
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -125,7 +121,7 @@ class ArticleTocSectionsTest(TestCase):
         self.xmltree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            dtd-version="1.0" article-type="research-article" xml:lang="es">
             <front>
                 <article-meta>
                     <title-group>
@@ -136,11 +132,8 @@ class ArticleTocSectionsTest(TestCase):
                     </article-categories>
                 </article-meta>
             </front>
-            <sub-article article-type="translation" xml:lang="en">
+            <sub-article article-type="translation" id="01" xml:lang="en">
                 <front-stub>
-                    <article-categories>
-
-                    </article-categories>
                     <title-group>
                         <article-title>Article title</article-title>
                     </title-group>
@@ -156,23 +149,102 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article or sub-article section title validation',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
+                'title': 'Article section title validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': "01",
                 'parent_lang': 'en',
                 'item': 'subj-group',
                 'sub_item': 'subject',
                 'validation_type': 'exist',
                 'response': 'CRITICAL',
-                'expected_value': {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']},
-                'got_value': {},
-                'message': "Got {}, expected {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']}",
-                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
-                'data': {},
+                'expected_value': ['Health Sciences'],
+                'got_value': None,
+                'message': "Got None, expected ['Health Sciences']",
+                'advice': 'Provide missing section for language: en',
+                'data': {
+                    'en': {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': "01",
+                        'parent_lang': 'en',
+                        'text': None
+                    },
+                    'es': {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'es',
+                        'text': None
+                    }
+                }
+            },
+            {
+                'title': 'Article section title validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'es',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': "subject value",
+                'got_value': None,
+                'message': "Got None, expected subject value",
+                'advice': 'Check unexpected section None for language: es',
+                'data': {
+                    'en': {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': "01",
+                        'parent_lang': 'en',
+                        'text': None
+                    },
+                    'es': {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'es',
+                        'text': None
+                    }
+                }
+            },
+            {
+                'title': 'Article section title validation',
+                'parent': None,
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': None,
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': ['Ciências da Saúde'],
+                'got_value': None,
+                'message': "Got None, expected ['Ciências da Saúde']",
+                'advice': 'Provide missing section for language: pt',
+                'data': {
+                    'en': {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': "01",
+                        'parent_lang': 'en',
+                        'text': None
+                    },
+                    'es': {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'es',
+                        'text': None
+                    }
+                }
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
+
+        self.assertEqual(len(obtained), 3)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -192,9 +264,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -204,9 +273,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                     <title-group>
@@ -288,6 +354,8 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
+        self.assertEqual(len(obtained), 2)
+
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -306,9 +374,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -318,9 +383,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                     <title-group>
@@ -402,6 +464,8 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
+        self.assertEqual(len(obtained), 2)
+
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -420,9 +484,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Public Health</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -432,9 +493,6 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
-                                <subject>Saúde Pública</subject>
-                            </subj-group>
                         </subj-group>
                     </article-categories>
                     <title-group>
@@ -516,6 +574,8 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
+        self.assertEqual(len(obtained), 2)
+
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -531,12 +591,12 @@ class ArticleTocSectionsTest(TestCase):
                     <title-group>
                         <article-title>Título del artículo</article-title>
                     </title-group>
-                    
+
                 </article-meta>
             </front>
             <sub-article article-type="translation" id="01" xml:lang="pt">
                 <front-stub>
-                    
+
                     <title-group>
                         <article-title>Article title</article-title>
                     </title-group>
@@ -549,7 +609,7 @@ class ArticleTocSectionsTest(TestCase):
         expected_section = {}
         expected = [
             {
-                'title': 'Article or sub-article section title validation',
+                'title': 'Article section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -558,14 +618,62 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'exist',
                 'response': 'CRITICAL',
-                'expected_value': {},
-                'got_value': {},
-                'message': 'Got {}, expected {}',
-                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
-                'data': {},
+                'expected_value': "subject value",
+                'got_value': None,
+                'message': 'Got None, expected subject value',
+                'advice': 'Check unexpected section None for language: en',
+                'data': {
+                    'en': {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'en',
+                        'text': None
+                    },
+                    'pt': {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': '01',
+                        'parent_lang': 'pt',
+                        'text': None
+                    }
+                },
+            },
+            {
+                'title': 'Article section title validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': "01",
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': "subject value",
+                'got_value': None,
+                'message': 'Got None, expected subject value',
+                'advice': 'Check unexpected section None for language: pt',
+                'data': {
+                    'en': {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'en',
+                        'text': None
+                    },
+                    'pt': {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': '01',
+                        'parent_lang': 'pt',
+                        'text': None
+                    }
+                },
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
+
+        self.assertEqual(len(obtained), 2)
 
         for i, item in enumerate(expected):
             with self.subTest(i):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma série de testes unitários para validar a funcionalidade da classe `ArticleTocSectionsValidation` do módulo `packtools.sps.validation.article_toc_sections`. Os testes cobrem diversos cenários para garantir a robustez e a precisão das validações realizadas pela classe. Especificamente, os testes visam:
- Verificar se as seções do TOC (Table of Contents) correspondem às seções esperadas.
- Garantir que o título do artigo seja diferente dos títulos das seções.

#### Onde a revisão poderia começar?
O revisor deve iniciar a leitura do código a partir do arquivo de testes:

`tests/sps/validation/test_article_toc_sections.py`


#### Como este poderia ser testado manualmente?
Para testar a funcionalidade manualmente, siga os passos abaixo:
1. Clone o repositório e navegue até a branch deste PR.
2. Certifique-se de ter as dependências instaladas (por exemplo, `lxml` e `unittest`).
3. Execute os testes utilizando o comando:

`python3 -m unittest -v tests/sps/validation/test_article_toc_sections.py`

4. Verifique se todos os testes passam sem erros.

#### Algum cenário de contexto que queira dar?
NA

#### Descrição dos Casos de Testes

1. **Validação de seções do TOC quando todas as seções esperadas são obtidas:**
- Um artigo com tipo de artigo `research-article` e idioma `en`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`.
- As seções esperadas são `Health Sciences` (en) e `Ciências da Saúde` (pt).

2. **Falha na validação de seções do TOC quando nenhuma seção é obtida:**
- Um artigo com tipo de artigo `research-article` e idioma `es`, sem categorias de artigo.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `en`, sem categorias de artigo.
- As seções esperadas são `Health Sciences` (en) e `Ciências da Saúde` (pt).

3. **Falha na validação de seções do TOC quando uma seção obtida não está na lista esperada:**
- Um artigo com tipo de artigo `research-article` e idioma `en`, com seção `Health Sciences`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, com seção `Ciências da Saúde`.
- As seções esperadas são `Article` (en) e `Artigo` (pt).

4. **Falha na validação de seções do TOC quando uma seção esperada não é obtida:**
- Um artigo com tipo de artigo `research-article` e idioma `en`, com seção `Health Sciences`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, com seção `Ciências da Saúde`.
- As seções esperadas são `Article` (en) e `Ciências da Saúde` (pt).

5. **Falha na validação de seções do TOC quando todas as seções obtidas não estão na lista esperada:**
- Um artigo com tipo de artigo `research-article` e idioma `en`, com seção `Health Sciences`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, com seção `Ciências da Saúde`.
- As seções esperadas são `Article` (en) e `Artigo` (pt).

6. **Falha na validação de seções do TOC quando nenhuma seção é obtida e não há seções esperadas:**
- Um artigo com tipo de artigo `research-article` e idioma `en`, sem categorias de artigo.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, sem categorias de artigo.
- Não há seções esperadas.

7. **Validação de que o título do artigo é diferente dos títulos das seções (sucesso):**
- Um artigo com tipo de artigo `research-article` e idioma `en`, com título `Health Sciences Studies` e seções `Health Sciences` e `Public Health`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, com título `Estudos sobre Ciências da Saúde` e seções `Ciências da Saúde` e `Saúde Pública`.

8. **Falha na validação de que o título do artigo é diferente dos títulos das seções:**
- Um artigo com tipo de artigo `research-article` e idioma `en`, com título `Health Sciences` e seções `Health Sciences` e `Public Health`.
- Um sub-artigo com tipo de artigo `translation`, id `01` e idioma `pt`, com título `Ciências da Saúde` e seções `Ciências da Saúde` e `Saúde Pública`.

### Screenshots
N/A

#### Quais são tickets relevantes?
TK #675 
