### PR TITLE
Feat: author notes validation

### DIFF
--- a/packtools/sps/validation/article_author_notes.py
+++ b/packtools/sps/validation/article_author_notes.py
@@ -263,8 +263,52 @@ class AuthorNotesValidation:
                 data=author_note
             )
 
+    def validate_current_affiliation_attrib_type_deprecation(self, author_note, error_level="ERROR"):
+        for fn_type in author_note.get("fn_types") or []:
+            if fn_type == "current-aff":
+                yield format_response(
+                    title="Author notes current aff deprecated validation",
+                    parent=author_note.get("parent"),
+                    parent_id=author_note.get("parent_id"),
+                    parent_article_type=author_note.get("parent_article_type"),
+                    parent_lang=author_note.get("parent_lang"),
+                    item="fn",
+                    sub_item="@fn-type",
+                    validation_type="exist",
+                    is_valid=False,
+                    expected=None,
+                    obtained=fn_type,
+                    advice=f"Author's mini CV/biography data use <bio>",
+                    error_level=error_level,
+                    data=author_note
+                )
+
+    def validate_contribution_attrib_type_deprecation(self, author_note, error_level="WARNING"):
+        roles = self.xmltree.xpath(".//role")
+        if len(roles) > 0:
+            for fn_type in author_note.get("fn_types") or []:
+                if fn_type == "con":
+                    yield format_response(
+                        title="Author notes contribution deprecated validation",
+                        parent=author_note.get("parent"),
+                        parent_id=author_note.get("parent_id"),
+                        parent_article_type=author_note.get("parent_article_type"),
+                        parent_lang=author_note.get("parent_lang"),
+                        item="fn",
+                        sub_item="@fn-type",
+                        validation_type="exist",
+                        is_valid=False,
+                        expected=None,
+                        obtained=fn_type,
+                        advice="Using @fn-type='con' for authorship contributions is discouraged; use <role> instead.",
+                        error_level=error_level,
+                        data=author_note
+                    )
+
     def validate_author_note(self, fn_type_list=None):
         for author_note in self.author_notes:
             yield from self.validate_corresp_tag_presence(author_note)
             yield from self.validate_fn_type_attribute_presence(author_note)
             yield from self.validate_fn_type_attribute_value(author_note, fn_type_list)
+            yield from self.validate_current_affiliation_attrib_type_deprecation(author_note)
+            yield from self.validate_contribution_attrib_type_deprecation(author_note)

--- a/packtools/sps/validation/article_author_notes.py
+++ b/packtools/sps/validation/article_author_notes.py
@@ -264,46 +264,42 @@ class AuthorNotesValidation:
             )
 
     def validate_current_affiliation_attrib_type_deprecation(self, author_note, error_level="ERROR"):
-        for fn_type in author_note.get("fn_types") or []:
-            if fn_type == "current-aff":
-                yield format_response(
-                    title="Author notes current aff deprecated validation",
-                    parent=author_note.get("parent"),
-                    parent_id=author_note.get("parent_id"),
-                    parent_article_type=author_note.get("parent_article_type"),
-                    parent_lang=author_note.get("parent_lang"),
-                    item="fn",
-                    sub_item="@fn-type",
-                    validation_type="exist",
-                    is_valid=False,
-                    expected=None,
-                    obtained=fn_type,
-                    advice=f"Author's mini CV/biography data use <bio>",
-                    error_level=error_level,
-                    data=author_note
-                )
+        if "current-aff" in author_note.get("fn_types") or []:
+            yield format_response(
+                title="Author notes current aff deprecated validation",
+                parent=author_note.get("parent"),
+                parent_id=author_note.get("parent_id"),
+                parent_article_type=author_note.get("parent_article_type"),
+                parent_lang=author_note.get("parent_lang"),
+                item="fn",
+                sub_item="@fn-type",
+                validation_type="exist",
+                is_valid=False,
+                expected=None,
+                obtained="current-aff",
+                advice=f"Use to identify Author's mini CV and use to identify current affiliation",
+                error_level=error_level,
+                data=author_note
+            )
 
     def validate_contribution_attrib_type_deprecation(self, author_note, error_level="WARNING"):
-        roles = self.xmltree.xpath(".//role")
-        if len(roles) > 0:
-            for fn_type in author_note.get("fn_types") or []:
-                if fn_type == "con":
-                    yield format_response(
-                        title="Author notes contribution deprecated validation",
-                        parent=author_note.get("parent"),
-                        parent_id=author_note.get("parent_id"),
-                        parent_article_type=author_note.get("parent_article_type"),
-                        parent_lang=author_note.get("parent_lang"),
-                        item="fn",
-                        sub_item="@fn-type",
-                        validation_type="exist",
-                        is_valid=False,
-                        expected=None,
-                        obtained=fn_type,
-                        advice="Using @fn-type='con' for authorship contributions is discouraged; use <role> instead.",
-                        error_level=error_level,
-                        data=author_note
-                    )
+        if "con" in author_note.get("fn_types") or []:
+            yield format_response(
+                title="Author notes contribution deprecated validation",
+                parent=author_note.get("parent"),
+                parent_id=author_note.get("parent_id"),
+                parent_article_type=author_note.get("parent_article_type"),
+                parent_lang=author_note.get("parent_lang"),
+                item="fn",
+                sub_item="@fn-type",
+                validation_type="exist",
+                is_valid=False,
+                expected=None,
+                obtained="con",
+                advice="Using @fn-type='con' for authorship contributions is discouraged; use <role> instead.",
+                error_level=error_level,
+                data=author_note
+            )
 
     def validate_author_note(self, fn_type_list=None):
         for author_note in self.author_notes:

--- a/tests/sps/validation/test_article_author_notes.py
+++ b/tests/sps/validation/test_article_author_notes.py
@@ -648,7 +648,7 @@ class ArticleAuthorNotesValidationTest(unittest.TestCase):
                 'expected_value': None,
                 'got_value': 'current-aff',
                 'message': 'Got current-aff, expected None',
-                'advice': "Author's mini CV/biography data use <bio>",
+                'advice': "Use to identify Author's mini CV and use to identify current affiliation",
                 'data': {
                     'corresp': [],
                     'fn_count': 1,

--- a/tests/sps/validation/test_article_author_notes.py
+++ b/tests/sps/validation/test_article_author_notes.py
@@ -599,6 +599,128 @@ class ArticleAuthorNotesValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
+    def test_validate_current_affiliation_attrib_type_deprecation(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <front>
+            <article-meta>
+            <author-notes>
+            <fn fn-type="current-aff">
+            <institution>Universidade de São Paulo</institution>
+            <addr-line>Departamento de Biologia</addr-line>
+            <city>São Paulo</city>
+            <country>Brasil</country>
+            </fn>
+            </author-notes>
+            </article-meta>
+            </front>
+            <sub-article article-type="translation" id="TRen" xml:lang="en">
+            <front-stub>
+            <author-notes>
+            <fn fn-type="current-aff">
+            <institution>University of São Paulo</institution>
+            <addr-line>Department of Biology</addr-line>
+            <city>São Paulo</city>
+            <country>Brazil</country>
+            </fn>
+            </author-notes>
+            </front-stub>
+            </sub-article>
+            </article>
+            '''
+        )
+
+        author_note = list(ArticleAuthorNotes(self.xmltree).author_notes)[0]
+        obtained = list(AuthorNotesValidation(self.xmltree).validate_current_affiliation_attrib_type_deprecation(author_note))
+        expected = [
+            {
+                'title': 'Author notes current aff deprecated validation',
+                'parent': 'article',
+                'parent_id': None,
+                'parent_article_type': 'research-article',
+                'parent_lang': 'pt',
+                'item': 'fn',
+                'sub_item': '@fn-type',
+                'validation_type': 'exist',
+                'response': 'ERROR',
+                'expected_value': None,
+                'got_value': 'current-aff',
+                'message': 'Got current-aff, expected None',
+                'advice': "Author's mini CV/biography data use <bio>",
+                'data': {
+                    'corresp': [],
+                    'fn_count': 1,
+                    'fn_types': ['current-aff'],
+                    'parent': 'article',
+                    'parent_id': None,
+                    'parent_article_type': 'research-article',
+                    'parent_lang': 'pt'
+                }
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_contribution_attrib_type_deprecation(self):
+        self.maxDiff = None
+        self.xmltree = etree.fromstring(
+            '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <front>
+            <article-meta>
+            <contrib-group>
+            <contrib contrib-type="author">
+            <name>
+            <surname>Silva</surname>
+            <given-names>João</given-names>
+            </name>
+            <role>Lead Author</role>
+            </contrib>
+            </contrib-group>
+            <author-notes>
+            <fn fn-type="con">Lead Author</fn>
+            </author-notes>
+            </article-meta>
+            </front>
+            </article>
+            '''
+        )
+
+        author_note = list(ArticleAuthorNotes(self.xmltree).author_notes)[0]
+        obtained = list(AuthorNotesValidation(self.xmltree).validate_contribution_attrib_type_deprecation(author_note))
+        expected = [
+            {
+                'title': 'Author notes contribution deprecated validation',
+                'parent': 'article',
+                'parent_id': None,
+                'parent_article_type': 'research-article',
+                'parent_lang': 'pt',
+                'item': 'fn',
+                'sub_item': '@fn-type',
+                'validation_type': 'exist',
+                'response': 'WARNING',
+                'expected_value': None,
+                'got_value': 'con',
+                'message': 'Got con, expected None',
+                'advice': "Using @fn-type='con' for authorship contributions is discouraged; use <role> instead.",
+                'data': {
+                    'corresp': [],
+                    'fn_count': 1,
+                    'fn_types': ['con'],
+                    'parent': 'article',
+                    'parent_id': None,
+                    'parent_article_type': 'research-article',
+                    'parent_lang': 'pt'
+                }
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona duas funções de validação para garantir o uso correto de atributos de notas de autor e desencorajar práticas obsoletas:

- `validate_current_affiliation_attrib_type_deprecation`: Essa função valida o uso do atributo `fn-type="current-aff"` em notas de autor, que está obsoleto para indicar afiliações atuais. Ela gera uma resposta de validação com nível de erro "ERROR", sugerindo o uso da tag `<bio>` para dados de mini CV ou biografia do autor.
- `validate_contribution_attrib_type_deprecation`: Esta função verifica o atributo obsoleto `fn-type="con" `em notas de autor para contribuições de autoria. Caso encontrado, a validação sugere o uso da tag `<role>` em vez de `fn-type="con"`, gerando uma resposta de validação com nível de aviso "WARNING".

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Avalie os teste automatizados.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

