### PR TITLE
Related article model review

### DIFF
--- a/packtools/sps/models/v2/related_articles.py
+++ b/packtools/sps/models/v2/related_articles.py
@@ -1,0 +1,67 @@
+"""
+<related-article ext-link-type="doi" id="A01" related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">
+Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en
+<italic>El coraje de la verdad</italic>
+de Foucault.
+<bold>Trans/form/ação</bold>
+: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.
+</related-article>
+"""
+
+from packtools.sps.utils.xml_utils import put_parent_context, process_subtags
+
+
+class RelatedArticle:
+    def __init__(self, related_article_node):
+        self.related_article_node = related_article_node
+        self.ext_link_type = self.related_article_node.get("ext-link-type")
+        self.related_article_type = self.related_article_node.get("related-article-type")
+        self.id = self.related_article_node.get("id")
+        self.href = self.related_article_node.get("{http://www.w3.org/1999/xlink}href")
+        self.text = process_subtags(self.related_article_node)
+
+    def data(self):
+        return {
+            "ext-link-type": self.ext_link_type,
+            "id": self.id,
+            "related-article-type": self.related_article_type,
+            "href": self.href,
+            "text": self.text
+        }
+
+
+class RelatedArticlesByNode:
+    def __init__(self, node):
+        self.node = node
+        self.node = node
+        self.parent = self.node.tag
+        self.parent_id = self.node.get("id")
+        self.article_type = node.get("article-type")
+        self.lang = self.node.get("{http://www.w3.org/XML/1998/namespace}lang")
+
+    def related_articles(self):
+        if self.parent == "article":
+            path = ".//article-meta//related-article"
+        else:
+            path = ".//front-stub//related-article"
+        for related_article in self.node.xpath(path):
+            data = RelatedArticle(related_article).data()
+            yield put_parent_context(
+                data, self.lang, self.article_type, self.parent, self.parent_id
+            )
+
+
+class RelatedArticles:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def article(self):
+        yield from RelatedArticlesByNode(self.xml_tree.find(".")).related_articles()
+
+    def sub_articles(self):
+        for sub_article in self.xml_tree.xpath(".//sub-article"):
+            yield from RelatedArticlesByNode(sub_article).related_articles()
+
+    def related_articles(self):
+        yield from self.article()
+        yield from self.sub_articles()

--- a/tests/sps/models/v2/test_related_articles.py
+++ b/tests/sps/models/v2/test_related_articles.py
@@ -1,0 +1,154 @@
+"""
+<related-article ext-link-type="doi" id="A01" related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">
+Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en
+<italic>El coraje de la verdad</italic>
+de Foucault.
+<bold>Trans/form/ação</bold>
+: revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.
+</related-article>
+"""
+
+from unittest import TestCase
+
+from packtools.sps.utils import xml_utils
+from packtools.sps.models.v2.related_articles import RelatedArticle, RelatedArticlesByNode, RelatedArticles
+
+
+class RelatedArticleTest(TestCase):
+    def test_related_article(self):
+        xml = """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+            <front>
+              <related-article ext-link-type="doi" id="A01" related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">
+                Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en
+                <italic>El coraje de la verdad</italic>
+                de Foucault.
+                <bold>Trans/form/ação</bold>
+                : revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.
+                </related-article>
+                </front>
+            </article>
+            """
+        obtained = RelatedArticle(xml_utils.get_xml_tree(xml).xpath(".//related-article")[0]).data()
+        expected = {
+            "ext-link-type": "doi",
+            "id": "A01",
+            "related-article-type": "commentary-article",
+            "href": "10.1590/0101-3173.2022.v45n1.p139",
+            "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
+                    "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
+                    "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+        }
+        self.assertDictEqual(obtained, expected)
+
+
+class RelatedArticlesByNodeTest(TestCase):
+    def test_related_articles(self):
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            article-type="article-commentary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            <front>
+            <article-meta>
+            <related-article ext-link-type="doi" id="A01" related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">
+            Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de Glucksmann en
+            <italic>El coraje de la verdad</italic>
+            de Foucault.
+            <bold>Trans/form/ação</bold>
+            : revista de Filosofia da Unesp, v. 45, n. 1, p. 139-158, 2022.
+            </related-article>
+            </article-meta>
+            </front>
+            </article>
+            """
+        obtained = list(RelatedArticlesByNode(xml_utils.get_xml_tree(xml).find(".")).related_articles())
+        expected = [
+            {
+                "parent": "article",
+                "parent_article_type": "article-commentary",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "ext-link-type": "doi",
+                "id": "A01",
+                "related-article-type": "commentary-article",
+                "href": "10.1590/0101-3173.2022.v45n1.p139",
+                "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
+                        "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
+                        "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class RelatedArticlesTest(TestCase):
+    def setUp(self):
+        self.xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/related-article/varias_erratas.xml")
+
+    def test_article(self):
+        obtained = list(RelatedArticles(self.xml_tree).article())
+        expected = [
+            {
+                'ext-link-type': 'doi',
+                'href': '10.1590/s1413-65382620000100001',
+                'id': 'RA1',
+                'parent': 'article',
+                'parent_article_type': 'correction',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'related-article-type': 'corrected-article',
+                'text': ''
+            },
+            {
+                'ext-link-type': 'doi',
+                'href': '10.1590/s1413-65382620000100009',
+                'id': 'RA9',
+                'parent': 'article',
+                'parent_article_type': 'correction',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'related-article-type': 'corrected-article',
+                'text': ''
+            },
+
+        ]
+        self.assertEqual(len(obtained), 9)
+        self.assertDictEqual(obtained[0], expected[0])
+        self.assertDictEqual(obtained[8], expected[1])
+
+    def test_sub_articles(self):
+        obtained = list(RelatedArticles(self.xml_tree).sub_articles())
+        expected = [
+            {
+                'ext-link-type': 'doi',
+                'href': '10.1590/s1413-65382620000100001',
+                'id': 'RA10',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': "s1",
+                'parent_lang': 'en',
+                'related-article-type': 'corrected-article',
+                'text': ''
+            },
+            {
+                'ext-link-type': 'doi',
+                'href': '10.1590/s1413-65382620000100009',
+                'id': 'RA18',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': "s1",
+                'parent_lang': 'en',
+                'related-article-type': 'corrected-article',
+                'text': ''
+            },
+
+        ]
+        self.assertEqual(len(obtained), 9)
+        self.assertDictEqual(obtained[0], expected[0])
+        self.assertDictEqual(obtained[8], expected[1])
+
+    def test_related_articles(self):
+        obtained = list(RelatedArticles(self.xml_tree).related_articles())
+
+        self.assertEqual(len(obtained), 18)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR introduz um modelo para representar o elemento `<related-article>` em documentos XML. A implementação inclui classes que extraem e estruturam informações dos artigos relacionados, como `ext-link-type`, `related-article-type`, `id,` `href`, e o texto contido nas subtags. O objetivo é padronizar a forma como os dados de artigos relacionados são obtidos, facilitando a manipulação e utilização dessas informações em diferentes partes do sistema.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/v2/test_related_articles.py
`
#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

