### PR TITLE
Corrige valores da resposta da validação de aff: title, sub-item, advice etc

### DIFF
--- a/packtools/sps/models/aff.py
+++ b/packtools/sps/models/aff.py
@@ -1,3 +1,5 @@
+import logging
+
 from packtools.sps.utils.xml_utils import (
     node_text_without_xref,
     get_parent_context,
@@ -194,7 +196,8 @@ class Affiliation:
                 try:
                     address["country_code"] = aff_node.find("country").get("country")
                 except AttributeError:
-                    pass
+                    address["country_code"] = None
+
                 address["email"] = aff_node.findtext("email")
 
                 item = {

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -165,7 +165,7 @@ class AffiliationValidation:
         original = self.affiliation.get("original")
         error_level = error_level or "ERROR"
         yield format_response(
-            title="Affiliation validation",
+            title="original",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -198,7 +198,7 @@ class AffiliationValidation:
         orgname = self.affiliation.get("orgname")
         error_level = error_level or "CRITICAL"
         yield format_response(
-            title="Affiliation validation",
+            title="orgname",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -231,7 +231,7 @@ class AffiliationValidation:
         country = self.affiliation.get("country_name")
         error_level = error_level or "CRITICAL"
         yield format_response(
-            title="Affiliation validation",
+            title="country name",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -271,7 +271,7 @@ class AffiliationValidation:
         country_code = self.affiliation.get("country_code")
         error_level = error_level or "CRITICAL"
         yield format_response(
-            title="Affiliation validation",
+            title="country code",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -304,7 +304,7 @@ class AffiliationValidation:
         state = self.affiliation.get("state")
         error_level = error_level or "ERROR"
         yield format_response(
-            title="Affiliation validation",
+            title="state",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -337,7 +337,7 @@ class AffiliationValidation:
         city = self.affiliation.get("city")
         error_level = error_level or "ERROR"
         yield format_response(
-            title="Affiliation validation",
+            title="city",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),
@@ -370,7 +370,7 @@ class AffiliationValidation:
         aff_id = self.affiliation.get("id")
         error_level = error_level or "CRITICAL"
         yield format_response(
-            title="Affiliation validation",
+            title="id",
             parent=self.affiliation.get("parent"),
             parent_id=self.affiliation.get("parent_id"),
             parent_article_type=self.affiliation.get("parent_article_type"),

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -1,8 +1,10 @@
+import logging
+
 from packtools.sps.models.v2.aff import ArticleAffiliations
 from packtools.sps.validation.exceptions import (
     AffiliationValidationValidateCountryCodeException,
 )
-from packtools.sps.validation.utils import format_response
+from packtools.sps.validation.utils import format_response, build_response
 from packtools.translator import _
 
 
@@ -32,9 +34,10 @@ class AffiliationsListValidation:
         self.xml_tree = xml_tree
         self.affiliations = ArticleAffiliations(xml_tree)
         self.affiliations_list = list(self.affiliations.article_affs()) + list(self.affiliations.sub_article_translation_affs())
+
         self.country_codes_list = country_codes_list
 
-    def validade_affiliations_list(self, country_codes_list=None):
+    def validate_affiliations_list(self, country_codes_list=None):
         """
         Validate the list of affiliations against a list of country codes.
 
@@ -49,14 +52,20 @@ class AffiliationsListValidation:
             A dictionary containing the validation results for each affiliation.
         """
         country_codes_list = country_codes_list or self.country_codes_list
-        if not country_codes_list:
-            raise AffiliationValidationValidateCountryCodeException(
-                "Function requires list of country codes"
-            )
-        for affiliation in self.affiliations_list:
+        yield from self.validate_main_affiliations(country_codes_list)
+        yield from self.validate_translated_affiliations(country_codes_list)
+
+    def validate_main_affiliations(self, country_codes_list=None):
+        for affiliation in self.affiliations.article_affs():
             yield from AffiliationValidation(
                 affiliation, country_codes_list
-            ).validate_affiliation()
+            ).validate_main_affiliation()
+
+    def validate_translated_affiliations(self, country_codes_list=None):
+        for affiliation in self.affiliations.sub_article_translation_affs():
+            yield from AffiliationValidation(
+                affiliation, country_codes_list
+            ).validate_translated_affiliation()
 
     def validate(self, data):
         """
@@ -77,7 +86,7 @@ class AffiliationsListValidation:
             raise AffiliationValidationValidateCountryCodeException(
                 "Function requires list of country codes"
             )
-        yield from self.validade_affiliations_list(country_codes_list)
+        yield from self.validate_affiliations_list(country_codes_list)
 
     def validate_affiliation_count_article_vs_sub_article(self, error_level="CRITICAL"):
         """
@@ -123,17 +132,6 @@ class AffiliationsListValidation:
 
 
 class AffiliationValidation:
-    """
-    Class for validating a single affiliation within an XML document.
-
-    Parameters
-    ----------
-    affiliation : dict
-        A dictionary containing the affiliation data.
-    country_codes_list : list, optional
-        List of valid country codes for validation.
-    """
-
     def __init__(self, affiliation, country_codes_list=None):
         """
         Initialize the AffiliationValidation object.
@@ -164,12 +162,9 @@ class AffiliationValidation:
         """
         original = self.affiliation.get("original")
         error_level = error_level or "ERROR"
-        yield format_response(
+        return build_response(
             title="original",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="institution",
             sub_item='@content-type="original"',
             validation_type="exist",
@@ -197,19 +192,16 @@ class AffiliationValidation:
         """
         orgname = self.affiliation.get("orgname")
         error_level = error_level or "CRITICAL"
-        yield format_response(
+        return build_response(
             title="orgname",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="institution",
             sub_item='@content-type="orgname"',
             validation_type="exist",
             is_valid=bool(orgname),
-            expected=_("orgname affiliation"),
+            expected=_("orgname"),
             obtained=orgname,
-            advice=_("provide the orgname affiliation"),
+            advice=_("provide the orgname"),
             data=self.affiliation,
             error_level=error_level,
         )
@@ -230,24 +222,21 @@ class AffiliationValidation:
         """
         country = self.affiliation.get("country_name")
         error_level = error_level or "CRITICAL"
-        yield format_response(
+        return build_response(
             title="country name",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="aff",
             sub_item="country",
             validation_type="exist",
             is_valid=bool(country),
-            expected=_("country affiliation"),
+            expected=_("country name"),
             obtained=country,
-            advice=_("provide the country affiliation"),
+            advice=_("provide the country name"),
             data=self.affiliation,
             error_level=error_level,
         )
 
-    def validate_country_code(self, country_codes_list=None, error_level=None):
+    def validate_country_code(self, error_level=None):
         """
         Validate the country code against a list of valid country codes.
 
@@ -263,26 +252,23 @@ class AffiliationValidation:
         dict
             A dictionary containing the validation result for the country code.
         """
-        country_codes_list = country_codes_list or self.country_codes_list
+        country_codes_list = self.country_codes_list
         if not country_codes_list:
             raise AffiliationValidationValidateCountryCodeException(
                 "Function requires list of country codes"
             )
         country_code = self.affiliation.get("country_code")
         error_level = error_level or "CRITICAL"
-        yield format_response(
+        return build_response(
             title="country code",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="country",
             sub_item="@country",
             validation_type="value in list",
             is_valid=country_code in country_codes_list,
             expected=self.country_codes_list,
             obtained=country_code,
-            advice=_("provide a valid @country affiliation"),
+            advice=_("provide a valid @country"),
             data=self.affiliation,
             error_level=error_level,
         )
@@ -303,19 +289,16 @@ class AffiliationValidation:
         """
         state = self.affiliation.get("state")
         error_level = error_level or "ERROR"
-        yield format_response(
+        return build_response(
             title="state",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="addr-line",
             sub_item="state",
             validation_type="exist",
             is_valid=bool(state),
-            expected=_("state affiliation"),
+            expected=_("state"),
             obtained=state,
-            advice=_("provide the state affiliation"),
+            advice=_("provide the state"),
             data=self.affiliation,
             error_level=error_level,
         )
@@ -336,19 +319,16 @@ class AffiliationValidation:
         """
         city = self.affiliation.get("city")
         error_level = error_level or "ERROR"
-        yield format_response(
+        return build_response(
             title="city",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="addr-line",
             sub_item="city",
             validation_type="exist",
             is_valid=bool(city),
-            expected=_("city affiliation"),
+            expected=_("city"),
             obtained=city,
-            advice=_("provide the city affiliation"),
+            advice=_("provide the city"),
             data=self.affiliation,
             error_level=error_level,
         )
@@ -369,12 +349,9 @@ class AffiliationValidation:
         """
         aff_id = self.affiliation.get("id")
         error_level = error_level or "CRITICAL"
-        yield format_response(
+        return build_response(
             title="id",
-            parent=self.affiliation.get("parent"),
-            parent_id=self.affiliation.get("parent_id"),
-            parent_article_type=self.affiliation.get("parent_article_type"),
-            parent_lang=self.affiliation.get("parent_lang"),
+            parent=self.affiliation,
             item="aff",
             sub_item="@id",
             validation_type="exist",
@@ -388,19 +365,43 @@ class AffiliationValidation:
 
     def validate_affiliation(self):
         """
-        Validate the affiliation based on its parent type.
+        Validate the affiliation
 
         Yields
         ------
         dict
             A dictionary containing the validation results for the affiliation.
         """
-        if self.affiliation.get("parent") == "article":
-            yield from self.validate_original()
-            yield from self.validate_orgname()
-            yield from self.validate_country()
-            yield from self.validate_country_code()
-            yield from self.validate_state()
-            yield from self.validate_city()
-        elif self.affiliation.get("parent_article_type") == "translation":
-            yield from self.validate_original()
+        yield self.validate_main_affiliation()
+        yield self.validate_translated_affiliation()
+
+    def validate_main_affiliation(self, id_error_level=None, original_error_level=None, orgname_error_level=None, country_error_level=None, country_code_error_level=None, state_error_level=None, city_error_level=None):
+        """
+        Validate the affiliation
+
+        Yields
+        ------
+        dict
+            A dictionary containing the validation results for the affiliation.
+        """
+        if self.affiliation.get("parent_article_type") != "translation":
+            yield self.validate_id(id_error_level)
+            yield self.validate_original(original_error_level)
+            yield self.validate_orgname(orgname_error_level)
+            yield self.validate_country(country_error_level)
+            yield self.validate_country_code(country_code_error_level)
+            yield self.validate_state(state_error_level)
+            yield self.validate_city(city_error_level)
+
+    def validate_translated_affiliation(self, id_error_level=None, original_error_level=None):
+        """
+        Validate the translated affiliation
+
+        Yields
+        ------
+        dict
+            A dictionary containing the validation results for the translated affiliation.
+        """
+        if self.affiliation.get("parent_article_type") == "translation":
+            yield self.validate_id(id_error_level)
+            yield self.validate_original(original_error_level)

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -39,6 +39,37 @@ def format_response(
     }
 
 
+def build_response(
+    title,
+    parent,
+    item,
+    sub_item,
+    validation_type,
+    is_valid,
+    expected,
+    obtained,
+    advice,
+    data,
+    error_level,
+):
+    return {
+        "title": title,
+        "parent": parent.get("parent"),
+        "parent_id": parent.get("parent_id"),
+        "parent_article_type": parent.get("parent_article_type"),
+        "parent_lang": parent.get("parent_lang"),
+        "item": item,
+        "sub_item": sub_item,
+        "validation_type": validation_type,
+        "response": "OK" if is_valid else error_level,
+        "expected_value": expected,
+        "got_value": obtained,
+        "message": f"Got {obtained}, expected {expected}",
+        "advice": None if is_valid else advice,
+        "data": data,
+    }
+
+
 def get_doi_information(doi):
     url = f"https://api.crossref.org/works/{doi}"
     response = fetch_data(url=url, json=True)

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import TestCase
 
 from lxml import etree
@@ -45,414 +46,17 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         obtained = list(
-            AffiliationsListValidation(xml_tree, ["BR"]).validade_affiliations_list()
+            AffiliationsListValidation(xml_tree, ["BR"]).validate_affiliations_list()
         )
-
         expected = [
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="original"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "original affiliation",
-                "got_value": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                "message": "Got Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil, expected original affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="orgname"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "orgname affiliation",
-                "got_value": "Secretaria Municipal de Saúde de Belo Horizonte",
-                "message": "Got Secretaria Municipal de Saúde de Belo Horizonte, expected orgname affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "aff",
-                "sub_item": "country",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "message": "Got Brasil, expected country affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "country",
-                "sub_item": "@country",
-                "validation_type": "value in list",
-                "response": "OK",
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "message": "Got BR, expected ['BR']",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "state",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "state affiliation",
-                "got_value": "MG",
-                "message": "Got MG, expected state affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "city",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "city affiliation",
-                "got_value": "Belo Horizonte",
-                "message": "Got Belo Horizonte, expected city affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="original"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "original affiliation",
-                "got_value": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. "
-                "Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
-                "message": "Got Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. "
-                "Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil, expected original "
-                "affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="orgname"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "orgname affiliation",
-                "got_value": "Universidade Federal de Minas Gerais",
-                "message": "Got Universidade Federal de Minas Gerais, expected orgname affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "aff",
-                "sub_item": "country",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "message": "Got Brasil, expected country affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "country",
-                "sub_item": "@country",
-                "validation_type": "value in list",
-                "response": "OK",
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "message": "Got BR, expected ['BR']",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "state",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "state affiliation",
-                "got_value": "MG",
-                "message": "Got MG, expected state affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "city",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "city affiliation",
-                "got_value": "Belo Horizonte",
-                "message": "Got Belo Horizonte, expected city affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
+            "id", "original", "orgname", "country name", "country code", "state", "city",
+            "id", "original", "orgname", "country name", "country code", "state", "city",
         ]
-
-        for i, item in enumerate(expected):
+        self.assertEqual(14, len(obtained))
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertEqual(expected[i], item["title"])
+
 
     def test_affiliation_without_original(self):
         self.maxDiff = None
@@ -476,11 +80,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_original())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_original()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "original",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -511,11 +114,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        self.assertDictEqual(expected, obtained)
 
     def test_affiliations_without_orgname(self):
         self.maxDiff = None
@@ -538,11 +137,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_orgname())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_orgname()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "orgname",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -551,10 +149,10 @@ class AffiliationValidationTest(TestCase):
                 "sub_item": '@content-type="orgname"',
                 "validation_type": "exist",
                 "response": "CRITICAL",
-                "expected_value": "orgname affiliation",
+                "expected_value": "orgname",
                 "got_value": None,
-                "message": "Got None, expected orgname affiliation",
-                "advice": "provide the orgname affiliation",
+                "message": "Got None, expected orgname",
+                "advice": "provide the orgname",
                 "data": {
                     "city": "Belo Horizonte",
                     "country_code": "BR",
@@ -574,11 +172,8 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
+        self.assertDictEqual(expected, obtained)
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
 
     def test_affiliations_without_country(self):
         self.maxDiff = None
@@ -602,11 +197,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_country())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_country()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "country name",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -615,10 +209,10 @@ class AffiliationValidationTest(TestCase):
                 "sub_item": "country",
                 "validation_type": "exist",
                 "response": "CRITICAL",
-                "expected_value": "country affiliation",
+                "expected_value": "country name",
                 "got_value": None,
-                "message": "Got None, expected country affiliation",
-                "advice": "provide the country affiliation",
+                "message": "Got None, expected country name",
+                "advice": "provide the country name",
                 "data": {
                     "city": "Belo Horizonte",
                     "country_code": None,
@@ -638,11 +232,8 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
+        self.assertDictEqual(expected, obtained)
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
 
     def test_affiliations_without_country_code(self):
         self.maxDiff = None
@@ -667,13 +258,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(
-            AffiliationValidation(affiliations_list[0], ["BR"]).validate_country_code()
-        )
+        obtained = AffiliationValidation(affiliations_list[0], ["BR"]).validate_country_code()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "country code",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -685,7 +273,7 @@ class AffiliationValidationTest(TestCase):
                 "expected_value": ["BR"],
                 "got_value": None,
                 "message": "Got None, expected ['BR']",
-                "advice": "provide a valid @country affiliation",
+                "advice": "provide a valid @country",
                 "data": {
                     "city": "Belo Horizonte",
                     "country_code": None,
@@ -705,11 +293,8 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
+        self.assertDictEqual(expected, obtained)
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
 
     def test_affiliations_without_state(self):
         self.maxDiff = None
@@ -733,11 +318,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_state())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_state()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "state",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -746,10 +330,10 @@ class AffiliationValidationTest(TestCase):
                 "sub_item": "state",
                 "validation_type": "exist",
                 "response": "ERROR",
-                "expected_value": "state affiliation",
+                "expected_value": "state",
                 "got_value": None,
-                "message": "Got None, expected state affiliation",
-                "advice": "provide the state affiliation",
+                "message": "Got None, expected state",
+                "advice": "provide the state",
                 "data": {
                     "city": "Belo Horizonte",
                     "country_code": "BR",
@@ -769,11 +353,7 @@ class AffiliationValidationTest(TestCase):
                     "state": None,
                 },
             }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        self.assertDictEqual(expected, obtained)
 
     def test_affiliations_without_city(self):
         self.maxDiff = None
@@ -797,11 +377,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_city())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_city()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "city",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -810,10 +389,10 @@ class AffiliationValidationTest(TestCase):
                 "sub_item": "city",
                 "validation_type": "exist",
                 "response": "ERROR",
-                "expected_value": "city affiliation",
+                "expected_value": "city",
                 "got_value": None,
-                "message": "Got None, expected city affiliation",
-                "advice": "provide the city affiliation",
+                "message": "Got None, expected city",
+                "advice": "provide the city",
                 "data": {
                     "city": None,
                     "country_name": "Brasil",
@@ -833,11 +412,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        self.assertDictEqual(expected, obtained)
 
     def test_affiliations_without_id(self):
         self.maxDiff = None
@@ -861,11 +436,10 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_id())
+        obtained = AffiliationValidation(affiliations_list[0]).validate_id()
 
-        expected = [
-            {
-                "title": "Affiliation validation",
+        expected = {
+                "title": "id",
                 "parent": "article",
                 "parent_id": None,
                 "parent_article_type": "research-article",
@@ -897,11 +471,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+        self.assertDictEqual(expected, obtained)
 
     def test_validate(self):
         self.maxDiff = None
@@ -940,410 +510,13 @@ class AffiliationValidationTest(TestCase):
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
 
         expected = [
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="original"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "original affiliation",
-                "got_value": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                "message": "Got Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil, expected original affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="orgname"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "orgname affiliation",
-                "got_value": "Secretaria Municipal de Saúde de Belo Horizonte",
-                "message": "Got Secretaria Municipal de Saúde de Belo Horizonte, expected orgname affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "aff",
-                "sub_item": "country",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "message": "Got Brasil, expected country affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "country",
-                "sub_item": "@country",
-                "validation_type": "value in list",
-                "response": "OK",
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "message": "Got BR, expected ['BR']",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "state",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "state affiliation",
-                "got_value": "MG",
-                "message": "Got MG, expected state affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "city",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "city affiliation",
-                "got_value": "Belo Horizonte",
-                "message": "Got Belo Horizonte, expected city affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
-                    "original": "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="original"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "original affiliation",
-                "got_value": "Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. "
-                "Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil",
-                "message": "Got Grupo de Pesquisas em Epidemiologia e Avaliação em Saúde. Faculdade de Medicina. "
-                "Universidade Federal de Minas Gerais. Belo Horizonte, MG, Brasil, expected original "
-                "affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="orgname"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "orgname affiliation",
-                "got_value": "Universidade Federal de Minas Gerais",
-                "message": "Got Universidade Federal de Minas Gerais, expected orgname affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "aff",
-                "sub_item": "country",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "message": "Got Brasil, expected country affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "country",
-                "sub_item": "@country",
-                "validation_type": "value in list",
-                "response": "OK",
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "message": "Got BR, expected ['BR']",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "state",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "state affiliation",
-                "got_value": "MG",
-                "message": "Got MG, expected state affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
-            {
-                "title": "Affiliation validation",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "addr-line",
-                "sub_item": "city",
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "city affiliation",
-                "got_value": "Belo Horizonte",
-                "message": "Got Belo Horizonte, expected city affiliation",
-                "advice": None,
-                "data": {
-                    "city": "Belo Horizonte",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff2",
-                    "label": "II",
-                    "orgdiv1": "Faculdade de Medicina",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal de Minas Gerais",
-                    "original": "Grupo de Pesquisas em Epidemiologia e Avaliação em "
-                    "Saúde. Faculdade de Medicina. Universidade Federal de "
-                    "Minas Gerais. Belo Horizonte, MG, Brasil",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                    "state": "MG",
-                },
-            },
+            "id", "original", "orgname", "country name", "country code", "state", "city",
+            "id", "original", "orgname", "country name", "country code", "state", "city",
         ]
-
-        for i, item in enumerate(expected):
+        self.assertEqual(14, len(obtained))
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertEqual(expected[i], item["title"])
 
     def test_validate_affiliation_sub_article_original_only(self):
         self.maxDiff = None
@@ -1363,52 +536,30 @@ class AffiliationValidationTest(TestCase):
                             </aff>
                         </front-stub>
                     </sub-article>
+                    <sub-article article-type="translation" id="TRes" xml:lang="es">
+                        <front-stub>
+                            <aff id="aff1002">
+                                <label>I</label>
+                                <country country="BR">Brasil</country>
+                                <institution content-type="original">Universidade Federal de Pelotas. Faculdade de Medicina. Programa de Pós-Graduação em Epidemiologia. Pelotas, RS, Brasil</institution>
+                            </aff>
+                        </front-stub>
+                    </sub-article>
                 </article>
                 """
 
         xml_tree = etree.fromstring(xml)
         data = {"country_codes_list": ["BR"]}
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
+
         expected = [
-            {
-                "title": "Affiliation validation",
-                "parent": "sub-article",
-                "parent_id": "TRpt",
-                "parent_article_type": "translation",
-                "parent_lang": "pt",
-                "item": "institution",
-                "sub_item": '@content-type="original"',
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "original affiliation",
-                "got_value": "Universidade Federal de Pelotas. Faculdade de Medicina. Programa de Pós-Graduação em Epidemiologia. Pelotas, RS, Brasil",
-                "message": "Got Universidade Federal de Pelotas. Faculdade de Medicina. Programa de Pós-Graduação em Epidemiologia. Pelotas, RS, Brasil, expected original affiliation",
-                "advice": None,
-                "data": {
-                    "city": None,
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1002",
-                    "label": "I",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": None,
-                    "original": "Universidade Federal de Pelotas. Faculdade de Medicina. Programa de Pós-Graduação em Epidemiologia. Pelotas, RS, Brasil",
-                    "parent": "sub-article",
-                    "parent_article_type": "translation",
-                    "parent_id": "TRpt",
-                    "parent_lang": "pt",
-                    "state": None,
-                }
-            }
-
+            "id", "original",
+            "id", "original",
         ]
-
-        self.assertEqual(len(obtained), 1)
-        for i, item in enumerate(expected):
+        self.assertEqual(4, len(obtained))
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertEqual(expected[i], item["title"])
 
     def test_validate_affiliation_count_article_vs_sub_article(self):
         self.maxDiff = None
@@ -1453,280 +604,17 @@ class AffiliationValidationTest(TestCase):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/bak/2176-4573-bak-p58270.xml")
         data = {"country_codes_list": ["BR"]}
-        obtained = list(AffiliationsListValidation(xml_tree).validate(data))
+        validation = AffiliationsListValidation(xml_tree)
+        obtained = list(validation.validate(data))
         expected = [
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": "original affiliation",
-                "got_value": "Mestre em Filosofia pelo Programa de\n"
-                             "                    Pós-Graduação em Filosofia da Universidade "
-                             "Federal da Paraíba -UFPB, João\n"
-                             "                    Pessoa, Paraíba, Brasil; "
-                             "kidinho_dc@hotmail.com",
-                "item": "institution",
-                "message": "Got Mestre em Filosofia pelo Programa de\n"
-                           "                    Pós-Graduação em Filosofia da Universidade "
-                           "Federal da Paraíba -UFPB, João\n"
-                           "                    Pessoa, Paraíba, Brasil; "
-                           "kidinho_dc@hotmail.com, expected original affiliation",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": '@content-type="original"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": "orgname affiliation",
-                "got_value": "Universidade Federal da Paraíba\n                    -UFPB",
-                "item": "institution",
-                "message": "Got Universidade Federal da Paraíba\n"
-                           "                    -UFPB, expected orgname affiliation",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": '@content-type="orgname"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "item": "aff",
-                "message": "Got Brasil, expected country affiliation",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "country",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "item": "country",
-                "message": "Got BR, expected ['BR']",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "@country",
-                "title": "Affiliation validation",
-                "validation_type": "value in list",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": "state affiliation",
-                "got_value": "Paraíba",
-                "item": "addr-line",
-                "message": "Got Paraíba, expected state affiliation",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "state",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "João Pessoa",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": "kidinho_dc@hotmail.com",
-                    "id": "aff1",
-                    "label": "*",
-                    "orgdiv1": "Programa de Pós-Graduação em\n" "                    Filosofia",
-                    "orgdiv2": None,
-                    "orgname": "Universidade Federal da Paraíba\n" "                    -UFPB",
-                    "original": "Mestre em Filosofia pelo Programa de\n"
-                                "                    Pós-Graduação em Filosofia da "
-                                "Universidade Federal da Paraíba -UFPB, João\n"
-                                "                    Pessoa, Paraíba, Brasil; "
-                                "kidinho_dc@hotmail.com",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "Paraíba",
-                },
-                "expected_value": "city affiliation",
-                "got_value": "João Pessoa",
-                "item": "addr-line",
-                "message": "Got João Pessoa, expected city affiliation",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "city",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": None,
-                    "country_code": None,
-                    "country_name": None,
-                    "email": None,
-                    "id": "aff2",
-                    "label": "*",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": None,
-                    "original": "MA in Philosophy from Programa de Pós-Graduação\n"
-                                "                    em Filosofia at Universidade "
-                                "Federal da Paraíba – UFPB, João Pessoa, Paraíba,\n"
-                                "                    Brazil; kidinho_dc@hotmail.com",
-                    "parent": "sub-article",
-                    "parent_article_type": "translation",
-                    "parent_id": "s1",
-                    "parent_lang": "en",
-                    "state": None,
-                },
-                "expected_value": "original affiliation",
-                "got_value": "MA in Philosophy from Programa de Pós-Graduação\n"
-                             "                    em Filosofia at Universidade Federal da "
-                             "Paraíba – UFPB, João Pessoa, Paraíba,\n"
-                             "                    Brazil; kidinho_dc@hotmail.com",
-                "item": "institution",
-                "message": "Got MA in Philosophy from Programa de Pós-Graduação\n"
-                           "                    em Filosofia at Universidade Federal da "
-                           "Paraíba – UFPB, João Pessoa, Paraíba,\n"
-                           "                    Brazil; kidinho_dc@hotmail.com, expected "
-                           "original affiliation",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": "s1",
-                "parent_lang": "en",
-                "response": "OK",
-                "sub_item": '@content-type="original"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            }
+            "id", "original", "orgname", "country name", "country code", "state", "city",
+            "id", "original",
         ]
-        self.assertEqual(len(obtained), 7)
-        for i, item in enumerate(expected):
+        self.assertEqual(9, len(obtained))
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertEqual(expected[i], item["title"])
+
 
     def test_validate_affiliation_count_2176_4573_bak_p58270(self):
         self.maxDiff = None
@@ -1770,237 +658,15 @@ class AffiliationValidationTest(TestCase):
         data = {"country_codes_list": ["BR"]}
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
         expected = [
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": "original affiliation",
-                "got_value": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                "item": "institution",
-                "message": "Got  Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil , "
-                           "expected original affiliation",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": '@content-type="original"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": "orgname affiliation",
-                "got_value": "Universidade do Sul de Santa Catarina",
-                "item": "institution",
-                "message": "Got Universidade do Sul de Santa Catarina, expected orgname "
-                           "affiliation",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": '@content-type="orgname"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": "country affiliation",
-                "got_value": "Brasil",
-                "item": "aff",
-                "message": "Got Brasil, expected country affiliation",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "country",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": ["BR"],
-                "got_value": "BR",
-                "item": "country",
-                "message": "Got BR, expected ['BR']",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "@country",
-                "title": "Affiliation validation",
-                "validation_type": "value in list",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": "state affiliation",
-                "got_value": "SC",
-                "item": "addr-line",
-                "message": "Got SC, expected state affiliation",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "state",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": "Tubarão",
-                    "country_code": "BR",
-                    "country_name": "Brasil",
-                    "email": None,
-                    "id": "aff1",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": "Universidade do Sul de Santa Catarina",
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brasil ",
-                    "parent": "article",
-                    "parent_article_type": "letter",
-                    "parent_id": None,
-                    "parent_lang": "pt",
-                    "state": "SC",
-                },
-                "expected_value": "city affiliation",
-                "got_value": "Tubarão",
-                "item": "addr-line",
-                "message": "Got Tubarão, expected city affiliation",
-                "parent": "article",
-                "parent_article_type": "letter",
-                "parent_id": None,
-                "parent_lang": "pt",
-                "response": "OK",
-                "sub_item": "city",
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            },
-            {
-                "advice": None,
-                "data": {
-                    "city": None,
-                    "country_code": "BR",
-                    "country_name": "Brazil",
-                    "email": None,
-                    "id": "aff1001",
-                    "label": " 1 ",
-                    "orgdiv1": None,
-                    "orgdiv2": None,
-                    "orgname": None,
-                    "original": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brazil ",
-                    "parent": "sub-article",
-                    "parent_article_type": "translation",
-                    "parent_id": "TRen",
-                    "parent_lang": "en",
-                    "state": None,
-                },
-                "expected_value": "original affiliation",
-                "got_value": " Universidade do Sul de Santa Catarina, Tubarão, SC – Brazil ",
-                "item": "institution",
-                "message": "Got  Universidade do Sul de Santa Catarina, Tubarão, SC – Brazil , expected original affiliation",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": "TRen",
-                "parent_lang": "en",
-                "response": "OK",
-                "sub_item": '@content-type="original"',
-                "title": "Affiliation validation",
-                "validation_type": "exist",
-            }
+            "id", "original", "orgname", "country name", "country code", "state", "city",
+            "id", "original",
+            "id", "original",
         ]
-        self.assertEqual(len(obtained), 7)
-        for i, item in enumerate(expected):
+        self.assertEqual(9, len(obtained))
+        for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+                self.assertEqual(expected[i], item["title"])
+
 
     def test_validate_affiliation_count_MNHpJQpnjvSX6pkKCg37yTJ(self):
         self.maxDiff = None


### PR DESCRIPTION
#### O que esse PR faz?
- Corrige valores da resposta da validação de aff: title, sub-item, advice etc.
- Refatora a resposta da validação
- Adiciona métodos para validar aff de article e aff de translation

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python -m unittest -v tests.sps.validation.test_aff
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

