### PR TITLE
Refactor: related-article-type=preprint validation

### DIFF
--- a/packtools/sps/validation/preprint.py
+++ b/packtools/sps/validation/preprint.py
@@ -1,20 +1,23 @@
-from packtools.sps.models.related_articles import RelatedItems
-from packtools.sps.models.dates import ArticleDates
+from packtools.sps.models.v2.related_articles import RelatedArticles
+from packtools.sps.models.article_dates import HistoryDates
+from packtools.sps.validation.utils import format_response
 
 
 class PreprintValidation:
-    def __init__(self, xmltree):
-        self.related_articles = RelatedItems(xmltree).related_articles
-        self.article_dates = ArticleDates(xmltree).history_dates_dict
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+        self.related_articles = RelatedArticles(xml_tree).related_articles()
+        self.article_dates = list(HistoryDates(xml_tree).history_dates())
 
     def _extract_preprint_status(self):
-        return [item.get('preprint') for item in self.related_articles]
+        return [item for item in self.related_articles if item.get('related-article-type') == "preprint"]
 
     def _extract_preprint_date(self):
-        preprint_date = self.article_dates.get('preprint')
-        return '-'.join([preprint_date[key] for key in ['year', 'month', 'day']]) if preprint_date else None
+        if self.article_dates:
+            preprint_date = self.article_dates[0].get("history", {}).get("preprint")
+            return '-'.join([preprint_date[key] for key in ['year', 'month', 'day']]) if preprint_date else None
 
-    def preprint_validation(self):
+    def preprint_validation(self, error_level="ERROR"):
         """
         Checks whether an article that has a preprint has the corresponding date in the history.
 
@@ -55,27 +58,31 @@ class PreprintValidation:
         if not (has_preprint or has_preprint_date):
             return []
 
-        response, expected_value, got_value, advice = 'OK', has_preprint_date, has_preprint_date, None
+        response, expected_value, got_value, advice = True, has_preprint_date, has_preprint_date, None
 
         if has_preprint and not has_preprint_date:
             response, expected_value, got_value, advice = \
-                'ERROR', 'The preprint publication date', None, 'Provide the publication date of the preprint'
+                False, 'The preprint publication date', None, 'Provide the publication date of the preprint'
         elif not has_preprint and has_preprint_date:
             response, expected_value, got_value, advice = \
-                'ERROR', None, has_preprint_date, 'The article does not reference the preprint, ' \
+                False, None, has_preprint_date, 'The article does not reference the preprint, ' \
                                                   'provide it as in the example: <related-article id="pp1" ' \
                                                   'related-article-type="preprint" ext-link-type="doi" ' \
                                                   'xlink:href="10.1590/SciELOPreprints.1174"/>'
 
-        return [
-            {
-                'title': 'Preprint validation',
-                'xpath': './/related-article[@related-article-type="preprint"] .//history//date[@date-type="preprint"]',
-                'validation_type': 'match',
-                'response': response,
-                'expected_value': expected_value,
-                'got_value': got_value,
-                'message': f'Got {got_value} expected {expected_value}',
-                'advice': advice
-            }
-        ]
+        yield format_response(
+            title='Preprint validation',
+            parent="article",
+            parent_id=None,
+            parent_article_type=self.xml_tree.get("article-type"),
+            parent_lang=self.xml_tree.get("{http://www.w3.org/XML/1998/namespace}lang"),
+            item='related-article / date',
+            sub_item='@related-article-type=preprint / @date-type=preprint',
+            validation_type='exist',
+            is_valid=response,
+            expected=expected_value,
+            obtained=got_value,
+            advice=advice,
+            data=has_preprint[0] if has_preprint else None,
+            error_level=error_level,
+        )

--- a/tests/sps/validation/test_preprint.py
+++ b/tests/sps/validation/test_preprint.py
@@ -9,36 +9,52 @@ class PreprintValidationTest(unittest.TestCase):
     def test_preprint_validation_preprint_ok_and_date_ok(self):
         self.maxDiff = None
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
-            <front>
-            <article-meta>
-            <history>
-            <date date-type="preprint">
-            <day>18</day>
-            <month>10</month>
-            <year>2002</year>
-            </date>
-            </history>
-            </article-meta>
-            </front>
-            <related-article id="pp1" related-article-type="preprint" ext-link-type="doi" xlink:href="10.1590/SciELOPreprints.1174"/>
-            </article>
-        """
+                    <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                    <front>
+                    <article-meta>
+                    <related-article id="pp1" related-article-type="preprint" ext-link-type="doi" xlink:href="10.1590/SciELOPreprints.1174"/>
+                    <history>
+                    <date date-type="preprint">
+                    <day>18</day>
+                    <month>10</month>
+                    <year>2002</year>
+                    </date>
+                    </history>
+                    </article-meta>
+                    </front>
+                    </article>
+                """
 
         obtained = PreprintValidation(get_xml_tree(xml_str)).preprint_validation()
 
         expected = [
             {
-                'title': 'Preprint validation',
-                'xpath': './/related-article[@related-article-type="preprint"] .//history//date[@date-type="preprint"]',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': '2002-10-18',
-                'got_value': '2002-10-18',
-                'message': 'Got 2002-10-18 expected 2002-10-18',
-                'advice': None
-
+                "title": "Preprint validation",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": None,
+                "item": "related-article / date",
+                "sub_item": "@related-article-type=preprint / @date-type=preprint",
+                "validation_type": "exist",
+                "response": "OK",
+                "expected_value": "2002-10-18",
+                "got_value": "2002-10-18",
+                "message": "Got 2002-10-18, expected 2002-10-18",
+                "advice": None,
+                "data": {
+                    "ext-link-type": "doi",
+                    "href": "10.1590/SciELOPreprints.1174",
+                    "id": "pp1",
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": None,
+                    "related-article-type": "preprint",
+                    "text": "",
+                },
             }
+
         ]
 
         for i, item in enumerate(obtained):
@@ -51,9 +67,9 @@ class PreprintValidationTest(unittest.TestCase):
             <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
             <front>
             <article-meta>
+            <related-article id="pp1" related-article-type="preprint" ext-link-type="doi" xlink:href="10.1590/SciELOPreprints.1174"/>
             </article-meta>
             </front>
-            <related-article id="pp1" related-article-type="preprint" ext-link-type="doi" xlink:href="10.1590/SciELOPreprints.1174"/>
             </article>
         """
 
@@ -61,14 +77,30 @@ class PreprintValidationTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'Preprint validation',
-                'xpath': './/related-article[@related-article-type="preprint"] .//history//date[@date-type="preprint"]',
-                'validation_type': 'match',
-                'response': 'ERROR',
-                'expected_value': 'The preprint publication date',
-                'got_value': None,
-                'message': 'Got None expected The preprint publication date',
-                'advice': 'Provide the publication date of the preprint'
+                "title": "Preprint validation",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": None,
+                "item": "related-article / date",
+                "sub_item": "@related-article-type=preprint / @date-type=preprint",
+                "validation_type": "exist",
+                "response": "ERROR",
+                "expected_value": "The preprint publication date",
+                "got_value": None,
+                "message": "Got None, expected The preprint publication date",
+                "advice": "Provide the publication date of the preprint",
+                "data": {
+                    "ext-link-type": "doi",
+                    "href": "10.1590/SciELOPreprints.1174",
+                    "id": "pp1",
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": None,
+                    "related-article-type": "preprint",
+                    "text": "",
+                },
 
             }
         ]
@@ -99,17 +131,22 @@ class PreprintValidationTest(unittest.TestCase):
 
         expected = [
             {
-                'title': 'Preprint validation',
-                'xpath': './/related-article[@related-article-type="preprint"] .//history//date[@date-type="preprint"]',
-                'validation_type': 'match',
-                'response': 'ERROR',
-                'expected_value': None,
-                'got_value': '2002-10-18',
-                'message': 'Got 2002-10-18 expected None',
-                'advice': 'The article does not reference the preprint, provide it as in the example: '
+                "title": "Preprint validation",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": None,
+                "item": "related-article / date",
+                "sub_item": "@related-article-type=preprint / @date-type=preprint",
+                "validation_type": "exist",
+                "response": "ERROR",
+                "expected_value": None,
+                "got_value": "2002-10-18",
+                "message": "Got 2002-10-18, expected None",
+                "advice": 'The article does not reference the preprint, provide it as in the example: '
                           '<related-article id="pp1" related-article-type="preprint" ext-link-type="doi" '
-                          'xlink:href="10.1590/SciELOPreprints.1174"/>'
-
+                          'xlink:href="10.1590/SciELOPreprints.1174"/>',
+                "data": None
             }
         ]
 
@@ -128,7 +165,7 @@ class PreprintValidationTest(unittest.TestCase):
             </article>
         """
 
-        obtained = PreprintValidation(get_xml_tree(xml_str)).preprint_validation()
+        obtained = list(PreprintValidation(get_xml_tree(xml_str)).preprint_validation())
 
         self.assertEqual([], obtained)
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma funcionalidade para validar a presença de `preprint` em artigos XML, verificando se há uma correspondência correta entre o `preprint` referenciado e sua data de publicação no histórico do artigo. Especificamente, o PR:

- Valida a Existência de `preprint`: Verifica se o artigo possui uma referência a um `preprint` através do elemento `<related-article>` com o tipo `related-article-type="preprint"`.
- Verifica a Data de Publicação do `preprint`: Confere se a data de publicação do `preprint` está presente no histórico do artigo (`<history>`) como um elemento `<date>` com o atributo `date-type="preprint"`.
- Gera Respostas de Validação: Produz mensagens de validação que indicam se o `preprint` e sua data de publicação estão corretamente configurados, e fornece conselhos sobre correções necessárias caso falte alguma informação ou estejam presentes informações incorretas.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?

1. Utilize um XML de artigo que inclua elementos `<related-article>` e `<history>`.
2. Certifique-se de incluir um `preprint` com uma data correspondente no histórico do artigo.
3. Execute o método `preprint_validation` e valide que:

- A validação passa com sucesso quando ambos o `preprint` e sua data estão presentes e corretos.
- Um erro é reportado se faltar a data de `preprint`.
- Um erro é reportado se a data do `preprint` estiver presente sem uma referência correspondente ao `preprint` no artigo.


#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

