### PR TITLE
Fix: unique orcid validation

### DIFF
--- a/packtools/sps/validation/article_contribs.py
+++ b/packtools/sps/validation/article_contribs.py
@@ -511,11 +511,12 @@ class ArticleContribsValidation:
                 }
             ]
         """
-        orcid_exclusive = set(self.orcid_list)
-        orcid_freq = {}
-        for orcid in orcid_exclusive:
-            orcid_freq[orcid] = self.orcid_list.count(orcid)
-        is_valid = len(self.orcid_list) == len(orcid_exclusive)
+        orcid_dict = {}
+        for contrib in self.contribs.contribs:
+            orcid = contrib.get("contrib_ids", {}).get("orcid")
+            if orcid:
+                orcid_dict.setdefault(orcid, [])
+                orcid_dict[orcid].append(contrib.get("contrib_full_name"))
 
         diff = []
         if not is_valid:

--- a/packtools/sps/validation/article_contribs.py
+++ b/packtools/sps/validation/article_contribs.py
@@ -518,9 +518,12 @@ class ArticleContribsValidation:
                 orcid_dict.setdefault(orcid, [])
                 orcid_dict[orcid].append(contrib.get("contrib_full_name"))
 
+        is_valid = True
         diff = []
-        if not is_valid:
-            diff = [item for item, freq in orcid_freq.items() if freq > 1]
+        for orcid, names in orcid_dict.items():
+            if len(names) > 1 and len(set(names)) > 1:
+                is_valid = False
+                diff.append(orcid)
 
         yield format_response(
             title="Author ORCID element is unique",
@@ -533,7 +536,7 @@ class ArticleContribsValidation:
             validation_type="uniqueness",
             is_valid=is_valid,
             expected="Unique ORCID values",
-            obtained=self.orcid_list,
+            obtained=orcid_dict,
             advice="Consider replacing the following ORCIDs that are not unique: {}".format(
                 " | ".join(diff)
             ),

--- a/packtools/sps/validation/article_contribs.py
+++ b/packtools/sps/validation/article_contribs.py
@@ -461,13 +461,6 @@ class ArticleContribsValidation:
             for contrib_group in self.xmltree.xpath('.//contrib-group')
         ]
 
-    @property
-    def orcid_list(self):
-        return [
-            contrib.get("contrib_ids", {}).get("orcid")
-            for contrib in self.contribs.contribs
-        ]
-
     def validate_contribs_orcid_is_unique(self, error_level="ERROR"):
         """
         Checks whether a contributor's ORCID is unique.

--- a/tests/sps/validation/test_article_contribs.py
+++ b/tests/sps/validation/test_article_contribs.py
@@ -846,8 +846,14 @@ class ArticleContribsValidationOrcidTest(TestCase):
                 "validation_type": "uniqueness",
                 "response": "OK",
                 "expected_value": "Unique ORCID values",
-                "got_value": ["0990-0001-0058-4853", "0000-3333-1238-6873"],
-                "message": "Got ['0990-0001-0058-4853', '0000-3333-1238-6873'], expected Unique ORCID values",
+                "got_value": {
+                    '0000-3333-1238-6873': ['Vanessa M. Higa'],
+                    '0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto']
+                },
+                "message": "Got {"
+                           "'0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'], "
+                           "'0000-3333-1238-6873': ['Vanessa M. Higa']"
+                           "}, expected Unique ORCID values",
                 "advice": None,
                 "data": None,
             }
@@ -906,8 +912,12 @@ class ArticleContribsValidationOrcidTest(TestCase):
                 "validation_type": "uniqueness",
                 "response": "ERROR",
                 "expected_value": "Unique ORCID values",
-                "got_value": ["0990-0001-0058-4853", "0990-0001-0058-4853"],
-                "message": "Got ['0990-0001-0058-4853', '0990-0001-0058-4853'], expected Unique ORCID values",
+                "got_value": {
+                    '0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', 'Vanessa M. Higa']
+                },
+                "message": "Got {"
+                           "'0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', 'Vanessa M. Higa']"
+                           "}, expected Unique ORCID values",
                 "advice": "Consider replacing the following ORCIDs that are not unique: 0990-0001-0058-4853",
                 "data": None,
             }
@@ -1285,8 +1295,14 @@ class ArticleContribsValidationOrcidTest(TestCase):
                 "validation_type": "uniqueness",
                 "response": "OK",
                 "expected_value": "Unique ORCID values",
-                "got_value": ["0990-0001-0058-4853", "0000-3333-1238-6873"],
-                "message": "Got ['0990-0001-0058-4853', '0000-3333-1238-6873'], expected Unique ORCID values",
+                "got_value": {
+                    '0000-3333-1238-6873': ['Vanessa M. Higa'],
+                    '0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto']
+                },
+                "message": "Got {"
+                           "'0990-0001-0058-4853': ['Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'], "
+                           "'0000-3333-1238-6873': ['Vanessa M. Higa']"
+                           "}, expected Unique ORCID values",
                 "advice": None,
                 "data": None,
             },
@@ -1473,6 +1489,158 @@ class ArticleContribsValidationOrcidTest(TestCase):
                     "parent_lang": "pt",
                 },
             },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_unique_orcid_for_authors_with_same_name(self):
+        self.maxDiff = None
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="en">
+                <front-stub>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                    </contrib-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        obtained = list(
+            ArticleContribsValidation(xmltree, data={}).validate_contribs_orcid_is_unique()
+        )
+
+        expected = [
+            {
+                "title": "Author ORCID element is unique",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "contrib-id",
+                "sub_item": '@contrib-id-type="orcid"',
+                "validation_type": "uniqueness",
+                "response": "OK",
+                "expected_value": "Unique ORCID values",
+                "got_value": {
+                    '0990-0001-0058-4853': [
+                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto',
+                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'
+                    ]
+                },
+                "message": "Got {"
+                           "'0990-0001-0058-4853': ["
+                           "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', "
+                           "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'"
+                           "]}, expected Unique ORCID values",
+                "advice": None,
+                "data": None,
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_unique_orcid_for_authors_with_different_names(self):
+        self.maxDiff = None
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <front>
+                <article-meta>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                                <prefix>Prof</prefix>
+                                <suffix>Nieto</suffix>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                    </contrib-group>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="en">
+                <front-stub>
+                    <contrib-group>
+                        <contrib contrib-type="author">
+                            <contrib-id contrib-id-type="orcid">0990-0001-0058-4853</contrib-id>
+                            <name>
+                                <surname>VENEGAS-MARTÍNEZ</surname>
+                                <given-names>FRANCISCO</given-names>
+                            </name>
+                            <xref ref-type="aff" rid="aff1"/>
+                        </contrib>
+                    </contrib-group>
+                </front-stub>
+            </sub-article>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        obtained = list(
+            ArticleContribsValidation(xmltree, data={}).validate_contribs_orcid_is_unique()
+        )
+
+        expected = [
+            {
+                "title": "Author ORCID element is unique",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "contrib-id",
+                "sub_item": '@contrib-id-type="orcid"',
+                "validation_type": "uniqueness",
+                "response": "ERROR",
+                "expected_value": "Unique ORCID values",
+                "got_value": {
+                    '0990-0001-0058-4853': [
+                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto',
+                        'FRANCISCO VENEGAS-MARTÍNEZ'
+                    ]
+                },
+                "message": "Got {"
+                           "'0990-0001-0058-4853': ["
+                           "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', "
+                           "'FRANCISCO VENEGAS-MARTÍNEZ'"
+                           "]}, expected Unique ORCID values",
+                "advice": 'Consider replacing the following ORCIDs that are not unique: 0990-0001-0058-4853',
+                "data": None,
+            }
         ]
 
         for i, item in enumerate(expected):

--- a/tests/sps/validation/test_article_contribs.py
+++ b/tests/sps/validation/test_article_contribs.py
@@ -1554,13 +1554,11 @@ class ArticleContribsValidationOrcidTest(TestCase):
                 "expected_value": "Unique ORCID values",
                 "got_value": {
                     '0990-0001-0058-4853': [
-                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto',
                         'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'
                     ]
                 },
                 "message": "Got {"
                            "'0990-0001-0058-4853': ["
-                           "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', "
                            "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'"
                            "]}, expected Unique ORCID values",
                 "advice": None,
@@ -1629,15 +1627,12 @@ class ArticleContribsValidationOrcidTest(TestCase):
                 "expected_value": "Unique ORCID values",
                 "got_value": {
                     '0990-0001-0058-4853': [
-                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto',
-                        'FRANCISCO VENEGAS-MARTÍNEZ'
+                        'FRANCISCO VENEGAS-MARTÍNEZ',
+                        'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto'
                     ]
                 },
-                "message": "Got {"
-                           "'0990-0001-0058-4853': ["
-                           "'Prof FRANCISCO VENEGAS-MARTÍNEZ Nieto', "
-                           "'FRANCISCO VENEGAS-MARTÍNEZ'"
-                           "]}, expected Unique ORCID values",
+                "message": "Got {'0990-0001-0058-4853': ['FRANCISCO VENEGAS-MARTÍNEZ', 'Prof "
+                           "FRANCISCO VENEGAS-MARTÍNEZ Nieto']}, expected Unique ORCID values",
                 "advice": 'Consider replacing the following ORCIDs that are not unique: 0990-0001-0058-4853',
                 "data": None,
             }


### PR DESCRIPTION
#### O que esse PR faz?
Este PR modifica a função `validate_contribs_orcid_is_unique` para melhorar a validação da unicidade do ORCID entre autores em documentos XML. A modificação garante que ORCIDs repetidos não sejam considerados duplicados quando associados ao mesmo nome de autor. Isso corrige um problema onde autores com o mesmo nome e ORCID eram incorretamente marcados como duplicados.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_contribs.py
`
#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
TK #681 

### Referências
NA

