### PR TITLE
Corrige a criação do elemento pub-date (pub) em XMLWithPre

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -843,8 +843,11 @@ class XMLWithPre:
                 "article-id",
             )
             for sibling_name in pub_date_preceding_siblings:
-                self.xmltree.find(f".//article-meta/{sibling_name}").append(node)
-                break
+                try:
+                    self.xmltree.find(f".//article-meta/{sibling_name}").addnext(node)
+                    break
+                except AttributeError:
+                    continue
 
         if node is not None:
             try:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a criação do elemento pub-date (pub) em XMLWithPre.
O defeito era que o pub-date estava sendo criado dentro de pub-date existente:
Incorreto
```xml
 <pub-date date-type="collection" publication-format="electronic">
        <month>04</month>
        <year>2006</year>
      <pub-date date-type="pub" publication-format="electronic"><day>06</day><month>09</month><year>2024</year></pub-date></pub-date>
```
correto:
```xml
 <pub-date date-type="collection" publication-format="electronic">
        <month>04</month>
        <year>2006</year>
</pub-date>
<pub-date date-type="pub" publication-format="electronic">
    <day>06</day><month>09</month><year>2024</year>
</pub-date>
```



#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando uma classe XMLWithPre um XML que não contém pub-date do tipo pub :

```python
for xml_with_pre in XMLWithPre.create(path=xml_path):
    xml_with_pre.article_pubication_date = {
        "year": 2020,
        "month": 1,
        "day": 1,
    }
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
