### PR TITLE
Fix: xref model

### DIFF
--- a/packtools/sps/models/v2/article_xref.py
+++ b/packtools/sps/models/v2/article_xref.py
@@ -1,0 +1,125 @@
+from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+
+
+class Xref:
+    """<xref ref-type="aff" rid="aff1">1</xref>"""
+
+    def __init__(self, node):
+        self.xref_node = node
+        self.xref_type = self.xref_node.get("ref-type")
+        self.xref_rid = self.xref_node.get("rid")
+        self.xref_parent = self.xref_node.getparent().tag
+        self.xref_text = self.xref_node.text
+
+    @property
+    def data(self):
+        return {
+            "ref-type": self.xref_type,
+            "rid": self.xref_rid,
+            "text": self.xref_text,
+            "parent-tag": self.xref_parent,
+        }
+
+
+class Id:
+    """<aff id="aff1"><p>affiliation</p></aff>"""
+
+    def __init__(self, node):
+        self.node = node
+        self.node_id = self.node.get("id")
+        self.node_tag = self.node.tag
+
+    @property
+    def data(self):
+        return {"tag": self.node_tag, "id": self.node_id}
+
+
+class Xrefs:
+    def __init__(self, node, lang, article_type, parent, parent_id):
+        self.node = node
+        self.lang = lang
+        self.article_type = article_type
+        self.parent = parent
+        self.parent_id = parent_id
+
+    def xrefs(self):
+        for xref_node in self.node.xpath(".//xref"):
+            xref_data = Xref(xref_node).data
+            yield put_parent_context(
+                xref_data, self.lang, self.article_type, self.parent, self.parent_id
+            )
+
+
+class Ids:
+    def __init__(self, node, lang, article_type, parent, parent_id):
+        self.node = node
+        self.lang = lang
+        self.article_type = article_type
+        self.parent = parent
+        self.parent_id = parent_id
+
+    def ids(self):
+        for id_node in self.node.xpath(".//*[@id]"):
+            id_data = Id(id_node).data
+            yield put_parent_context(
+                id_data, self.lang, self.article_type, self.parent, self.parent_id
+            )
+
+
+class ArticleXref:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def all_ids(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            yield from Ids(node, lang, article_type, parent, parent_id).ids()
+
+    def all_xref_rids(self):
+        for node, lang, article_type, parent, parent_id in get_parent_context(
+            self.xml_tree
+        ):
+            yield from Xrefs(node, lang, article_type, parent, parent_id).xrefs()
+
+    def article_ids(self):
+        for item in self.all_ids():
+            if item.get("parent") == "article":
+                yield item
+
+    def article_xref_rids(self):
+        for item in self.all_xref_rids():
+            if item.get("parent") == "article":
+                yield item
+
+    def sub_article_translation_ids(self):
+        for item in self.all_ids():
+            if (
+                item.get("parent") == "sub-article"
+                and item.get("parent_article_type") == "translation"
+            ):
+                yield item
+
+    def sub_article_translation_xref_rids(self):
+        for item in self.all_xref_rids():
+            if (
+                item.get("parent") == "sub-article"
+                and item.get("parent_article_type") == "translation"
+            ):
+                yield item
+
+    def sub_article_non_translation_ids(self):
+        for item in self.all_ids():
+            if (
+                item.get("parent") == "sub-article"
+                and item.get("parent_article_type") != "translation"
+            ):
+                yield item
+
+    def sub_article_non_translation_xref_rids(self):
+        for item in self.all_xref_rids():
+            if (
+                item.get("parent") == "sub-article"
+                and item.get("parent_article_type") != "translation"
+            ):
+                yield item

--- a/packtools/sps/models/v2/article_xref.py
+++ b/packtools/sps/models/v2/article_xref.py
@@ -38,7 +38,9 @@ class Ids:
     def __init__(self, node):
         self.node = node
 
-    def ids(self, element_name):
+    def ids(self, element_name=None):
+        if not element_name:
+            element_name = "*"
         parent = self.node.tag
         parent_id = self.node.get("id")
 

--- a/packtools/sps/models/v2/article_xref.py
+++ b/packtools/sps/models/v2/article_xref.py
@@ -1,6 +1,6 @@
 import itertools
 
-from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
+from packtools.sps.utils.xml_utils import put_parent_context, tostring
 
 
 class Xref:
@@ -28,6 +28,11 @@ class Id:
         self.node = node
         self.node_id = self.node.get("id")
         self.node_tag = self.node.tag
+        self.str_main_tag = f'<{self.node_tag} id="{self.node_id}">'
+        self.xml = tostring(node=self.node, doctype=None, pretty_print=True, xml_declaration=True)
+
+    def __str__(self):
+        return tostring(self.node)
 
     @property
     def data(self):
@@ -36,6 +41,14 @@ class Id:
 
 class Ids:
     def __init__(self, node):
+        """
+        Initializes the Ids class with an XML node.
+
+        Parameters:
+        node : lxml.etree._Element
+            The XML node (element) that contains one or more <node @id> elements.
+            This can be the root of an `xml_tree` or a node representing a `sub-article`.
+        """
         self.node = node
 
     def ids(self, element_name=None):

--- a/packtools/sps/models/v2/article_xref.py
+++ b/packtools/sps/models/v2/article_xref.py
@@ -29,7 +29,9 @@ class Id:
         self.node_id = self.node.get("id")
         self.node_tag = self.node.tag
         self.str_main_tag = f'<{self.node_tag} id="{self.node_id}">'
-        self.xml = tostring(node=self.node, doctype=None, pretty_print=True, xml_declaration=True)
+
+    def xml(self, doctype=None, pretty_print=True, xml_declaration=True):
+        return tostring(node=self.node, doctype=doctype, pretty_print=pretty_print, xml_declaration=xml_declaration)
 
     def __str__(self):
         return tostring(self.node)
@@ -49,7 +51,7 @@ class Ids:
             The XML node (element) that contains one or more <node @id> elements.
             This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
-        self.node = node.find(".") if node.tag == "article" else node
+        self.node = node
         self.parent = self.node.tag
         self.parent_id = self.node.get("id")
         self.article_type = node.get("article-type")
@@ -95,7 +97,7 @@ class ArticleXref:
         return response
 
     def article_ids(self, element_name):
-        yield from Ids(self.xml_tree).ids(element_name)
+        yield from Ids(self.xml_tree.find(".")).ids(element_name)
 
     def sub_article_translation_ids(self, element_name):
         for node in self.xml_tree.xpath(".//sub-article[@article-type='translation']"):

--- a/packtools/sps/models/v2/article_xref.py
+++ b/packtools/sps/models/v2/article_xref.py
@@ -49,29 +49,23 @@ class Ids:
             The XML node (element) that contains one or more <node @id> elements.
             This can be the root of an `xml_tree` or a node representing a `sub-article`.
         """
-        self.node = node
+        self.node = node.find(".") if node.tag == "article" else node
+        self.parent = self.node.tag
+        self.parent_id = self.node.get("id")
+        self.article_type = node.get("article-type")
+        self.lang = self.node.get("{http://www.w3.org/XML/1998/namespace}lang")
 
-    def ids(self, element_name=None):
-        if not element_name:
-            element_name = "*"
-        parent = self.node.tag
-        parent_id = self.node.get("id")
-
-        if parent == "article":
-            root = self.node.xpath(".")[0]
+    def ids(self, element_name="*"):
+        if self.parent == "article":
             path = f"./front//{element_name}[@id] | ./body//{element_name}[@id] | ./back//{element_name}[@id]"
         else:
-            root = self.node
             path = f".//{element_name}[@id]"
-
-        lang = root.get("{http://www.w3.org/XML/1998/namespace}lang")
-        article_type = root.get("article-type")
 
         for id_node in self.node.xpath(path):
             id_data = Id(id_node).data
 
             yield put_parent_context(
-                id_data, lang, article_type, parent, parent_id
+                id_data, self.lang, self.article_type, self.parent, self.parent_id
             )
 
 

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -7,7 +7,7 @@ class ArticleXrefValidation:
         self.xml_tree = xml_tree
         self.article_xref = ArticleXref(xml_tree)
 
-    def validate_rid(self, element_name, error_level="ERROR"):
+    def validate_rid(self, element_name=None, error_level="ERROR"):
         """
         Checks if all `rid` attributes (source) in `<xref>` elements have corresponding `id` attributes (destination)
         in the XML document.
@@ -62,7 +62,7 @@ class ArticleXrefValidation:
                     error_level=error_level,
                 )
 
-    def validate_id(self, element_name, error_level="ERROR"):
+    def validate_id(self, element_name=None, error_level="ERROR"):
         """
         Checks if all `id` attributes (destination) in the XML document have corresponding `rid` attributes (source)
         in `<xref>` elements.

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -1,71 +1,56 @@
-from packtools.sps.models.article_xref import ArticleXref
+from packtools.sps.models.v2.article_xref import ArticleXref
 from packtools.sps.validation.utils import format_response
 
 
 class ArticleXrefValidation:
-    def __init__(self, xmltree):
-        self.xmltree = xmltree
-        self.article_xref = ArticleXref(xmltree)
-        self.data = list(self.article_xref.data())
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+        self.article_xref = ArticleXref(xml_tree)
 
-    def validate_rid(self, error_level="ERROR"):
+    def validate_rid(self, element_name, error_level="ERROR"):
         """
-        Checks if all rids (source) have the respective ids (destination)
+        Checks if all `rid` attributes (source) in `<xref>` elements have corresponding `id` attributes (destination)
+        in the XML document.
 
-        Returns
-        -------
-        dict
-            A dictionary that registers the rids, ids, the difference between them and a message.
+    Parameters
+    ----------
+    element_name : str
+        The name of the element to be validated.
+    error_level : str, optional
+        The level of error reporting (default is "ERROR").
 
-        Examples
-        --------
-        >>> validate_rid()
-
-        [
-            {
-            'title': 'xref element rid attribute validation',
-            'xpath': './/xref[@rid]',
-            'validation_type': 'match',
-            'response': 'OK',
-            'expected_value': aff1,
-            'got_value': aff1,
-            'message': 'Got aff1, expected aff1',
-            'advice': 'For each xref[@rid="aff1"] must have at least one corresponding element which @id="aff1"'
-            },
-            {
-            'title': 'xref element rid attribute validation',
-            'xpath': './/xref[@rid]',
-            'validation_type': 'match',
-            'response': 'OK',
-            'expected_value': fig1,
-            'got_value': fig1,
-            'message': 'Got fig1, expected fig1',
-            'advice': 'For each xref[@rid="fig1"] must have at least one corresponding element which @id="fig1"'
-            },
-            {
-            'title': 'xref element rid attribute validation',
-            'xpath': './/xref[@rid]',
-            'validation_type': 'match',
-            'response': 'ERROR',
-            'expected_value': table1,
-            'got_value': None,
-            'message': 'Got None, expected table1',
-            'advice': 'For each xref[@rid="table1"] must have at least one corresponding element which @id="table1"'
-            }
-        ]
-
+    Yields
+    ------
+    dict
+        A dictionary containing the following keys:
+        - title (str): The title of the validation.
+        - xpath (str): The XPath query used to locate the elements being validated.
+        - validation_type (str): The type of validation being performed (e.g., "match").
+        - response (str): The result of the validation ("OK" or "ERROR").
+        - expected_value (str): The expected `rid` value.
+        - got_value (str or None): The actual value found or `None` if not found.
+        - message (str): A message explaining the result of the validation.
+        - advice (str): A recommendation or advice based on the validation result.
+        - error_level (str): The level of error reporting.
+        - data (dict): Additional data related to the validation context, which includes:
+            - parent (str): The parent element's tag.
+            - parent_id (str or None): The `id` of the parent element, if available.
+            - parent_article_type (str): The type of the article (e.g., "research-article").
+            - parent_lang (str): The language of the parent element.
+            - tag (str): The tag of the element being validated.
+            - attributes (dict): A dictionary of the element's attributes.
         """
-        for item in self.data:
-            rids = item.get("rids")
-            ids = [id_tuple[1] for id_tuple in item.get("ids")]
-            for rid in rids:
+
+        ids = self.article_xref.all_ids(element_name)
+        for rid, rid_list in self.article_xref.all_xref_rids().items():
+            for rid_data in rid_list:
                 is_valid = rid in ids
                 yield format_response(
                     title="xref element rid attribute validation",
-                    parent=item.get("parent"),
-                    parent_id=item.get("parent_id"),
-                    parent_article_type=item.get("parent_article_type"),
-                    parent_lang=item.get("parent_lang"),
+                    parent="article",
+                    parent_id=None,
+                    parent_article_type=self.xml_tree.get("article-type"),
+                    parent_lang=self.xml_tree.get("{http://www.w3.org/XML/1998/namespace}lang"),
                     item="xref",
                     sub_item="@rid",
                     validation_type="match",
@@ -73,76 +58,61 @@ class ArticleXrefValidation:
                     expected=rid,
                     obtained=rid if is_valid else None,
                     advice='For each xref[@rid="{}"] must have at least one corresponding element which @id="{}"'.format(rid, rid),
-                    data=item,
+                    data=rid_data,
                     error_level=error_level,
                 )
 
-    def validate_id(self, error_level="ERROR"):
+    def validate_id(self, element_name, error_level="ERROR"):
         """
-        Checks if all ids (destination) have the respective rids (source)
+        Checks if all `id` attributes (destination) in the XML document have corresponding `rid` attributes (source)
+        in `<xref>` elements.
 
-        Returns
-        -------
-        dict
-            A dictionary that registers the rids, ids, the difference between them and a message.
+    Parameters
+    ----------
+    element_name : str
+        The name of the element to be validated.
+    error_level : str, optional
+        The level of error reporting (default is "ERROR").
 
-        Examples
-        --------
-        >>> validate_id()
-
-       [
-            {
-            'title': 'xref element id attribute validation',
-            'xpath': './/*[@id]',
-            'validation_type': 'match',
-            'response': 'OK',
-            'expected_value': aff1,
-            'got_value': aff1,
-            'message': 'Got aff1, expected aff1',
-            'advice': 'For each @id="aff1" must have at least one corresponding element which xref[@rid="aff1"]'
-            },
-            {
-            'title': 'xref element id attribute validation',
-            'xpath': './/*[@id]',
-            'validation_type': 'match',
-            'response': 'OK',
-            'expected_value': fig1,
-            'got_value': fig1,
-            'message': 'Got fig1, expected fig1',
-            'advice': 'For each @id="fig1" must have at least one corresponding element which xref[@rid="fig1"]'
-            },
-            {
-            'title': 'xref element id attribute validation',
-            'xpath': './/*[@id]',
-            'validation_type': 'match',
-            'response': 'ERROR',
-            'expected_value': table1,
-            'got_value': None,
-            'message': 'Got None, expected table1',
-            'advice': 'For each @id="table1" must have at least one corresponding element which xref[@rid="table1"]'
-            }
-        ]
+    Yields
+    ------
+    dict
+        A dictionary containing the following keys:
+        - title (str): The title of the validation.
+        - xpath (str): The XPath query used to locate the elements being validated.
+        - validation_type (str): The type of validation being performed (e.g., "match").
+        - response (str): The result of the validation ("OK" or "ERROR").
+        - expected_value (str): The expected `id` value.
+        - got_value (str or None): The actual value found or `None` if not found.
+        - message (str): A message explaining the result of the validation.
+        - advice (str): A recommendation or advice based on the validation result.
+        - error_level (str): The level of error reporting.
+        - data (dict): Additional data related to the validation context, which includes:
+            - parent (str): The parent element's tag.
+            - parent_id (str or None): The `id` of the parent element, if available.
+            - parent_article_type (str): The type of the article (e.g., "research-article").
+            - parent_lang (str): The language of the parent element.
+            - tag (str): The tag of the element being validated.
+            - attributes (dict): A dictionary of the element's attributes.
         """
-        for item in self.data:
-            rids = item.get("rids")
-            ids = item.get("ids")
-            for id_tuple in ids:
-                tag, id = id_tuple
+        rids = self.article_xref.all_xref_rids()
+        for id, id_list in self.article_xref.all_ids(element_name).items():
+            for id_data in id_list:
                 is_valid = id in rids
                 yield format_response(
                     title="element id attribute validation",
-                    parent=item.get("parent"),
-                    parent_id=item.get("parent_id"),
-                    parent_article_type=item.get("parent_article_type"),
-                    parent_lang=item.get("parent_lang"),
-                    item=tag,
+                    parent=id_data.get("parent"),
+                    parent_id=id_data.get("parent_id"),
+                    parent_article_type=id_data.get("parent_article_type"),
+                    parent_lang=id_data.get("parent_lang"),
+                    item=id_data.get("tag"),
                     sub_item="@id",
                     validation_type="match",
                     is_valid=is_valid,
                     expected=id,
                     obtained=id if is_valid else None,
                     advice='For each @id="{}" must have at least one corresponding element which xref[@rid="{}"]'.format(id, id),
-                    data=item,
+                    data=id_data,
                     error_level=error_level,
                 )
 

--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -62,6 +62,33 @@ class IdTest(TestCase):
         obtained = {"tag": "aff", "id": "aff1"}
         self.assertDictEqual(self.node_id.data, obtained)
 
+    def test_str_main_tag(self):
+        self.assertEqual(
+            self.node_id.str_main_tag,
+            '<aff id="aff1">'
+        )
+
+    def test_str(self):
+        self.assertEqual(
+            str(self.node_id),
+            """<?xml version='1.0' encoding='utf-8'?>
+<aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+                """
+        )
+
+    def test_xml(self):
+        self.assertEqual(
+            self.node_id.xml,
+            """<?xml version='1.0' encoding='utf-8'?>
+<aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+                
+"""
+        )
+
 
 class IdsTest(TestCase):
     def setUp(self):

--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -78,16 +78,34 @@ class IdTest(TestCase):
                 """
         )
 
-    def test_xml(self):
-        self.assertEqual(
-            self.node_id.xml,
-            """<?xml version='1.0' encoding='utf-8'?>
+    def test_xml_1(self):
+        self.maxDiff = None
+        result = self.node_id.xml(doctype=None, pretty_print=True, xml_declaration=True)
+        expected = """<?xml version='1.0' encoding='utf-8'?>
 <aff id="aff1">
                         <p>affiliation</p>
                     </aff>
                 
 """
-        )
+        self.assertEqual(result, expected)
+
+    def test_xml_2(self):
+        self.maxDiff = None
+        result = self.node_id.xml(doctype=None, pretty_print=True, xml_declaration=None)
+        expected = """<aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+                
+"""
+        self.assertEqual(result, expected)
+
+    def test_xml_3(self):
+        self.maxDiff = None
+        result = self.node_id.xml(doctype=None, pretty_print=None, xml_declaration=None)
+        expected = """<aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>"""
+        self.assertEqual(result.strip(), expected)
 
 
 class IdsTest(TestCase):

--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from lxml import etree
 
-from packtools.sps.models.v2.article_xref import Xref, Id, Xrefs, Ids, ArticleXref
+from packtools.sps.models.v2.article_xref import Xref, Id, Ids, ArticleXref
 
 
 class XrefTest(TestCase):
@@ -27,14 +27,11 @@ class XrefTest(TestCase):
     def test_rid(self):
         self.assertEqual(self.xref.xref_rid, "aff1")
 
-    def test_parent(self):
-        self.assertEqual(self.xref.xref_parent, "p")
-
     def test_text(self):
         self.assertEqual(self.xref.xref_text, "1")
 
     def test_data(self):
-        obtained = {"ref-type": "aff", "rid": "aff1", "text": "1", "parent-tag": "p"}
+        obtained = {"ref-type": "aff", "rid": "aff1", "text": "1"}
         self.assertDictEqual(self.xref.data, obtained)
 
 
@@ -66,106 +63,38 @@ class IdTest(TestCase):
         self.assertDictEqual(self.node_id.data, obtained)
 
 
-class XrefsTest(TestCase):
-    def setUp(self):
-        self.xml_tree = etree.fromstring(
-            """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
-                <article-meta>
-                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
-                    <aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>
-
-                    <p><xref ref-type="fig" rid="fig1">1</xref></p>
-                    <fig id="fig1">
-                        <p>figure</p>
-                    </fig>
-
-                    <p><xref ref-type="table" rid="table1">1</xref></p>
-                    <table id="table1">
-                        <p>table</p>
-                    </table>
-                </article-meta>
-            </article>
-            """
-        )
-        self.xrefs = Xrefs(
-            self.xml_tree.xpath(".")[0], "en", "research-article", "article", None
-        )
-
-    def test_xrefs(self):
-        obtained = list(self.xrefs.xrefs())
-        expected = [
-            {
-                "parent": "article",
-                "parent-tag": "p",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "ref-type": "aff",
-                "rid": "aff1",
-                "text": "1",
-            },
-            {
-                "parent": "article",
-                "parent-tag": "p",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "ref-type": "fig",
-                "rid": "fig1",
-                "text": "1",
-            },
-            {
-                "parent": "article",
-                "parent-tag": "p",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "ref-type": "table",
-                "rid": "table1",
-                "text": "1",
-            },
-        ]
-        self.assertEqual(len(obtained), 3)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
-
 class IdsTest(TestCase):
     def setUp(self):
         self.xml_tree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
-                <article-meta>
-                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
-                    <aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>
-
-                    <p><xref ref-type="fig" rid="fig1">1</xref></p>
-                    <fig id="fig1">
-                        <p>figure</p>
-                    </fig>
-
-                    <p><xref ref-type="table" rid="table1">1</xref></p>
-                    <table id="table1">
-                        <p>table</p>
-                    </table>
-                </article-meta>
+                <front>
+                    <article-meta>
+                    
+                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                        <aff id="aff1">
+                            <p>affiliation</p>
+                        </aff>
+    
+                        <p><xref ref-type="fig" rid="fig1">1</xref></p>
+                        <fig id="fig1">
+                            <p>figure</p>
+                        </fig>
+                        <p><xref ref-type="table" rid="table1">1</xref></p>
+                        <table id="table1">
+                            <p>table</p>
+                        </table>
+                    
+                    </article-meta>
+                </front>
             </article>
             """
         )
-        self.ids = Ids(
-            self.xml_tree.xpath(".")[0], "en", "research-article", "article", None
-        )
+        self.ids = Ids(self.xml_tree)
 
     def test_ids(self):
-        obtained = list(self.ids.ids())
+        obtained = list(self.ids.ids(element_name="aff"))
         expected = [
             {
                 "id": "aff1",
@@ -174,25 +103,9 @@ class IdsTest(TestCase):
                 "parent_id": None,
                 "parent_lang": "en",
                 "tag": "aff",
-            },
-            {
-                "id": "fig1",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "fig",
-            },
-            {
-                "id": "table1",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "table",
-            },
+            }
         ]
-        self.assertEqual(len(obtained), 3)
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
@@ -202,7 +115,7 @@ class ArticleXrefTest(TestCase):
     def setUp(self):
         self.xml_tree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
                      dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
                 <front>
                     <article-meta>
@@ -212,7 +125,7 @@ class ArticleXrefTest(TestCase):
                         </aff>
                     </article-meta>
                 </front>
-            
+
                 <sub-article article-type="translation" xml:lang="es">
                     <front-stub>
                         <contrib-group>
@@ -236,61 +149,61 @@ class ArticleXrefTest(TestCase):
         self.article_xref = ArticleXref(self.xml_tree)
 
     def test_all_ids(self):
-        obtained = list(self.article_xref.all_ids())
-        expected = [
-            {
-                "id": "aff1",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "aff",
-            },
-            {
-                "id": "aff2",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "es",
-                "tag": "aff",
-            },
-        ]
+        obtained = self.article_xref.all_ids(element_name="aff")
+        expected = {
+            "aff1": [
+                {
+                    "id": "aff1",
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": "en",
+                    "tag": "aff",
+                }
+            ],
+            "aff2": [
+                {
+                    "id": "aff2",
+                    "parent": "sub-article",
+                    "parent_article_type": "translation",
+                    "parent_id": None,
+                    "parent_lang": "es",
+                    "tag": "aff",
+                }
+            ]
+        }
         self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        for id, item in expected.items():
+            for i, subitem in enumerate(item):
+                with self.subTest(id):
+                    self.assertDictEqual(subitem, obtained[id][i])
 
     def test_all_xref_rids(self):
-        obtained = list(self.article_xref.all_xref_rids())
-        expected = [
-            {
-                "parent": "article",
-                "parent-tag": "p",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "ref-type": "aff",
-                "rid": "aff1",
-                "text": "1",
-            },
-            {
-                "parent": "sub-article",
-                "parent-tag": "contrib",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "es",
-                "ref-type": "aff",
-                "rid": "aff2",
-                "text": "2",
-            },
-        ]
+        obtained = self.article_xref.all_xref_rids()
+        expected = {
+            "aff1": [
+                {
+                    "ref-type": "aff",
+                    "rid": "aff1",
+                    "text": "1",
+                }
+            ],
+            "aff2": [
+                {
+                    "ref-type": "aff",
+                    "rid": "aff2",
+                    "text": "2",
+                }
+            ]
+        }
         self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        for rid, item in expected.items():
+            for i, subitem in enumerate(item):
+                with self.subTest(rid):
+                    self.assertDictEqual(subitem, obtained[rid][i])
 
     def test_article_ids(self):
-        obtained = list(self.article_xref.article_ids())
+        obtained = list(self.article_xref.article_ids(element_name="aff"))
         expected = [
             {
                 "id": "aff1",
@@ -299,25 +212,6 @@ class ArticleXrefTest(TestCase):
                 "parent_id": None,
                 "parent_lang": "en",
                 "tag": "aff",
-            }
-        ]
-        self.assertEqual(len(obtained), 1)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
-    def test_article_xref_rids(self):
-        obtained = list(self.article_xref.article_xref_rids())
-        expected = [
-            {
-                "parent": "article",
-                "parent-tag": "p",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "ref-type": "aff",
-                "rid": "aff1",
-                "text": "1",
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -326,7 +220,7 @@ class ArticleXrefTest(TestCase):
                 self.assertDictEqual(item, obtained[i])
 
     def test_sub_article_translation_ids(self):
-        obtained = list(self.article_xref.sub_article_translation_ids())
+        obtained = list(self.article_xref.sub_article_translation_ids(element_name="aff"))
         expected = [
             {
                 "id": "aff2",
@@ -342,29 +236,6 @@ class ArticleXrefTest(TestCase):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
 
-    def test_sub_article_translation_xref_rids(self):
-        obtained = list(self.article_xref.sub_article_translation_xref_rids())
-        expected = [
-            {
-                "parent": "sub-article",
-                "parent-tag": "contrib",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "es",
-                "ref-type": "aff",
-                "rid": "aff2",
-                "text": "2",
-            }
-        ]
-        self.assertEqual(len(obtained), 1)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
     def test_sub_article_non_translation_ids(self):
-        obtained = list(self.article_xref.sub_article_non_translation_ids())
-        self.assertEqual(len(obtained), 0)
-
-    def test_sub_article_non_translation_xref_rids(self):
-        obtained = list(self.article_xref.sub_article_non_translation_xref_rids())
+        obtained = list(self.article_xref.sub_article_non_translation_ids(element_name="aff"))
         self.assertEqual(len(obtained), 0)

--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -1,0 +1,370 @@
+from unittest import TestCase
+from lxml import etree
+
+from packtools.sps.models.v2.article_xref import Xref, Id, Xrefs, Ids, ArticleXref
+
+
+class XrefTest(TestCase):
+    def setUp(self):
+        self.xml_tree = etree.fromstring(
+            """
+            <article>
+                <article-meta>
+                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                    <aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+                </article-meta>
+            </article>
+            """
+        )
+        self.node = self.xml_tree.xpath(".//xref")[0]
+        self.xref = Xref(self.node)
+
+    def test_ref_type(self):
+        self.assertEqual(self.xref.xref_type, "aff")
+
+    def test_rid(self):
+        self.assertEqual(self.xref.xref_rid, "aff1")
+
+    def test_parent(self):
+        self.assertEqual(self.xref.xref_parent, "p")
+
+    def test_text(self):
+        self.assertEqual(self.xref.xref_text, "1")
+
+    def test_data(self):
+        obtained = {"ref-type": "aff", "rid": "aff1", "text": "1", "parent-tag": "p"}
+        self.assertDictEqual(self.xref.data, obtained)
+
+
+class IdTest(TestCase):
+    def setUp(self):
+        self.xml_tree = etree.fromstring(
+            """
+            <article>
+                <article-meta>
+                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                    <aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+                </article-meta>
+            </article>
+            """
+        )
+        self.node = self.xml_tree.xpath(".//aff")[0]
+        self.node_id = Id(self.node)
+
+    def test_node_id(self):
+        self.assertEqual(self.node_id.node_id, "aff1")
+
+    def test_node_tag(self):
+        self.assertEqual(self.node_id.node_tag, "aff")
+
+    def test_data(self):
+        obtained = {"tag": "aff", "id": "aff1"}
+        self.assertDictEqual(self.node_id.data, obtained)
+
+
+class XrefsTest(TestCase):
+    def setUp(self):
+        self.xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
+                <article-meta>
+                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                    <aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+
+                    <p><xref ref-type="fig" rid="fig1">1</xref></p>
+                    <fig id="fig1">
+                        <p>figure</p>
+                    </fig>
+
+                    <p><xref ref-type="table" rid="table1">1</xref></p>
+                    <table id="table1">
+                        <p>table</p>
+                    </table>
+                </article-meta>
+            </article>
+            """
+        )
+        self.xrefs = Xrefs(
+            self.xml_tree.xpath(".")[0], "en", "research-article", "article", None
+        )
+
+    def test_xrefs(self):
+        obtained = list(self.xrefs.xrefs())
+        expected = [
+            {
+                "parent": "article",
+                "parent-tag": "p",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "ref-type": "aff",
+                "rid": "aff1",
+                "text": "1",
+            },
+            {
+                "parent": "article",
+                "parent-tag": "p",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "ref-type": "fig",
+                "rid": "fig1",
+                "text": "1",
+            },
+            {
+                "parent": "article",
+                "parent-tag": "p",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "ref-type": "table",
+                "rid": "table1",
+                "text": "1",
+            },
+        ]
+        self.assertEqual(len(obtained), 3)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+class IdsTest(TestCase):
+    def setUp(self):
+        self.xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
+                <article-meta>
+                    <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                    <aff id="aff1">
+                        <p>affiliation</p>
+                    </aff>
+
+                    <p><xref ref-type="fig" rid="fig1">1</xref></p>
+                    <fig id="fig1">
+                        <p>figure</p>
+                    </fig>
+
+                    <p><xref ref-type="table" rid="table1">1</xref></p>
+                    <table id="table1">
+                        <p>table</p>
+                    </table>
+                </article-meta>
+            </article>
+            """
+        )
+        self.ids = Ids(
+            self.xml_tree.xpath(".")[0], "en", "research-article", "article", None
+        )
+
+    def test_ids(self):
+        obtained = list(self.ids.ids())
+        expected = [
+            {
+                "id": "aff1",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "aff",
+            },
+            {
+                "id": "fig1",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "fig",
+            },
+            {
+                "id": "table1",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "table",
+            },
+        ]
+        self.assertEqual(len(obtained), 3)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+
+class ArticleXrefTest(TestCase):
+    def setUp(self):
+        self.xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+                     dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
+                <front>
+                    <article-meta>
+                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
+                        <aff id="aff1">
+                            <p>affiliation</p>
+                        </aff>
+                    </article-meta>
+                </front>
+            
+                <sub-article article-type="translation" xml:lang="es">
+                    <front-stub>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>García</surname>
+                                    <given-names>Juan</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff2">2</xref>
+                            </contrib>
+                        </contrib-group>
+                        <aff id="aff2">
+                            <institution>Universidad Ejemplo</institution>
+                        </aff>
+                    </front-stub>
+                </sub-article>
+            </article>
+
+            """
+        )
+        self.article_xref = ArticleXref(self.xml_tree)
+
+    def test_all_ids(self):
+        obtained = list(self.article_xref.all_ids())
+        expected = [
+            {
+                "id": "aff1",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "aff",
+            },
+            {
+                "id": "aff2",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "es",
+                "tag": "aff",
+            },
+        ]
+        self.assertEqual(len(obtained), 2)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_all_xref_rids(self):
+        obtained = list(self.article_xref.all_xref_rids())
+        expected = [
+            {
+                "parent": "article",
+                "parent-tag": "p",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "ref-type": "aff",
+                "rid": "aff1",
+                "text": "1",
+            },
+            {
+                "parent": "sub-article",
+                "parent-tag": "contrib",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "es",
+                "ref-type": "aff",
+                "rid": "aff2",
+                "text": "2",
+            },
+        ]
+        self.assertEqual(len(obtained), 2)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_article_ids(self):
+        obtained = list(self.article_xref.article_ids())
+        expected = [
+            {
+                "id": "aff1",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "aff",
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_article_xref_rids(self):
+        obtained = list(self.article_xref.article_xref_rids())
+        expected = [
+            {
+                "parent": "article",
+                "parent-tag": "p",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "ref-type": "aff",
+                "rid": "aff1",
+                "text": "1",
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_sub_article_translation_ids(self):
+        obtained = list(self.article_xref.sub_article_translation_ids())
+        expected = [
+            {
+                "id": "aff2",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "es",
+                "tag": "aff",
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_sub_article_translation_xref_rids(self):
+        obtained = list(self.article_xref.sub_article_translation_xref_rids())
+        expected = [
+            {
+                "parent": "sub-article",
+                "parent-tag": "contrib",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "es",
+                "ref-type": "aff",
+                "rid": "aff2",
+                "text": "2",
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_sub_article_non_translation_ids(self):
+        obtained = list(self.article_xref.sub_article_non_translation_ids())
+        self.assertEqual(len(obtained), 0)
+
+    def test_sub_article_non_translation_xref_rids(self):
+        obtained = list(self.article_xref.sub_article_non_translation_xref_rids())
+        self.assertEqual(len(obtained), 0)

--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -103,7 +103,11 @@ class IdsTest(TestCase):
                         <aff id="aff1">
                             <p>affiliation</p>
                         </aff>
-    
+                        
+                        <aff id="aff2">
+                            <p>affiliation</p>
+                        </aff>    
+        
                         <p><xref ref-type="fig" rid="fig1">1</xref></p>
                         <fig id="fig1">
                             <p>figure</p>
@@ -130,9 +134,17 @@ class IdsTest(TestCase):
                 "parent_id": None,
                 "parent_lang": "en",
                 "tag": "aff",
+            },
+            {
+                "id": "aff2",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "aff",
             }
         ]
-        self.assertEqual(len(obtained), 1)
+        self.assertEqual(len(obtained), 2)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
@@ -150,6 +162,9 @@ class ArticleXrefTest(TestCase):
                         <aff id="aff1">
                             <p>affiliation</p>
                         </aff>
+                        <aff id="aff2">
+                            <p>affiliation</p>
+                        </aff>
                     </article-meta>
                 </front>
 
@@ -164,7 +179,10 @@ class ArticleXrefTest(TestCase):
                                 <xref ref-type="aff" rid="aff2">2</xref>
                             </contrib>
                         </contrib-group>
-                        <aff id="aff2">
+                        <aff id="aff3">
+                            <institution>Universidad Ejemplo</institution>
+                        </aff>
+                        <aff id="aff4">
                             <institution>Universidad Ejemplo</institution>
                         </aff>
                     </front-stub>
@@ -191,6 +209,26 @@ class ArticleXrefTest(TestCase):
             "aff2": [
                 {
                     "id": "aff2",
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": "en",
+                    "tag": "aff",
+                }
+            ],
+            "aff3": [
+                {
+                    "id": "aff3",
+                    "parent": "sub-article",
+                    "parent_article_type": "translation",
+                    "parent_id": None,
+                    "parent_lang": "es",
+                    "tag": "aff",
+                }
+            ],
+            "aff4": [
+                {
+                    "id": "aff4",
                     "parent": "sub-article",
                     "parent_article_type": "translation",
                     "parent_id": None,
@@ -199,7 +237,7 @@ class ArticleXrefTest(TestCase):
                 }
             ]
         }
-        self.assertEqual(len(obtained), 2)
+        self.assertEqual(len(obtained), 4)
         for id, item in expected.items():
             for i, subitem in enumerate(item):
                 with self.subTest(id):
@@ -239,9 +277,17 @@ class ArticleXrefTest(TestCase):
                 "parent_id": None,
                 "parent_lang": "en",
                 "tag": "aff",
+            },
+            {
+                "id": "aff2",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "en",
+                "tag": "aff",
             }
         ]
-        self.assertEqual(len(obtained), 1)
+        self.assertEqual(len(obtained), 2)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])
@@ -250,7 +296,15 @@ class ArticleXrefTest(TestCase):
         obtained = list(self.article_xref.sub_article_translation_ids(element_name="aff"))
         expected = [
             {
-                "id": "aff2",
+                "id": "aff3",
+                "parent": "sub-article",
+                "parent_article_type": "translation",
+                "parent_id": None,
+                "parent_lang": "es",
+                "tag": "aff",
+            },
+            {
+                "id": "aff4",
                 "parent": "sub-article",
                 "parent_article_type": "translation",
                 "parent_id": None,
@@ -258,7 +312,7 @@ class ArticleXrefTest(TestCase):
                 "tag": "aff",
             }
         ]
-        self.assertEqual(len(obtained), 1)
+        self.assertEqual(len(obtained), 2)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -9,7 +9,7 @@ class ArticleXrefValidationTest(TestCase):
 
     def test_validate_rids_matches(self):
         self.maxDiff = None
-        self.xmltree = etree.fromstring(
+        self.xml_tree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
@@ -34,7 +34,7 @@ class ArticleXrefValidationTest(TestCase):
             </article>
             """
         )
-        obtained = list(ArticleXrefValidation(self.xmltree).validate_rid())
+        obtained = list(ArticleXrefValidation(self.xml_tree).validate_rid(element_name="*"))
 
         expected = [
             {
@@ -52,12 +52,10 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got aff1, expected aff1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -74,12 +72,10 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got fig1, expected fig1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'fig',
+                    'rid': 'fig1',
+                    'text': '1'
+                }
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -96,14 +92,13 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got table1, expected table1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'table',
+                    'rid': 'table1',
+                    'text': '1'
+                }
             }
         ]
+        self.assertEqual(len(obtained), 3)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -112,21 +107,21 @@ class ArticleXrefValidationTest(TestCase):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
-                        <p><xref ref-type="aff" rid="aff1">1</xref></p>     
+                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
                         <aff id="aff1">
                             <p>affiliation</p>
                         </aff>
-    
-                        <p><xref ref-type="fig" rid="fig1">1</xref></p>     
+
+                        <p><xref ref-type="fig" rid="fig1">1</xref></p>
                         <fig id="fig1">
                             <p>figure</p>
                         </fig>
-    
-                        <p><xref ref-type="table" rid="table1">1</xref></p>     
+
+                        <p><xref ref-type="table" rid="table1">1</xref></p>
                     </article-meta>
                 </front>
             </article>
@@ -150,12 +145,10 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got aff1, expected aff1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'aff',
+                    'rid': 'aff1',
+                    'text': '1'
+                }
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -172,12 +165,10 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got fig1, expected fig1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'fig',
+                    'rid': 'fig1',
+                    'text': '1'
+                }
             },
             {
                 'title': 'xref element rid attribute validation',
@@ -194,15 +185,14 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got None, expected table1',
                 'advice': 'For each xref[@rid="table1"] must have at least one corresponding element which @id="table1"',
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1')],
-                    'parent': 'article',
-                    'parent_article_type': "research-article",
-                    'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']},
+                    'ref-type': 'table',
+                    'rid': 'table1',
+                    'text': '1'
+                },
             }
         ]
-        obtained = list(self.article_xref.validate_rid())
+        obtained = list(self.article_xref.validate_rid(element_name="*"))
+        self.assertEqual(len(obtained), 3)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -211,21 +201,21 @@ class ArticleXrefValidationTest(TestCase):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
-                        <p><xref ref-type="aff" rid="aff1">1</xref></p>     
+                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
                         <aff id="aff1">
                             <p>affiliation</p>
                         </aff>
-    
-                        <p><xref ref-type="fig" rid="fig1">1</xref></p>     
+
+                        <p><xref ref-type="fig" rid="fig1">1</xref></p>
                         <fig id="fig1">
                             <p>figure</p>
                         </fig>
-    
-                        <p><xref ref-type="table" rid="table1">1</xref></p>     
+
+                        <p><xref ref-type="table" rid="table1">1</xref></p>
                         <table id="table1">
                             <p>table</p>
                         </table>
@@ -252,12 +242,12 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got aff1, expected aff1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'aff1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']
+                    'parent_lang': 'pt',
+                    'tag': 'aff'
                 }
             },
             {
@@ -275,12 +265,12 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got fig1, expected fig1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'fig1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']
+                    'parent_lang': 'pt',
+                    'tag': 'fig'
                 }
             },
             {
@@ -298,17 +288,17 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got table1, expected table1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'table1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1', 'table1']
+                    'parent_lang': 'pt',
+                    'tag': 'table'
                 }
             }
         ]
 
-        obtained = list(self.article_xref.validate_id())
+        obtained = list(self.article_xref.validate_id(element_name="*"))
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -318,20 +308,20 @@ class ArticleXrefValidationTest(TestCase):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.0" article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
-                        <p><xref ref-type="aff" rid="aff1">1</xref></p>     
+                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
                         <aff id="aff1">
                             <p>affiliation</p>
                         </aff>
-    
-                        <p><xref ref-type="fig" rid="fig1">1</xref></p>     
+
+                        <p><xref ref-type="fig" rid="fig1">1</xref></p>
                         <fig id="fig1">
                             <p>figure</p>
                         </fig>
-        
+
                         <table id="table1">
                             <p>table</p>
                         </table>
@@ -358,13 +348,13 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got aff1, expected aff1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'aff1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1']
-                },
+                    'parent_lang': 'pt',
+                    'tag': 'aff'
+                }
             },
             {
                 'title': 'element id attribute validation',
@@ -381,13 +371,13 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got fig1, expected fig1',
                 'advice': None,
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'fig1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1']
-                },
+                    'parent_lang': 'pt',
+                    'tag': 'fig'
+                }
             },
             {
                 'title': 'element id attribute validation',
@@ -404,17 +394,17 @@ class ArticleXrefValidationTest(TestCase):
                 'message': 'Got None, expected table1',
                 'advice': 'For each @id="table1" must have at least one corresponding element which xref[@rid="table1"]',
                 'data': {
-                    'ids': [('aff', 'aff1'), ('fig', 'fig1'), ('table', 'table1')],
+                    'id': 'table1',
                     'parent': 'article',
-                    'parent_article_type': "research-article",
+                    'parent_article_type': 'research-article',
                     'parent_id': None,
-                    'parent_lang': "pt",
-                    'rids': ['aff1', 'fig1']
+                    'parent_lang': 'pt',
+                    'tag': 'table'
                 },
             }
         ]
 
-        obtained = list(self.article_xref.validate_id())
+        obtained = list(self.article_xref.validate_id(element_name="*"))
 
         for i, item in enumerate(expected):
             with self.subTest(i):

--- a/tests/sps/validation/test_article_xref.py
+++ b/tests/sps/validation/test_article_xref.py
@@ -34,7 +34,7 @@ class ArticleXrefValidationTest(TestCase):
             </article>
             """
         )
-        obtained = list(ArticleXrefValidation(self.xml_tree).validate_rid(element_name="*"))
+        obtained = list(ArticleXrefValidation(self.xml_tree).validate_rid())
 
         expected = [
             {
@@ -191,7 +191,7 @@ class ArticleXrefValidationTest(TestCase):
                 },
             }
         ]
-        obtained = list(self.article_xref.validate_rid(element_name="*"))
+        obtained = list(self.article_xref.validate_rid())
         self.assertEqual(len(obtained), 3)
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -298,7 +298,7 @@ class ArticleXrefValidationTest(TestCase):
             }
         ]
 
-        obtained = list(self.article_xref.validate_id(element_name="*"))
+        obtained = list(self.article_xref.validate_id())
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -404,7 +404,7 @@ class ArticleXrefValidationTest(TestCase):
             }
         ]
 
-        obtained = list(self.article_xref.validate_id(element_name="*"))
+        obtained = list(self.article_xref.validate_id())
 
         for i, item in enumerate(expected):
             with self.subTest(i):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR implementa uma série de classes (`Xref`, `Id`, `Xrefs`, `Ids`, `ArticleXref`) para facilitar a extração de referências (`xref`) e IDs de elementos em documentos XML de artigos científicos, incluindo suporte específico para sub-artigos de tradução. Com essas classes, é possível iterar sobre todos os IDs e referências de um artigo, identificando se eles pertencem ao artigo principal ou a sub-artigos, e se esses sub-artigos são traduções ou não. Além disso, este PR inclui um conjunto abrangente de testes unitários para validar a funcionalidade implementada.

#### Onde a revisão poderia começar?
A revisão pode começar pelos seguintes arquivos:

- `article_xref.py`
- `test_article_xref.py`

#### Como este poderia ser testado manualmente?
Para testar manualmente as funcionalidades deste PR:

1. Carregue um documento XML de artigo científico que contenha referências (xref) e IDs em suas tags.
2. Utilize as classes ArticleXref, Xrefs, e Ids para extrair e iterar sobre as referências e IDs do documento.
3. Verifique se as extrações estão corretas, especialmente diferenciando entre o conteúdo do artigo principal e sub-artigos de tradução.
4. Execute os testes unitários fornecidos para garantir que todas as funcionalidades estão funcionando conforme o esperado.

#### Algum cenário de contexto que queira dar?
A modificação dessa classe tem por objetivo facilitar na validação de `@id`.

### Screenshots
NA

#### Quais são tickets relevantes?
TK #684 

### Referências
NA
