### PR TITLE
Feat: different doi in translation validation

### DIFF
--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -405,3 +405,24 @@ class ArticleDoiValidation:
                     data=self.doi.data,
                     error_level=error_level,
                 )
+
+    def validate_different_doi_in_translation(self, error_level="WARNING"):
+        article_doi = self.doi.main_doi
+        for doi in self.doi.data:
+            if doi["parent_article_type"] == "translation" and doi["value"] == article_doi:
+                yield format_response(
+                    title='Different DOIs for tranaltions',
+                    parent=doi.get("parent"),
+                    parent_id=doi.get("parent_id"),
+                    parent_article_type=doi.get("parent_article_type"),
+                    parent_lang=doi.get("lang"),
+                    item="article-id",
+                    sub_item='@pub-id-type="doi"',
+                    validation_type='match',
+                    is_valid=False,
+                    expected="use unique DOIs for articles and sub-articles",
+                    obtained=f"article DOI: {article_doi}, sub-article DOI: {doi['value']}",
+                    advice="consider using different DOIs for article and sub-article",
+                    data=self.doi.data,
+                    error_level=error_level,
+                )

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -1707,6 +1707,65 @@ class ArticleDoiTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
+    def test_validate_different_doi_in_translation(self):
+        self.maxDiff = None
+        xml_str = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
+            article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
+            <front>
+                <article-id specific-use="previous-pid" pub-id-type="publisher-id">S2176-45732023005002205</article-id>
+                <article-id specific-use="scielo-v3" pub-id-type="publisher-id">PqQCH4JjQTWmwYF97s4YGKv</article-id>
+                <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S2176-45732023000200226</article-id>
+                <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+            </front>
+            <sub-article article-type="reviewer-report" id="s2" xml:lang="pt" />
+            <sub-article article-type="reviewer-report" id="s3" xml:lang="pt" />
+            <sub-article article-type="translation" id="s1" xml:lang="en">
+                <front-stub>
+                    <article-id pub-id-type="doi">10.1590/2176-4573p59270</article-id>
+                </front-stub>
+            </sub-article>
+            </article>
+            """
+        xml_tree = get_xml_tree(xml_str)
+        obtained = list(ArticleDoiValidation(xml_tree).validate_different_doi_in_translation())
+        expected = [
+            {
+                'title': 'Different DOIs for tranaltions',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 's1',
+                'parent_lang': 'en',
+                'item': 'article-id',
+                'sub_item': '@pub-id-type="doi"',
+                'validation_type': 'match',
+                'response': 'WARNING',
+                'expected_value': 'use unique DOIs for articles and sub-articles',
+                'got_value': 'article DOI: 10.1590/2176-4573p59270, sub-article DOI: 10.1590/2176-4573p59270',
+                'message': 'Got article DOI: 10.1590/2176-4573p59270, sub-article DOI: 10.1590/2176-4573p59270, '
+                           'expected use unique DOIs for articles and sub-articles',
+                'advice': 'consider using different DOIs for article and sub-article',
+                'data': [
+                    {
+                        'lang': 'pt',
+                        'parent': 'article',
+                        'parent_article_type': 'research-article',
+                        'value': '10.1590/2176-4573p59270'
+                    },
+                    {
+                        'lang': 'en',
+                        'parent': 'sub-article',
+                        'parent_article_type': 'translation',
+                        'parent_id': 's1',
+                        'value': '10.1590/2176-4573p59270'
+                    }
+                ],
+            }
+        ]
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma nova validação para garantir que os DOIs de artigos e sub-artigos de tradução sejam distintos. A função `validate_different_doi_in_translation` verifica se o DOI do sub-artigo (tradução) é igual ao DOI do artigo principal e, caso sejam iguais, gera um aviso recomendando o uso de DOIs únicos para o artigo e o sub-artigo.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?

1. Utilize um XML de artigo que inclua DOIs para o artigo principal e para sub-artigos de tradução.
2. Assegure-se de que o DOI do artigo principal e do sub-artigo de tradução sejam iguais em alguns casos.
3. Execute a função `validate_different_doi_in_translation`.
4. Verifique que um aviso é gerado quando os DOIs do artigo e do sub-artigo de tradução são iguais, sugerindo o uso de DOIs distintos.

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

