### PR TITLE
Feat: subsection validation

### DIFF
--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -9,16 +9,9 @@ class ArticleTocSections:
     @property
     def sections(self):
         for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
-            found = False
             for item in node.xpath(".//subj-group[@subj-group-type='heading']/subject"):
-                found = True
                 _section = {
                     "text": node_text_without_xref(item),
-                }
-                yield put_parent_context(_section, lang, article_type, parent, parent_id)
-            if not found:
-                _section = {
-                    "text": None,
                 }
                 yield put_parent_context(_section, lang, article_type, parent, parent_id)
 

--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -9,15 +9,22 @@ class ArticleTocSections:
     @property
     def sections(self):
         for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
-            for item in node.xpath(".//subj-group[@subj-group-type='heading']/subject"):
+            for item in node.xpath(".//subj-group"):
                 _section = {
-                    "text": node_text_without_xref(item),
+                    "subj_group_type": item.get("subj-group-type"),
+                    "section": node_text_without_xref(section := item.find("./subject"))
                 }
+                subsections = []
+                for subsection in item.xpath(".//subject"):
+                    if subsection is not None and subsection != section:
+                        subsections.append(node_text_without_xref(subsection))
+                _section["subsections"] = subsections
                 yield put_parent_context(_section, lang, article_type, parent, parent_id)
 
     @property
     def sections_dict(self):
-        return {
-            item['parent_lang']: item
-            for item in self.sections
-        }
+        response = {}
+        for item in self.sections:
+            response.setdefault(item["parent_lang"], [])
+            response[item["parent_lang"]].append(item)
+        return response

--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -10,14 +10,14 @@ class ArticleTocSections:
     def sections(self):
         for node, lang, article_type, parent, parent_id in get_parent_context(self.xmltree):
             for item in node.xpath(".//subj-group"):
+                section = node_text_without_xref(item.find("./subject")) or None
                 _section = {
                     "subj_group_type": item.get("subj-group-type"),
-                    "section": node_text_without_xref(section := item.find("./subject"))
+                    "section": section
                 }
                 subsections = []
                 for subsection in item.xpath(".//subject"):
-                    if subsection is not None and subsection != section:
-                        subsections.append(node_text_without_xref(subsection))
+                    subsections.append(node_text_without_xref(subsection) or None)
                 _section["subsections"] = subsections
                 yield put_parent_context(_section, lang, article_type, parent, parent_id)
 

--- a/packtools/sps/models/v2/article_toc_sections.py
+++ b/packtools/sps/models/v2/article_toc_sections.py
@@ -16,7 +16,7 @@ class ArticleTocSections:
                     "section": section
                 }
                 subsections = []
-                for subsection in item.xpath(".//subject"):
+                for subsection in item.xpath("./subj-group//subject"):
                     subsections.append(node_text_without_xref(subsection) or None)
                 _section["subsections"] = subsections
                 yield put_parent_context(_section, lang, article_type, parent, parent_id)

--- a/packtools/sps/validation/article_toc_sections.py
+++ b/packtools/sps/validation/article_toc_sections.py
@@ -32,55 +32,54 @@ class ArticleTocSectionsValidation:
         expected_toc_sections = expected_toc_sections or self.expected_toc_sections
         if not expected_toc_sections:
             raise ValidationExpectedTocSectionsException("Function requires a dict of expected toc sections.")
-        obtained_toc_sections = self.article_toc_sections.sections_dict
-        if obtained_toc_sections:
-            for lang, sections_list in obtained_toc_sections.items():
-                for obtained in sections_list:
-                    # Valida o valor do atributo subj-group-type
-                    if (subject_type := obtained["subj_group_type"]) != "heading":
-                        yield format_response(
-                            title="Attribute '@subj-group-type' validation",
-                            parent=obtained["parent"],
-                            parent_id=obtained["parent_id"],
-                            parent_article_type=obtained["parent_article_type"],
-                            parent_lang=obtained["parent_lang"],
-                            item="subj-group",
-                            sub_item="@subj-group-type",
-                            is_valid=False,
-                            validation_type="match",
-                            expected="heading",
-                            obtained=subject_type,
-                            advice="the value for '@subj-group-type' must be heading",
-                            data=obtained_toc_sections,
-                            error_level=error_level,
-                        )
 
-                    else:
-                        # Se subj-group-type está correto, valida o título
-                        is_valid = False
-                        expected = expected_toc_sections.get(lang)
-                        obtained_subject = obtained['section']
-                        validation_type = 'exist'
-                        if obtained_subject:
-                            # verifica se o título de seção está presente na lista esperada
-                            is_valid = obtained_subject.split(":")[0] in expected
-                            validation_type = 'value in list'
-                        yield format_response(
-                            title='Document section title validation',
-                            parent=obtained["parent"],
-                            parent_id=obtained["parent_id"],
-                            parent_article_type=obtained["parent_article_type"],
-                            parent_lang=obtained["parent_lang"],
-                            item="subj-group",
-                            sub_item="subject",
-                            is_valid=is_valid,
-                            validation_type=validation_type,
-                            expected=expected or "subject value",
-                            obtained=obtained_subject,
-                            advice='Provide missing section for language: {}'.format(lang),
-                            data=obtained_toc_sections,
-                            error_level=error_level,
-                        )
+        for lang, sections_list in self.article_toc_sections.sections_dict.items():
+            for obtained in sections_list:
+                # Valida o valor do atributo subj-group-type
+                if (subject_type := obtained["subj_group_type"]) != "heading":
+                    yield format_response(
+                        title="Attribute '@subj-group-type' validation",
+                        parent=obtained["parent"],
+                        parent_id=obtained["parent_id"],
+                        parent_article_type=obtained["parent_article_type"],
+                        parent_lang=obtained["parent_lang"],
+                        item="subj-group",
+                        sub_item="@subj-group-type",
+                        is_valid=False,
+                        validation_type="match",
+                        expected="heading",
+                        obtained=subject_type,
+                        advice="the value for '@subj-group-type' must be heading",
+                        data=obtained,
+                        error_level=error_level,
+                    )
+
+                else:
+                    # Se subj-group-type está correto, valida o título
+                    is_valid = False
+                    expected = expected_toc_sections.get(lang)
+                    obtained_subject = obtained['section']
+                    validation_type = 'exist'
+                    if obtained_subject:
+                        # verifica se o título de seção está presente na lista esperada
+                        is_valid = obtained_subject.split(":")[0] in expected
+                        validation_type = 'value in list'
+                    yield format_response(
+                        title='Document section title validation',
+                        parent=obtained["parent"],
+                        parent_id=obtained["parent_id"],
+                        parent_article_type=obtained["parent_article_type"],
+                        parent_lang=obtained["parent_lang"],
+                        item="subj-group",
+                        sub_item="subject",
+                        is_valid=is_valid,
+                        validation_type=validation_type,
+                        expected=expected or "subject value",
+                        obtained=obtained_subject,
+                        advice='Provide missing section for language: {}'.format(lang),
+                        data=obtained,
+                        error_level=error_level,
+                    )
 
     def validade_article_title_is_different_from_section_titles(self, error_level="ERROR"):
         """
@@ -218,7 +217,7 @@ class ArticleTocSectionsValidation:
                 )
             if has_subsections:
                 yield format_response(
-                    title="Incorrect subsection structure in XML for article TOC",
+                    title="Unexpected XML structure: article-categories/subject-group/subject-group/subject",
                     parent=subject[0]["parent"],
                     parent_id=subject[0]["parent_id"],
                     parent_article_type=subject[0]["parent_article_type"],

--- a/packtools/sps/validation/article_toc_sections.py
+++ b/packtools/sps/validation/article_toc_sections.py
@@ -206,12 +206,7 @@ class ArticleTocSectionsValidation:
                 )
 
     def validate_article_subsections(self, error_level="CRITICAL"):
-        subjects = {}
-        for subject in self.article_toc_sections.sections:
-            lang = subject.get("parent_lang")
-            subjects.setdefault(lang, [])
-            subjects[lang].append(subject)
-        for lang, subject in subjects.items():
+        for lang, subject in self.article_toc_sections.sections_dict.items():
             if len(subject) > 1:
                 _subjects = [item.get("section") for item in subject]
                 yield format_response(

--- a/packtools/sps/validation/article_toc_sections.py
+++ b/packtools/sps/validation/article_toc_sections.py
@@ -54,32 +54,31 @@ class ArticleTocSectionsValidation:
                         error_level=error_level,
                     )
 
-                else:
-                    # Se subj-group-type está correto, valida o título
-                    is_valid = False
-                    expected = expected_toc_sections.get(lang)
-                    obtained_subject = obtained['section']
-                    validation_type = 'exist'
-                    if obtained_subject:
-                        # verifica se o título de seção está presente na lista esperada
-                        is_valid = obtained_subject.split(":")[0] in expected
-                        validation_type = 'value in list'
-                    yield format_response(
-                        title='Document section title validation',
-                        parent=obtained["parent"],
-                        parent_id=obtained["parent_id"],
-                        parent_article_type=obtained["parent_article_type"],
-                        parent_lang=obtained["parent_lang"],
-                        item="subj-group",
-                        sub_item="subject",
-                        is_valid=is_valid,
-                        validation_type=validation_type,
-                        expected=expected or "subject value",
-                        obtained=obtained_subject,
-                        advice='Provide missing section for language: {}'.format(lang),
-                        data=obtained,
-                        error_level=error_level,
-                    )
+                # Valida o título
+                is_valid = False
+                expected = expected_toc_sections.get(lang)
+                obtained_subject = obtained['section']
+                validation_type = 'exist'
+                if obtained_subject:
+                    # verifica se o título de seção está presente na lista esperada
+                    is_valid = obtained_subject.split(":")[0] in expected
+                    validation_type = 'value in list'
+                yield format_response(
+                    title='Document section title validation',
+                    parent=obtained["parent"],
+                    parent_id=obtained["parent_id"],
+                    parent_article_type=obtained["parent_article_type"],
+                    parent_lang=obtained["parent_lang"],
+                    item="subj-group",
+                    sub_item="subject",
+                    is_valid=is_valid,
+                    validation_type=validation_type,
+                    expected=expected or "subject value",
+                    obtained=obtained_subject,
+                    advice='Provide missing section for language: {}'.format(lang),
+                    data=obtained,
+                    error_level=error_level,
+                )
 
     def validade_article_title_is_different_from_section_titles(self, error_level="ERROR"):
         """
@@ -200,7 +199,7 @@ class ArticleTocSectionsValidation:
 
             if has_multiple_subjects:
                 yield format_response(
-                    title="Multiple Subjects Validation in Article TOC",
+                    title="Exceding subject-group/subject",
                     parent=subject[0]["parent"],
                     parent_id=subject[0]["parent_id"],
                     parent_article_type=subject[0]["parent_article_type"],

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -90,3 +90,7 @@ class ValidationAlternativesException(Exception):
 
 class ValidationFnTypeException(Exception):
     ...
+
+
+class ValidationExpectedTocSectionsException(Exception):
+    ...

--- a/tests/sps/models/test_article_toc_sections.py
+++ b/tests/sps/models/test_article_toc_sections.py
@@ -210,26 +210,6 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSections(self.xmltree)
 
-        expected = [
-            {
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'text': None
-            },
-            {
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': '01',
-                'parent_lang': 'pt',
-                'text': None
-            }
-        ]
         obtained = list(self.article_toc_sections.sections)
 
-        self.assertEqual(len(obtained), 2)
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(len(obtained), 0)

--- a/tests/sps/models/test_article_toc_sections.py
+++ b/tests/sps/models/test_article_toc_sections.py
@@ -46,14 +46,79 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'en',
-                'text': 'Health Sciences'
+                'section': 'Health Sciences',
+                'subj_group_type': 'heading',
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
                 'parent_lang': 'pt',
-                'text': 'Ciências da Saúde'
+                'section': 'Ciências da Saúde',
+                'subj_group_type': 'heading',
+                'subsections': []
+            }
+        ]
+        obtained = list(self.article_toc_sections.sections)
+
+        self.assertEqual(len(obtained), 2)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_article_section_without_heading(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título del artículo</article-title>
+                    </title-group>
+                    <article-categories>
+                        <subj-group>
+                            <subject>Health Sciences</subject>
+                        </subj-group>
+                    </article-categories>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="pt">
+                <front-stub>
+                    <subj-group>
+                        <subject>Ciências da Saúde</subject>
+                    </subj-group>
+                    <title-group>
+                        <article-title>Article title</article-title>
+                    </title-group>
+                </front-stub>
+            </sub-article>        
+            </article>
+            """
+        )
+        self.article_toc_sections = ArticleTocSections(self.xmltree)
+
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'section': 'Health Sciences',
+                'subj_group_type': None,
+                'subsections': []
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'section': 'Ciências da Saúde',
+                'subj_group_type': None,
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -100,20 +165,28 @@ class ArticleTocSectionsTest(TestCase):
         self.article_toc_sections = ArticleTocSections(self.xmltree)
 
         expected = {
-            'en': {
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'text': 'Health Sciences'
-            },
-            'pt': {
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': '01',
-                'parent_lang': 'pt',
-                'text': 'Ciências da Saúde'
-            }
+            'en': [
+                {
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
+            ],
+            'pt': [
+                {
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
+            ]
         }
 
         obtained = self.article_toc_sections.sections_dict
@@ -124,7 +197,7 @@ class ArticleTocSectionsTest(TestCase):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.0" article-type="research-article" xml:lang="en">
             <front>
                 <article-meta>
@@ -147,7 +220,7 @@ class ArticleTocSectionsTest(TestCase):
                         <article-title>Article title</article-title>
                     </title-group>
                 </front-stub>
-            </sub-article>        
+            </sub-article>
             </article>
             """
         )
@@ -159,14 +232,18 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'en',
-                'text': ''
+                'section': '',
+                'subj_group_type': 'heading',
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
                 'parent_lang': 'pt',
-                'text': ''
+                'section': '',
+                'subj_group_type': 'heading',
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -181,7 +258,7 @@ class ArticleTocSectionsTest(TestCase):
         self.maxDiff = None
         self.xmltree = etree.fromstring(
             """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
             dtd-version="1.0" article-type="research-article" xml:lang="en">
             <front>
                 <article-meta>
@@ -190,7 +267,7 @@ class ArticleTocSectionsTest(TestCase):
                     </title-group>
                     <article-categories>
                         <subj-group subj-group-type="heading">
-            
+
                         </subj-group>
                     </article-categories>
                 </article-meta>
@@ -204,12 +281,212 @@ class ArticleTocSectionsTest(TestCase):
                         <article-title>Article title</article-title>
                     </title-group>
                 </front-stub>
+            </sub-article>
+            </article>
+            """
+        )
+        self.article_toc_sections = ArticleTocSections(self.xmltree)
+
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'section': None,
+                'subj_group_type': 'heading',
+                'subsections': []
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'section': None,
+                'subj_group_type': 'heading',
+                'subsections': []
+            }
+        ]
+
+        obtained = list(self.article_toc_sections.sections)
+
+        self.assertEqual(len(obtained), 2)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_article_section_with_subsection(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título del artículo</article-title>
+                    </title-group>
+                    <article-categories>
+                        <subj-group subj-group-type="heading">
+                            <subject>Health Sciences</subject>
+                            <subj-group subj-group-type="heading">
+                                <subject>Health Sciences Subsection</subject>
+                            </subj-group>
+                        </subj-group>
+                    </article-categories>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="pt">
+                <front-stub>
+                    <subj-group subj-group-type="heading">
+                        <subject>Ciências da Saúde</subject>
+                        <subj-group subj-group-type="heading">
+                            <subject>Subseção Ciências da Saúde</subject>
+                        </subj-group>
+                    </subj-group>
+                    <title-group>
+                        <article-title>Article title</article-title>
+                    </title-group>
+                </front-stub>
             </sub-article>        
             </article>
             """
         )
         self.article_toc_sections = ArticleTocSections(self.xmltree)
 
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'section': 'Health Sciences',
+                'subj_group_type': 'heading',
+                'subsections': ['Health Sciences Subsection']
+            },
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'section': 'Health Sciences Subsection',
+                'subj_group_type': 'heading',
+                'subsections': []
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'section': 'Ciências da Saúde',
+                'subj_group_type': 'heading',
+                'subsections': ['Subseção Ciências da Saúde']
+            },
+            {
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'section': 'Subseção Ciências da Saúde',
+                'subj_group_type': 'heading',
+                'subsections': []
+            }
+        ]
         obtained = list(self.article_toc_sections.sections)
 
-        self.assertEqual(len(obtained), 0)
+        self.assertEqual(len(obtained), 4)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_article_section_with_subsection_dict(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título del artículo</article-title>
+                    </title-group>
+                    <article-categories>
+                        <subj-group subj-group-type="heading">
+                            <subject>Health Sciences</subject>
+                            <subj-group subj-group-type="heading">
+                                <subject>Health Sciences Subsection</subject>
+                            </subj-group>
+                        </subj-group>
+                    </article-categories>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="pt">
+                <front-stub>
+                    <subj-group subj-group-type="heading">
+                        <subject>Ciências da Saúde</subject>
+                        <subj-group subj-group-type="heading">
+                            <subject>Subseção Ciências da Saúde</subject>
+                        </subj-group>
+                    </subj-group>
+                    <title-group>
+                        <article-title>Article title</article-title>
+                    </title-group>
+                </front-stub>
+            </sub-article>        
+            </article>
+            """
+        )
+        self.article_toc_sections = ArticleTocSections(self.xmltree)
+
+        expected = {
+            "en": [
+                {
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': ['Health Sciences Subsection']
+                },
+                {
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences Subsection',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
+            ],
+            "pt": [
+                {
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': ['Subseção Ciências da Saúde']
+                },
+                {
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Subseção Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
+            ]
+        }
+        obtained = self.article_toc_sections.sections_dict
+
+        self.assertEqual(len(obtained), 2)
+
+        for lang, sections_list in obtained.items():
+            for i, item in enumerate(sections_list):
+                with self.subTest(lang):
+                    self.assertDictEqual(expected[lang][i], item)

--- a/tests/sps/models/test_article_toc_sections.py
+++ b/tests/sps/models/test_article_toc_sections.py
@@ -48,7 +48,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': ['Health Sciences']
             },
             {
                 'parent': 'sub-article',
@@ -57,7 +57,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': ['Ciências da Saúde']
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -109,7 +109,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': None,
-                'subsections': []
+                'subsections': ['Health Sciences']
             },
             {
                 'parent': 'sub-article',
@@ -118,7 +118,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': None,
-                'subsections': []
+                'subsections': ['Ciências da Saúde']
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -173,7 +173,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences',
                     'subj_group_type': 'heading',
-                    'subsections': []
+                    'subsections': ['Health Sciences']
                 }
             ],
             'pt': [
@@ -184,7 +184,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': []
+                    'subsections': ['Ciências da Saúde']
                 }
             ]
         }
@@ -232,18 +232,18 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'en',
-                'section': '',
+                'section': None,
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': [None]
             },
             {
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
                 'parent_lang': 'pt',
-                'section': '',
+                'section': None,
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': [None]
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -363,7 +363,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': 'heading',
-                'subsections': ['Health Sciences Subsection']
+                'subsections': ['Health Sciences', 'Health Sciences Subsection']
             },
             {
                 'parent': 'article',
@@ -372,7 +372,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences Subsection',
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': ['Health Sciences Subsection']
             },
             {
                 'parent': 'sub-article',
@@ -381,7 +381,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': ['Subseção Ciências da Saúde']
+                'subsections': ['Ciências da Saúde', 'Subseção Ciências da Saúde']
             },
             {
                 'parent': 'sub-article',
@@ -390,7 +390,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Subseção Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': []
+                'subsections': ['Subseção Ciências da Saúde']
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -449,7 +449,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences',
                     'subj_group_type': 'heading',
-                    'subsections': ['Health Sciences Subsection']
+                    'subsections': ['Health Sciences', 'Health Sciences Subsection']
                 },
                 {
                     'parent': 'article',
@@ -458,7 +458,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences Subsection',
                     'subj_group_type': 'heading',
-                    'subsections': []
+                    'subsections': ['Health Sciences Subsection']
                 }
             ],
             "pt": [
@@ -469,7 +469,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': ['Subseção Ciências da Saúde']
+                    'subsections': ['Ciências da Saúde', 'Subseção Ciências da Saúde']
                 },
                 {
                     'parent': 'sub-article',
@@ -478,7 +478,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Subseção Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': []
+                    'subsections': ['Subseção Ciências da Saúde']
                 }
             ]
         }

--- a/tests/sps/models/test_article_toc_sections.py
+++ b/tests/sps/models/test_article_toc_sections.py
@@ -48,7 +48,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': 'heading',
-                'subsections': ['Health Sciences']
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
@@ -57,7 +57,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': ['Ciências da Saúde']
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -109,7 +109,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': None,
-                'subsections': ['Health Sciences']
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
@@ -118,7 +118,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': None,
-                'subsections': ['Ciências da Saúde']
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -173,7 +173,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences',
                     'subj_group_type': 'heading',
-                    'subsections': ['Health Sciences']
+                    'subsections': []
                 }
             ],
             'pt': [
@@ -184,7 +184,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': ['Ciências da Saúde']
+                    'subsections': []
                 }
             ]
         }
@@ -234,7 +234,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': None,
                 'subj_group_type': 'heading',
-                'subsections': [None]
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
@@ -243,7 +243,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': None,
                 'subj_group_type': 'heading',
-                'subsections': [None]
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -363,7 +363,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences',
                 'subj_group_type': 'heading',
-                'subsections': ['Health Sciences', 'Health Sciences Subsection']
+                'subsections': ['Health Sciences Subsection']
             },
             {
                 'parent': 'article',
@@ -372,7 +372,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'en',
                 'section': 'Health Sciences Subsection',
                 'subj_group_type': 'heading',
-                'subsections': ['Health Sciences Subsection']
+                'subsections': []
             },
             {
                 'parent': 'sub-article',
@@ -381,7 +381,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': ['Ciências da Saúde', 'Subseção Ciências da Saúde']
+                'subsections': ['Subseção Ciências da Saúde']
             },
             {
                 'parent': 'sub-article',
@@ -390,7 +390,7 @@ class ArticleTocSectionsTest(TestCase):
                 'parent_lang': 'pt',
                 'section': 'Subseção Ciências da Saúde',
                 'subj_group_type': 'heading',
-                'subsections': ['Subseção Ciências da Saúde']
+                'subsections': []
             }
         ]
         obtained = list(self.article_toc_sections.sections)
@@ -449,7 +449,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences',
                     'subj_group_type': 'heading',
-                    'subsections': ['Health Sciences', 'Health Sciences Subsection']
+                    'subsections': ['Health Sciences Subsection']
                 },
                 {
                     'parent': 'article',
@@ -458,7 +458,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'en',
                     'section': 'Health Sciences Subsection',
                     'subj_group_type': 'heading',
-                    'subsections': ['Health Sciences Subsection']
+                    'subsections': []
                 }
             ],
             "pt": [
@@ -469,7 +469,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': ['Ciências da Saúde', 'Subseção Ciências da Saúde']
+                    'subsections': ['Subseção Ciências da Saúde']
                 },
                 {
                     'parent': 'sub-article',
@@ -478,7 +478,7 @@ class ArticleTocSectionsTest(TestCase):
                     'parent_lang': 'pt',
                     'section': 'Subseção Ciências da Saúde',
                     'subj_group_type': 'heading',
-                    'subsections': ['Subseção Ciências da Saúde']
+                    'subsections': []
                 }
             ]
         }

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -62,29 +62,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Health Sciences, expected Health Sciences",
                 'advice': None,
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
             {
                 'title': 'Document section title validation',
@@ -101,29 +86,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Ciências da Saúde, expected Ciências da Saúde",
                 'advice': None,
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
@@ -224,29 +194,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
             {
                 'title': 'Document section title validation',
@@ -263,29 +218,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Ciências da Saúde, expected Artigo",
                 'advice': 'Provide missing section for language: pt',
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
@@ -350,29 +290,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
             {
                 'title': 'Document section title validation',
@@ -389,29 +314,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Ciências da Saúde, expected Ciências da Saúde",
                 'advice': None,
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
@@ -476,29 +386,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
             {
                 'title': 'Document section title validation',
@@ -515,29 +410,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Ciências da Saúde, expected Artigo",
                 'advice': 'Provide missing section for language: pt',
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
@@ -1181,18 +1061,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Comments, expected ['Comments']",
                 'advice': None,
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'other',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Comments',
-                            'subj_group_type': 'heading',
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'other',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Comments',
+                    'subj_group_type': 'heading',
+                    'subsections': []
+                }
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
@@ -1378,29 +1254,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': 'Got None, expected heading',
                 'advice': "the value for '@subj-group-type' must be heading",
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': None,
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': None,
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': None,
+                    'subsections': []
+                }
             },
             {
                 'title': "Attribute '@subj-group-type' validation",
@@ -1417,29 +1278,14 @@ class ArticleTocSectionsTest(TestCase):
                 'message': 'Got None, expected heading',
                 'advice': "the value for '@subj-group-type' must be heading",
                 'data': {
-                    'en': [
-                        {
-                            'parent': 'article',
-                            'parent_article_type': 'research-article',
-                            'parent_id': None,
-                            'parent_lang': 'en',
-                            'section': 'Health Sciences',
-                            'subj_group_type': None,
-                            'subsections': []
-                        }
-                    ],
-                    'pt': [
-                        {
-                            'parent': 'sub-article',
-                            'parent_article_type': 'translation',
-                            'parent_id': '01',
-                            'parent_lang': 'pt',
-                            'section': 'Ciências da Saúde',
-                            'subj_group_type': None,
-                            'subsections': []
-                        }
-                    ]
-                },
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': None,
+                    'subsections': []
+                }
             },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -70,7 +70,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -81,7 +81,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -109,7 +109,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -120,7 +120,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -232,7 +232,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -243,7 +243,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -271,7 +271,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -282,7 +282,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -358,7 +358,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -369,7 +369,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -397,7 +397,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -408,7 +408,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -484,7 +484,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -495,7 +495,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -523,7 +523,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -534,7 +534,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -648,7 +648,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -657,7 +657,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -668,7 +668,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -677,7 +677,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -708,7 +708,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -717,7 +717,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -728,7 +728,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -737,7 +737,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -768,7 +768,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -777,7 +777,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -788,7 +788,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -797,7 +797,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -827,7 +827,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -836,7 +836,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -847,7 +847,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -856,7 +856,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -937,7 +937,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -946,7 +946,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -957,7 +957,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -966,7 +966,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -997,7 +997,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1006,7 +1006,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -1017,7 +1017,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1026,7 +1026,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -1057,7 +1057,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1066,7 +1066,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -1077,7 +1077,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1086,7 +1086,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -1115,7 +1115,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Health Sciences', 'Public Health']
+                            'subsections': ['Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1124,7 +1124,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -1135,7 +1135,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
+                            'subsections': ['Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1144,7 +1144,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': []
                         }
                     ]
                 },
@@ -1189,7 +1189,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Comments',
                             'subj_group_type': 'heading',
-                            'subsections': ['Comments']
+                            'subsections': []
                         }
                     ]
                 },
@@ -1258,7 +1258,7 @@ class ArticleTocSectionsTest(TestCase):
                 'expected_value': 'only one subject per language',
                 'got_value': 'Health Sciences | Improper Subject',
                 'message': 'Got Health Sciences | Improper Subject, expected only one subject per language',
-                'advice': "Ensure only one subject per language. Current subjects: ['Health Sciences', 'Improper Subject'].",
+                'advice': "One subject per language. Current subjects (en): ['Health Sciences', 'Improper Subject'].",
                 'data': [
                     {
                         'parent': 'article',
@@ -1267,7 +1267,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'en',
                         'section': 'Health Sciences',
                         'subj_group_type': 'heading',
-                        'subsections': ['Health Sciences', 'Improper Subject']
+                        'subsections': ['Improper Subject']
                     },
                     {
                         'parent': 'article',
@@ -1276,7 +1276,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'en',
                         'section': 'Improper Subject',
                         'subj_group_type': None,
-                        'subsections': ['Improper Subject']
+                        'subsections': []
                     }
                 ]
             },
@@ -1293,7 +1293,7 @@ class ArticleTocSectionsTest(TestCase):
                 'expected_value': 'only one subject per language',
                 'got_value': 'Ciências da Saúde | Assunto Indevido',
                 'message': 'Got Ciências da Saúde | Assunto Indevido, expected only one subject per language',
-                'advice': "Ensure only one subject per language. Current subjects: ['Ciências da Saúde', 'Assunto Indevido'].",
+                'advice': "One subject per language. Current subjects (pt): ['Ciências da Saúde', 'Assunto Indevido'].",
                 'data': [
                     {
                         'parent': 'sub-article',
@@ -1302,7 +1302,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'pt',
                         'section': 'Ciências da Saúde',
                         'subj_group_type': 'heading',
-                        'subsections': ['Ciências da Saúde', 'Assunto Indevido']
+                        'subsections': ['Assunto Indevido']
                     },
                     {
                         'parent': 'sub-article',
@@ -1311,7 +1311,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'pt',
                         'section': 'Assunto Indevido',
                         'subj_group_type': None,
-                        'subsections': ['Assunto Indevido']
+                        'subsections': []
                     }
                 ]
             }
@@ -1386,7 +1386,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': None,
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -1397,7 +1397,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': None,
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },
@@ -1425,7 +1425,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': None,
-                            'subsections': ['Health Sciences']
+                            'subsections': []
                         }
                     ],
                     'pt': [
@@ -1436,7 +1436,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': None,
-                            'subsections': ['Ciências da Saúde']
+                            'subsections': []
                         }
                     ]
                 },

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -48,7 +48,7 @@ class ArticleTocSectionsTest(TestCase):
             }
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Document section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -70,7 +70,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -81,13 +81,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document section title validation',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -109,7 +109,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -120,7 +120,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
@@ -165,47 +165,10 @@ class ArticleTocSectionsTest(TestCase):
             "en": "Health Sciences",
             "pt": "Ciências da Saúde"
         }
-        expected = [
-            {
-                'title': 'Article or sub-article section title validation',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
-                'parent_lang': 'es',
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': "<subject>Health Sciences</subject> for 'en' language",
-                'got_value': {},
-                'message': "Got {}, expected <subject>Health Sciences</subject> for 'en' language",
-                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
-                'data': {}
-            },
-            {
-                'title': 'Article or sub-article section title validation',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
-                'parent_lang': 'es',
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': "<subject>Ciências da Saúde</subject> for 'pt' language",
-                'got_value': {},
-                'message': "Got {}, expected <subject>Ciências da Saúde</subject> for 'pt' language",
-                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
-                'data': {}
-            }
-        ]
+
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
-        self.assertEqual(len(obtained), 2)
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(len(obtained), 0)
 
     def test_validate_article_toc_sections_fail_section_obtained_not_in_expected(self):
         self.maxDiff = None
@@ -247,7 +210,7 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Document section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -269,7 +232,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -280,13 +243,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document section title validation',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -308,7 +271,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -319,7 +282,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
@@ -373,7 +336,7 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Document section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -395,7 +358,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -406,13 +369,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document section title validation',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -434,7 +397,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -445,7 +408,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
@@ -499,7 +462,7 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Document section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -521,7 +484,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -532,13 +495,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document section title validation',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -560,7 +523,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Health Sciences']
                         }
                     ],
                     'pt': [
@@ -571,7 +534,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Ciências da Saúde']
                         }
                     ]
                 },
@@ -615,7 +578,7 @@ class ArticleTocSectionsTest(TestCase):
         with self.assertRaises(ValidationExpectedTocSectionsException) as context:
             obtained = list(self.article_toc_sections.validate_article_toc_sections())
 
-        self.assertEqual(str(context.exception), "Function requires a list of expected toc sections.")
+        self.assertEqual(str(context.exception), "Function requires a dict of expected toc sections.")
 
     def test_validade_article_title_is_different_from_section_titles_success(self):
         self.maxDiff = None
@@ -660,7 +623,7 @@ class ArticleTocSectionsTest(TestCase):
 
         expected = [
             {
-                'title': 'Article or sub-article section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -685,7 +648,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -694,7 +657,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -705,7 +668,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -714,13 +677,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Article or sub-article section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -745,7 +708,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -754,7 +717,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -765,7 +728,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -774,13 +737,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -805,7 +768,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -814,7 +777,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -825,7 +788,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -834,13 +797,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -864,7 +827,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -873,7 +836,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -884,7 +847,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -893,7 +856,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
@@ -949,7 +912,7 @@ class ArticleTocSectionsTest(TestCase):
 
         expected = [
             {
-                'title': 'Article or sub-article section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -974,7 +937,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -983,7 +946,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -994,7 +957,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1003,13 +966,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Article or sub-article section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -1034,7 +997,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1043,7 +1006,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -1054,7 +1017,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1063,13 +1026,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -1094,7 +1057,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1103,7 +1066,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -1114,7 +1077,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1123,13 +1086,13 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
             },
             {
-                'title': 'Sub-article (id=01) section title validation',
+                'title': 'Document title must not be similar to section title',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -1152,7 +1115,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Health Sciences',
                             'subj_group_type': 'heading',
-                            'subsections': ['Public Health']
+                            'subsections': ['Health Sciences', 'Public Health']
                         },
                         {
                             'parent': 'article',
@@ -1161,7 +1124,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Public Health',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Public Health']
                         }
                     ],
                     'pt': [
@@ -1172,7 +1135,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Ciências da Saúde',
                             'subj_group_type': 'heading',
-                            'subsections': ['Saúde Pública']
+                            'subsections': ['Ciências da Saúde', 'Saúde Pública']
                         },
                         {
                             'parent': 'sub-article',
@@ -1181,7 +1144,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'pt',
                             'section': 'Saúde Pública',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Saúde Pública']
                         }
                     ]
                 },
@@ -1189,6 +1152,7 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validade_article_title_is_different_from_section_titles())
 
+        self.assertEqual(len(obtained), 4)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -1203,7 +1167,7 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Document section title validation',
                 'parent': 'article',
                 'parent_article_type': 'other',
                 'parent_id': None,
@@ -1225,7 +1189,7 @@ class ArticleTocSectionsTest(TestCase):
                             'parent_lang': 'en',
                             'section': 'Comments',
                             'subj_group_type': 'heading',
-                            'subsections': []
+                            'subsections': ['Comments']
                         }
                     ]
                 },
@@ -1233,11 +1197,11 @@ class ArticleTocSectionsTest(TestCase):
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
+        self.assertEqual(len(obtained), 1)
+
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
-
-        self.assertEqual(len(obtained), 1)
 
     def test_validate_article_toc_sections_more_then_one(self):
         self.maxDiff = None
@@ -1282,7 +1246,7 @@ class ArticleTocSectionsTest(TestCase):
 
         expected = [
             {
-                'title': 'subsection validation',
+                'title': 'Multiple Subjects Validation in Article TOC',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -1294,7 +1258,7 @@ class ArticleTocSectionsTest(TestCase):
                 'expected_value': 'only one subject per language',
                 'got_value': 'Health Sciences | Improper Subject',
                 'message': 'Got Health Sciences | Improper Subject, expected only one subject per language',
-                'advice': 'use the following pattern: <subject>Health Sciences: Improper Subject</subject>',
+                'advice': "Ensure only one subject per language. Current subjects: ['Health Sciences', 'Improper Subject'].",
                 'data': [
                     {
                         'parent': 'article',
@@ -1303,7 +1267,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'en',
                         'section': 'Health Sciences',
                         'subj_group_type': 'heading',
-                        'subsections': ['Improper Subject']
+                        'subsections': ['Health Sciences', 'Improper Subject']
                     },
                     {
                         'parent': 'article',
@@ -1312,12 +1276,12 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'en',
                         'section': 'Improper Subject',
                         'subj_group_type': None,
-                        'subsections': []
+                        'subsections': ['Improper Subject']
                     }
                 ]
             },
             {
-                'title': 'subsection validation',
+                'title': 'Multiple Subjects Validation in Article TOC',
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -1329,7 +1293,7 @@ class ArticleTocSectionsTest(TestCase):
                 'expected_value': 'only one subject per language',
                 'got_value': 'Ciências da Saúde | Assunto Indevido',
                 'message': 'Got Ciências da Saúde | Assunto Indevido, expected only one subject per language',
-                'advice': 'use the following pattern: <subject>Ciências da Saúde: Assunto Indevido</subject>',
+                'advice': "Ensure only one subject per language. Current subjects: ['Ciências da Saúde', 'Assunto Indevido'].",
                 'data': [
                     {
                         'parent': 'sub-article',
@@ -1338,7 +1302,7 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'pt',
                         'section': 'Ciências da Saúde',
                         'subj_group_type': 'heading',
-                        'subsections': ['Assunto Indevido']
+                        'subsections': ['Ciências da Saúde', 'Assunto Indevido']
                     },
                     {
                         'parent': 'sub-article',
@@ -1347,12 +1311,138 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_lang': 'pt',
                         'section': 'Assunto Indevido',
                         'subj_group_type': None,
-                        'subsections': []
+                        'subsections': ['Assunto Indevido']
                     }
                 ]
             }
         ]
-        obtained = list(self.article_toc_sections.validate_article_subsections())
+        obtained = list(self.article_toc_sections.validate_article_section_and_subsection_number())
+
+        self.assertEqual(len(obtained), 2)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_toc_sections_subj_group_type(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título del artículo</article-title>
+                    </title-group>
+                    <article-categories>
+                        <subj-group>
+                            <subject>Health Sciences</subject>
+                        </subj-group>
+                    </article-categories>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="pt">
+                <front-stub>
+                    <article-categories>
+                        <subj-group>
+                            <subject>Ciências da Saúde</subject>
+                        </subj-group>
+                    </article-categories>
+                    <title-group>
+                        <article-title>Article title</article-title>
+                    </title-group>
+                </front-stub>
+            </sub-article>
+            </article>
+            """
+        )
+        self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
+        expected_section = {
+                "en": "Health Sciences",
+                "pt": "Ciências da Saúde"
+            }
+        expected = [
+            {
+                'title': "Attribute '@subj-group-type' validation",
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'subj-group',
+                'sub_item': '@subj-group-type',
+                'validation_type': 'match',
+                'response': 'CRITICAL',
+                'expected_value': 'heading',
+                'got_value': None,
+                'message': 'Got None, expected heading',
+                'advice': "the value for '@subj-group-type' must be heading",
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': None,
+                            'subsections': ['Health Sciences']
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': None,
+                            'subsections': ['Ciências da Saúde']
+                        }
+                    ]
+                },
+            },
+            {
+                'title': "Attribute '@subj-group-type' validation",
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': '@subj-group-type',
+                'validation_type': 'match',
+                'response': 'CRITICAL',
+                'expected_value': 'heading',
+                'got_value': None,
+                'message': 'Got None, expected heading',
+                'advice': "the value for '@subj-group-type' must be heading",
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': None,
+                            'subsections': ['Health Sciences']
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': None,
+                            'subsections': ['Ciências da Saúde']
+                        }
+                    ]
+                },
+            },
+        ]
+        obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
         self.assertEqual(len(obtained), 2)
 

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -150,38 +150,7 @@ class ArticleTocSectionsTest(TestCase):
         }
         expected = [
             {
-                'title': 'Article section title validation',
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': "01",
-                'parent_lang': 'en',
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': ['Health Sciences'],
-                'got_value': None,
-                'message': "Got None, expected ['Health Sciences']",
-                'advice': 'Provide missing section for language: en',
-                'data': {
-                    'en': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': "01",
-                        'parent_lang': 'en',
-                        'text': None
-                    },
-                    'es': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'es',
-                        'text': None
-                    }
-                }
-            },
-            {
-                'title': 'Article section title validation',
+                'title': 'Article or sub-article section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -190,62 +159,16 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'exist',
                 'response': 'CRITICAL',
-                'expected_value': "subject value",
-                'got_value': None,
-                'message': "Got None, expected subject value",
-                'advice': 'Check unexpected section None for language: es',
-                'data': {
-                    'en': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': "01",
-                        'parent_lang': 'en',
-                        'text': None
-                    },
-                    'es': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'es',
-                        'text': None
-                    }
-                }
-            },
-            {
-                'title': 'Article section title validation',
-                'parent': None,
-                'parent_article_type': None,
-                'parent_id': None,
-                'parent_lang': None,
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': ['Ciências da Saúde'],
-                'got_value': None,
-                'message': "Got None, expected ['Ciências da Saúde']",
-                'advice': 'Provide missing section for language: pt',
-                'data': {
-                    'en': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': "01",
-                        'parent_lang': 'en',
-                        'text': None
-                    },
-                    'es': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'es',
-                        'text': None
-                    }
-                }
+                'expected_value': {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']},
+                'got_value': {},
+                'message': "Got {}, expected {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']}",
+                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
+                'data': {}
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
-        self.assertEqual(len(obtained), 3)
+        self.assertEqual(len(obtained), 1)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -610,7 +533,7 @@ class ArticleTocSectionsTest(TestCase):
         expected_section = {}
         expected = [
             {
-                'title': 'Article section title validation',
+                'title': 'Article or sub-article section title validation',
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -620,61 +543,15 @@ class ArticleTocSectionsTest(TestCase):
                 'validation_type': 'exist',
                 'response': 'CRITICAL',
                 'expected_value': "subject value",
-                'got_value': None,
-                'message': 'Got None, expected subject value',
-                'advice': 'Check unexpected section None for language: en',
-                'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': None
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': None
-                    }
-                },
-            },
-            {
-                'title': 'Article section title validation',
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': "01",
-                'parent_lang': 'pt',
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': "subject value",
-                'got_value': None,
-                'message': 'Got None, expected subject value',
-                'advice': 'Check unexpected section None for language: pt',
-                'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': None
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': None
-                    }
-                },
+                'got_value': {},
+                'message': 'Got {}, expected subject value',
+                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
+                'data': {},
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
-        self.assertEqual(len(obtained), 2)
+        self.assertEqual(len(obtained), 1)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -917,7 +794,6 @@ class ArticleTocSectionsTest(TestCase):
     def test_validate_article_toc_sections_to_fix_bug(self):
         self.maxDiff = None
         self.xmltree = xml_utils.get_xml_tree('tests/samples/1518-8787-rsp-56-37.xml')
-
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
              "en": ["Comments"],
@@ -956,3 +832,116 @@ class ArticleTocSectionsTest(TestCase):
                 self.assertDictEqual(obtained[i], item)
 
         self.assertEqual(len(obtained), 1)
+
+    def test_validate_article_toc_sections_more_then_one(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            dtd-version="1.0" article-type="research-article" xml:lang="en">
+            <front>
+                <article-meta>
+                    <title-group>
+                        <article-title>Título del artículo</article-title>
+                    </title-group>
+                    <article-categories>
+                        <subj-group subj-group-type="heading">
+                            <subject>Health Sciences</subject>
+                            <subj-group subj-group-type="heading">
+                                <subject>Improper Subject</subject>
+                            </subj-group>
+                        </subj-group>
+                    </article-categories>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" id="01" xml:lang="pt">
+                <front-stub>
+                    <article-categories>
+                        <subj-group subj-group-type="heading">
+                            <subject>Ciências da Saúde</subject>
+                            <subj-group subj-group-type="heading">
+                                <subject>Assunto Indevido</subject>
+                            </subj-group>
+                        </subj-group>
+                    </article-categories>
+                    <title-group>
+                        <article-title>Article title</article-title>
+                    </title-group>
+                </front-stub>
+            </sub-article>
+            </article>
+            """
+        )
+        self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
+
+        expected = [
+            {
+                'title': 'subsection validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': 'only one subject per language',
+                'got_value': 'Health Sciences | Improper Subject',
+                'message': 'Got Health Sciences | Improper Subject, expected only one subject per language',
+                'advice': 'use the following pattern: <subject>Health Sciences: Improper Subject</subject>',
+                'data': [
+                    {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'en',
+                        'text': 'Health Sciences'
+                    },
+                    {
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'parent_id': None,
+                        'parent_lang': 'en',
+                        'text': 'Improper Subject'
+                    }
+                ]
+            },
+            {
+                'title': 'subsection validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': 'only one subject per language',
+                'got_value': 'Ciências da Saúde | Assunto Indevido',
+                'message': 'Got Ciências da Saúde | Assunto Indevido, expected only one subject per language',
+                'advice': 'use the following pattern: <subject>Ciências da Saúde: Assunto Indevido</subject>',
+                'data': [
+                    {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': '01',
+                        'parent_lang': 'pt',
+                        'text': 'Ciências da Saúde'
+                    },
+                    {
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': '01',
+                        'parent_lang': 'pt',
+                        'text': 'Assunto Indevido'
+                    }
+                ]
+            }
+        ]
+        obtained = list(self.article_toc_sections.validate_article_subsections())
+
+        self.assertEqual(len(obtained), 2)
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -4,6 +4,7 @@ from lxml import etree
 
 from packtools.sps.utils import xml_utils
 from packtools.sps.validation.article_toc_sections import ArticleTocSectionsValidation
+from packtools.sps.validation.exceptions import ValidationExpectedTocSectionsException
 
 
 class ArticleTocSectionsTest(TestCase):
@@ -42,8 +43,8 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
-                "en": ["Health Sciences"],
-                "pt": ["Ciências da Saúde"]
+                "en": "Health Sciences",
+                "pt": "Ciências da Saúde"
             }
         expected = [
             {
@@ -56,25 +57,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'OK',
-                'expected_value': ['Health Sciences'],
+                'expected_value': 'Health Sciences',
                 'got_value': 'Health Sciences',
-                'message': "Got Health Sciences, expected ['Health Sciences']",
+                'message': "Got Health Sciences, expected Health Sciences",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -87,25 +96,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'OK',
-                'expected_value': ['Ciências da Saúde'],
+                'expected_value': 'Ciências da Saúde',
                 'got_value': 'Ciências da Saúde',
-                'message': "Got Ciências da Saúde, expected ['Ciências da Saúde']",
+                'message': "Got Ciências da Saúde, expected Ciências da Saúde",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
@@ -145,8 +162,8 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
-            "en": ["Health Sciences"],
-            "pt": ["Ciências da Saúde"]
+            "en": "Health Sciences",
+            "pt": "Ciências da Saúde"
         }
         expected = [
             {
@@ -159,16 +176,32 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'exist',
                 'response': 'CRITICAL',
-                'expected_value': {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']},
+                'expected_value': "<subject>Health Sciences</subject> for 'en' language",
                 'got_value': {},
-                'message': "Got {}, expected {'en': ['Health Sciences'], 'pt': ['Ciências da Saúde']}",
+                'message': "Got {}, expected <subject>Health Sciences</subject> for 'en' language",
+                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
+                'data': {}
+            },
+            {
+                'title': 'Article or sub-article section title validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'es',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'exist',
+                'response': 'CRITICAL',
+                'expected_value': "<subject>Ciências da Saúde</subject> for 'pt' language",
+                'got_value': {},
+                'message': "Got {}, expected <subject>Ciências da Saúde</subject> for 'pt' language",
                 'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
                 'data': {}
             }
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
-        self.assertEqual(len(obtained), 1)
+        self.assertEqual(len(obtained), 2)
 
         for i, item in enumerate(expected):
             with self.subTest(i):
@@ -209,8 +242,8 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
-            "en": ["Article"],
-            "pt": ["Artigo"]
+            "en": "Article",
+            "pt": "Artigo"
         }
         expected = [
             {
@@ -223,25 +256,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'CRITICAL',
-                'expected_value': ['Article'],
+                'expected_value': 'Article',
                 'got_value': 'Health Sciences',
-                'message': "Got Health Sciences, expected ['Article']",
+                'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -254,25 +295,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'CRITICAL',
-                'expected_value': ['Artigo'],
+                'expected_value': 'Artigo',
                 'got_value': 'Ciências da Saúde',
-                'message': "Got Ciências da Saúde, expected ['Artigo']",
+                'message': "Got Ciências da Saúde, expected Artigo",
                 'advice': 'Provide missing section for language: pt',
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
@@ -319,8 +368,8 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
-            "en": ["Article"],
-            "pt": ["Ciências da Saúde"]
+            "en": "Article",
+            "pt": "Ciências da Saúde"
         }
         expected = [
             {
@@ -333,25 +382,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'CRITICAL',
-                'expected_value': ['Article'],
+                'expected_value': 'Article',
                 'got_value': 'Health Sciences',
-                'message': "Got Health Sciences, expected ['Article']",
+                'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -364,25 +421,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'OK',
-                'expected_value': ['Ciências da Saúde'],
+                'expected_value': 'Ciências da Saúde',
                 'got_value': 'Ciências da Saúde',
-                'message': "Got Ciências da Saúde, expected ['Ciências da Saúde']",
+                'message': "Got Ciências da Saúde, expected Ciências da Saúde",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
@@ -429,8 +494,8 @@ class ArticleTocSectionsTest(TestCase):
         )
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
         expected_section = {
-            "en": ["Article"],
-            "pt": ["Artigo"]
+            "en": "Article",
+            "pt": "Artigo"
         }
         expected = [
             {
@@ -443,25 +508,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'CRITICAL',
-                'expected_value': ['Article'],
+                'expected_value': 'Article',
                 'got_value': 'Health Sciences',
-                'message': "Got Health Sciences, expected ['Article']",
+                'message': "Got Health Sciences, expected Article",
                 'advice': 'Provide missing section for language: en',
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -474,25 +547,33 @@ class ArticleTocSectionsTest(TestCase):
                 'sub_item': 'subject',
                 'validation_type': 'value in list',
                 'response': 'CRITICAL',
-                'expected_value': ['Artigo'],
+                'expected_value': 'Artigo',
                 'got_value': 'Ciências da Saúde',
-                'message': "Got Ciências da Saúde, expected ['Artigo']",
+                'message': "Got Ciências da Saúde, expected Artigo",
                 'advice': 'Provide missing section for language: pt',
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
@@ -529,33 +610,12 @@ class ArticleTocSectionsTest(TestCase):
             </article>
             """
         )
+
         self.article_toc_sections = ArticleTocSectionsValidation(self.xmltree)
-        expected_section = {}
-        expected = [
-            {
-                'title': 'Article or sub-article section title validation',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'item': 'subj-group',
-                'sub_item': 'subject',
-                'validation_type': 'exist',
-                'response': 'CRITICAL',
-                'expected_value': "subject value",
-                'got_value': {},
-                'message': 'Got {}, expected subject value',
-                'advice': 'Provide a subject value for <subj-group subj-group-type="heading">',
-                'data': {},
-            }
-        ]
-        obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
+        with self.assertRaises(ValidationExpectedTocSectionsException) as context:
+            obtained = list(self.article_toc_sections.validate_article_toc_sections())
 
-        self.assertEqual(len(obtained), 1)
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(str(context.exception), "Function requires a list of expected toc sections.")
 
     def test_validade_article_title_is_different_from_section_titles_success(self):
         self.maxDiff = None
@@ -571,7 +631,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
+                            <subj-group subj-group-type="heading">
                                 <subject>Public Health</subject>
                             </subj-group>
                         </subj-group>
@@ -583,7 +643,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
+                            <subj-group subj-group-type="heading">
                                 <subject>Saúde Pública</subject>
                             </subj-group>
                         </subj-group>
@@ -617,20 +677,106 @@ class ArticleTocSectionsTest(TestCase):
                            "section titles)",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
+                },
+            },
+            {
+                'title': 'Article or sub-article section title validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': "'Health Sciences Studies' (article title) different from 'Public Health' ("
+                                  "section titles)",
+                'got_value': "article title: 'Health Sciences Studies', section titles: 'Public Health'",
+                'message': "Got article title: 'Health Sciences Studies', section titles: 'Public Health', "
+                           "expected 'Health Sciences Studies' (article title) different from 'Public Health' ("
+                           "section titles)",
+                'advice': None,
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -651,25 +797,111 @@ class ArticleTocSectionsTest(TestCase):
                            "'Ciências da Saúde' (section titles)",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
+                },
+            },
+            {
+                'title': 'Sub-article (id=01) section title validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': "'Estudos sobre Ciências da Saúde' (article title) different from 'Saúde Pública' (section titles)",
+                'got_value': "article title: 'Estudos sobre Ciências da Saúde', section titles: 'Saúde Pública'",
+                'message': "Got article title: 'Estudos sobre Ciências da Saúde', section titles: 'Saúde Pública', "
+                           "expected 'Estudos sobre Ciências da Saúde' (article title) different from "
+                           "'Saúde Pública' (section titles)",
+                'advice': None,
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
         obtained = list(self.article_toc_sections.validade_article_title_is_different_from_section_titles())
 
+        self.assertEqual(len(obtained), 4)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
@@ -688,7 +920,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="sub-heading">
+                            <subj-group subj-group-type="heading">
                                 <subject>Public Health</subject>
                             </subj-group>
                         </subj-group>
@@ -700,7 +932,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="sub-heading">
+                            <subj-group subj-group-type="heading">
                                 <subject>Saúde Pública</subject>
                             </subj-group>
                         </subj-group>
@@ -734,20 +966,106 @@ class ArticleTocSectionsTest(TestCase):
                            "section titles)",
                 'advice': "Provide different titles for article and section (subj-group[@subj-group-type='heading']/subject)",
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
+                },
+            },
+            {
+                'title': 'Article or sub-article section title validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': "'Health Sciences' (article title) different from 'Public Health' ("
+                                  "section titles)",
+                'got_value': "article title: 'Health Sciences', section titles: 'Public Health'",
+                'message': "Got article title: 'Health Sciences', section titles: 'Public Health', "
+                           "expected 'Health Sciences' (article title) different from 'Public Health' ("
+                           "section titles)",
+                'advice': None,
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
             {
@@ -768,20 +1086,104 @@ class ArticleTocSectionsTest(TestCase):
                            "'Ciências da Saúde' (section titles)",
                 'advice': "Provide different titles for article and section (subj-group[@subj-group-type='heading']/subject)",
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'research-article',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Health Sciences'
-                    },
-                    'pt': {
-                        'parent': 'sub-article',
-                        'parent_article_type': 'translation',
-                        'parent_id': '01',
-                        'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
+                },
+            },
+            {
+                'title': 'Sub-article (id=01) section title validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': "'Ciências da Saúde' (article title) different from 'Saúde Pública' (section titles)",
+                'got_value': "article title: 'Ciências da Saúde', section titles: 'Saúde Pública'",
+                'message': "Got article title: 'Ciências da Saúde', section titles: 'Saúde Pública', expected 'Ciências da Saúde' (article title) different from "
+                           "'Saúde Pública' (section titles)",
+                'advice': None,
+                'data': {
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Health Sciences',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Public Health']
+                        },
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'research-article',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Public Health',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ],
+                    'pt': [
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Ciências da Saúde',
+                            'subj_group_type': 'heading',
+                            'subsections': ['Saúde Pública']
+                        },
+                        {
+                            'parent': 'sub-article',
+                            'parent_article_type': 'translation',
+                            'parent_id': '01',
+                            'parent_lang': 'pt',
+                            'section': 'Saúde Pública',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             },
         ]
@@ -815,13 +1217,17 @@ class ArticleTocSectionsTest(TestCase):
                 'message': "Got Comments, expected ['Comments']",
                 'advice': None,
                 'data': {
-                    'en': {
-                        'parent': 'article',
-                        'parent_article_type': 'other',
-                        'parent_id': None,
-                        'parent_lang': 'en',
-                        'text': 'Comments'
-                    }
+                    'en': [
+                        {
+                            'parent': 'article',
+                            'parent_article_type': 'other',
+                            'parent_id': None,
+                            'parent_lang': 'en',
+                            'section': 'Comments',
+                            'subj_group_type': 'heading',
+                            'subsections': []
+                        }
+                    ]
                 },
             }
         ]
@@ -847,7 +1253,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Health Sciences</subject>
-                            <subj-group subj-group-type="heading">
+                            <subj-group>
                                 <subject>Improper Subject</subject>
                             </subj-group>
                         </subj-group>
@@ -859,7 +1265,7 @@ class ArticleTocSectionsTest(TestCase):
                     <article-categories>
                         <subj-group subj-group-type="heading">
                             <subject>Ciências da Saúde</subject>
-                            <subj-group subj-group-type="heading">
+                            <subj-group>
                                 <subject>Assunto Indevido</subject>
                             </subj-group>
                         </subj-group>
@@ -895,14 +1301,18 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_article_type': 'research-article',
                         'parent_id': None,
                         'parent_lang': 'en',
-                        'text': 'Health Sciences'
+                        'section': 'Health Sciences',
+                        'subj_group_type': 'heading',
+                        'subsections': ['Improper Subject']
                     },
                     {
                         'parent': 'article',
                         'parent_article_type': 'research-article',
                         'parent_id': None,
                         'parent_lang': 'en',
-                        'text': 'Improper Subject'
+                        'section': 'Improper Subject',
+                        'subj_group_type': None,
+                        'subsections': []
                     }
                 ]
             },
@@ -926,14 +1336,18 @@ class ArticleTocSectionsTest(TestCase):
                         'parent_article_type': 'translation',
                         'parent_id': '01',
                         'parent_lang': 'pt',
-                        'text': 'Ciências da Saúde'
+                        'section': 'Ciências da Saúde',
+                        'subj_group_type': 'heading',
+                        'subsections': ['Assunto Indevido']
                     },
                     {
                         'parent': 'sub-article',
                         'parent_article_type': 'translation',
                         'parent_id': '01',
                         'parent_lang': 'pt',
-                        'text': 'Assunto Indevido'
+                        'section': 'Assunto Indevido',
+                        'subj_group_type': None,
+                        'subsections': []
                     }
                 ]
             }

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -1122,7 +1122,7 @@ class ArticleTocSectionsTest(TestCase):
 
         expected = [
             {
-                'title': 'Multiple Subjects Validation in Article TOC',
+                'title': "Exceding subject-group/subject",
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
@@ -1157,7 +1157,7 @@ class ArticleTocSectionsTest(TestCase):
                 ]
             },
             {
-                'title': 'Multiple Subjects Validation in Article TOC',
+                'title': "Exceding subject-group/subject",
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
                 'parent_id': '01',
@@ -1264,6 +1264,30 @@ class ArticleTocSectionsTest(TestCase):
                 }
             },
             {
+                'title': 'Document section title validation',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': 'Health Sciences',
+                'got_value': 'Health Sciences',
+                'message': 'Got Health Sciences, expected Health Sciences',
+                'advice': None,
+                'data': {
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'section': 'Health Sciences',
+                    'subj_group_type': None,
+                    'subsections': []
+                 }
+            },
+            {
                 'title': "Attribute '@subj-group-type' validation",
                 'parent': 'sub-article',
                 'parent_article_type': 'translation',
@@ -1287,10 +1311,34 @@ class ArticleTocSectionsTest(TestCase):
                     'subsections': []
                 }
             },
+            {
+                'title': 'Document section title validation',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': '01',
+                'parent_lang': 'pt',
+                'item': 'subj-group',
+                'sub_item': 'subject',
+                'validation_type': 'value in list',
+                'response': 'OK',
+                'expected_value': 'Ciências da Saúde',
+                'got_value': 'Ciências da Saúde',
+                'message': 'Got Ciências da Saúde, expected Ciências da Saúde',
+                'advice': None,
+                'data': {
+                    'parent': 'sub-article',
+                    'parent_article_type': 'translation',
+                    'parent_id': '01',
+                    'parent_lang': 'pt',
+                    'section': 'Ciências da Saúde',
+                    'subj_group_type': None,
+                    'subsections': []
+                }
+            },
         ]
         obtained = list(self.article_toc_sections.validate_article_toc_sections(expected_section))
 
-        self.assertEqual(len(obtained), 2)
+        self.assertEqual(len(obtained), 4)
 
         for i, item in enumerate(expected):
             with self.subTest(i):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma nova funcionalidade de validação para garantir que cada idioma em um artigo contenha apenas um `subject` dentro das subseções (subj-group). Ele soluciona o problema de múltiplos `subjects` sendo associados ao mesmo idioma, o que não é permitido. A validação é implementada na função `validate_article_subsections`, que gera mensagens de erro detalhadas quando múltiplos `subject` são encontrados, oferecendo sugestões de como corrigir o formato.

#### Onde a revisão poderia começar?
Sugiro começar a leitura do código pelos seguintes arquivos e locais:

Arquivo de validação: Localize a função `validate_article_subsections` dentro do arquivo onde as validações do artigo são implementadas.
Arquivo de testes: Verifique o método `test_validate_article_toc_sections_more_then_one` no arquivo de testes para entender como a validação é testada.

#### Como este poderia ser testado manualmente?
Para testar manualmente, siga os passos abaixo:

1. Carregue um arquivo XML de artigo que contenha múltiplos sujeitos por idioma.
2. Execute o script de validação que inclui a função `validate_article_subsections`.
3. Verifique as saídas geradas, confirmando que a validação identifica corretamente os casos com mais de um `subject` por idioma e que as mensagens de erro fornecem o formato sugerido para correção.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA. 

#### Quais são tickets relevantes?
NA.

### Referências
NA.
