### PR TITLE
Feat: citation ext link validation

### DIFF
--- a/packtools/sps/models/article_citations.py
+++ b/packtools/sps/models/article_citations.py
@@ -87,6 +87,10 @@ def get_ref_id(node):
     return node.get("id")
 
 
+def get_ext_link(node):
+    return [node_plain_text(item) for item in node.xpath(".//element-citation//ext-link")]
+
+
 class ArticleCitations:
 
     def __init__(self, xmltree):
@@ -95,7 +99,7 @@ class ArticleCitations:
     @property
     def article_citations(self):
         for node, lang, article_type, parent, parent_id in get_parent_context(
-            self.xmltree
+                self.xmltree
         ):
             for item in node.xpath("./ref-list//ref"):
                 tags = [
@@ -114,6 +118,7 @@ class ArticleCitations:
                     ("article_title", get_article_title(item)),
                     ("citation_ids", get_citation_ids(item)),
                     ("mixed_citation", get_mixed_citation(item)),
+                    ("ext_link", get_ext_link(item)),
                 ]
                 d = dict()
                 for name, value in tags:

--- a/packtools/sps/validation/article_citations.py
+++ b/packtools/sps/validation/article_citations.py
@@ -421,6 +421,26 @@ class ArticleCitationValidation:
             error_level=error_level,
         )
 
+    def validate_article_citation_ext_link(self, error_level="ERROR"):
+        links = self.citation.get("ext_link")
+        is_valid = len(links) == 1
+        yield format_response(
+            title="element citation validation",
+            parent=self.citation.get("parent"),
+            parent_id=self.citation.get("parent_id"),
+            parent_article_type=self.citation.get("parent_article_type"),
+            parent_lang=self.citation.get("parent_lang"),
+            item="element-citation",
+            sub_item="ext-link",
+            is_valid=is_valid,
+            validation_type="exist",
+            expected="1 <ext-link> per reference",
+            obtained=f"{len(links)} <ext-link> per reference",
+            advice=f"The source in reference (ref-id: {self.citation.get('ref_id')}) has {len(links)} <ext-link> per reference",
+            data=self.citation,
+            error_level=error_level,
+        )
+
 
 class ArticleCitationsValidation:
     def __init__(self, xmltree, publication_type_list=None):
@@ -444,3 +464,4 @@ class ArticleCitationsValidation:
             yield from citation.validate_article_citation_publication_type(
                 publication_type_list
             )
+            yield from citation.validate_article_citation_ext_link()

--- a/tests/sps/models/test_article_citations.py
+++ b/tests/sps/models/test_article_citations.py
@@ -108,6 +108,7 @@ class AuthorsTest(TestCase):
                 "parent_id": None,
                 "parent_article_type": "research-article",
                 "parent_lang": "en",
+                "ext_link": ['https://doi.org/10.1016/j.drugalcdep.2015.02.028'],
             }
         ]
         for i, item in enumerate(expected):
@@ -151,7 +152,7 @@ class AuthorsTest(TestCase):
                 "ref_id": "B2",
                 "publication_type": "book",
                 "author_type": "person",
-                "mixed_citation": "BARTHES, Roland. Aula . São Pulo: Cultrix, 1987.",
+                "mixed_citation": "BARTHES, Roland. Aula. São Pulo: Cultrix, 1987.",
                 "source": "Aula",
                 "main_author": {"surname": "BARTHES", "given-names": "Roland"},
                 "all_authors": [{"surname": "BARTHES", "given-names": "Roland"}],

--- a/tests/sps/validation/test_article_citations.py
+++ b/tests/sps/validation/test_article_citations.py
@@ -129,6 +129,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -264,6 +265,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -399,6 +401,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -533,6 +536,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -667,6 +671,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -801,6 +806,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -939,6 +945,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1072,6 +1079,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1207,6 +1215,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1402,6 +1411,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1531,6 +1541,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1667,6 +1678,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1804,6 +1816,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1865,6 +1878,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1930,6 +1944,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -1991,6 +2006,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -2052,6 +2068,7 @@ class ArticleCitationValidationTest(TestCase):
                         "pmid": "00000000",
                     },
                     "elocation_id": "elocation_B1",
+                    "ext_link": ["https://doi.org/10.1016/j.drugalcdep.2015.02.028"],
                     "fpage": "85",
                     "label": "1",
                     "lpage": "91",
@@ -2061,6 +2078,113 @@ class ArticleCitationValidationTest(TestCase):
                         "suffix": "III",
                         "surname": "Tran",
                     },
+                    "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm "
+                    "LR. Smoking and potentially preventable "
+                    "hospitalisation: the benefit of smoking cessation "
+                    "in older ages. Drug Alcohol Depend. "
+                    "2015;150:85-91. DOI: "
+                    "https://doi.org/10.1016/j.drugalcdep.2015.02.028",
+                    "publication_type": "journal",
+                    "ref_id": "B1",
+                    "source": "Drug Alcohol Depend.",
+                    "volume": "150",
+                    "year": "2015",
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "en",
+                },
+            },
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_validate_article_citation_ext_link(self):
+        self.maxDiff = None
+        xml = """
+        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+        article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+        <back>
+        <ref-list>
+        <title>REFERENCES</title>
+        <ref id="B1">
+        <label>1.</label>
+        <mixed-citation>
+        1. Tran B, Falster MO, Douglas K, Blyth F, Jorm LR. Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages. 
+        Drug Alcohol Depend. 2015;150:85-91. DOI: 
+        <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">
+        https://doi.org/10.1016/j.drugalcdep.2015.02.028
+        </ext-link>
+        </mixed-citation>
+        <element-citation publication-type="journal">
+        <article-title>Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages</article-title>
+        <source>Drug Alcohol Depend.</source>
+        <year>2015</year>
+        <volume>150</volume>
+        <fpage>85</fpage>
+        <lpage>91</lpage>
+        <pub-id pub-id-type="doi">10.1016/B1</pub-id>
+        <elocation-id>elocation_B1</elocation-id>
+        <pub-id pub-id-type="pmid">00000000</pub-id>
+        <pub-id pub-id-type="pmcid">11111111</pub-id>
+        <comment>
+        DOI:
+        <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.1016/j.drugalcdep.2015.02.028">
+        https://doi.org/10.1016/j.drugalcdep.2015.02.028
+        </ext-link>. 
+        Full text available at: 
+        <ext-link ext-link-type="uri" xlink:href="https://www.example.com/fulltext">
+        https://www.example.com/fulltext
+        </ext-link>
+        </comment>
+        </element-citation>
+        </ref>
+        </ref-list>
+        </back>
+        </article>
+        """
+
+        xmltree = etree.fromstring(xml)
+        citation = list(ArticleCitations(xmltree).article_citations)[0]
+        obtained = list(
+            ArticleCitationValidation(
+                xmltree, citation
+            ).validate_article_citation_ext_link()
+        )
+
+        expected = [
+            {
+                "title": "element citation validation",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "en",
+                "item": "element-citation",
+                'sub_item': 'ext-link',
+                "validation_type": "exist",
+                "response": "ERROR",
+                'expected_value': '1 <ext-link> per reference',
+                'got_value': '2 <ext-link> per reference',
+                'message': 'Got 2 <ext-link> per reference, expected 1 <ext-link> per reference',
+                'advice': 'The source in reference (ref-id: B1) has 2 <ext-link> per reference',
+                "data": {
+                    "article_title": "Smoking and potentially preventable hospitalisation: the benefit of smoking cessation in older ages",
+                    "author_type": "person",
+                    "citation_ids": {
+                        "doi": "10.1016/B1",
+                        "pmcid": "11111111",
+                        "pmid": "00000000",
+                    },
+                    "elocation_id": "elocation_B1",
+                    "ext_link": [
+                        "https://doi.org/10.1016/j.drugalcdep.2015.02.028",
+                        "https://www.example.com/fulltext"
+                    ],
+                    "fpage": "85",
+                    "label": "1",
+                    "lpage": "91",
                     "mixed_citation": "1. Tran B, Falster MO, Douglas K, Blyth F, Jorm "
                     "LR. Smoking and potentially preventable "
                     "hospitalisation: the benefit of smoking cessation "


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma nova função de validação chamada `validate_article_citation_ext_link` que verifica se há exatamente um `<ext-link>` por referência em citações de artigos. A função é projetada para garantir que cada citação no elemento `<element-citation>` contenha um único link externo, evitando múltiplos links que possam causar confusão ou problemas de formatação.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Para testar manualmente a funcionalidade:

1. Insira ou modifique citações de artigos em um XML de teste para incluir diferentes quantidades de `<ext-link>`.
2. Execute a validação para verificar as respostas geradas.
3. Confirme que o sistema acusa um erro ("ERROR") se houver mais ou menos de um `<ext-link>` por citação de referência.
4. Valide se as mensagens geradas correspondem ao esperado, incluindo o número de links obtidos e o conselho para correção.

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

