### PR TITLE
Feat: url validation

### DIFF
--- a/packtools/sps/models/article_citations.py
+++ b/packtools/sps/models/article_citations.py
@@ -1,4 +1,5 @@
 from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context, node_plain_text
+from packtools.sps.validation.utils import extract_urls_from_node
 
 
 def get_label(node):
@@ -142,6 +143,7 @@ class ArticleCitations:
         for citation in self.article_citations():
             print(citation)
         """
+        for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
             for item in node.xpath("./ref-list//ref"):
                 tags = [
                     ("ref_id", get_ref_id(item)),
@@ -159,6 +161,7 @@ class ArticleCitations:
                     ("article_title", get_article_title(item)),
                     ("citation_ids", get_citation_ids(item)),
                     ("mixed_citation", get_mixed_citation(item)),
+                    ("xlinks", extract_urls_from_node(item))
                 ]
                 d = dict()
                 for name, value in tags:
@@ -169,3 +172,4 @@ class ArticleCitations:
                             d[name] = value
                 d["author_type"] = "institutional" if get_collab(item) else "person"
                 yield put_parent_context(d, lang, article_type, parent, parent_id)
+

--- a/packtools/sps/models/article_citations.py
+++ b/packtools/sps/models/article_citations.py
@@ -94,9 +94,54 @@ class ArticleCitations:
 
     @property
     def article_citations(self):
-        for node, lang, article_type, parent, parent_id in get_parent_context(
-            self.xmltree
-        ):
+        """
+        Generates a dictionary containing citation data from article references.
+
+        This function iterates over all citation nodes in an XML document, extracting
+        various pieces of information from each reference, such as authors, publication details,
+        and associated URLs. It then yields a dictionary for each citation, including
+        contextual information about the parent article.
+
+        The function is designed to be used as a generator, yielding one citation dictionary
+        at a time.
+
+        Parameters:
+        -----------
+        None (This is a method of a class and assumes `self.xmltree` is available within the instance)
+
+        Yields:
+        -------
+        dict
+            A dictionary containing the extracted citation data along with parent context.
+            The dictionary includes the following keys:
+            - 'ref_id': Identifier of the reference.
+            - 'label': The label of the reference (e.g., "1", "A").
+            - 'publication_type': The type of publication (e.g., "journal", "book").
+            - 'source': The source title of the citation.
+            - 'main_author': The main author of the reference.
+            - 'all_authors': All authors of the reference.
+            - 'volume': The volume of the cited work.
+            - 'issue': The issue number of the cited work.
+            - 'fpage': The first page of the cited work.
+            - 'lpage': The last page of the cited work.
+            - 'elocation_id': The e-location ID of the cited work.
+            - 'year': The publication year of the cited work.
+            - 'article_title': The title of the cited article.
+            - 'citation_ids': Any identifiers associated with the citation (e.g., DOI).
+            - 'mixed_citation': The mixed citation text.
+            - 'xlinks': A dictionary of URLs found within the reference.
+            - 'author_type': The type of author ('institutional' or 'person').
+            - Additional contextual information about the parent node, including:
+                - 'lang': The language of the parent article.
+                - 'article_type': The type of the parent article.
+                - 'parent': The parent node in the XML structure.
+                - 'parent_id': The identifier of the parent node.
+
+        Example:
+        --------
+        for citation in self.article_citations():
+            print(citation)
+        """
             for item in node.xpath("./ref-list//ref"):
                 tags = [
                     ("ref_id", get_ref_id(item)),

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -1,7 +1,7 @@
 from packtools.sps.models.article_citations import ArticleCitations
 from packtools.sps.models.dates import ArticleDates
 from packtools.sps.validation.exceptions import ValidationArticleCitationsException
-from packtools.sps.validation.utils import format_response
+from packtools.sps.validation.utils import format_response, is_valid_url_format
 
 
 class ArticleCitationValidation:
@@ -432,6 +432,28 @@ class ArticleCitationsValidation:
         self, xmltree, publication_type_list=None, start_year=None, end_year=None
     ):
         for article_citation in self.article_citations:
+            xlinks = article_citation.get("xlinks")
+            if xlinks:
+                for tag, urls in xlinks.items():
+                    for url in urls:
+                        if not is_valid_url_format(url):
+                            yield format_response(
+                                title="invalid URL",
+                                parent=article_citation.get("parent"),
+                                parent_id=article_citation.get("parent_id"),
+                                parent_article_type=article_citation.get("parent_article_type"),
+                                parent_lang=article_citation.get("parent_lang"),
+                                item="ref",
+                                sub_item=tag,
+                                validation_type="format",
+                                is_valid=False,
+                                expected="a valid URL",
+                                obtained=url,
+                                advice="Check the format of the provided URL",
+                                data=None,
+                                error_level="ERROR",
+                            )
+
             citation = ArticleCitationValidation(
                 xmltree, article_citation, publication_type_list
             )

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -1,5 +1,6 @@
-import requests
+import urllib.parse
 from langdetect import detect
+import xml.etree.ElementTree as ET
 
 from packtools.sps.libs.requester import fetch_data
 
@@ -67,3 +68,14 @@ def get_doi_information(doi):
     ]
 
     return result
+
+
+def is_valid_url_format(text):
+    """Checks if a given text string resembles a URL pattern using urllib.parse."""
+    try:
+        parsed_url = urllib.parse.urlparse(text)
+        return bool(parsed_url.scheme) and bool(parsed_url.netloc)
+    except ValueError:
+        return False
+
+

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -79,3 +79,68 @@ def is_valid_url_format(text):
         return False
 
 
+def extract_urls_from_node(xml_node):
+    """
+    Extracts all URLs from the given XML node and its descendants.
+
+    This function searches for any attributes with the `xlink:href` namespace
+    in the provided XML node and its children. It returns a dictionary where
+    the keys are the tag names and the values are lists of URLs associated
+    with each tag.
+
+    Parameters:
+    -----------
+    xml_node : xml.etree.ElementTree.Element
+        The XML node from which URLs are to be extracted.
+
+    Returns:
+    --------
+    dict
+        A dictionary where each key is the name of a tag containing a URL,
+        and each value is a list of URLs found within that tag.
+        Example:
+        {
+            'ext-link': ['https://example.com', 'https://another-example.com'],
+            'graphic': ['https://images.example.com/image1.jpg']
+        }
+
+    Example:
+    --------
+    xml_data = '''
+    <article xmlns:xlink="http://www.w3.org/1999/xlink">
+        <ext-link xlink:href="https://example.com"/>
+        <sec>
+            <ext-link xlink:href="https://another-example.com"/>
+            <graphic xlink:href="https://images.example.com/image1.jpg"/>
+        </sec>
+    </article>
+    '''
+
+    xml_tree = etree.fromstring(xml_data)
+    links_dict = extract_urls_from_node(xml_tree)
+    print(links_dict)
+    # Output:
+    # {
+    #     'ext-link': ['https://example.com', 'https://another-example.com'],
+    #     'graphic': ['https://images.example.com/image1.jpg']
+    # }
+    """
+    links_dict = {}
+
+    # Verifica se o nó atual tem o atributo xlink:href considerando o namespace
+    xlink_href = xml_node.get('{http://www.w3.org/1999/xlink}href')
+    if xlink_href:
+        tag = xml_node.tag
+        links_dict.setdefault(tag, [])
+        links_dict[tag].append(xlink_href)
+
+    # Recursivamente aplica o mesmo processo aos filhos do nó atual
+    for child in xml_node:
+        child_links = extract_urls_from_node(child)
+        for tag, urls in child_links.items():
+            links_dict.setdefault(tag, [])
+            links_dict[tag].extend(urls)
+
+    return links_dict
+
+

--- a/tests/samples/artigo-com-links-invalidos.xml
+++ b/tests/samples/artigo-com-links-invalidos.xml
@@ -1,0 +1,1067 @@
+<articles xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://raw.githubusercontent.com/scieloorg/articles_meta/master/tests/xsd/scielo_sci/ThomsonReuters_publishing.xsd" dtd-version="1.10">
+<article lang_id="es" article-type="research-article">
+<front>
+<journal-meta>
+<journal-id journal-id-type="publisher">aci</journal-id>
+<journal-title-group>
+<journal-title>ACIMED</journal-title>
+<abbrev-journal-title>ACIMED</abbrev-journal-title>
+</journal-title-group>
+<issn>1561-2880</issn>
+<collection>SciELO Cuba</collection>
+<publisher>
+<publisher-name>Centro Nacional de Información de Ciencias Médicas</publisher-name>
+</publisher>
+</journal-meta>
+<article-meta>
+<unique-article-id pub-id-type="publisher-id">S1024-94352003000500002</unique-article-id>
+<article-id pub-id-type="publisher-id">S1024-94352003000500002</article-id>
+<title-group>
+<article-title lang_id="es">Motores de búsqueda sobre salud en Internet</article-title>
+</title-group>
+<contrib-group>
+<contrib contrib-type="author">
+<name>
+<surname>Rodríguez Camiño</surname>
+<given-names>Reinaldo</given-names>
+</name>
+<xref ref-type="aff" rid="A01"/>
+</contrib>
+</contrib-group>
+<aff id="A01">
+<institution>Escuela Latinoamericana de Medicina.</institution>
+</aff>
+<pub-date>
+<month>10</month>
+<year>2003</year>
+</pub-date>
+<volume>11</volume>
+<issue>5</issue>
+<permissions>
+<license license-type="open-access" href="http://creativecommons.org/licenses/by-nc/4.0/">
+<license-p>This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License.</license-p>
+</license>
+</permissions>
+<self-uri href="http://scielo.sld.cu/scielo.php?script=sci_issuetoc&amp;pid=1024-943520030005&amp;lng=en" content-type="issue_page"/>
+<self-uri href="http://scielo.sld.cu/scielo.php?script=sci_serial&amp;pid=1024-9435&amp;lng=en" content-type="journal_page"/>
+<self-uri href="http://scielo.sld.cu/scielo.php?script=sci_arttext&amp;pid=S1024-94352003000500002&amp;lng=en&amp;tlng=en" content-type="full_text_page"/>
+<abstract lang_id="es">
+<p>Con la aparición del WWW, a principios de los años 90 del pasado siglo, se produjo un crecimiento vertiginoso del número de usuarios y recursos de información en Internet. Ante estas circunstancias, se desarrollaron los llamados motores de búsqueda, un tipo de herramienta imprescindible para explorar el océano de información existente en la red. Con el objetivo de comprender e identificar los principales motores de búsqueda especializados en salud pública y biomedicina, se realizó una profunda revisión del tema en Internet. Para ello, se emplearon: Google, Altavista, Yahoo, AOL y otros; algunos metabuscadores como Ixquick y un grupo de buscadores orientados a temas de salud. También, se consultaron bases de datos como Medline y Documents in Information Science (DoIS), esta última especializada en ciencias de la información. La información recopilada se introdujo en una base de datos creada en Microsoft Access. De ella, se extrajo una lista de 76 buscadores especializados en el tema objeto de estudio, con el propósito de crear una fuente de información y referencia, útil a los profesionales y técnicos de la salud, especialmente a los trabajadores del Sistema Nacional de Información de Ciencias Médicas. Ellos complementan la información que ofrecen grandes bases de datos biomédicas en línea como Medline, Current Contents, LILACS, Biosis y otras.</p>
+</abstract>
+<trans-abstract lang_id="en">
+<p>With the WWW, at the beginning of the 90's of the last century, a vertiginous growth of the number of users and resources of information in Internet took place. In these circumstances, the search engines were developed, a type of tool essential to explore the ocean of existing information in the network. With the purpose of understanding and identifying the main specialized search engines in public and biomedicine, a deep review of the subject was carried out in Internet. For it, we used: Google, Altavista, Yahoo, etc.; some metasearchesrs like Ixcquix and a group of finders oriented to health care subjects. Also, the data bases Medline and Documents in Information Science were consulted (DoIS), the last one is specialized in sciences of the information. The compiled information was introduced in a data base created in Microsoft Access. Of this, a list of 76 finders specialized in the subject was extracted study object in order to create a source of information and reference, useful to the professionals and technicians of the health care system, specially to the workers of the National System of Information of Medical Sciences. They enriched the information offered by great online biomedical database such as como Medline, Current Contents, LILACS, Biosis and others.</p>
+</trans-abstract>
+<kwd-group lang_id="es" kwd-group-type="author-generated">
+<kwd>INTERNET</kwd>
+<kwd>INFORMATICA MEDICA</kwd>
+<kwd>BIBLIOGRAFIA DE MEDICINA</kwd>
+<kwd>BASES DE DATOS BIBLIOGRAFICAS</kwd>
+<kwd>MOTORES DE BUSQUEDA</kwd>
+<kwd>INTERNET</kwd>
+<kwd>RECUPERACION DE LA INFORMACION</kwd>
+<kwd>ESTRATEGIAS DE BUSQUEDAS</kwd>
+<kwd>METABUSCADORES</kwd>
+<kwd>INDICES</kwd>
+<kwd>BASES DE DATOS BIBLIOGRAFICAS</kwd>
+</kwd-group>
+<kwd-group lang_id="en" kwd-group-type="author-generated">
+<kwd>INTERNET</kwd>
+<kwd>MEDICAL INFORMATICS</kwd>
+<kwd>BIBLIOGRAPHY OF MEDICINE</kwd>
+<kwd>DATABASES BIBLIOGRAPHIC</kwd>
+<kwd>SEARCH ENGINES</kwd>
+<kwd>INTERNET</kwd>
+<kwd>INFORMATION RETRIEVAL</kwd>
+<kwd>SEARCH STRATEGIES</kwd>
+<kwd>META-SEARCH ENGINES</kwd>
+<kwd>INDEXES</kwd>
+<kwd>DATABASES, BIBLIOGRAPHIC</kwd>
+</kwd-group>
+</article-meta>
+</front>
+<back>
+<ref-list>
+<ref id="B1">
+<element-citation publication-type="book">
+<source>La era de las nuevas tecnologías</source>
+<date>
+<year>1998</year>
+</date>
+<person-group>
+<name>
+<surname>González Manet</surname>
+<given-names>E</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B2">
+<element-citation publication-type="book">
+<source>Una breve historia de Internet</source>
+</element-citation>
+</ref>
+<ref id="B3">
+<element-citation publication-type="article">
+<article-title>Elementos conceptuales básicos útiles para comprender las redes de telecomunicaciones</article-title>
+<source>Acimed</source>
+<date>
+<year>2002</year>
+</date>
+<issue>6</issue>
+<volume>10</volume>
+<person-group>
+<name>
+<surname>Zayas Buigas</surname>
+<given-names>L de</given-names>
+</name>
+<name>
+<surname>Sao Avilés</surname>
+<given-names>A</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="Disponible%20en%3A%20http%3A//bvs.sld.cu/aci/vol10_6_01/aci030602.htm">Disponible en: http://bvs.sld.cu/aci/vol10_6_01/aci030602.htm</ext-link>
+</element-citation>
+</ref>
+<ref id="B4">
+<element-citation publication-type="book">
+<source>Buscadores especializados: profundizando en Internet</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>05</day>
+</date>
+<person-group>
+<name>
+<surname>Corredor</surname>
+<given-names>C</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B5">
+<element-citation publication-type="article">
+<article-title>Intramet</article-title>
+<source>Informátic@ Médica</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>08</day>
+</date>
+<issue>1</issue>
+<volume>2002</volume>
+<ext-link ext-link-type="uri" href="%3A%20http%3A//www.informaticamedica.org.ar">: http://www.informaticamedica.org.ar</ext-link>
+</element-citation>
+</ref>
+<ref id="B6">
+<element-citation publication-type="article">
+<article-title>Los portales de salud en la práctica médica</article-title>
+<source>Informátic@ Médica</source>
+<date>
+<year>2002</year>
+</date>
+<issue>1</issue>
+<volume>4</volume>
+<person-group>
+<name>
+<surname>Caño</surname>
+<given-names>E del</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.informaticamedica.org.ar">http://www.informaticamedica.org.ar</ext-link>
+</element-citation>
+</ref>
+<ref id="B7">
+<element-citation publication-type="article">
+<article-title>The quest for information: a guide to search the Internet</article-title>
+<source>J Contemp Dent Pract</source>
+<date>
+<year>2001</year>
+</date>
+<fpage>33</fpage>
+<lpage>4</lpage>
+<issue>4</issue>
+<volume>2</volume>
+<person-group>
+<name>
+<surname>Day</surname>
+<given-names>J</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.thejcdp.com/issue008/day/index_nlm.htm">http://www.thejcdp.com/issue008/day/index_nlm.htm</ext-link>
+</element-citation>
+</ref>
+<ref id="B8">
+<element-citation publication-type="book">
+<source>Pasado, presente y futuro de la recuperación de información en Internet [Monografía en línea]. Ponencia presentada en Congreso Internacional sobre Retos de la Alfabetización Tecnológica en un mundo de red</source>
+<date>
+<year>2000</year>
+</date>
+<person-group>
+<name>
+<surname>Moreno Romero</surname>
+<given-names>J</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B9">
+<element-citation publication-type="book">
+<source>Nua Internet Surveys. How many online?</source>
+</element-citation>
+</ref>
+<ref id="B10">
+<element-citation publication-type="article">
+<article-title>Internet... saber buscar. Giga</article-title>
+<source>Rev Cubana Computac</source>
+<date>
+<year>1999</year>
+</date>
+<fpage>44</fpage>
+<lpage>50</lpage>
+<issue>2</issue>
+<person-group>
+<name>
+<surname>Pérez Gómez</surname>
+<given-names>E</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B11">
+<element-citation publication-type="book">
+<source>Cómo utilizar herramientas de búsqueda en Internet sin terminar enloquecido?</source>
+<person-group>
+<name>
+<surname>Cowan</surname>
+<given-names>A</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B12">
+<element-citation publication-type="article">
+<article-title>Northern Light: poderosa e innovadora capacidad</article-title>
+<source>Prof Inform</source>
+<date>
+<year>2000</year>
+</date>
+<fpage>25</fpage>
+<lpage>34</lpage>
+<issue>10</issue>
+<volume>9</volume>
+<person-group>
+<name>
+<surname>García Testal</surname>
+<given-names>C</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B13">
+<element-citation publication-type="article">
+<article-title>Criterios para la evaluación de la calidad de las fuentes de información sobre salud en Internet</article-title>
+<source>Acimed</source>
+<date>
+<year>2002</year>
+</date>
+<issue>5</issue>
+<volume>10</volume>
+<person-group>
+<name>
+<surname>Núñez Gudás</surname>
+<given-names>M</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://bvs.sld.cu/revistas/aci/vol10_5_02/aci050502.htm%20%5B">http://bvs.sld.cu/revistas/aci/vol10_5_02/aci050502.htm [</ext-link>
+</element-citation>
+</ref>
+<ref id="B14">
+<element-citation publication-type="article">
+<article-title>Herramientas avanzadas para la búsqueda de información médica en el WEB</article-title>
+<source>Atención primaria</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>246</fpage>
+<lpage>52</lpage>
+<issue>4</issue>
+<volume>29</volume>
+<person-group>
+<name>
+<surname>Aguillo</surname>
+<given-names>IF</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://db.doyma.es/pdf/27/27v29n4a13027627pdf001.pdf%20%5B">http://db.doyma.es/pdf/27/27v29n4a13027627pdf001.pdf [</ext-link>
+</element-citation>
+</ref>
+<ref id="B15">
+<element-citation publication-type="article">
+<article-title>Indicators of accuracy of consumer health information on the Internet; a study of indicadors relating to information for managing fever in children in the home</article-title>
+<source>J Am Med Inform Assoc</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>73</fpage>
+<lpage>9</lpage>
+<issue>1</issue>
+<volume>9</volume>
+<person-group>
+<name>
+<surname>Fallés</surname>
+<given-names>D</given-names>
+</name>
+<name>
+<surname>Frické</surname>
+<given-names>M</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.jamia.org/cgi/content/full/9/1/73%20%5B">http://www.jamia.org/cgi/content/full/9/1/73 [</ext-link>
+</element-citation>
+</ref>
+<ref id="B16">
+<element-citation publication-type="article">
+<article-title>Toward quality management of medical information in the Internet: evaluation, labelling and filtering of information</article-title>
+<source>BMJ</source>
+<date>
+<year>1998</year>
+</date>
+<fpage>1496</fpage>
+<lpage>502</lpage>
+<volume>317</volume>
+<person-group>
+<name>
+<surname>Eysenbach</surname>
+<given-names>G</given-names>
+</name>
+<name>
+<surname>Diepgen</surname>
+<given-names>T</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://bmj.com/cgi/content/full/317/7171/1496%20%5B">http://bmj.com/cgi/content/full/317/7171/1496 [</ext-link>
+</element-citation>
+</ref>
+<ref id="B17">
+<element-citation publication-type="article">
+<article-title>La calidad de los contenidos médicos en Internet</article-title>
+<source>Informátic@ Médica</source>
+<date>
+<year>2001</year>
+</date>
+<issue>7</issue>
+<volume>3</volume>
+<person-group>
+<name>
+<surname>Melamud</surname>
+<given-names>AL</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="Disponible%20en%3A%20http%3A//www.informaticamedica.com.ar.">Disponible en: http://www.informaticamedica.com.ar.</ext-link>
+</element-citation>
+</ref>
+<ref id="B18">
+<element-citation publication-type="article">
+<article-title>Review of Internet health information: quality initiators</article-title>
+<source>J Med Internet Res</source>
+<date>
+<year>2001</year>
+</date>
+<fpage>28</fpage>
+<issue>4</issue>
+<volume>3</volume>
+<person-group>
+<name>
+<surname>Risk</surname>
+<given-names>A</given-names>
+</name>
+<name>
+<surname>Dzenowagis</surname>
+<given-names>J</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.jmir.org. [">http://www.jmir.org. [</ext-link>
+</element-citation>
+</ref>
+<ref id="B19">
+<element-citation publication-type="article">
+<article-title>Guidelines for medical and health information on the Internet</article-title>
+<source>JAMA</source>
+<date>
+<year>2000</year>
+</date>
+<fpage>1600</fpage>
+<lpage>6.</lpage>
+<volume>2831</volume>
+<person-group>
+<collab>American Medical Association</collab>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.ama-assn.org/pub/category/1905.html%20%5B">http://www.ama-assn.org/pub/category/1905.html [</ext-link>
+</element-citation>
+</ref>
+<ref id="B20">
+<element-citation publication-type="article">
+<article-title>The poor quality of information about laparoscopy on the World Wide Web as indexed by popular search engine</article-title>
+<source>Surg Endos</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>170</fpage>
+<lpage>2</lpage>
+<volume>16</volume>
+<person-group>
+<name>
+<surname>Allen</surname>
+<given-names>JW</given-names>
+</name>
+<name>
+<surname>Finch</surname>
+<given-names>RJ</given-names>
+</name>
+<name>
+<surname>Coleman</surname>
+<given-names>MG</given-names>
+</name>
+<name>
+<surname>Nathanson</surname>
+<given-names>LK</given-names>
+</name>
+<name>
+<surname>Rourke</surname>
+<given-names>NAO</given-names>
+</name>
+<name>
+<surname>Fielding</surname>
+<given-names>GA</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B21">
+<element-citation publication-type="book">
+<source>Cómo sobrevivir a la infoxicación?</source>
+<person-group>
+<name>
+<surname>Cornella</surname>
+<given-names>A</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B22">
+<element-citation publication-type="book">
+<source>Infoxicación</source>
+</element-citation>
+</ref>
+<ref id="B23">
+<element-citation publication-type="article">
+<article-title>Cómo funcionan los servicios de búsqueda en Internet?: un informe especial para navegantes y creadores de información (Parte I)</article-title>
+<source>Prof Informac</source>
+<date>
+<year>1997</year>
+</date>
+<issue>5</issue>
+<volume>6</volume>
+<person-group>
+<name>
+<surname>Marcus Mora</surname>
+<given-names>MC</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.doc6.es/iwe%20%5B">http://www.doc6.es/iwe [</ext-link>
+</element-citation>
+</ref>
+<ref id="B24">
+<element-citation publication-type="article">
+<article-title>Motores de recuperación de información: un análisis comparativo (Parte I)</article-title>
+<source>Prof Informac</source>
+<date>
+<year>1998</year>
+</date>
+<issue>1-2</issue>
+<volume>7</volume>
+<person-group>
+<name>
+<surname>Marcus Mora</surname>
+<given-names>MC</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="Disponible%20en%3A%20http%3A//www.doc6.es/iwe%20%5B">Disponible en: http://www.doc6.es/iwe [</ext-link>
+</element-citation>
+</ref>
+<ref id="B25">
+<element-citation publication-type="book">
+<source>Buscadores en Internet</source>
+<date>
+<year>2002</year>
+<month>11</month>
+<day>18</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B26">
+<element-citation publication-type="book">
+<source>Buscadores temáticos de salud</source>
+<date>
+<year>2002</year>
+<month>01</month>
+<day>15</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B27">
+<element-citation publication-type="book">
+<source>Qué es la Internet invisible?, una puerta a lo inaccesible</source>
+<date>
+<year>2002</year>
+<month>01</month>
+<day>15</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B28">
+<element-citation publication-type="book">
+<source>Internet visible e invisible</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>10</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B29">
+<element-citation publication-type="book">
+<source>The megasite project: a metasite</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>29</day>
+</date>
+<person-group>
+<name>
+<surname>Anderson</surname>
+<given-names>PF</given-names>
+</name>
+<name>
+<surname>Allee</surname>
+<given-names>N</given-names>
+</name>
+<name>
+<surname>Chung</surname>
+<given-names>J</given-names>
+</name>
+<name>
+<surname>Westra</surname>
+<given-names>B</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B30">
+<element-citation publication-type="article">
+<article-title>Lo que Internet esconde y por qué</article-title>
+<source>Prof Informac</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>109</fpage>
+<lpage>12</lpage>
+<issue>2</issue>
+<volume>11</volume>
+<person-group>
+<name>
+<surname>Marcus Mora</surname>
+<given-names>MC</given-names>
+</name>
+<name>
+<surname>Codina</surname>
+<given-names>L</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B31">
+<element-citation publication-type="article">
+<article-title>Motores de recuperación de información: un análisis comparativo (Parte II)</article-title>
+<source>Prof Informac</source>
+<date>
+<year>1998</year>
+</date>
+<issue>1-2</issue>
+<volume>7</volume>
+<person-group>
+<name>
+<surname>Marcus Mora</surname>
+<given-names>MC</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.doc6.es/iwe">http://www.doc6.es/iwe</ext-link>
+</element-citation>
+</ref>
+<ref id="B32">
+<element-citation publication-type="book">
+<source>Buscadores: pequeños trucos para usar los buscadores</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>12</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B33">
+<element-citation publication-type="book">
+<source>Motores de búsqueda</source>
+<date>
+<year>1998</year>
+</date>
+<person-group>
+<name>
+<surname>Filiberti</surname>
+<given-names>FL</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B34">
+<element-citation publication-type="article">
+<article-title>Motores de navegación</article-title>
+<source>Giga; Rev Cubana Computac</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>32</fpage>
+<lpage>5</lpage>
+<issue>2</issue>
+<person-group>
+<name>
+<surname>Becerra López</surname>
+<given-names>H</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B35">
+<element-citation publication-type="article">
+<article-title>Los buscadores, las minas y el oro</article-title>
+<source>Giga; Rev Cubana Computac</source>
+<date>
+<year>1999</year>
+</date>
+<fpage>36</fpage>
+<lpage>41</lpage>
+<issue>4</issue>
+<person-group>
+<name>
+<surname>Osa Díaz</surname>
+<given-names>R de la</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B36">
+<element-citation publication-type="conference">
+<conf-name>Congreso Internacional de Información INFO'99</conf-name>
+<conf-loc>La Habana</conf-loc>
+<source>Algunas herramientas de búsqueda en Internet: Su evolución y estado actual [Monografía en CD/ROM</source>
+<date>
+<year>1999</year>
+</date>
+<person-group>
+<name>
+<surname>Hernández Muguercia</surname>
+<given-names>G</given-names>
+</name>
+<name>
+<surname>Valdés Morris</surname>
+<given-names>M</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B37">
+<element-citation publication-type="conference">
+<conf-name>III Jornada Científica de la Biblioteca Médica Nacional</conf-name>
+<conf-loc>La Habana</conf-loc>
+<source>El uso de los buscadores en Internet</source>
+<date>
+<year>2002</year>
+<month>07</month>
+<day>15</day>
+</date>
+<person-group>
+<name>
+<surname>Torres Pombert</surname>
+<given-names>A</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B38">
+<element-citation publication-type="conference">
+<conf-name>IV Congreso Nacional de Usuarios de Internet e Intranet.</conf-name>
+<conf-loc>Madrid</conf-loc>
+<source>El futuro de la búsqueda de información en Internet</source>
+<date>
+<year>2002</year>
+<month>09</month>
+<day>18</day>
+</date>
+<person-group>
+<name>
+<surname>García Alonso</surname>
+<given-names>JJ</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B39">
+<element-citation publication-type="conference">
+<conf-name>VI Jornadas Españolas de Documentación FESABID'98</conf-name>
+<conf-loc>Valencia</conf-loc>
+<source>Evaluación de los principales buscadores desde el punto de vista documental: recogida, análisis y recuperación de recursos de información</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>15</day>
+</date>
+<person-group>
+<name>
+<surname>Maldonado Martínez</surname>
+<given-names>A</given-names>
+</name>
+<name>
+<surname>Fernández Sánchez</surname>
+<given-names>E</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B40">
+<element-citation publication-type="book">
+<source>Buscar por la WEB: Los trucos para no perderse en Internet</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>17</day>
+</date>
+<person-group>
+<name>
+<surname>Grau</surname>
+<given-names>A</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B41">
+<element-citation publication-type="book">
+<source>Historia del directorio Yahoo</source>
+<date>
+<year>2002</year>
+<month>04</month>
+<day>04</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B42">
+<element-citation publication-type="article">
+<article-title>Análisis del buscador múltiple Copernic 2001 Pro</article-title>
+<source>BID</source>
+<date>
+<year>2001</year>
+</date>
+<issue>6</issue>
+<person-group>
+<name>
+<surname>Franganillo</surname>
+<given-names>J</given-names>
+</name>
+<name>
+<surname>Figuerola</surname>
+<given-names>TM</given-names>
+</name>
+</person-group>
+<ext-link ext-link-type="uri" href="http://www.ub.es/bid/06frang2.htm">http://www.ub.es/bid/06frang2.htm</ext-link>
+</element-citation>
+</ref>
+<ref id="B43">
+<element-citation publication-type="book">
+<source>Web search strategies</source>
+<date>
+<year>2002</year>
+<month>09</month>
+<day>15</day>
+</date>
+<person-group>
+<name>
+<surname>Flanagan</surname>
+<given-names>O</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B44">
+<element-citation publication-type="book">
+<source>Searching the Internet: recommended sites and search techniques</source>
+<date>
+<year>2002</year>
+<month>06</month>
+<day>08</day>
+</date>
+<person-group>
+<collab>University at Albany Libraries</collab>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B45">
+<element-citation publication-type="book">
+<source>Guía para el uso de la base de datos REPIDISCA en el CD/ROM OPS</source>
+<date>
+<year>1991</year>
+</date>
+<person-group>
+<name>
+<surname>Bryce</surname>
+<given-names>M</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B46">
+<element-citation publication-type="book">
+<source>The anatomy of a large-scale hypertextual web search engine</source>
+<date>
+<year>2002</year>
+<month>07</month>
+<day>17</day>
+</date>
+<person-group>
+<name>
+<surname>Brin</surname>
+<given-names>S</given-names>
+</name>
+<name>
+<surname>Page</surname>
+<given-names>L</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B47">
+<element-citation publication-type="article">
+<article-title>Information retrieval on the Internet: a guide for dental practitioners</article-title>
+<source>Dent Clin N Am</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>435</fpage>
+<lpage>62</lpage>
+<volume>46</volume>
+<person-group>
+<name>
+<surname>Spallek</surname>
+<given-names>H</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B48">
+<element-citation publication-type="article">
+<article-title>Using Internet search engines to estimate word frequency</article-title>
+<source>Behav Res Meth, Instrum &amp; Comp</source>
+<date>
+<year>2002</year>
+</date>
+<fpage>286</fpage>
+<lpage>90</lpage>
+<issue>2</issue>
+<volume>34</volume>
+<person-group>
+<name>
+<surname>Blair</surname>
+<given-names>IV</given-names>
+</name>
+<name>
+<surname>Urland</surname>
+<given-names>GR</given-names>
+</name>
+<name>
+<surname>Ma</surname>
+<given-names>JE</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B49">
+<element-citation publication-type="article">
+<article-title>Relación de algunos recursos y sitios de interés biomédico en Internet</article-title>
+<source>Acimed</source>
+<date>
+<year>2000</year>
+</date>
+<fpage>157</fpage>
+<lpage>60</lpage>
+<issue>2</issue>
+<volume>8</volume>
+<ext-link ext-link-type="uri" href="http://bvs.sld.cu/revistas/aci/vol8_2_00/aci10200.html">http://bvs.sld.cu/revistas/aci/vol8_2_00/aci10200.html</ext-link>
+</element-citation>
+</ref>
+<ref id="B50">
+<element-citation publication-type="conference">
+<conf-name>Congreso Internacional de Información INFO'2002</conf-name>
+<conf-loc>La Habana</conf-loc>
+<source>Directorio de buscadores de salud en Internet [Monografía en CD/ROM]</source>
+<date>
+<year>2002</year>
+</date>
+<person-group>
+<name>
+<surname>Sarduy Domínguez</surname>
+<given-names>Y</given-names>
+</name>
+</person-group>
+</element-citation>
+</ref>
+<ref id="B51">
+<element-citation publication-type="book">
+<source>Buscadores en salud-Internet</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>15</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B52">
+<element-citation publication-type="book">
+<source>Buscador de links de medicina</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>18</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B53">
+<element-citation publication-type="book">
+<source>Buscador de salud en español</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>22</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B54">
+<element-citation publication-type="book">
+<source>Buscadores de salud</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>22</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B55">
+<element-citation publication-type="book">
+<source>Guía de búsqueda en medicina</source>
+<date>
+<year>2002</year>
+<month>09</month>
+<day>10</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B56">
+<element-citation publication-type="book">
+<source>Información y directorio de los principales motores de búsqueda mundiales y regionales.</source>
+<date>
+<year>2002</year>
+<month>10</month>
+<day>20</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B57">
+<element-citation publication-type="book">
+<source>Los mejores buscadores de Internet</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>12</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B58">
+<element-citation publication-type="book">
+<source>Busca ya; tu guía de buscadores, recopilados de buscadores</source>
+<date>
+<year>2002</year>
+<month>11</month>
+<day>18</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B59">
+<element-citation publication-type="book">
+<source>Buscadores de salud en inglés</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>18</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B60">
+<element-citation publication-type="book">
+<source>Indice de buscadores de la web</source>
+<date>
+<year>2002</year>
+<month>01</month>
+<day>18</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B61">
+<element-citation publication-type="book">
+<source>Buscadores salud y medicina</source>
+<date>
+<year>2003</year>
+<month>01</month>
+<day>15</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B62">
+<element-citation publication-type="book">
+<source>Buscadores médicos y bases de datos</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>20</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B63">
+<element-citation publication-type="book">
+<source>Buscadores de salud</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>21</day>
+</date>
+</element-citation>
+</ref>
+<ref id="B64">
+<element-citation publication-type="book">
+<source>Buscadores médicos</source>
+<date>
+<year>2002</year>
+<month>12</month>
+<day>22</day>
+</date>
+</element-citation>
+</ref>
+</ref-list>
+</back>
+</article>
+</articles>

--- a/tests/sps/models/test_article_citations.py
+++ b/tests/sps/models/test_article_citations.py
@@ -8,14 +8,18 @@ class AuthorsTest(TestCase):
     def test_citations_many_authors(self):
         self.maxDiff = None
         xml = """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <back>
             <ref-list>
             <title>REFERENCES</title>
             <ref id="B1">
             <label>1.</label>
             <mixed-citation>
-            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: 
+            the benefit of smoking cessation in older ages. Drug Alcohol Depend. 2015;150:85-91. DOI: 
+            <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">
+            https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
             </mixed-citation>
             <element-citation publication-type="journal">
             <person-group person-group-type="author">
@@ -108,6 +112,12 @@ class AuthorsTest(TestCase):
                 "parent_id": None,
                 "parent_article_type": "research-article",
                 "parent_lang": "en",
+                'xlinks': {
+                    'ext-link': [
+                        'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                        'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                    ]
+                },
             }
         ]
         for i, item in enumerate(expected):
@@ -151,7 +161,7 @@ class AuthorsTest(TestCase):
                 "ref_id": "B2",
                 "publication_type": "book",
                 "author_type": "person",
-                "mixed_citation": "BARTHES, Roland. Aula . São Pulo: Cultrix, 1987.",
+                "mixed_citation": "BARTHES, Roland. Aula. São Pulo: Cultrix, 1987.",
                 "source": "Aula",
                 "main_author": {"surname": "BARTHES", "given-names": "Roland"},
                 "all_authors": [{"surname": "BARTHES", "given-names": "Roland"}],

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -148,6 +148,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -283,6 +289,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -418,6 +430,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "201a",
                     "parent": "article",
                     "parent_id": None,
@@ -551,6 +569,12 @@ class ArticleCitationValidationTest(TestCase):
                     "publication_type": "journal",
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "volume": "150",
                     "parent": "article",
                     "parent_id": None,
@@ -686,6 +710,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -819,6 +849,12 @@ class ArticleCitationValidationTest(TestCase):
                     "publication_type": "journal",
                     "ref_id": "B1",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -958,6 +994,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1091,6 +1133,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1226,6 +1274,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1415,6 +1469,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1550,6 +1610,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1686,6 +1752,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1823,6 +1895,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1884,6 +1962,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -1949,6 +2033,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -2010,6 +2100,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -2071,6 +2167,12 @@ class ArticleCitationValidationTest(TestCase):
                     "ref_id": "B1",
                     "source": "Drug Alcohol Depend.",
                     "volume": "150",
+                    "xlinks": {
+                        'ext-link': [
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                            'https://doi.org/10.1016/j.drugalcdep.2015.02.028'
+                        ]
+                    },
                     "year": "2015",
                     "parent": "article",
                     "parent_id": None,
@@ -2078,6 +2180,94 @@ class ArticleCitationValidationTest(TestCase):
                     "parent_lang": "en",
                 },
             },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_xlink(self):
+        self.maxDiff = None
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <back>
+            <ref-list>
+            <title>REFERENCES</title>
+            <ref id="B1">
+            <label>1.</label>
+            <element-citation publication-type="journal">
+            <person-group person-group-type="author">
+            <name>
+            <surname>Tran</surname>
+            <given-names>B</given-names>
+            <prefix>The Honorable</prefix>
+            <suffix>III</suffix>
+            </name>
+            <name>
+            <surname>Falster</surname>
+            <given-names>MO</given-names>
+            </name>
+            <name>
+            <surname>Douglas</surname>
+            <given-names>K</given-names>
+            </name>
+            <name>
+            <surname>Blyth</surname>
+            <given-names>F</given-names>
+            </name>
+            <name>
+            <surname>Jorm</surname>
+            <given-names>LR</given-names>
+            </name>
+            </person-group>
+            <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+            <source>Drug Alcohol Depend.</source>
+            <year>2015</year>
+            <volume>150</volume>
+            <fpage>85</fpage>
+            <lpage>91</lpage>
+            <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+            <elocation-id>elocation_B1</elocation-id>
+            <pub-id pub-id-type="pmid">00000000</pub-id>
+            <pub-id pub-id-type="pmcid">11111111</pub-id>
+            <comment>
+            DOI:
+            <ext-link ext-link-type="uri" xlink:href="[https://doi.org/10.1016/j.drugalcdep.2015.02.028">https://doi.org/10.1016/j.drugalcdep.2015.02.028</ext-link>
+            </comment>
+            </element-citation>
+            </ref>
+            </ref-list>
+            </back>
+            </article>
+        """
+        xmltree = etree.fromstring(xml)
+        obtained = list(
+            ArticleCitationsValidation(xmltree).validate_article_citations(
+                xmltree,
+                publication_type_list=["journal", "book"],
+                start_year=2000,
+                end_year=2020,
+            )
+        )
+
+        expected = [
+            {
+                'title': 'invalid URL',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'ref',
+                'sub_item': 'ext-link',
+                'validation_type': 'format',
+                'response': 'ERROR',
+                'expected_value': 'a valid URL',
+                'got_value': '[https://doi.org/10.1016/j.drugalcdep.2015.02.028',
+                'message': 'Got [https://doi.org/10.1016/j.drugalcdep.2015.02.028, expected a valid URL',
+                'advice': 'Check the format of the provided URL',
+                'data': None,
+            }
         ]
 
         for i, item in enumerate(expected):

--- a/tests/sps/validation/test_utils.py
+++ b/tests/sps/validation/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from lxml import etree
 
 from packtools.sps.utils import xml_utils
 from packtools.sps.validation.utils import get_doi_information, is_valid_url_format, extract_urls_from_node
@@ -55,6 +56,109 @@ class MyTestCase(unittest.TestCase):
             with self.subTest(i):
                 obtained = get_doi_information(doi)
                 self.assertDictEqual(expected[i], obtained)
+
+    def test_is_valid_url_format(self):
+        self.maxDiff = None
+        xml_tree = xml_utils.get_xml_tree('tests/samples/artigo-com-links-invalidos.xml')
+        ext_links = _get_all_ext_links(xml_tree)
+
+        obtained = [
+            (link, is_valid_url_format(link))
+            for link in ext_links
+        ]
+
+        expected = [
+            ('Disponible%20en%3A%20http%3A//bvs.sld.cu/aci/vol10_6_01/aci030602.htm', False),
+            ('%3A%20http%3A//www.informaticamedica.org.ar', False),
+            ('http://www.informaticamedica.org.ar', True),
+            ('http://www.thejcdp.com/issue008/day/index_nlm.htm', True),
+            ('http://bvs.sld.cu/revistas/aci/vol10_5_02/aci050502.htm%20%5B', True),
+            ('http://db.doyma.es/pdf/27/27v29n4a13027627pdf001.pdf%20%5B', True),
+            ('http://www.jamia.org/cgi/content/full/9/1/73%20%5B', True),
+            ('http://bmj.com/cgi/content/full/317/7171/1496%20%5B', True),
+            ('Disponible%20en%3A%20http%3A//www.informaticamedica.com.ar.', False),
+            ('http://www.jmir.org. [', False),
+            ('http://www.ama-assn.org/pub/category/1905.html%20%5B', True),
+            ('http://www.doc6.es/iwe%20%5B', True),
+            ('Disponible%20en%3A%20http%3A//www.doc6.es/iwe%20%5B', False),
+            ('http://www.doc6.es/iwe', True),
+            ('http://www.ub.es/bid/06frang2.htm', True),
+            ('http://bvs.sld.cu/revistas/aci/vol8_2_00/aci10200.html', True)
+        ]
+
+        self.assertEqual(obtained, expected)
+
+    def test_extract_url_from_node(self):
+        xml_data = '''
+        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+        article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+                <article-meta>
+                    <permissions>
+                        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by/4.0/" xml:lang="en">
+                            <license-p>This is an Open Access article distributed under the terms of the Creative Commons Attribution License, which permits unrestricted use, distribution, and reproduction in any medium, provided the original work is properly cited.</license-p>
+                        </license>
+                    </permissions>
+                </article-meta>
+            </front>
+            <body>
+                <sec sec-type="results">
+                    <p>
+                        <fig id="f1">
+                            <alternatives>
+                                <graphic xlink:href=""/>
+                                <graphic xlink:href="https://minio.scielo.br/documentstore/1518-8345/TPg77CCrGj4wcbLCh9vG8bS/93646bf6194a04743642b91240adef621257b46f.jpg"/>
+                            </alternatives>
+                        </fig>
+                    </p>
+                </sec>
+            </body>
+            <back>
+                <ref-list>
+                    <ref id="B1">
+                    <comment>Disponible en: <ext-link ext-link-type="uri" xlink:href="https://hdl.handle.net/11441/69000">https://hdl.handle.net/11441/69000</ext-link>
+                    </comment>
+                    </ref>
+                </ref-list>
+            </back>
+        </article>
+        '''
+        xml_tree = etree.fromstring(xml_data)
+
+        # Teste para o nó raiz
+        url = extract_urls_from_node(xml_tree)
+        self.assertEqual(
+            url,
+            {
+                "license": ["https://creativecommons.org/licenses/by/4.0/"],
+                "graphic": ["https://minio.scielo.br/documentstore/1518-8345/TPg77CCrGj4wcbLCh9vG8bS/93646bf6194a04743642b91240adef621257b46f.jpg"],
+                "ext-link": ["https://hdl.handle.net/11441/69000"]
+            }
+        )
+
+        # Teste para o nó <license>
+        node_license = xml_tree.xpath(".//license")[0]
+        url = extract_urls_from_node(node_license)
+        self.assertEqual(
+            url,
+            {"license": ["https://creativecommons.org/licenses/by/4.0/"]}
+        )
+
+        # Teste para o nó <graphic> com a imagem
+        node_graphic = xml_tree.xpath(".//graphic")[1]
+        url = extract_urls_from_node(node_graphic)
+        self.assertEqual(
+            url,
+            {"graphic": ["https://minio.scielo.br/documentstore/1518-8345/TPg77CCrGj4wcbLCh9vG8bS/93646bf6194a04743642b91240adef621257b46f.jpg"]}
+        )
+
+        # Teste para o nó <ext-link>
+        node_ext_link = xml_tree.xpath(".//ext-link")[0]
+        url = extract_urls_from_node(node_ext_link)
+        self.assertEqual(
+            url,
+            {"ext-link": ["https://hdl.handle.net/11441/69000"]}
+        )
 
 
 if __name__ == '__main__':

--- a/tests/sps/validation/test_utils.py
+++ b/tests/sps/validation/test_utils.py
@@ -1,6 +1,19 @@
 import unittest
 
-from packtools.sps.validation.utils import get_doi_information
+from packtools.sps.utils import xml_utils
+from packtools.sps.validation.utils import get_doi_information, is_valid_url_format, extract_urls_from_node
+
+
+def _get_all_ext_links(xml_node):
+    ext_links = []
+    if xml_node.tag == 'ext-link':
+        href = xml_node.attrib.get('href', None)
+        if href:
+            ext_links.append(href)
+    for child in xml_node:
+        ext_links.extend(_get_all_ext_links(child))
+
+    return ext_links
 
 
 class MyTestCase(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona novas funcionalidades e melhorias ao processo de extração e validação de citações de artigos em documentos XML. Especificamente, ele:

1. Introduz uma função para validar se uma string é uma URL válida.
2. Adiciona uma função que extrai todas as URLs presentes em um nó XML e seus descendentes, organizando-as em um dicionário.
3. Implementa uma classe para extrair citações de artigos de um documento XML, organizando os dados em dicionários estruturados.
4. Adiciona uma classe para validar as citações de artigos, com foco na validação de URLs, anos de publicação, fontes, títulos de artigos e autores.

Essas mudanças melhoram a robustez e a modularidade do código, facilitando a manutenção e futura expansão.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
python3 -m unittest -v tests/sps/validation/test_utils.py
python3 -m unittest -v tests/sps/models/test_article_citations.py
python3 -m unittest -v tests/sps/validation/test_article_citations.py

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
TK #678 

### Referências
NA

