### PR TITLE
Fix: article lang validation

### DIFF
--- a/packtools/sps/models/article_and_subarticles.py
+++ b/packtools/sps/models/article_and_subarticles.py
@@ -53,6 +53,7 @@ class ArticleAndSubArticles:
                 "article_id": None,
                 "line_number": self.main_line_number,
                 "subject": self.main_subject,
+                "parent_name": "article",
             })
 
         for sub_article in self.xmltree.xpath(".//sub-article"):
@@ -65,6 +66,7 @@ class ArticleAndSubArticles:
                 "article_type": sub_article.get('article-type'),
                 "article_id": sub_article.get('id'),
                 "line_number": sub_article.sourceline,
-                "subject": subject.text if subject is not None else None
+                "subject": subject.text if subject is not None else None,
+                "parent_name": "sub-article",
             })
         return _data

--- a/packtools/sps/models/article_titles.py
+++ b/packtools/sps/models/article_titles.py
@@ -39,19 +39,20 @@ class ArticleTitles:
         for node_with_lang in xml_utils.get_nodes_with_lang(
                 self.xmltree,
                 ".", ".//article-meta//article-title"):
-            return {
-                "parent_name": "article",
-                "lang": node_with_lang["lang"],
-                "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
-                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
-                "html_text": xml_utils.process_subtags(
-                    node_with_lang["node"],
-                    tags_to_keep=self.tags_to_keep,
-                    tags_to_keep_with_content=self.tags_to_keep_with_content,
-                    tags_to_remove_with_content=self.tags_to_remove_with_content,
-                    tags_to_convert_to_html=self.tags_to_convert_to_html
-                )
-            }
+            if node_with_lang["node"] is not None:
+                return {
+                    "parent_name": "article",
+                    "lang": node_with_lang["lang"],
+                    "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                    "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                    "html_text": xml_utils.process_subtags(
+                        node_with_lang["node"],
+                        tags_to_keep=self.tags_to_keep,
+                        tags_to_keep_with_content=self.tags_to_keep_with_content,
+                        tags_to_remove_with_content=self.tags_to_remove_with_content,
+                        tags_to_convert_to_html=self.tags_to_convert_to_html
+                    )
+                }
 
     @property
     def trans_titles(self):
@@ -59,20 +60,21 @@ class ArticleTitles:
         for node_with_lang in xml_utils.get_nodes_with_lang(
                 self.xmltree,
                 ".//article-meta//trans-title-group", "trans-title"):
-            _title = {
-                "parent_name": "article",
-                "lang": node_with_lang["lang"],
-                "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
-                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
-                "html_text": xml_utils.process_subtags(
-                    node_with_lang["node"],
-                    tags_to_keep=self.tags_to_keep,
-                    tags_to_keep_with_content=self.tags_to_keep_with_content,
-                    tags_to_remove_with_content=self.tags_to_remove_with_content,
-                    tags_to_convert_to_html=self.tags_to_convert_to_html
-                )
-            }
-            _titles.append(_title)
+            if node_with_lang["node"] is not None:
+                _title = {
+                    "parent_name": "article",
+                    "lang": node_with_lang["lang"],
+                    "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                    "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                    "html_text": xml_utils.process_subtags(
+                        node_with_lang["node"],
+                        tags_to_keep=self.tags_to_keep,
+                        tags_to_keep_with_content=self.tags_to_keep_with_content,
+                        tags_to_remove_with_content=self.tags_to_remove_with_content,
+                        tags_to_convert_to_html=self.tags_to_convert_to_html
+                    )
+                }
+                _titles.append(_title)
         return _titles
 
     @property
@@ -82,19 +84,20 @@ class ArticleTitles:
                 self.xmltree,
                 ".//sub-article[@article-type='translation']",
                 ".//front-stub//article-title"):
-            _title = {
-                "parent_name": "sub-article",
-                "lang": node_with_lang["lang"],
-                "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
-                "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
-                "html_text": xml_utils.process_subtags(
-                    node_with_lang["node"],
-                    tags_to_keep=self.tags_to_keep,
-                    tags_to_keep_with_content=self.tags_to_keep_with_content,
-                    tags_to_remove_with_content=self.tags_to_remove_with_content,
-                    tags_to_convert_to_html=self.tags_to_convert_to_html
-                ),
-                "id": node_with_lang["id"]
-            }
-            _titles.append(_title)
+            if node_with_lang["node"] is not None:
+                _title = {
+                    "parent_name": "sub-article",
+                    "lang": node_with_lang["lang"],
+                    "text": xml_utils.node_text_without_xref(node_with_lang["node"]),
+                    "plain_text": xml_utils.node_plain_text(node_with_lang["node"]),
+                    "html_text": xml_utils.process_subtags(
+                        node_with_lang["node"],
+                        tags_to_keep=self.tags_to_keep,
+                        tags_to_keep_with_content=self.tags_to_keep_with_content,
+                        tags_to_remove_with_content=self.tags_to_remove_with_content,
+                        tags_to_convert_to_html=self.tags_to_convert_to_html
+                    ),
+                    "id": node_with_lang["id"]
+                }
+                _titles.append(_title)
         return _titles

--- a/packtools/sps/models/article_titles.py
+++ b/packtools/sps/models/article_titles.py
@@ -29,10 +29,11 @@ class ArticleTitles:
 
     @property
     def article_title_dict(self):
-        return {
-            item['lang']: item['text']
-            for item in self.article_title_list
-        }
+        resp = {}
+        for item in self.article_title_list:
+            if item and item.get('lang'):
+                resp[item['lang']] = item
+        return resp
 
     @property
     def article_title(self):

--- a/packtools/sps/models/v2/related_articles.py
+++ b/packtools/sps/models/v2/related_articles.py
@@ -8,6 +8,8 @@ de Foucault.
 </related-article>
 """
 
+import xml.etree.ElementTree as ET
+
 from packtools.sps.utils.xml_utils import put_parent_context, process_subtags
 
 
@@ -26,8 +28,15 @@ class RelatedArticle:
             "id": self.id,
             "related-article-type": self.related_article_type,
             "href": self.href,
-            "text": self.text
+            "text": self.text,
+            "full_tag": self.full_tag
         }
+
+    @property
+    def full_tag(self):
+        ET.register_namespace('xlink', "http://www.w3.org/1999/xlink")
+        opening_tag = ET.tostring(self.related_article_node, encoding='unicode').split('>')[0] + '>'
+        return opening_tag
 
 
 class RelatedArticlesByNode:

--- a/packtools/sps/validation/article_lang.py
+++ b/packtools/sps/validation/article_lang.py
@@ -1,214 +1,124 @@
-from packtools.sps.models import (
-    article_titles,
-    article_abstract,
-    kwd_group,
-    article_and_subarticles,
-)
+from packtools.sps.models import article_and_subarticles, article_titles, article_abstract, kwd_group
+from packtools.sps.validation.utils import format_response
 
 
-def _elements_exist(parent, titles, abstracts, keywords):
+def _elements_exist(title, abstract, keyword):
     """
-    Verifica se os elementos de título, resumo e palavras-chave estão presentes no XML.
+    Verifica a existência dos elementos de título, resumo e palavras-chave no XML.
 
-    Args:
-        parent (str): Nome do elemento pai.
-        titles (list): Lista de títulos no XML com 'parent' e 'lang' filtrados.
-        abstracts (list): Lista de resumos no XML com 'parent' e 'lang' filtrados.
-        keywords (list): Lista de palavras-chave no XML com 'parent' e 'lang' filtrados.
+    Parâmetros
+    ----------
+    title : dict
+        Dicionário com dados do título do artigo no XML.
+    abstract : dict
+        Dicionário com dados do resumo do artigo no XML.
+    keyword : dict
+        Dicionário com dados dss palavras-chave do artigo no XML.
 
-    Returns:
-        tuple: Um tupla contendo:
-            - bool: Indica se os elementos existem.
-            - bool: Indica se o elemento é obrigatório.
-            - str: Nome do elemento ausente, se houver.
-            - str: XPath do elemento ausente, se houver.
-            - str: Valor esperado para o elemento ausente.
+    Retorna
+    -------
+    tuple
+        Um tuple contendo três valores:
+        - bool: Se todos os elementos necessários estão presentes.
+        - bool: Se o elemento ausente é obrigatório.
+        - str: O nome do elemento ausente, se houver.
     """
-    # verifica se existe título no XML
-    if not titles:
-        return False, True, 'title', './/article-title/@xml:lang', f'title for the {parent}'
-    # verifica se existe palavras-chave sem resumo
-    if abstracts == [] and keywords != []:
-        return False, True, 'abstract', './/abstract/@xml:lang', f'abstract for the {parent}'
-    # verifica se existe resumo sem palavras-chave
-    if abstracts != [] and keywords == []:
-        return False, True, 'kwd-group', './/kwd-group/@xml:lang', f'keywords for the {parent}'
-    # verifica se o teste é necessário
-    if abstracts == [] and keywords == []:
-        return True, False, None, None, None
-    return True, True, None, None, None
-
-
-def get_element_langs(elements):
-    """
-    Extrai informações de idioma e nome do elemento pai de uma lista de elementos.
-
-    Args:
-        elements (list): Lista de elementos contendo dados de idioma e nome do pai.
-
-    Returns:
-        list: Lista de dicionários contendo as chaves 'parent_name', 'lang' e, opcionalmente, 'id' ou 'article_id'.
-    """
-    return [
-        {
-            'parent_name': item.get('parent_name'),
-            'lang': item.get('lang'),
-            **({'id': item['id']} if 'id' in item else {}),
-            **({'id': item['article_id']} if 'article_id' in item else {})
-        }
-        for item in elements if item
-    ]
-
-
-def get_advice(element, element_dict):
-    """
-    Gera uma mensagem de conselho sobre a falta de um elemento baseado no idioma e no nome do pai.
-
-    Args:
-        element (str): O tipo de elemento (por exemplo, 'title', 'abstract', 'kwd-group').
-        element_dict (dict): Dicionário contendo informações sobre o idioma e o elemento pai.
-
-    Returns:
-        str: Mensagem de conselho formatada.
-    """
-    advice = f'Provide {element} in the \'{element_dict.get("lang")}\' language for {element_dict.get("parent_name")}'
-    if element_dict.get("id") is not None:
-        advice += f' ({element_dict.get("id")})'
-    return advice
-
-
-def filter_by_parent_and_lang(element_list, parent, lang):
-    """
-    Filtra uma lista de elementos pelo nome do pai e pelo idioma.
-
-    Args:
-        element_list (list): Lista de dicionários de elementos.
-        parent (str): Nome do elemento pai a ser filtrado.
-        lang (str): Idioma a ser filtrado.
-
-    Returns:
-        list: Lista filtrada de elementos que correspondem ao pai e idioma fornecidos.
-    """
-    return [element_dict for element_dict in element_list if
-            element_dict['parent_name'] == parent and element_dict['lang'] == lang]
+    # Verifica se existe título no XML
+    if not title:
+        return False, True, 'title'
+    # Verifica se existe palavras-chave sem resumo
+    if not abstract and keyword:
+        return False, True, 'abstract'
+    # Verifica se existe resumo sem palavras-chave
+    if abstract and not keyword:
+        return False, True, 'kwd-group'
+    return True, False, None
 
 
 class ArticleLangValidation:
     """
-    Classe que realiza validações de idiomas para os elementos de um artigo como títulos, resumos e palavras-chave.
+    Classe para validação de idiomas de artigos no XML. Verifica se os elementos
+    de título, resumo e palavras-chave estão presentes no XML e se os respectivos
+    idiomas correspondem.
 
-    Args:
-        xml_tree (lxml.etree._Element): A árvore XML que representa o artigo.
+    Atributos
+    ---------
+    article_and_subarticles : ArticleAndSubArticles
+        Instância que contém dados de artigos e subartigos do XML.
+    article_title : ArticleTitles
+        Instância que contém títulos do artigo por idioma.
+    article_abstract : ArticleAbstract
+        Instância que contém resumos do artigo por idioma.
+    article_kwd : ArticleKeywords
+        Instância que contém palavras-chave do artigo por idioma.
     """
 
     def __init__(self, xml_tree):
-        self.article_title = article_titles.ArticleTitles(xml_tree)
-        self.article_abstract = article_abstract.Abstract(xml_tree)
-        self.article_kwd = kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None)
+        """
+        Inicializa a classe com a árvore XML fornecida.
+
+        Parâmetros
+        ----------
+        xml_tree : ElementTree
+            A árvore XML do artigo a ser validado.
+        """
         self.article_and_subarticles = article_and_subarticles.ArticleAndSubArticles(xml_tree)
+        self.article_title = article_titles.ArticleTitles(xml_tree)
+        self.article_abstract = article_abstract.ArticleAbstract(xml_tree)
+        self.article_kwd = kwd_group.ArticleKeywords(xml_tree)
 
-    def validate_article_lang(self):
+    def validate_article_lang(self, error_level="ERROR"):
         """
-        Verifica se os elementos de título, resumo e palavras-chave estão presentes no XML
-        e se os respectivos idiomas correspondem.
+        Valida os idiomas dos elementos de título, resumo e palavras-chave no XML,
+        e gera uma resposta de validação para cada verificação.
 
-        XML de entrada
-        --------------
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-        </article>
+        Parâmetros
+        ----------
+        error_level : str, opcional
+            O nível de erro a ser retornado na resposta (padrão é "ERROR").
 
-        Returns
+        Retorna
         -------
-        list of dict
-            Uma lista de dicionários, como:
-            [
-                {
-                    'title': 'abstract element lang attribute validation',
-                    'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': 'pt',
-                    'got_value': 'pt',
-                    'message': 'Got pt expected pt',
-                    'advice': None
-                },...
-            ]
+        generator
+            Gera dicionários que contêm os resultados de validação para cada
+            idioma de artigo/subartigo, com as informações sobre a validação e
+            eventuais erros encontrados.
         """
-        # obtem uma lista de dicionários com dados de artigo e sub-artigos: [{'parent_name': 'article', 'lang': 'pt'},...]
-        article_and_subarticles_list = get_element_langs(self.article_and_subarticles.data)
+        # Títulos indexados por idioma
+        titles_by_lang = self.article_title.article_title_dict
 
-        # obtem uma lista de dicionários com dados de títulos: [{'parent_name': 'article', 'lang': 'pt'},...]
-        titles_list = get_element_langs(self.article_title.data)
+        # Resumos indexados por idioma
+        abstracts_by_lang = self.article_abstract.get_abstracts_by_lang()
 
-        # obtem uma lista de dicionários com dados de resumos: [{'parent_name': 'article', 'lang': 'pt'},...]
-        abstracts_list = get_element_langs(self.article_abstract.get_abstracts(style='inline'))
+        # Palavras-chave indexadas por idioma
+        self.article_kwd.configure()
+        keywords_by_lang = self.article_kwd.items_by_lang
 
-        # obtem uma lista de dicionários com dados de palavras-chave: [{'parent_name': 'article', 'lang': 'pt'},...]
-        keywords_list = get_element_langs(self.article_kwd)
+        # Verifica a existência dos elementos no XML
+        for item in self.article_and_subarticles.data:
+            lang = item.get("lang")
 
-        # verifica a existência dos elementos no XML
-        for article_and_subarticles_dict in article_and_subarticles_list:
-            parent = article_and_subarticles_dict['parent_name']
-            lang = article_and_subarticles_dict['lang']
-            titles_filtered = filter_by_parent_and_lang(titles_list, parent, lang)
-            abstracts_filtered = filter_by_parent_and_lang(abstracts_list, parent, lang)
-            keywords_filtered = filter_by_parent_and_lang(keywords_list, parent, lang)
+            title = titles_by_lang.get(lang)
+            abstract = abstracts_by_lang.get(lang)
+            keyword = keywords_by_lang.get(lang)
 
-            exist, is_required, element, xpath, expected = _elements_exist(
-                parent,
-                titles_filtered,
-                abstracts_filtered,
-                keywords_filtered
-            )
+            exist, is_required, missing_element_name = _elements_exist(title, abstract, keyword)
 
-            if exist and is_required:
-                # validação de correspondência entre os idiomas, usando como base o título
-                for element, langs in zip(['title', 'abstract', 'kwd-group'],
-                                          [titles_filtered, abstracts_filtered, keywords_filtered]):
-                    advice = get_advice(element, article_and_subarticles_dict)
-                    is_valid = article_and_subarticles_dict in langs
-                    expected = article_and_subarticles_dict.get('lang')
-                    obtained = article_and_subarticles_dict.get('lang') if is_valid else None
-                    yield {
-                        'title': f'{article_and_subarticles_dict.get("parent_name")} {element} element lang attribute validation',
-                        'xpath': f'.//article-title/@xml:lang .//{element}/@xml:lang',
-                        'validation_type': 'match',
-                        'response': 'OK' if is_valid else 'ERROR',
-                        'expected_value': expected,
-                        'got_value': obtained,
-                        'message': f'Got {obtained} expected {expected}',
-                        'advice': None if is_valid else advice
-                    }
-            elif is_required:
-                # resposta para a verificação de ausência de elementos
-                advice = get_advice(element, article_and_subarticles_dict)
-                yield {
-                    'title': f'{article_and_subarticles_dict.get("parent_name")} {element} element lang attribute validation',
-                    'xpath': xpath,
-                    'validation_type': 'exist',
-                    'response': 'ERROR',
-                    'expected_value': expected,
-                    'got_value': None,
-                    'message': f'Got None expected {expected}',
-                    'advice': advice
-                }
+            if not exist and is_required:
+                # Resposta para a verificação de ausência de elementos
+                yield format_response(
+                    title=f'{missing_element_name} element lang attribute',
+                    parent=item.get("parent_name"),
+                    parent_id=item.get("article_id"),
+                    parent_article_type=item.get("article_type"),
+                    parent_lang=lang,
+                    item=missing_element_name,
+                    sub_item=None,
+                    validation_type='match',
+                    is_valid=False,
+                    expected=f"{missing_element_name} in {lang}",
+                    obtained=None,
+                    advice=f'Provide {missing_element_name} in the {lang} language for {item.get("parent_name")}',
+                    data=item,
+                    error_level=error_level,
+                )

--- a/tests/sps/models/test_article_and_subarticles.py
+++ b/tests/sps/models/test_article_and_subarticles.py
@@ -53,42 +53,48 @@ class ArticleAndSubarticlesTest(TestCase):
                 'article_type': 'research-article',
                 'lang': 'pt',
                 'line_number': 2,
-                'subject': 'ARTIGOS'
+                'subject': 'ARTIGOS',
+                'parent_name': 'article',
             },
             {
                 'article_id': 's2',
                 'article_type': 'reviewer-report',
                 'lang': 'pt',
                 'line_number': 93,
-                'subject': 'Pareceres'
+                'subject': 'Pareceres',
+                'parent_name': 'sub-article',
             },
             {
                 'article_id': 's3',
                 'article_type': 'reviewer-report',
                 'lang': 'pt',
                 'line_number': 141,
-                'subject': 'Pareceres'
+                'subject': 'Pareceres',
+                'parent_name': 'sub-article',
             },
             {
                 'article_id': 's1',
                 'article_type': 'translation',
                 'lang': 'en',
                 'line_number': 189,
-                'subject': 'ARTICLES'
+                'subject': 'ARTICLES',
+                'parent_name': 'sub-article',
             },
             {
                 'article_id': 's5',
                 'article_type': 'reviewer-report',
                 'lang': 'en',
                 'line_number': 233,
-                'subject': 'Reviews'
+                'subject': 'Reviews',
+                'parent_name': 'sub-article',
             },
             {
                 'article_id': 's6',
                 'article_type': 'reviewer-report',
                 'lang': 'en',
                 'line_number': 271,
-                'subject': 'Reviews'
+                'subject': 'Reviews',
+                'parent_name': 'sub-article',
             }
         ]
         obtained = [d for d in ArticleAndSubArticles(xmltree).data]

--- a/tests/sps/models/v2/test_related_articles.py
+++ b/tests/sps/models/v2/test_related_articles.py
@@ -16,6 +16,7 @@ from packtools.sps.models.v2.related_articles import RelatedArticle, RelatedArti
 
 class RelatedArticleTest(TestCase):
     def test_related_article(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <front>
@@ -37,13 +38,16 @@ class RelatedArticleTest(TestCase):
             "href": "10.1590/0101-3173.2022.v45n1.p139",
             "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                     "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                    "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                    "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+            'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                        'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
         }
         self.assertDictEqual(obtained, expected)
 
 
 class RelatedArticlesByNodeTest(TestCase):
     def test_related_articles(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="article-commentary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
@@ -73,7 +77,9 @@ class RelatedArticlesByNodeTest(TestCase):
                 "href": "10.1590/0101-3173.2022.v45n1.p139",
                 "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                         "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                        "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                        "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                            'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -98,7 +104,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA1" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -109,7 +118,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA9" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]
@@ -129,7 +141,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA10" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -140,7 +155,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA18" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -28,8 +28,8 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'title element lang attribute',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
+                'parent': None,
+                'parent_article_type': None,
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'item': 'title',
@@ -39,15 +39,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'title in pt',
                 'got_value': None,
                 'message': 'Got None, expected title in pt',
-                'advice': 'Provide title in the pt language for article',
-                'data': {
-                    'article_id': None,
-                    'article_type': 'research-article',
-                    'lang': 'pt',
-                    'line_number': 3,
-                    'parent_name': 'article',
-                    'subject': None
-                },
+                'advice': 'Provide title in the pt language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -86,9 +79,9 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'title element lang attribute',
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': 'TRen',
+                'parent': None,
+                'parent_article_type': None,
+                'parent_id': None,
                 'parent_lang': 'en',
                 'item': 'title',
                 'sub_item': None,
@@ -97,15 +90,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'title in en',
                 'got_value': None,
                 'message': 'Got None, expected title in en',
-                'advice': 'Provide title in the en language for sub-article',
-                'data': {
-                    'article_id': 'TRen',
-                    'article_type': 'translation',
-                    'lang': 'en',
-                    'line_number': 10,
-                    'parent_name': 'sub-article',
-                    'subject': None
-                },
+                'advice': 'Provide title in the en language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -116,7 +102,7 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_without_abstract(self):
         self.maxDiff = None
         xml_str = """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1"
             specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
@@ -138,8 +124,8 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'abstract element lang attribute',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
+                'parent': None,
+                'parent_article_type': None,
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'item': 'abstract',
@@ -149,15 +135,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'abstract in pt',
                 'got_value': None,
                 'message': 'Got None, expected abstract in pt',
-                'advice': 'Provide abstract in the pt language for article',
-                'data': {
-                    'article_id': None,
-                    'article_type': 'research-article',
-                    'lang': 'pt',
-                    'line_number': 3,
-                    'parent_name': 'article',
-                    'subject': None
-                },
+                'advice': 'Provide abstract in the pt language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -196,9 +175,9 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'abstract element lang attribute',
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': 'TRen',
+                'parent': None,
+                'parent_article_type': None,
+                'parent_id': None,
                 'parent_lang': 'en',
                 'item': 'abstract',
                 'sub_item': None,
@@ -207,15 +186,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'abstract in en',
                 'got_value': None,
                 'message': 'Got None, expected abstract in en',
-                'advice': 'Provide abstract in the en language for sub-article',
-                'data': {
-                    'article_id': 'TRen',
-                    'article_type': 'translation',
-                    'lang': 'en',
-                    'line_number': 10,
-                    'parent_name': 'sub-article',
-                    'subject': None
-                },
+                'advice': 'Provide abstract in the en language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -226,7 +198,7 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_without_kwd_group(self):
         self.maxDiff = None
         xml_str = """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1"
             specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
@@ -245,8 +217,8 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'kwd-group element lang attribute',
-                'parent': 'article',
-                'parent_article_type': 'research-article',
+                'parent': None,
+                'parent_article_type': None,
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'item': 'kwd-group',
@@ -256,15 +228,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'kwd-group in pt',
                 'got_value': None,
                 'message': 'Got None, expected kwd-group in pt',
-                'advice': 'Provide kwd-group in the pt language for article',
-                'data': {
-                    'article_id': None,
-                    'article_type': 'research-article',
-                    'lang': 'pt',
-                    'line_number': 3,
-                    'parent_name': 'article',
-                    'subject': None
-                },
+                'advice': 'Provide kwd-group in the pt language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -302,9 +267,9 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'kwd-group element lang attribute',
-                'parent': 'sub-article',
-                'parent_article_type': 'translation',
-                'parent_id': 'TRen',
+                'parent': None,
+                'parent_article_type': None,
+                'parent_id': None,
                 'parent_lang': 'en',
                 'item': 'kwd-group',
                 'sub_item': None,
@@ -313,15 +278,8 @@ class ArticleLangTest(unittest.TestCase):
                 'expected_value': 'kwd-group in en',
                 'got_value': None,
                 'message': 'Got None, expected kwd-group in en',
-                'advice': 'Provide kwd-group in the en language for sub-article',
-                'data': {
-                    'article_id': 'TRen',
-                    'article_type': 'translation',
-                    'lang': 'en',
-                    'line_number': 10,
-                    'parent_name': 'sub-article',
-                    'subject': None
-                },
+                'advice': 'Provide kwd-group in the en language',
+                'data': None
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -332,7 +290,7 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_with_title_only(self):
         self.maxDiff = None
         xml_str = """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1"
             specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
@@ -357,7 +315,7 @@ class ArticleLangTest(unittest.TestCase):
         xml_str = """
         <article  xml:lang="pt">
             <front>
-                
+
             </front>
             <sub-article article-type="translation" id="TRen" xml:lang="en">
                 <front-stub>
@@ -370,9 +328,30 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
-        self.assertEqual(list(obtained), [])
+        expected = [
+            {
+                'title': 'title element lang attribute',
+                'parent': None,
+                'parent_article_type': None,
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'title',
+                'sub_item': None,
+                'validation_type': 'match',
+                'response': 'ERROR',
+                'expected_value': 'title in pt',
+                'got_value': None,
+                'message': 'Got None, expected title in pt',
+                'advice': 'Provide title in the pt language',
+                'data': None
+            }
+        ]
+        self.assertEqual(len(obtained), 1)
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
     def test_issue_712(self):
         self.maxDiff = None

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -1,387 +1,21 @@
 import unittest
 
 from packtools.sps.utils.xml_utils import get_xml_tree
-from packtools.sps.validation.article_lang import (
-    ArticleLangValidation,
-    get_element_langs,
-    _elements_exist
-)
-from packtools.sps.models import article_titles, article_abstract, kwd_group
-
-
-class AuxiliaryFunctionsTest(unittest.TestCase):
-    def test_get_title_langs(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                 <front-stub>
-                     <title-group>
-                         <article-title xml:lang="en">Title in english</article-title>
-                     </title-group>
-                 <abstract xml:lang="en">
-                     Abstract in english
-                 </abstract>
-                 <kwd-group xml:lang="en">
-                     <kwd>Keyword 1</kwd>
-                     <kwd>Keyword 2</kwd>
-                 </kwd-group>
-                 </front-stub>
-             </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-        article_title = article_titles.ArticleTitles(xml_tree).data
-
-        obtained = get_element_langs(article_title)
-
-        expected = [
-            {
-                'parent_name': 'article',
-                'lang': 'pt'
-            },
-            {
-                'parent_name': 'article',
-                'lang': 'en'
-            },
-            {
-                'parent_name': 'sub-article',
-                'lang': 'en',
-                'id': 'TRen'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_get_abstract_langs(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                 <front-stub>
-                     <title-group>
-                         <article-title xml:lang="en">Title in english</article-title>
-                     </title-group>
-                     <abstract xml:lang="en">
-                         Abstract in english
-                     </abstract>
-                     <kwd-group xml:lang="en">
-                         <kwd>Keyword 1</kwd>
-                         <kwd>Keyword 2</kwd>
-                     </kwd-group>
-                 </front-stub>
-             </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-        abstract = article_abstract.Abstract(xml_tree).get_abstracts()
-
-        obtained = get_element_langs(abstract)
-
-        expected = [
-            {
-                'parent_name': 'article',
-                'lang': 'pt'
-            },
-            {
-                'parent_name': 'article',
-                'lang': 'en'
-            },
-            {
-                'parent_name': 'sub-article',
-                'lang': 'en',
-                'id': 'TRen'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_get_keyword_langs(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                 <front-stub>
-                     <title-group>
-                         <article-title xml:lang="en">Title in english</article-title>
-                     </title-group>
-                 <abstract xml:lang="en">
-                     Abstract in english
-                 </abstract>
-                 <kwd-group xml:lang="en">
-                     <kwd>Keyword 1</kwd>
-                     <kwd>Keyword 2</kwd>
-                 </kwd-group>
-                 </front-stub>
-             </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-        kwd = kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text_by_article_type(None)
-
-        obtained = get_element_langs(kwd)
-
-        expected = [
-            {
-                'parent_name': 'article',
-                'lang': 'pt'
-            },
-            {
-                'parent_name': 'article',
-                'lang': 'en'
-            },
-            {
-                'parent_name': 'sub-article',
-                'lang': 'en',
-                'id': 'TRen'
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test__elements_exist(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                 <front-stub>
-                     <title-group>
-                         <article-title xml:lang="en">Title in english</article-title>
-                     </title-group>
-                 <abstract xml:lang="en">
-                     Abstract in english
-                 </abstract>
-                 <kwd-group xml:lang="en">
-                     <kwd>Keyword 1</kwd>
-                     <kwd>Keyword 2</kwd>
-                 </kwd-group>
-                 </front-stub>
-             </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-        title = {'parent_name': 'article', 'lang': 'en'}
-        title_object = article_titles.ArticleTitles(xml_tree)
-        abstracts = [
-            {'parent_name': 'article', 'lang': 'pt'},
-            {'parent_name': 'article', 'lang': 'en'},
-            {'parent_name': 'sub-article', 'lang': 'en', 'id': 'TRen'}
-        ]
-
-        keywords = [
-            {'parent_name': 'article', 'lang': 'en'},
-            {'parent_name': 'article', 'lang': 'en'},
-            {'parent_name': 'sub-article', 'lang': 'en', 'id': 'TRen'}
-        ]
-
-        obtained = _elements_exist(title, title_object, abstracts, keywords)
-
-        expected = (True, True, None, None, None)
-
-        self.assertEqual(expected, obtained)
-
-    def test__elements_exist_missing_title(self):
-        self.maxDiff = None
-        """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                </article-meta>
-            </front>
-        </article>
-        """
-        titles = []
-        abstracts = []
-        keywords = []
-
-        obtained = _elements_exist("article", titles, abstracts, keywords)
-
-        expected = (False, True, 'title', './/article-title/@xml:lang', 'title for the article')
-
-        self.assertEqual(expected, obtained)
-
-    def test__elements_exist_missing_abstract(self):
-        self.maxDiff = None
-        """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-        </article>
-        """
-        titles = [{'parent_name': 'article', 'lang': 'pt'}, {'parent_name': 'article', 'lang': 'en'}]
-        abstracts = []
-        keywords = [{'element_name': 'article', 'lang': 'pt'}, {'element_name': 'article', 'lang': 'en'}]
-
-        obtained = _elements_exist("article", titles, abstracts, keywords)
-
-        expected = (False, True, 'abstract', './/abstract/@xml:lang', 'abstract for the article')
-
-        self.assertEqual(expected, obtained)
-
-    def test__elements_exist_missing_kwd(self):
-        self.maxDiff = None
-        """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                </article-meta>
-            </front>
-        </article>
-        """
-        titles = [{'parent_name': 'article', 'lang': 'pt'}]
-        abstracts = [{'element_name': 'article', 'lang': 'pt'}]
-        keywords = []
-
-        obtained = _elements_exist("article", titles, abstracts, keywords)
-
-        expected = (False, True, 'kwd-group', './/kwd-group/@xml:lang', 'keywords for the article')
-
-        self.assertEqual(expected, obtained)
-
-    def test__elements_exist_is_required(self):
-        self.maxDiff = None
-        """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
-                </article-meta>
-            </front>
-        </article>
-        """
-
-        titles = [{'parent_name': 'article', 'lang': 'pt'}]
-        abstracts = []
-        keywords = []
-
-        obtained = _elements_exist("article", titles, abstracts, keywords)
-
-        expected = (True, False, None, None, None)
-
-        self.assertEqual(expected, obtained)
+from packtools.sps.validation.article_lang import ArticleLangValidation
 
 
 class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_without_title(self):
         self.maxDiff = None
         xml_str = """
-        <article  xml:lang="pt">
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+            specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
                     <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
                     <kwd-group xml:lang="pt">
                         <kwd>Palavra chave 1</kwd>
                         <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
                     </kwd-group>
                 </article-meta>
             </front>
@@ -389,21 +23,34 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'article title element lang attribute validation',
-                'xpath': './/article-title/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'title element lang attribute',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'title',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'title for the article',
+                'expected_value': 'title in pt',
                 'got_value': None,
-                'message': 'Got None expected title for the article',
-                'advice': 'Provide title in the \'pt\' language for article'
+                'message': 'Got None, expected title in pt',
+                'advice': 'Provide title in the pt language for article',
+                'data': {
+                    'article_id': None,
+                    'article_type': 'research-article',
+                    'lang': 'pt',
+                    'line_number': 3,
+                    'parent_name': 'article',
+                    'subject': None
+                },
             }
         ]
-
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -434,435 +81,31 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'sub-article title element lang attribute validation',
-                'xpath': './/article-title/@xml:lang',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'title for the sub-article',
-                'got_value': None,
-                'message': 'Got None expected title for the sub-article',
-                'advice': 'Provide title in the \'en\' language for sub-article (TRen)'
-            },
-            {}
-        ]
-
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_article_lang_success(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_sub_article_lang_success(self):
-        self.maxDiff = None
-        xml_str = """
-        <article xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                <front-stub>
-                    <title-group>
-                        <article-title>Title in english</article-title>
-                    </title-group>
-                    <abstract xml:lang="en">
-                        Abstract in english
-                    </abstract>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </front-stub>
-            </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'sub-article title element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//title/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-            },
-            {
-                'title': 'sub-article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
-                'title': 'sub-article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_article_lang_fail_abstract_does_not_match(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="es">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="pt">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'ERROR',
-                'expected_value': 'en',
-                'got_value': None,
-                'message': 'Got None expected en',
-                'advice': "Provide abstract in the 'en' language for article",
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_sub_article_lang_fail_abstract_does_not_match(self):
-        self.maxDiff = None
-        xml_str = """
-        <article>
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                <front-stub>
-                    <title-group>
-                        <article-title xml:lang="en">Title in english</article-title>
-                    </title-group>
-                <abstract xml:lang="pt">
-                    Abstract in english
-                </abstract>
-                <kwd-group xml:lang="en">
-                    <kwd>Keyword 1</kwd>
-                    <kwd>Keyword 2</kwd>
-                </kwd-group>
-                </front-stub>
-            </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'sub-article abstract element lang attribute validation',
-                'xpath': './/abstract/@xml:lang',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'abstract for the sub-article',
-                'got_value': None,
-                'message': 'Got None expected abstract for the sub-article',
-                'advice': "Provide abstract in the 'en' language for sub-article (TRen)",
-
-            },
-            {
-                'title': 'sub-article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_article_lang_fail_kwd_group_does_not_match(self):
-        self.maxDiff = None
-        xml_str = """
-        <article  xml:lang="pt">
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                    <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
-                    <kwd-group xml:lang="en">
-                        <kwd>Palavra chave 1</kwd>
-                        <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
-                    </kwd-group>
-                </article-meta>
-            </front>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
-
-        expected = [
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'pt',
-                'got_value': 'pt',
-                'message': 'Got pt expected pt',
-                'advice': None
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'ERROR',
-                'expected_value': 'pt',
-                'got_value': None,
-                'message': 'Got None expected pt',
-                'advice': "Provide kwd-group in the 'pt' language for article",
-
-            },
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            }
-        ]
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
-
-    def test_validate_sub_article_lang_fail_kwd_group_does_not_match(self):
-        self.maxDiff = None
-        xml_str = """
-        <article>
-            <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
-                </article-meta>
-            </front>
-            <sub-article article-type="translation" id="TRen" xml:lang="en">
-                <front-stub>
-                    <title-group>
-                        <article-title xml:lang="en">Title in english</article-title>
-                    </title-group>
-                <abstract xml:lang="en">
-                    Abstract in english
-                </abstract>
-                <kwd-group xml:lang="pt">
-                    <kwd>Keyword 1</kwd>
-                    <kwd>Keyword 2</kwd>
-                </kwd-group>
-                </front-stub>
-            </sub-article>
-        </article>
-        """
-        xml_tree = get_xml_tree(xml_str)
-
         obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'sub-article kwd-group element lang attribute validation',
-                'xpath': './/kwd-group/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'title element lang attribute',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 'TRen',
+                'parent_lang': 'en',
+                'item': 'title',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'keywords for the sub-article',
+                'expected_value': 'title in en',
                 'got_value': None,
-                'message': 'Got None expected keywords for the sub-article',
-                'advice': "Provide kwd-group in the 'en' language for sub-article (TRen)",
-
+                'message': 'Got None, expected title in en',
+                'advice': 'Provide title in the en language for sub-article',
+                'data': {
+                    'article_id': 'TRen',
+                    'article_type': 'translation',
+                    'lang': 'en',
+                    'line_number': 10,
+                    'parent_name': 'sub-article',
+                    'subject': None
+                },
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -873,22 +116,16 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_without_abstract(self):
         self.maxDiff = None
         xml_str = """
-        <article  xml:lang="pt">
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+            specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
                     <title-group>
                         <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
                     </title-group>
                     <kwd-group xml:lang="pt">
                         <kwd>Palavra chave 1</kwd>
                         <kwd>Palavra chave 2</kwd>
-                    </kwd-group>
-                    <kwd-group xml:lang="en">
-                        <kwd>Keyword 1</kwd>
-                        <kwd>Keyword 2</kwd>
                     </kwd-group>
                 </article-meta>
             </front>
@@ -896,31 +133,34 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/abstract/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'abstract element lang attribute',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'abstract',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'abstract for the article',
+                'expected_value': 'abstract in pt',
                 'got_value': None,
-                'message': 'Got None expected abstract for the article',
-                'advice': "Provide abstract in the 'pt' language for article",
-
-            },
-            {
-                'title': 'article abstract element lang attribute validation',
-                'xpath': './/abstract/@xml:lang',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'abstract for the article',
-                'got_value': None,
-                'message': 'Got None expected abstract for the article',
-                'advice': "Provide abstract in the 'en' language for article",
+                'message': 'Got None, expected abstract in pt',
+                'advice': 'Provide abstract in the pt language for article',
+                'data': {
+                    'article_id': None,
+                    'article_type': 'research-article',
+                    'lang': 'pt',
+                    'line_number': 3,
+                    'parent_name': 'article',
+                    'subject': None
+                },
             }
         ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -951,20 +191,34 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'sub-article abstract element lang attribute validation',
-                'xpath': './/abstract/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'abstract element lang attribute',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 'TRen',
+                'parent_lang': 'en',
+                'item': 'abstract',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'abstract for the sub-article',
+                'expected_value': 'abstract in en',
                 'got_value': None,
-                'message': 'Got None expected abstract for the sub-article',
-                'advice': "Provide abstract in the 'en' language for sub-article (TRen)",
+                'message': 'Got None, expected abstract in en',
+                'advice': 'Provide abstract in the en language for sub-article',
+                'data': {
+                    'article_id': 'TRen',
+                    'article_type': 'translation',
+                    'lang': 'en',
+                    'line_number': 10,
+                    'parent_name': 'sub-article',
+                    'subject': None
+                },
             }
         ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -972,49 +226,48 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_without_kwd_group(self):
         self.maxDiff = None
         xml_str = """
-        <article  xml:lang="pt">
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+            specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
                     <title-group>
                         <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
                     </title-group>
                     <abstract><p>Resumo em português</p></abstract>
-                    <trans-abstract xml:lang="en">Abstract in english</trans-abstract>
                 </article-meta>
             </front>
         </article>
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/kwd-group/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'kwd-group element lang attribute',
+                'parent': 'article',
+                'parent_article_type': 'research-article',
+                'parent_id': None,
+                'parent_lang': 'pt',
+                'item': 'kwd-group',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'keywords for the article',
+                'expected_value': 'kwd-group in pt',
                 'got_value': None,
-                'message': 'Got None expected keywords for the article',
-                'advice': "Provide kwd-group in the 'pt' language for article"
-
-            },
-            {
-                'title': 'article kwd-group element lang attribute validation',
-                'xpath': './/kwd-group/@xml:lang',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'keywords for the article',
-                'got_value': None,
-                'message': 'Got None expected keywords for the article',
-                'advice': "Provide kwd-group in the 'en' language for article"
-
+                'message': 'Got None, expected kwd-group in pt',
+                'advice': 'Provide kwd-group in the pt language for article',
+                'data': {
+                    'article_id': None,
+                    'article_type': 'research-article',
+                    'lang': 'pt',
+                    'line_number': 3,
+                    'parent_name': 'article',
+                    'subject': None
+                },
             }
         ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -1044,20 +297,34 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'sub-article kwd-group element lang attribute validation',
-                'xpath': './/kwd-group/@xml:lang',
-                'validation_type': 'exist',
+                'title': 'kwd-group element lang attribute',
+                'parent': 'sub-article',
+                'parent_article_type': 'translation',
+                'parent_id': 'TRen',
+                'parent_lang': 'en',
+                'item': 'kwd-group',
+                'sub_item': None,
+                'validation_type': 'match',
                 'response': 'ERROR',
-                'expected_value': 'keywords for the sub-article',
+                'expected_value': 'kwd-group in en',
                 'got_value': None,
-                'message': 'Got None expected keywords for the sub-article',
-                'advice': "Provide kwd-group in the 'en' language for sub-article (TRen)",
+                'message': 'Got None, expected kwd-group in en',
+                'advice': 'Provide kwd-group in the en language for sub-article',
+                'data': {
+                    'article_id': 'TRen',
+                    'article_type': 'translation',
+                    'lang': 'en',
+                    'line_number': 10,
+                    'parent_name': 'sub-article',
+                    'subject': None
+                },
             }
         ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -1065,7 +332,8 @@ class ArticleLangTest(unittest.TestCase):
     def test_validate_article_lang_with_title_only(self):
         self.maxDiff = None
         xml_str = """
-        <article  xml:lang="pt">
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" dtd-version="1.1" 
+            specific-use="sps-1.9" xml:lang="pt">
             <front>
                 <article-meta>
                     <title-group>
@@ -1082,22 +350,14 @@ class ArticleLangTest(unittest.TestCase):
 
         obtained = ArticleLangValidation(xml_tree).validate_article_lang()
 
-        expected = []
-        self.assertEqual(list(obtained), expected)
+        self.assertEqual(list(obtained), [])
 
     def test_validate_sub_article_lang_with_title_only(self):
         self.maxDiff = None
         xml_str = """
         <article  xml:lang="pt">
             <front>
-                <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                        <trans-title-group xml:lang="en">
-                            <trans-title>Title in english</trans-title>
-                        </trans-title-group>
-                    </title-group>
-                </article-meta>
+                
             </front>
             <sub-article article-type="translation" id="TRen" xml:lang="en">
                 <front-stub>
@@ -1112,8 +372,7 @@ class ArticleLangTest(unittest.TestCase):
 
         obtained = ArticleLangValidation(xml_tree).validate_article_lang()
 
-        expected = []
-        self.assertEqual(list(obtained), expected)
+        self.assertEqual(list(obtained), [])
 
     def test_issue_712(self):
         self.maxDiff = None
@@ -1202,12 +461,7 @@ class ArticleLangTest(unittest.TestCase):
 
         obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
-        expected = []
-
         self.assertEqual(len(obtained), 0)
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertDictEqual(expected[i], item)
 
 
 if __name__ == '__main__':

--- a/tests/sps/validation/test_article_lang.py
+++ b/tests/sps/validation/test_article_lang.py
@@ -265,27 +265,19 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
     def test__elements_exist_missing_title(self):
         self.maxDiff = None
-        xml_str = """
+        """
         <article  xml:lang="pt">
             <front>
                 <article-meta>
-                    <title-group>
-                        <article-title>Título em português</article-title>
-                    </title-group>
                 </article-meta>
             </front>
         </article>
         """
-        xml_tree = get_xml_tree(xml_str)
-        title = {
-            'parent_name': 'article',
-            'lang': 'en'
-        }
-        title_object = article_titles.ArticleTitles(xml_tree)
+        titles = []
         abstracts = []
         keywords = []
 
-        obtained = _elements_exist(title, title_object, abstracts, keywords)
+        obtained = _elements_exist("article", titles, abstracts, keywords)
 
         expected = (False, True, 'title', './/article-title/@xml:lang', 'title for the article')
 
@@ -293,7 +285,7 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
     def test__elements_exist_missing_abstract(self):
         self.maxDiff = None
-        xml_str = """
+        """
         <article  xml:lang="pt">
             <front>
                 <article-meta>
@@ -315,16 +307,11 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
             </front>
         </article>
         """
-        xml_tree = get_xml_tree(xml_str)
-        title = {
-            'parent_name': 'article',
-            'lang': 'pt'
-        }
-        title_object = article_titles.ArticleTitles(xml_tree)
+        titles = [{'parent_name': 'article', 'lang': 'pt'}, {'parent_name': 'article', 'lang': 'en'}]
         abstracts = []
         keywords = [{'element_name': 'article', 'lang': 'pt'}, {'element_name': 'article', 'lang': 'en'}]
 
-        obtained = _elements_exist(title, title_object, abstracts, keywords)
+        obtained = _elements_exist("article", titles, abstracts, keywords)
 
         expected = (False, True, 'abstract', './/abstract/@xml:lang', 'abstract for the article')
 
@@ -332,7 +319,7 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
     def test__elements_exist_missing_kwd(self):
         self.maxDiff = None
-        xml_str = """
+        """
         <article  xml:lang="pt">
             <front>
                 <article-meta>
@@ -344,17 +331,11 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
             </front>
         </article>
         """
-        xml_tree = get_xml_tree(xml_str)
-        title = {
-            'parent_name': 'article',
-            'lang': 'pt',
-            'id': 'main'
-        }
-        title_object = article_titles.ArticleTitles(xml_tree)
+        titles = [{'parent_name': 'article', 'lang': 'pt'}]
         abstracts = [{'element_name': 'article', 'lang': 'pt'}]
         keywords = []
 
-        obtained = _elements_exist(title, title_object, abstracts, keywords)
+        obtained = _elements_exist("article", titles, abstracts, keywords)
 
         expected = (False, True, 'kwd-group', './/kwd-group/@xml:lang', 'keywords for the article')
 
@@ -362,7 +343,7 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
 
     def test__elements_exist_is_required(self):
         self.maxDiff = None
-        xml_str = """
+        """
         <article  xml:lang="pt">
             <front>
                 <article-meta>
@@ -373,17 +354,12 @@ class AuxiliaryFunctionsTest(unittest.TestCase):
             </front>
         </article>
         """
-        xml_tree = get_xml_tree(xml_str)
-        title = {
-            'parent_name': 'article',
-            'lang': 'pt',
-            'id': 'main'
-        }
-        title_object = article_titles.ArticleTitles(xml_tree)
+
+        titles = [{'parent_name': 'article', 'lang': 'pt'}]
         abstracts = []
         keywords = []
 
-        obtained = _elements_exist(title, title_object, abstracts, keywords)
+        obtained = _elements_exist("article", titles, abstracts, keywords)
 
         expected = (True, False, None, None, None)
 
@@ -470,7 +446,8 @@ class ArticleLangTest(unittest.TestCase):
                 'got_value': None,
                 'message': 'Got None expected title for the sub-article',
                 'advice': 'Provide title in the \'en\' language for sub-article (TRen)'
-            }
+            },
+            {}
         ]
 
         for i, item in enumerate(obtained):
@@ -571,7 +548,7 @@ class ArticleLangTest(unittest.TestCase):
             <sub-article article-type="translation" id="TRen" xml:lang="en">
                 <front-stub>
                     <title-group>
-                        <article-title xml:lang="en">Title in english</article-title>
+                        <article-title>Title in english</article-title>
                     </title-group>
                     <abstract xml:lang="en">
                         Abstract in english
@@ -589,6 +566,16 @@ class ArticleLangTest(unittest.TestCase):
         obtained = ArticleLangValidation(xml_tree).validate_article_lang()
 
         expected = [
+            {
+                'title': 'sub-article title element lang attribute validation',
+                'xpath': './/article-title/@xml:lang .//title/@xml:lang',
+                'validation_type': 'match',
+                'response': 'OK',
+                'expected_value': 'en',
+                'got_value': 'en',
+                'message': 'Got en expected en',
+                'advice': None
+            },
             {
                 'title': 'sub-article abstract element lang attribute validation',
                 'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
@@ -729,12 +716,12 @@ class ArticleLangTest(unittest.TestCase):
         expected = [
             {
                 'title': 'sub-article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
+                'xpath': './/abstract/@xml:lang',
+                'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'en',
+                'expected_value': 'abstract for the sub-article',
                 'got_value': None,
-                'message': 'Got None expected en',
+                'message': 'Got None expected abstract for the sub-article',
                 'advice': "Provide abstract in the 'en' language for sub-article (TRen)",
 
             },
@@ -863,32 +850,22 @@ class ArticleLangTest(unittest.TestCase):
         """
         xml_tree = get_xml_tree(xml_str)
 
-        obtained = ArticleLangValidation(xml_tree).validate_article_lang()
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
 
         expected = [
             {
-                'title': 'sub-article abstract element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//abstract/@xml:lang',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': 'en',
-                'got_value': 'en',
-                'message': 'Got en expected en',
-                'advice': None
-
-            },
-            {
                 'title': 'sub-article kwd-group element lang attribute validation',
-                'xpath': './/article-title/@xml:lang .//kwd-group/@xml:lang',
-                'validation_type': 'match',
+                'xpath': './/kwd-group/@xml:lang',
+                'validation_type': 'exist',
                 'response': 'ERROR',
-                'expected_value': 'en',
+                'expected_value': 'keywords for the sub-article',
                 'got_value': None,
-                'message': 'Got None expected en',
+                'message': 'Got None expected keywords for the sub-article',
                 'advice': "Provide kwd-group in the 'en' language for sub-article (TRen)",
 
             }
         ]
+        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertDictEqual(expected[i], item)
@@ -1137,6 +1114,100 @@ class ArticleLangTest(unittest.TestCase):
 
         expected = []
         self.assertEqual(list(obtained), expected)
+
+    def test_issue_712(self):
+        self.maxDiff = None
+        xml_str = """
+        <article article-type="editorial" dtd-version="1.1" specific-use="sps-1.9" xml:lang="es" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <front>
+        <journal-meta>
+        <journal-id journal-id-type="publisher-id">cys</journal-id>
+        <journal-title-group>
+        <journal-title>Ciencia y Sociedad</journal-title>
+        <abbrev-journal-title abbrev-type="publisher">cys</abbrev-journal-title>
+        </journal-title-group>
+        <issn pub-type="ppub">0378-7680</issn>
+        <issn pub-type="epub">2613-8751</issn>
+        <publisher>
+        <publisher-name>Instituto Tecnol&#x00F3;gico de Santo Domingo (INTEC)</publisher-name>
+        </publisher>
+        </journal-meta>
+        <article-meta>
+        <article-id pub-id-type="publisher-id">cys.2023.v48i4.3014</article-id>
+        <article-id pub-id-type="doi">10.22206/cys.2023.v48i4.3014</article-id>
+        <article-categories>
+        <subj-group subj-group-type="heading">
+        <subject>Editorial</subject>
+        </subj-group>
+        </article-categories>
+        <title-group>
+        <article-title><italic>SECUELAS, SERVICIOS P&#x00DA;BLICOS E IM&#x00C1;GENES. TRES TEMAS PARA UN CIERRE</italic></article-title>
+        </title-group>
+        <contrib-group>
+        <contrib contrib-type="author" corresp="yes">
+        <name>
+        <surname>Ulloa Hung</surname>
+        <given-names>Jorge</given-names>
+        <prefix>Dr.</prefix>
+        </name>
+        <xref ref-type="aff" rid="aff1"/>
+        <role>Profesor Investigador</role>
+        </contrib>
+        <aff id="aff1">
+        <institution content-type="original">Profesor Investigador Instituto Tecnol&#x00F3;gico de Santo Domingo (INTEC) Director de Ciencia y Sociedad</institution>
+        <institution content-type="orgname">Instituto Tecnol&#x00F3;gico de Santo Domingo (INTEC)</institution>
+            <institution content-type="orgdiv1">Profesor Investigador</institution>
+        <institution content-type="orgdiv1">Director de Ciencia y Sociedad</institution>
+        <country country="DO">República Dominicana</country>
+        <email>jorge.ulloa@intec.edu.do</email>
+        P&#x00E1;gina web: <ext-link ext-link-type="uri" xlink:href="https://www.intec.edu.do">https://www.intec.edu.do</ext-link>
+        </aff>
+        </contrib-group>
+        <pub-date publication-format="electronic" date-type="pub">
+        <day>29</day>
+        <month>12</month>
+        <year>2023</year>
+        </pub-date>
+        <volume>48</volume>
+        <issue>4</issue>
+        <fpage>1</fpage>
+        <lpage>4</lpage>
+        <permissions>
+        <copyright-statement>&#x00A9; Ciencia y Sociedad, 2023</copyright-statement>
+        <copyright-year>2023</copyright-year>
+        <license license-type="open-access" xlink:href="https://creativecommons.org/licenses/by-nc-sa/4.0/deed.es" xml:lang="es">
+        <license-p>Esta obra est&#x00E1; bajo una licencia internacional Creative Commons Atribuci&#x00F3;n-NoComercial-CompartirIgual 4.0. CC BY-NC-SA</license-p>
+        </license>
+        </permissions>
+        </article-meta>
+        </front>
+        <body>
+        <p>En este n&#x00FA;mero de cierre del 2023 <italic>Ciencia y Sociedad</italic> centra su atenci&#x00F3;n en tres aspectos esenciales, las secuelas de la pandemia del COVID 19, la percepci&#x00F3;n sobre servicios p&#x00FA;blicos esenciales como el transporte y los servicios de salud, y finalmente el tema de la imagen. Este &#x00FA;ltimo presente a trav&#x00E9;s del an&#x00E1;lisis iconogr&#x00E1;fico de una de las especies animales caribe&#x00F1;as vinculada a momentos precolombinos y vigente dentro del universo de representaci&#x00F3;n de lo americano desplegado a partir de 1492.</p>
+        <p>Las secuelas de la pandemia de COVID se enfocan en dos elementos centrales, el consumo de drogas y los riesgos de ruptura o separaci&#x00F3;n sentimental. El primero, es abordado a partir de un estudio con alcance descriptivo-transversal sobre el impacto generado por la pandemia en la salud mental de jov&#x00E9;nes estudiantes en diversas universidades de la regi&#x00F3;n del Caribe colombiano. Esta colaboraci&#x00F3;n, que constituye la apertura de la secci&#x00F3;n <italic>Articulo originales</italic>, intenta describir y comparar aspectos como la frecuencia, lugares, y circunstancias asociadas al consumo de drogas, antes y durante la pandemia dentro de la poblaci&#x00F3;n objeto de estudio.</p>
+        <p>Sus resultados esenciales no solo revelan la existencia de drogas legales e ilegales en los entornos universitarios de la regi&#x00F3;n estudiada, sino tambi&#x00E9;n su aumento sustancial debido a los cambios en la forma de vida provocados por la situaci&#x00F3;n global de salud vinculada a la dispersi&#x00F3;n del COVID 19. Por otro lado, evidencian la necesidad de implementar programas de prevenci&#x00F3;n y promoci&#x00F3;n de salud mental espec&#x00ED;ficamente enfocados en la poblaci&#x00F3;n juvenil universitaria de la regi&#x00F3;n objeto de estudio, y en general de todo el territorio colombiano. Aspecto que entronca con la propuesta de considerar esta l&#x00ED;nea de investigaci&#x00F3;n prospectiva como una constante para comprender a fondo situaciones que generen trastornos psicol&#x00F3;gicos en estudiantes universitarios, y establecer estrategias de atenci&#x00F3;n integral sobre su salud emocional y mental m&#x00E1;s all&#x00E1; de las circunstancias espec&#x00ED;ficas experimentadas durante la pandemia.</p>
+        <p>La segunda colaboraci&#x00F3;n en este n&#x00FA;mero de <italic>Ciencia y Sociedad</italic> centrada en las secuelas de la pandemia de COVID 19 tiene como objetivo identificar variables que puedan predecir de manera m&#x00E1;s eficiente el riesgo de ruptura o separaci&#x00F3;n sentimental en las parejas. El estudio maneja como escenario el contexto social dominicano e intenta probar una hip&#x00F3;tesis donde la angustia psicol&#x00F3;gica, la percepcion de equidad, el apoyo de la pareja y la satisfacci&#x00F3;n se consideran factores o variables esenciales en el riesgo percibido de separaci&#x00F3;n.</p>
+        <p>Esta investigaci&#x00F3;n desarrollada desde un enfoque cuantitativo muestra entre sus resultados m&#x00E1;s relevantes la identificaci&#x00F3;n de estas cuatro variables que afectan significativamente el riesgo de separaci&#x00F3;n entre los sujetos estudiados. Adem&#x00E1;s, en comparaci&#x00F3;n con otras investigaciones que han evaluado el riesgo de separaci&#x00F3;n de pareja muestra que a pesar de existir una asociacion entre las variables estudiadas no todas tienen el mismo peso dentro de los predictores significativos de riesgo . En ese caso las dificultades en una relaci&#x00F3;n antes de establecerse la cohabitaci&#x00F3;n forzosa creada por la pandemia constituye un elemento central considerado. En general el modelo desarrollado por esta investigaci&#x00F3;n combina un &#x00E9;nfasis en aspectos como la satisfacci&#x00F3;n conyugal, la percepcion del riesgo de separaci&#x00F3;n, el tipo de convivencia, y la cantidad de tiempo de calidad en las parejas antes de la pandemia, como predictores esenciales para pensar en la disoluci&#x00F3;n de una relaci&#x00F3;n a partir del detonante de las condiciones sociales at&#x00ED;picas impuesta por esa situacion sanitaria. Aspecto que por otro lado tributa a una discusi&#x00F3;n del rol del g&#x00E9;nero en este fen&#x00F3;meno, sobre todo al considerar que la mayor&#x00ED;a de la muestra vinculada al estudio estuvo compuesta por mujeres.</p>
+        <p>La percepci&#x00F3;n sobre los servicios p&#x00FA;blicos como tema en esta edici&#x00F3;n de <italic>Ciencia y Sociedad</italic> tiene como escenario los espacios sociales de Ecuador y M&#x00E9;xico. A trav&#x00E9;s de un estudio de caso que eval&#x00FA;a los servicios de transporte p&#x00FA;blico en la ciudad de Cuenca -Ecuador, la primera de estas contribuciones realiza una medici&#x00F3;n que busca aportar a los procesos de movilizaci&#x00F3;n de la poblaci&#x00F3;n, as&#x00ED; como contribuir a mejorar las condiciones sociales, econ&#x00F3;micas y ambientales vinculadas a ese fen&#x00F3;meno. Desde un enfoque de investigaci&#x00F3;n mixto que incluye entrevistas semiestructuradas y cuestionarios aplicados a una muestra no probabilista de diferentes actores dentro del sistema de transporte p&#x00FA;blico, el estudio arroja aspectos esenciales caracterizadores de ese servicio. Un aspecto valioso de sus resultados es que fomentan una perspectiva diagn&#x00F3;stica que puede ser una de las bases fundamentales para un programa que garantice la movilidad eficiente, equitativa y sostenible en esta ciudad. Aspecto que como bien se&#x00F1;alan los autores de la colaboraci&#x00F3;n es imprescindible para su desarrollo econ&#x00F3;mico, su cohesi&#x00F3;n y movilidad social adem&#x00E1;s de la protecci&#x00F3;n de su ambiente. En esencia para la mejor calidad de vida y creaci&#x00F3;n de oportunidades a nivel individual y comunitario.</p>
+        <p>El ausentismo y la satisfacci&#x00F3;n laboral en un hospital de segundo nivel de atenci&#x00F3;n en M&#x00E9;xico constituye el tema de la segunda colaboraci&#x00F3;n relacionada con los servicios p&#x00FA;blicos en este n&#x00FA;mero de <italic>Ciencia y Sociedad</italic>. Su objetivo central es determinar la relaci&#x00F3;n entre ambas variables dentro del personal vinculado a servicios de enfermer&#x00ED;a en una instituci&#x00F3;n de esa naturaleza localizada en San Luis Potos&#x00ED;. Con alcance descriptivo- correlacional y a partir de un enfoque cuantitativo esta investigaci&#x00F3;n indaga sobre las principales razones que generan ausentismo y sus v&#x00ED;nculos con los &#x00ED;ndices de satisfacci&#x00F3;n laboral. Un aspecto que resaltar dentro de esta colaboraci&#x00F3;n, al igual que en el caso anterior, es su sentido diagn&#x00F3;stico y predictivo, as&#x00ED; como su aliciente o fundamento para implementar estrategias de mejora de los servicios de salud considerando la autopercepci&#x00F3;n de sus proveedores. Estrategias que a partir de los resultados obtenidos apuntan hacia factores como ambiente f&#x00ED;sico, pol&#x00ED;ticas salariales y cultura laboral. Aspectos remarcables no solo para el caso estudiado, sino tambi&#x00E9;n para otros servicios de salud en espacios de Am&#x00E9;rica Latina.</p>
+        <p>Finalmente, dentro de la secci&#x00F3;n <italic>Art&#x00ED;culos originales</italic> de esta entrega el estudio de las im&#x00E1;genes se materializa a trav&#x00E9;s del an&#x00E1;lisis est&#x00E9;tico de las variantes iconogr&#x00E1;ficas y el simbolismo de la llamada zarig&#x00FC;eya com&#x00FA;n de orejas negras (<italic>Didelphis marsupialis</italic> Linnaeus 1758). Especie animal presente en adornos cer&#x00E1;micos de origen ind&#x00ED;gena localizados en las Antillas Menores y Venezuela, as&#x00ED; como dentro del corpus de impresos, descripciones e ilustraciones creados por artistas europeos. La manera en que cronistas y artistas usaron un esquema anal&#x00F3;gico comparativo para crear un nuevo concepto y mostrar algo desconocido es el aspecto central en el an&#x00E1;lisis de este art&#x00ED;culo.</p>
+        <p>A trav&#x00E9;s de un recorrido hist&#x00F3;rico cr&#x00ED;tico, que incluye diversos autores y formas de representaci&#x00F3;n de este animal, la colaboraci&#x00F3;n tiene la capacidad de definir y caracterizar diversas tendencias en cuanto a sus interpretaciones y significados. Estas tendencias no solo son propias de diferentes momentos y se vinculan a los avances en el estudio emp&#x00ED;rico y anat&#x00F3;mico de la especie, sino que al mismo tiempo se relacionan con visiones más cercanas y objetivas o m&#x00E1;s alejadas y remotas sobre el universo americano y caribe&#x00F1;o.</p>
+        <p>La acostumbrada secci&#x00F3;n de <italic>Rese&#x00F1;as y revisiones de libros</italic> en esta entrega final del 2023 de <italic>Ciencia y Sociedad</italic> incluye las rese&#x00F1;as de dos obras recientemente publicadas en el espacio editorial y acad&#x00E9;mico dominicano, <italic>Miradas Desencadenantes. Construcci&#x00F3;n de conocimientos para la igualdad</italic> y <italic>Sociedades ind&#x00ED;genas en la isla de Santo Domingo: una mirada desde las colecciones arqueol&#x00F3;gicas del Centro Le&#x00F3;n</italic>.</p>
+        <p>La primera de estas obras fue publicada en marzo del 2023 por el Centro de Estudios de G&#x00E9;nero de INTEC y constituye el volumen n&#x00FA;mero 6 de la serie &#x201C;Miradas Desencadenantes&#x201D; que tradicionalmente agrupa art&#x00ED;culos presentados en el marco de las Conferencias Dominicanas de Estudios de G&#x00E9;nero organizadas por esa instituci&#x00F3;n. Los art&#x00ED;culos compilados en ese volumen incluyen una diversidad de tem&#x00E1;ticas, vivencias y experiencias que como bien anuncia la autora de la rese&#x00F1;a tienen especial relevancia al plasmar de manera critica distintas facetas de la estratificaci&#x00F3;n de g&#x00E9;nero que viven las mujeres en la Rep&#x00FA;blica Dominicana. Aspecto que convierte el volumen en una herramienta pedag&#x00F3;gica y de construcci&#x00F3;n de pensamiento cr&#x00ED;tico desde la perspectiva de g&#x00E9;nero y a su vez en un desaf&#x00ED;o para convertir los temas fundamentales abordados a trav&#x00E9;s de este en parte del debate p&#x00FA;blico.</p>
+        <p><italic>Sociedades ind&#x00ED;genas en la isla de Santo Domingo: una mirada desde las colecciones arqueol&#x00F3;gicas del Centro Le&#x00F3;n</italic> constituye la segunda obra rese&#x00F1;ada en esta edici&#x00F3;n de <italic>Ciencia y Sociedad e</italic> ilustra sobre una obra que tiene la capacidad de cruzar las fronteras y romper con los clich&#x00E9;s tradicionales en la representaci&#x00F3;n de estas culturas. En ella, la tradicional exotizaci&#x00F3;n a trav&#x00E9;s de objetos extraordinarios o &#x00FA;nicos y el aislamiento de esta parte del pasado seden lugar a una representaci&#x00F3;n m&#x00E1;s compleja y al reconocimiento de una persistencia cultural a trav&#x00E9;s del legado que alcanza diversas esferas de la vida social del dominicano.</p>
+        <p>Esta obra cuya conformaci&#x00F3;n es resultado del proyecto Investigaci&#x00F3;n colaborativa y capacitaci&#x00F3;n basada en intercambios en gesti&#x00F3;n de colecciones, ejecutado por el Centro Cultural Eduardo Le&#x00F3;n y financiado por el Fondo de Embajadores de los Estados Unidos para la Preservaci&#x00F3;n de la Cultura, constituye adem&#x00E1;s un rescate y valorizaci&#x00F3;n cient&#x00ED;fica de testimonios y evidencias arqueol&#x00F3;gicas cuyos or&#x00ED;genes o formas de registro est&#x00E1;n marcados por el uso de pr&#x00E1;cticas poco controladas o el mero inter&#x00E9;s coleccionista. En esencia, se trata de una obra que intenta otorgar vida y reconocimiento no solo a esos artefactos a trav&#x00E9;s de su estudio cient&#x00ED;fico y exposici&#x00F3;n, sino tambi&#x00E9;n a una parte relevante de la historia y la cultura dominicana muchas veces reducida a an&#x00E9;cdota de inicio o expresi&#x00F3;n est&#x00E9;tica de unas culturas cuya diversidad y trascendencia merece ser mejor estudiada.</p>
+        </body>
+        </article>
+        """
+        xml_tree = get_xml_tree(xml_str)
+
+        obtained = list(ArticleLangValidation(xml_tree).validate_article_lang())
+
+        expected = []
+
+        self.assertEqual(len(obtained), 0)
+        for i, item in enumerate(obtained):
+            with self.subTest(i):
+                self.assertDictEqual(expected[i], item)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### O que esse PR faz?
Altera a iteração sobre os títulos para o artigo e sub-artigos.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/validation/test_article_lang.py
`
#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
TK #712 

### Referências
NA.

