### PR TITLE
Feat: table wrap elements

### DIFF
--- a/packtools/sps/validation/tablewrap.py
+++ b/packtools/sps/validation/tablewrap.py
@@ -43,3 +43,29 @@ class TableWrapValidation:
                 data=None,
                 error_level=error_level,
             )
+
+    def validate_tablewrap_elements(self, error_level="ERROR"):
+        if self.table_wrappers:
+            for table_wrap_data in self.table_wrappers:
+                elements_found = []
+                for element in ["table_wrap_id", "label", "caption"]:
+                    value = table_wrap_data.get(element)
+                    if value:
+                        elements_found.append(value)
+                if not bool(elements_found):
+                    yield format_response(
+                        title="table-wrap elements",
+                        parent=table_wrap_data.get("parent"),
+                        parent_id=table_wrap_data.get("parent_id"),
+                        parent_article_type=table_wrap_data.get("parent_article_type"),
+                        parent_lang=table_wrap_data.get("parent_lang"),
+                        item="table-wrap",
+                        sub_item="<table-wrap @id> / <label> / <caption>",
+                        validation_type="exist",
+                        is_valid=False,
+                        expected="<table-wrap @id> or <label> or <caption> elements",
+                        obtained=elements_found,
+                        advice="provide <table-wrap @id> or <label> or <caption> for <table-wrap>",
+                        data=table_wrap_data,
+                        error_level=error_level,
+                    )

--- a/tests/sps/validation/test_tablewrap.py
+++ b/tests/sps/validation/test_tablewrap.py
@@ -187,6 +187,71 @@ class TableWrapValidationTest(unittest.TestCase):
         self.assertDictEqual(expected[0], obtained[0])
         self.assertDictEqual(expected[1], obtained[7])
 
+    def test_validate_tablewrap_elements(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<table-wrap>'
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</table-wrap>"
+            "</body>"
+            '<sub-article article-type="translation" xml:lang="en">'
+            "<body>"
+            '<table-wrap id="t01">'
+            "<label>Table 1:</label>"
+            "<caption>Table caption</caption>"
+            "<alternatives>"
+            '<graphic xlink:href="image1-lowres.png" mime-subtype="low-resolution"/>'
+            '<graphic xlink:href="image1-highres.png" mime-subtype="high-resolution"/>'
+            "</alternatives>"
+            "</table-wrap>"
+            "</body>"
+            "</sub-article>"
+            "</article>"
+        )
+        obtained = list(TableWrapValidation(xmltree).validate_tablewrap_elements())
+
+        expected = [
+            {
+                "advice": "provide <table-wrap @id> or <label> or <caption> for <table-wrap>",
+                "data": {
+                    "alternative_elements": ["graphic", "graphic"],
+                    "alternative_parent": "table-wrap",
+                    "caption": "",
+                    "footnote": "",
+                    "footnote_id": None,
+                    "footnote_label": None,
+                    "label": None,
+                    "parent": "article",
+                    "parent_article_type": "research-article",
+                    "parent_id": None,
+                    "parent_lang": "pt",
+                    "table_wrap_id": None,
+                },
+                "expected_value": "<table-wrap @id> or <label> or <caption> elements",
+                "got_value": [],
+                "item": "table-wrap",
+                "message": "Got [], expected <table-wrap @id> or <label> or <caption> elements",
+                "parent": "article",
+                "parent_article_type": "research-article",
+                "parent_id": None,
+                "parent_lang": "pt",
+                "response": "ERROR",
+                "sub_item": "<table-wrap @id> / <label> / <caption>",
+                "title": "table-wrap elements",
+                "validation_type": "exist",
+            }
+        ]
+
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona validação para elementos de `<table-wrap>`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_tablewrap.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

