### PR TITLE
Refactor: article notes (fn-group / author-notes)

### DIFF
--- a/packtools/sps/models/v2/notes.py
+++ b/packtools/sps/models/v2/notes.py
@@ -1,0 +1,113 @@
+from packtools.sps.utils.xml_utils import process_subtags, put_parent_context
+
+
+class Fn:
+    def __init__(self, fn_node):
+        self.fn_node = fn_node
+        self.fn_id = self.fn_node.get("id")
+        self.fn_type = self.fn_node.get("fn-type")
+        self.fn_label = self.fn_node.findtext("label")
+        self.fn_text = process_subtags(self.fn_node)
+
+    def data(self):
+        return {
+            "fn_id": self.fn_id,
+            "fn_type": self.fn_type,
+            "fn_label": self.fn_label,
+            "fn_text": self.fn_text
+        }
+
+
+class Fns:
+    def __init__(self, node):
+        self.node = node
+
+    def fns(self):
+        for fn_node in self.node.xpath(".//fn"):
+            fn = Fn(fn_node)
+            yield fn.data()
+
+
+class FnGroup:
+    def __init__(self, node):
+        self.node = node
+
+    def fn_group(self):
+        for data in Fns(self.node).fns():
+            data["fn_parent"] = "fn-group"
+            yield data
+
+
+class FnGroups:
+    def __init__(self, node):
+        self.node = node
+        self.parent = node.tag
+        self.parent_id = node.get("id")
+        self.parent_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
+        self.parent_article_type = self.node.get("article-type")
+
+    def fn_groups(self):
+        for fn_group in self.node.xpath(".//fn-group"):
+            data = {
+                "fns": [fn for fn in FnGroup(fn_group).fn_group()]
+            }
+            yield put_parent_context(data, self.parent_lang, self.parent_article_type, self.parent, self.parent_id)
+
+
+class AuthorNote:
+    def __init__(self, node):
+        self.node = node
+
+    def author_note(self):
+        for data in Fns(self.node).fns():
+            data["fn_parent"] = "author-notes"
+            yield data
+
+
+class AuthorNotes:
+    def __init__(self, node):
+        self.node = node
+        self.parent = node.tag
+        self.parent_id = node.get("id")
+        self.parent_lang = node.get("{http://www.w3.org/XML/1998/namespace}lang")
+        self.parent_article_type = self.node.get("article-type")
+
+    def author_notes(self):
+        for author_note in self.node.xpath(".//author-notes"):
+            data = {
+                "corresp": process_subtags(author_note.find("corresp")),
+                "corresp_label": process_subtags(author_note.find("corresp/label")),
+                "fns": [fn for fn in AuthorNote(author_note).author_note()]
+            }
+            yield put_parent_context(data, self.parent_lang, self.parent_article_type, self.parent, self.parent_id)
+
+
+class ArticleNotes:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    def article_author_notes(self):
+        yield from AuthorNotes(self.xml_tree.find(".")).author_notes()
+
+    def article_fn_groups_notes(self):
+        yield from FnGroups(self.xml_tree.find(".")).fn_groups()
+
+    def article_notes(self):
+        yield from self.article_fn_groups_notes()
+        yield from self.article_author_notes()
+
+    def sub_article_author_notes(self):
+        for sub_article in self.xml_tree.xpath(".//sub-article"):
+            yield from AuthorNotes(sub_article).author_notes()
+
+    def sub_article_fn_groups_notes(self):
+        for sub_article in self.xml_tree.xpath(".//sub-article"):
+            yield from FnGroups(sub_article).fn_groups()
+
+    def sub_article_notes(self):
+        yield from self.sub_article_fn_groups_notes()
+        yield from self.sub_article_author_notes()
+
+    def all_notes(self):
+        yield from self.article_notes()
+        yield from self.sub_article_notes()

--- a/packtools/sps/models/v2/notes.py
+++ b/packtools/sps/models/v2/notes.py
@@ -4,14 +4,13 @@ from packtools.sps.utils.xml_utils import process_subtags, put_parent_context
 class BaseNoteGroup:
     def __init__(self, fn_parent_node):
         self.fn_parent_node = fn_parent_node
-        self.fn_parent_tag_name = fn_parent_node.tag
 
     @property
     def fns(self):
         for fn_node in self.fn_parent_node.xpath(".//fn"):
             fn = Fn(fn_node)
             data = fn.data
-            data["fn_parent"] = self.fn_parent_tag_name
+            data["fn_parent"] = self.fn_parent_node.tag
             yield data
 
     @property
@@ -45,7 +44,7 @@ class Fn:
         self.type = self.node.get("fn-type")
         self.label = self.node.findtext("label")
         self.text = process_subtags(self.node)
-        self.has_bold = bool(self.node.findtext("bold"))
+        self.bold = self.node.findtext("bold")
 
     @property
     def data(self):
@@ -54,7 +53,7 @@ class Fn:
             "fn_type": self.type,
             "fn_label": self.label,
             "fn_text": self.text,
-            "fn_has_bold": self.has_bold
+            "fn_bold": self.bold
         }
 
 

--- a/tests/sps/models/v2/test_notes.py
+++ b/tests/sps/models/v2/test_notes.py
@@ -43,8 +43,8 @@ class FnTest(TestCase):
     def test_text(self):
         self.assertEqual(self.fn.text, "*1Os autores declaram não haver conflito de interesses.")
 
-    def test_has_bold(self):
-        self.assertTrue(self.fn.has_bold)
+    def test_bold(self):
+        self.assertTrue(self.fn.bold)
 
     def test_fn_data(self):
         self.assertDictEqual(
@@ -54,7 +54,7 @@ class FnTest(TestCase):
                 "fn_type": "conflict",
                 "fn_label": "1",
                 "fn_text": "*1Os autores declaram não haver conflito de interesses.",
-                "fn_has_bold": True
+                "fn_bold": "*"
             }
         )
 
@@ -91,7 +91,7 @@ class FnGroupTest(TestCase):
                 'fn_label': None,
                 'fn_type': 'other',
                 'fn_parent': 'fn-group',
-                'fn_has_bold': False
+                'fn_bold': None
             },
             {
                 'fn_id': 'fn3',
@@ -100,7 +100,7 @@ class FnGroupTest(TestCase):
                 'fn_label': None,
                 'fn_type': 'other',
                 'fn_parent': 'fn-group',
-                'fn_has_bold': False
+                'fn_bold': None
             },
             {
                 'fn_id': 'fn4',
@@ -109,7 +109,7 @@ class FnGroupTest(TestCase):
                 'fn_label': None,
                 'fn_type': 'other',
                 'fn_parent': 'fn-group',
-                'fn_has_bold': False
+                'fn_bold': None
             }
         ]
         for i, item in enumerate(obtained):
@@ -158,7 +158,7 @@ class FnGroupsTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                     {
                         'fn_id': 'fn3',
@@ -167,7 +167,7 @@ class FnGroupsTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                     {
                         'fn_id': 'fn4',
@@ -176,7 +176,7 @@ class FnGroupsTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     }
                 ]
             }
@@ -219,7 +219,7 @@ class AuthorNoteTest(TestCase):
                 'fn_parent': 'author-notes',
                 'fn_text': '1Os autores declaram não haver conflito de interesses.',
                 'fn_type': 'conflict',
-                'fn_has_bold': False
+                'fn_bold': None
             }
         ]
         for i, item in enumerate(obtained):
@@ -285,7 +285,7 @@ class AuthorNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': '1Os autores declaram não haver conflito de interesses.',
                         'fn_type': 'conflict',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                 ]
             },
@@ -304,7 +304,7 @@ class AuthorNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
                         'fn_type': 'coi-statement',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                     {
                         'fn_id': None,
@@ -312,7 +312,7 @@ class AuthorNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
                         'fn_type': 'equal',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     }
                 ]
             }
@@ -392,7 +392,7 @@ class ArticleNotesTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': True
+                        'fn_bold': "A)"
                     },
                     {
                         'fn_id': 'fn3',
@@ -401,7 +401,7 @@ class ArticleNotesTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                     {
                         'fn_id': 'fn4',
@@ -410,7 +410,7 @@ class ArticleNotesTest(TestCase):
                         'fn_label': None,
                         'fn_type': 'other',
                         'fn_parent': 'fn-group',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     }
                 ]
             },
@@ -431,7 +431,7 @@ class ArticleNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': '1Os autores declaram não haver conflito de interesses.',
                         'fn_type': 'conflict',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                 ]
             },
@@ -450,7 +450,7 @@ class ArticleNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
                         'fn_type': 'coi-statement',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     },
                     {
                         'fn_id': None,
@@ -458,7 +458,7 @@ class ArticleNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
                         'fn_type': 'equal',
-                        'fn_has_bold': False
+                        'fn_bold': None
                     }
                 ]
             }

--- a/tests/sps/models/v2/test_notes.py
+++ b/tests/sps/models/v2/test_notes.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from lxml import etree
 
-from packtools.sps.models.v2.notes import Fn, Fns, FnGroup, FnGroups, AuthorNote, AuthorNotes, ArticleNotes
+from packtools.sps.models.v2.notes import Fn, FnGroup, FnGroups, AuthorNote, AuthorNotes, ArticleNotes
 
 
 class FnTest(TestCase):
@@ -19,6 +19,7 @@ class FnTest(TestCase):
             '<email>roseanap@gmail.com</email>'
             '</corresp>'
             '<fn id="fn_01" fn-type="conflict">'
+            '<bold>*</bold>'
             '<label>1</label>'
             '<p>Os autores declaram não haver conflito de interesses.</p>'
             '</fn>'
@@ -30,80 +31,32 @@ class FnTest(TestCase):
         xmltree = etree.fromstring(xml)
         self.fn = Fn(xmltree.xpath(".//fn")[0])
 
-    def test_fn_id(self):
-        self.assertEqual(self.fn.fn_id, "fn_01")
+    def test_id(self):
+        self.assertEqual(self.fn.id, "fn_01")
 
-    def test_fn_type(self):
-        self.assertEqual(self.fn.fn_type, "conflict")
+    def test_type(self):
+        self.assertEqual(self.fn.type, "conflict")
 
-    def test_fn_label(self):
-        self.assertEqual(self.fn.fn_label, "1")
+    def test_label(self):
+        self.assertEqual(self.fn.label, "1")
 
-    def test_fn_text(self):
-        self.assertEqual(self.fn.fn_text, "1Os autores declaram não haver conflito de interesses.")
+    def test_text(self):
+        self.assertEqual(self.fn.text, "*1Os autores declaram não haver conflito de interesses.")
+
+    def test_has_bold(self):
+        self.assertTrue(self.fn.has_bold)
 
     def test_fn_data(self):
         self.assertDictEqual(
-            self.fn.data(),
+            self.fn.data,
             {
                 "fn_id": "fn_01",
                 "fn_type": "conflict",
                 "fn_label": "1",
-                "fn_text": "1Os autores declaram não haver conflito de interesses."
+                "fn_text": "*1Os autores declaram não haver conflito de interesses.",
+                "fn_has_bold": True
             }
         )
-
-
-class FnsTest(TestCase):
-    def setUp(self):
-        xml = (
-            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            '<back>'
-            '<fn-group>'
-            '<title>Highlights: </title>'
-            '<fn fn-type="other" id="fn2">'
-            '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
-            '</fn>'
-            '<fn fn-type="other" id="fn3">'
-            '<p>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</p>'
-            '</fn>'
-            '<fn fn-type="other" id="fn4">'
-            '<p>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</p>'
-            '</fn>'
-            '</fn-group>'
-            '</back>'
-            '</article>'
-        )
-        self.xml_tree = etree.fromstring(xml)
-
-    def test_fns(self):
-        obtained = list(Fns(self.xml_tree).fns())
-        expected = [
-            {
-                'fn_id': 'fn2',
-                'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
-                'fn_label': None,
-                'fn_type': 'other'
-            },
-            {
-                'fn_id': 'fn3',
-                'fn_text': 'The LED lamp switches on and off automatically, controls the battery charge and indicates '
-                           'the operating status of the system.',
-                'fn_label': None,
-                'fn_type': 'other'
-            },
-            {
-                'fn_id': 'fn4',
-                'fn_text': 'The LED lamp is a superior substitute for the standard fluorescent lamps used in '
-                           'conventional light traps.',
-                'fn_label': None,
-                'fn_type': 'other'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(item, expected[i])
 
 
 class FnGroupTest(TestCase):
@@ -130,14 +83,15 @@ class FnGroupTest(TestCase):
         self.xml_tree = etree.fromstring(xml)
 
     def test_fn_group(self):
-        obtained = list(FnGroup(self.xml_tree.xpath(".//fn-group")[0]).fn_group())
+        obtained = list(FnGroup(self.xml_tree.xpath(".//fn-group")[0]).fns)
         expected = [
             {
                 'fn_id': 'fn2',
                 'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
                 'fn_label': None,
                 'fn_type': 'other',
-                'fn_parent': 'fn-group'
+                'fn_parent': 'fn-group',
+                'fn_has_bold': False
             },
             {
                 'fn_id': 'fn3',
@@ -145,7 +99,8 @@ class FnGroupTest(TestCase):
                            'the operating status of the system.',
                 'fn_label': None,
                 'fn_type': 'other',
-                'fn_parent': 'fn-group'
+                'fn_parent': 'fn-group',
+                'fn_has_bold': False
             },
             {
                 'fn_id': 'fn4',
@@ -153,7 +108,8 @@ class FnGroupTest(TestCase):
                            'conventional light traps.',
                 'fn_label': None,
                 'fn_type': 'other',
-                'fn_parent': 'fn-group'
+                'fn_parent': 'fn-group',
+                'fn_has_bold': False
             }
         ]
         for i, item in enumerate(obtained):
@@ -186,20 +142,23 @@ class FnGroupsTest(TestCase):
 
     def test_fn_groups(self):
         self.maxDiff = None
-        obtained = list(FnGroups(self.xml_tree.find(".")).fn_groups())
+        obtained = list(FnGroups(self.xml_tree.find(".")).items)
         expected = [
             {
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'pt',
+                'label': None,
+                'title': 'Highlights: ',
                 'fns': [
                     {
                         'fn_id': 'fn2',
                         'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': False
                     },
                     {
                         'fn_id': 'fn3',
@@ -207,7 +166,8 @@ class FnGroupsTest(TestCase):
                                    'the operating status of the system.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': False
                     },
                     {
                         'fn_id': 'fn4',
@@ -215,7 +175,8 @@ class FnGroupsTest(TestCase):
                                    'conventional light traps.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': False
                     }
                 ]
             }
@@ -250,7 +211,7 @@ class AuthorNoteTest(TestCase):
         self.xml_tree = etree.fromstring(xml)
 
     def test_author_note(self):
-        obtained = list(AuthorNote(self.xml_tree.xpath(".//author-notes")[0]).author_note())
+        obtained = list(AuthorNote(self.xml_tree.xpath(".//author-notes")[0]).fns)
         expected = [
             {
                 'fn_id': 'fn_01',
@@ -258,6 +219,7 @@ class AuthorNoteTest(TestCase):
                 'fn_parent': 'author-notes',
                 'fn_text': '1Os autores declaram não haver conflito de interesses.',
                 'fn_type': 'conflict',
+                'fn_has_bold': False
             }
         ]
         for i, item in enumerate(obtained):
@@ -304,7 +266,7 @@ class AuthorNotesTest(TestCase):
 
     def test_author_notes(self):
         self.maxDiff = None
-        obtained = list(AuthorNotes(self.xml_tree.find(".")).author_notes())
+        obtained = list(AuthorNotes(self.xml_tree.find(".")).items)
         expected = [
             {
                 'parent': 'article',
@@ -323,6 +285,7 @@ class AuthorNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': '1Os autores declaram não haver conflito de interesses.',
                         'fn_type': 'conflict',
+                        'fn_has_bold': False
                     },
                 ]
             },
@@ -340,14 +303,16 @@ class AuthorNotesTest(TestCase):
                         'fn_label': None,
                         'fn_parent': 'author-notes',
                         'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
-                        'fn_type': 'coi-statement'
+                        'fn_type': 'coi-statement',
+                        'fn_has_bold': False
                     },
                     {
                         'fn_id': None,
                         'fn_label': None,
                         'fn_parent': 'author-notes',
                         'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
-                        'fn_type': 'equal'
+                        'fn_type': 'equal',
+                        'fn_has_bold': False
                     }
                 ]
             }
@@ -394,6 +359,7 @@ class ArticleNotesTest(TestCase):
             '<fn-group>'
             '<title>Highlights: </title>'
             '<fn fn-type="other" id="fn2">'
+            '<bold>A)</bold>'
             '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
             '</fn>'
             '<fn fn-type="other" id="fn3">'
@@ -417,13 +383,16 @@ class ArticleNotesTest(TestCase):
                 'parent_article_type': 'research-article',
                 'parent_id': None,
                 'parent_lang': 'pt',
+                'label': None,
+                'title': 'Highlights: ',
                 'fns': [
                     {
                         'fn_id': 'fn2',
-                        'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
+                        'fn_text': 'A)Study presents design and production of an LED lamp for photovoltaic light traps.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': True
                     },
                     {
                         'fn_id': 'fn3',
@@ -431,7 +400,8 @@ class ArticleNotesTest(TestCase):
                                    'the operating status of the system.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': False
                     },
                     {
                         'fn_id': 'fn4',
@@ -439,7 +409,8 @@ class ArticleNotesTest(TestCase):
                                    'conventional light traps.',
                         'fn_label': None,
                         'fn_type': 'other',
-                        'fn_parent': 'fn-group'
+                        'fn_parent': 'fn-group',
+                        'fn_has_bold': False
                     }
                 ]
             },
@@ -460,6 +431,7 @@ class ArticleNotesTest(TestCase):
                         'fn_parent': 'author-notes',
                         'fn_text': '1Os autores declaram não haver conflito de interesses.',
                         'fn_type': 'conflict',
+                        'fn_has_bold': False
                     },
                 ]
             },
@@ -477,14 +449,16 @@ class ArticleNotesTest(TestCase):
                         'fn_label': None,
                         'fn_parent': 'author-notes',
                         'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
-                        'fn_type': 'coi-statement'
+                        'fn_type': 'coi-statement',
+                        'fn_has_bold': False
                     },
                     {
                         'fn_id': None,
                         'fn_label': None,
                         'fn_parent': 'author-notes',
                         'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
-                        'fn_type': 'equal'
+                        'fn_type': 'equal',
+                        'fn_has_bold': False
                     }
                 ]
             }

--- a/tests/sps/models/v2/test_notes.py
+++ b/tests/sps/models/v2/test_notes.py
@@ -1,0 +1,494 @@
+from unittest import TestCase
+
+from lxml import etree
+
+from packtools.sps.models.v2.notes import Fn, Fns, FnGroup, FnGroups, AuthorNote, AuthorNotes, ArticleNotes
+
+
+class FnTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '<corresp>'
+            '<label>Correspondência</label>:  Roseana Mara Aredes Priuli  Av. Juscelino Kubistcheck de Oliveira, 1220, '
+            'Jardim Panorama, Condomínio Recanto Real Rua 4, 440  15021-450 São José do Rio Preto, SP, Brasil  E-mail: '
+            '<email>roseanap@gmail.com</email>'
+            '</corresp>'
+            '<fn id="fn_01" fn-type="conflict">'
+            '<label>1</label>'
+            '<p>Os autores declaram não haver conflito de interesses.</p>'
+            '</fn>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+        xmltree = etree.fromstring(xml)
+        self.fn = Fn(xmltree.xpath(".//fn")[0])
+
+    def test_fn_id(self):
+        self.assertEqual(self.fn.fn_id, "fn_01")
+
+    def test_fn_type(self):
+        self.assertEqual(self.fn.fn_type, "conflict")
+
+    def test_fn_label(self):
+        self.assertEqual(self.fn.fn_label, "1")
+
+    def test_fn_text(self):
+        self.assertEqual(self.fn.fn_text, "1Os autores declaram não haver conflito de interesses.")
+
+    def test_fn_data(self):
+        self.assertDictEqual(
+            self.fn.data(),
+            {
+                "fn_id": "fn_01",
+                "fn_type": "conflict",
+                "fn_label": "1",
+                "fn_text": "1Os autores declaram não haver conflito de interesses."
+            }
+        )
+
+
+class FnsTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<back>'
+            '<fn-group>'
+            '<title>Highlights: </title>'
+            '<fn fn-type="other" id="fn2">'
+            '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn3">'
+            '<p>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn4">'
+            '<p>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</p>'
+            '</fn>'
+            '</fn-group>'
+            '</back>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_fns(self):
+        obtained = list(Fns(self.xml_tree).fns())
+        expected = [
+            {
+                'fn_id': 'fn2',
+                'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
+                'fn_label': None,
+                'fn_type': 'other'
+            },
+            {
+                'fn_id': 'fn3',
+                'fn_text': 'The LED lamp switches on and off automatically, controls the battery charge and indicates '
+                           'the operating status of the system.',
+                'fn_label': None,
+                'fn_type': 'other'
+            },
+            {
+                'fn_id': 'fn4',
+                'fn_text': 'The LED lamp is a superior substitute for the standard fluorescent lamps used in '
+                           'conventional light traps.',
+                'fn_label': None,
+                'fn_type': 'other'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class FnGroupTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<back>'
+            '<fn-group>'
+            '<title>Highlights: </title>'
+            '<fn fn-type="other" id="fn2">'
+            '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn3">'
+            '<p>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn4">'
+            '<p>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</p>'
+            '</fn>'
+            '</fn-group>'
+            '</back>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_fn_group(self):
+        obtained = list(FnGroup(self.xml_tree.xpath(".//fn-group")[0]).fn_group())
+        expected = [
+            {
+                'fn_id': 'fn2',
+                'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
+                'fn_label': None,
+                'fn_type': 'other',
+                'fn_parent': 'fn-group'
+            },
+            {
+                'fn_id': 'fn3',
+                'fn_text': 'The LED lamp switches on and off automatically, controls the battery charge and indicates '
+                           'the operating status of the system.',
+                'fn_label': None,
+                'fn_type': 'other',
+                'fn_parent': 'fn-group'
+            },
+            {
+                'fn_id': 'fn4',
+                'fn_text': 'The LED lamp is a superior substitute for the standard fluorescent lamps used in '
+                           'conventional light traps.',
+                'fn_label': None,
+                'fn_type': 'other',
+                'fn_parent': 'fn-group'
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class FnGroupsTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<back>'
+            '<fn-group>'
+            '<title>Highlights: </title>'
+            '<fn fn-type="other" id="fn2">'
+            '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn3">'
+            '<p>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn4">'
+            '<p>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</p>'
+            '</fn>'
+            '</fn-group>'
+            '</back>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_fn_groups(self):
+        self.maxDiff = None
+        obtained = list(FnGroups(self.xml_tree.find(".")).fn_groups())
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'fns': [
+                    {
+                        'fn_id': 'fn2',
+                        'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    },
+                    {
+                        'fn_id': 'fn3',
+                        'fn_text': 'The LED lamp switches on and off automatically, controls the battery charge and indicates '
+                                   'the operating status of the system.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    },
+                    {
+                        'fn_id': 'fn4',
+                        'fn_text': 'The LED lamp is a superior substitute for the standard fluorescent lamps used in '
+                                   'conventional light traps.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    }
+                ]
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class AuthorNoteTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '<corresp>'
+            '<label>Correspondência</label>:  Roseana Mara Aredes Priuli  Av. Juscelino Kubistcheck de Oliveira, 1220, '
+            'Jardim Panorama, Condomínio Recanto Real Rua 4, 440  15021-450 São José do Rio Preto, SP, Brasil  E-mail: '
+            '<email>roseanap@gmail.com</email>'
+            '</corresp>'
+            '<fn id="fn_01" fn-type="conflict">'
+            '<label>1</label>'
+            '<p>Os autores declaram não haver conflito de interesses.</p>'
+            '</fn>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_author_note(self):
+        obtained = list(AuthorNote(self.xml_tree.xpath(".//author-notes")[0]).author_note())
+        expected = [
+            {
+                'fn_id': 'fn_01',
+                'fn_label': '1',
+                'fn_parent': 'author-notes',
+                'fn_text': '1Os autores declaram não haver conflito de interesses.',
+                'fn_type': 'conflict',
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class AuthorNotesTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '<corresp>'
+            '<label>Correspondência</label>:  Roseana Mara Aredes Priuli  Av. Juscelino Kubistcheck de Oliveira, 1220, '
+            'Jardim Panorama, Condomínio Recanto Real Rua 4, 440  15021-450 São José do Rio Preto, SP, Brasil  E-mail: '
+            '<email>roseanap@gmail.com</email>'
+            '</corresp>'
+            '<fn id="fn_01" fn-type="conflict">'
+            '<label>1</label>'
+            '<p>Os autores declaram não haver conflito de interesses.</p>'
+            '</fn>'
+            '</author-notes>'
+            '<author-notes>'
+            '<corresp id="c01">'
+            '<label>*</label>'
+            '<bold>Correspondence</bold>: Dr. Edmundo Figueira Departamento de Fisioterapia,'
+            'Universidade FISP - Hogwarts,'
+            '</corresp>'
+            'Brasil. E-mail: <email>contato@foo.com</email><fn fn-type="coi-statement">'
+            '<p>Não há conflito de interesse entre os autores do artigo.</p>'
+            '</fn>'
+            '<fn fn-type="equal">'
+            '<p>Todos os autores tiveram contribuição igualitária na criação do artigo.</p>'
+            '</fn>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_author_notes(self):
+        self.maxDiff = None
+        obtained = list(AuthorNotes(self.xml_tree.find(".")).author_notes())
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'corresp': 'Correspondência: Roseana Mara Aredes Priuli Av. Juscelino '
+                           'Kubistcheck de Oliveira, 1220, Jardim Panorama, Condomínio '
+                           'Recanto Real Rua 4, 440 15021-450 São José do Rio Preto, SP, '
+                           'Brasil E-mail: roseanap@gmail.com',
+                'corresp_label': 'Correspondência',
+                'fns': [
+                    {
+                        'fn_id': 'fn_01',
+                        'fn_label': '1',
+                        'fn_parent': 'author-notes',
+                        'fn_text': '1Os autores declaram não haver conflito de interesses.',
+                        'fn_type': 'conflict',
+                    },
+                ]
+            },
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'corresp': '*Correspondence: Dr. Edmundo Figueira Departamento de '
+                           'Fisioterapia,Universidade FISP - Hogwarts,',
+                'corresp_label': '*',
+                'fns': [
+                    {
+                        'fn_id': None,
+                        'fn_label': None,
+                        'fn_parent': 'author-notes',
+                        'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
+                        'fn_type': 'coi-statement'
+                    },
+                    {
+                        'fn_id': None,
+                        'fn_label': None,
+                        'fn_parent': 'author-notes',
+                        'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
+                        'fn_type': 'equal'
+                    }
+                ]
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])
+
+
+class ArticleNotesTest(TestCase):
+    def setUp(self):
+        xml = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '<corresp>'
+            '<label>Correspondência</label>:  Roseana Mara Aredes Priuli  Av. Juscelino Kubistcheck de Oliveira, 1220, '
+            'Jardim Panorama, Condomínio Recanto Real Rua 4, 440  15021-450 São José do Rio Preto, SP, Brasil  E-mail: '
+            '<email>roseanap@gmail.com</email>'
+            '</corresp>'
+            '<fn id="fn_01" fn-type="conflict">'
+            '<label>1</label>'
+            '<p>Os autores declaram não haver conflito de interesses.</p>'
+            '</fn>'
+            '</author-notes>'
+            '<author-notes>'
+            '<corresp id="c01">'
+            '<label>*</label>'
+            '<bold>Correspondence</bold>: Dr. Edmundo Figueira Departamento de Fisioterapia,'
+            'Universidade FISP - Hogwarts,'
+            '</corresp>'
+            'Brasil. E-mail: <email>contato@foo.com</email><fn fn-type="coi-statement">'
+            '<p>Não há conflito de interesse entre os autores do artigo.</p>'
+            '</fn>'
+            '<fn fn-type="equal">'
+            '<p>Todos os autores tiveram contribuição igualitária na criação do artigo.</p>'
+            '</fn>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '<back>'
+            '<fn-group>'
+            '<title>Highlights: </title>'
+            '<fn fn-type="other" id="fn2">'
+            '<p>Study presents design and production of an LED lamp for photovoltaic light traps.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn3">'
+            '<p>The LED lamp switches on and off automatically, controls the battery charge and indicates the operating status of the system.</p>'
+            '</fn>'
+            '<fn fn-type="other" id="fn4">'
+            '<p>The LED lamp is a superior substitute for the standard fluorescent lamps used in conventional light traps.</p>'
+            '</fn>'
+            '</fn-group>'
+            '</back>'
+            '</article>'
+        )
+        self.xml_tree = etree.fromstring(xml)
+
+    def test_all_notes(self):
+        self.maxDiff = None
+        obtained = list(ArticleNotes(self.xml_tree).all_notes())
+        expected = [
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'fns': [
+                    {
+                        'fn_id': 'fn2',
+                        'fn_text': 'Study presents design and production of an LED lamp for photovoltaic light traps.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    },
+                    {
+                        'fn_id': 'fn3',
+                        'fn_text': 'The LED lamp switches on and off automatically, controls the battery charge and indicates '
+                                   'the operating status of the system.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    },
+                    {
+                        'fn_id': 'fn4',
+                        'fn_text': 'The LED lamp is a superior substitute for the standard fluorescent lamps used in '
+                                   'conventional light traps.',
+                        'fn_label': None,
+                        'fn_type': 'other',
+                        'fn_parent': 'fn-group'
+                    }
+                ]
+            },
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'corresp': 'Correspondência: Roseana Mara Aredes Priuli Av. Juscelino '
+                           'Kubistcheck de Oliveira, 1220, Jardim Panorama, Condomínio '
+                           'Recanto Real Rua 4, 440 15021-450 São José do Rio Preto, SP, '
+                           'Brasil E-mail: roseanap@gmail.com',
+                'corresp_label': 'Correspondência',
+                'fns': [
+                    {
+                        'fn_id': 'fn_01',
+                        'fn_label': '1',
+                        'fn_parent': 'author-notes',
+                        'fn_text': '1Os autores declaram não haver conflito de interesses.',
+                        'fn_type': 'conflict',
+                    },
+                ]
+            },
+            {
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'corresp': '*Correspondence: Dr. Edmundo Figueira Departamento de '
+                           'Fisioterapia,Universidade FISP - Hogwarts,',
+                'corresp_label': '*',
+                'fns': [
+                    {
+                        'fn_id': None,
+                        'fn_label': None,
+                        'fn_parent': 'author-notes',
+                        'fn_text': 'Não há conflito de interesse entre os autores do artigo.',
+                        'fn_type': 'coi-statement'
+                    },
+                    {
+                        'fn_id': None,
+                        'fn_label': None,
+                        'fn_parent': 'author-notes',
+                        'fn_text': 'Todos os autores tiveram contribuição igualitária na criação do artigo.',
+                        'fn_type': 'equal'
+                    }
+                ]
+            }
+        ]
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(item, expected[i])


### PR DESCRIPTION
#### O que esse PR faz?
Este PR implementa uma série de classes para o processamento de notas de artigos (`<fn>`, `<fn-group>`, `<author-notes>`) em documentos XML no formato SciELO PS. O objetivo é extrair, organizar e contextualizar essas notas em estruturas de dicionário que incluem informações detalhadas sobre o artigo, como tipo de artigo, idioma e identificadores. Esta implementação resolve o problema de extração manual e complexa de dados de notas, facilitando o uso programático dessas informações. Além disso, foram adicionados testes unitários abrangentes para validar o funcionamento correto de cada classe.

#### Onde a revisão poderia começar?
A revisão pode começar pelo arquivo `packtools/sps/models/v2/notes.py`, onde as classes `Fn`, `Fns`, `FnGroup`, `FnGroups`, `AuthorNote`, `AuthorNotes`, e `ArticleNotes` estão implementadas. Em seguida, revise os testes correspondentes em `tests/sps/models/v2/test_notes.py` para garantir a cobertura de funcionalidades.

#### Como este poderia ser testado manualmente?

1. Clone o repositório e navegue até o diretório do projeto.
2. Instale as dependências necessárias com `pip install -r requirements.txt`.
3. Execute os testes unitários com o comando `python3 -m unittest -v tests/sps/models/v2/test_notes.py` para verificar se todas as funcionalidades estão sendo testadas corretamente.
4. Para testes manuais, crie um arquivo XML de exemplo seguindo o padrão SciELO e utilize as classes implementadas para verificar a extração e formatação das notas.

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

