### PR TITLE
Feat: related-article attributes order validation

### DIFF
--- a/packtools/sps/models/v2/related_articles.py
+++ b/packtools/sps/models/v2/related_articles.py
@@ -8,6 +8,8 @@ de Foucault.
 </related-article>
 """
 
+import xml.etree.ElementTree as ET
+
 from packtools.sps.utils.xml_utils import put_parent_context, process_subtags
 
 
@@ -26,8 +28,15 @@ class RelatedArticle:
             "id": self.id,
             "related-article-type": self.related_article_type,
             "href": self.href,
-            "text": self.text
+            "text": self.text,
+            "full_tag": self.full_tag
         }
+
+    @property
+    def full_tag(self):
+        ET.register_namespace('xlink', "http://www.w3.org/1999/xlink")
+        opening_tag = ET.tostring(self.related_article_node, encoding='unicode').split('>')[0] + '>'
+        return opening_tag
 
 
 class RelatedArticlesByNode:

--- a/tests/sps/models/v2/test_related_articles.py
+++ b/tests/sps/models/v2/test_related_articles.py
@@ -16,6 +16,7 @@ from packtools.sps.models.v2.related_articles import RelatedArticle, RelatedArti
 
 class RelatedArticleTest(TestCase):
     def test_related_article(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <front>
@@ -37,13 +38,16 @@ class RelatedArticleTest(TestCase):
             "href": "10.1590/0101-3173.2022.v45n1.p139",
             "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                     "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                    "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                    "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+            'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                        'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
         }
         self.assertDictEqual(obtained, expected)
 
 
 class RelatedArticlesByNodeTest(TestCase):
     def test_related_articles(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="article-commentary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
@@ -73,7 +77,9 @@ class RelatedArticlesByNodeTest(TestCase):
                 "href": "10.1590/0101-3173.2022.v45n1.p139",
                 "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                         "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                        "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                        "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                            'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -98,7 +104,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA1" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -109,7 +118,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA9" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]
@@ -129,7 +141,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA10" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -140,7 +155,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA18" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -14,7 +14,9 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
+            <article-meta>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
+            </article-meta>
             </front>
             </article>
 
@@ -56,7 +58,11 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'ext-link-type': 'doi',
                     'href': '10.1590/1808-057x202090350',
                     'id': 'ra1',
-                    'related-article-type': 'corrected-article'
+                    'related-article-type': 'corrected-article',
+                    'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" '
+                                'id="ra1" related-article-type="corrected-article" '
+                                'xlink:href="10.1590/1808-057x202090350" />',
+                    'text': '',
                 }
             }
         ]
@@ -72,7 +78,9 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="retraction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
+            <article-meta>
             <related-article ext-link-type="doi" id="ra1" related-article-type="retraction-forward" xlink:href="10.1590/1808-057x202090350"/>
+            </article-meta>
             </front>
             </article>
 
@@ -115,7 +123,11 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'ext-link-type': 'doi',
                     'href': '10.1590/1808-057x202090350',
                     'id': 'ra1',
-                    'related-article-type': 'retraction-forward'
+                    'related-article-type': 'retraction-forward',
+                    'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" '
+                                'id="ra1" related-article-type="retraction-forward" '
+                                'xlink:href="10.1590/1808-057x202090350" />',
+                    'text': ''
                 }
             }
         ]
@@ -131,7 +143,9 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
+            <article-meta>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
+            </article-meta>
             </front>
             </article>
 
@@ -162,7 +176,11 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'ext-link-type': 'doi',
                     'href': '10.1590/1808-057x202090350',
                     'id': 'ra1',
-                    'related-article-type': 'corrected-article'
+                    'related-article-type': 'corrected-article',
+                    'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" '
+                                'id="ra1" related-article-type="corrected-article" '
+                                'xlink:href="10.1590/1808-057x202090350" />',
+                    'text': ''
                 }
             }
         ]
@@ -178,7 +196,9 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
+            <article-meta>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" />
+            </article-meta>
             </front>
             </article>
 
@@ -209,11 +229,76 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'parent_lang': 'en',
                     'ext-link-type': 'doi',
                     'id': 'ra1',
-                    'related-article-type': 'corrected-article'
+                    'related-article-type': 'corrected-article',
+                    'full_tag': '<related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" />',
+                    'href': None,
+                    'text': ''
                 }
             }
         ]
 
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(obtained[i], item)
+
+    def test_attrib_order_in_related_article_tag(self):
+        self.maxDiff = None
+        xmltree = etree.fromstring(
+            """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
+            <front>
+            <article-meta>
+            <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
+            <related-article related-article-type="corrected-article" id="ra1" ext-link-type="doi" xlink:href="10.1590/1808-057x202090350"/>
+            </article-meta>
+            </front>
+            </article>
+
+            """
+        )
+        obtained = list(RelatedArticlesValidation(xmltree).attrib_order_in_related_article_tag())
+
+        expected = [
+            {
+                'title': 'attrib order in related article tag',
+                'parent': 'article',
+                'parent_article_type': 'correction-forward',
+                'parent_id': None,
+                'parent_lang': 'en',
+                'item': 'related-article',
+                'sub_item': None,
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': '<related-article related-article-type="TYPE" id="ID" xlink:href="HREF" '
+                                  'ext-link-type="doi">',
+                'got_value': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" '
+                             'id="ra1" related-article-type="corrected-article" '
+                             'xlink:href="10.1590/1808-057x202090350" />',
+                'message': 'Got <related-article xmlns:xlink="http://www.w3.org/1999/xlink" '
+                           'ext-link-type="doi" id="ra1" '
+                           'related-article-type="corrected-article" '
+                           'xlink:href="10.1590/1808-057x202090350" />, expected '
+                           '<related-article related-article-type="TYPE" id="ID" '
+                           'xlink:href="HREF" ext-link-type="doi">',
+                'advice': 'provide the attributes in the specified order',
+                'data': {
+                    'parent': 'article',
+                    'parent_article_type': 'correction-forward',
+                    'parent_id': None,
+                    'parent_lang': 'en',
+                    'ext-link-type': 'doi',
+                    'href': '10.1590/1808-057x202090350',
+                    'id': 'ra1',
+                    'related-article-type': 'corrected-article',
+                    'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" '
+                                'id="ra1" related-article-type="corrected-article" '
+                                'xlink:href="10.1590/1808-057x202090350" />',
+                    'text': ''
+                }
+            },
+        ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR implementa uma validação que garante a ordem correta dos atributos na tag `<related-article>`. O problema resolvido é que, em alguns casos, os atributos estavam fora de ordem, o que poderia causar erros na interpretação dos dados XML. Esta validação assegura que os atributos `related-article-type`, `id`, `xlink:href` e `ext-link-type` (com o valor "doi") apareçam na ordem correta, com o namespace `xmlns:xlink ` sendo opcional. Além disso, foram adicionados testes automatizados para verificar essa funcionalidade.

#### Onde a revisão poderia começar?
O revisor deve começar pela leitura dos seguintes arquivos:

- `related_article_validation.py`: contém a implementação da função `attrib_order_in_related_article_tag`.
- `test_related_article_validation.py`: contém os testes automatizados para essa nova validação.


#### Como este poderia ser testado manualmente?
Para testar manualmente, siga os passos:

1. Crie um arquivo XML contendo uma tag `<related-article> `com os atributos em ordem correta e incorreta.
2. Execute a validação com o novo código.
3. Verifique se a saída do validador corresponde ao esperado, detectando erros quando os atributos estão fora de ordem e passando quando a ordem está correta.

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

