### PR TITLE
Adiciona error_level como parâmetros de AffiliationValidation.validate_main_affiliations e validate_translated_affiliations

### DIFF
--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -39,7 +39,7 @@ class AffiliationsListValidation:
 
     def validate_affiliations_list(self, country_codes_list=None):
         """
-        Validate the list of affiliations against a list of country codes.
+        Validate all the document affiliations
 
         Parameters
         ----------
@@ -55,17 +55,35 @@ class AffiliationsListValidation:
         yield from self.validate_main_affiliations(country_codes_list)
         yield from self.validate_translated_affiliations(country_codes_list)
 
-    def validate_main_affiliations(self, country_codes_list=None):
-        for affiliation in self.affiliations.article_affs():
+    def validate_main_affiliations(self, country_codes_list=None, id_error_level=None, label_error_level=None, original_error_level=None, orgname_error_level=None, country_error_level=None, country_code_error_level=None, state_error_level=None, city_error_level=None):
+        items = list(self.affiliations.article_affs())
+        total = len(items)
+        if total == 1:
+            label_error_level = "INFO"
+        for affiliation in items:
             yield from AffiliationValidation(
                 affiliation, country_codes_list
-            ).validate_main_affiliation()
+            ).validate(
+                id_error_level, label_error_level, original_error_level, orgname_error_level, country_error_level, country_code_error_level, state_error_level, city_error_level
+            )
 
-    def validate_translated_affiliations(self, country_codes_list=None):
-        for affiliation in self.affiliations.sub_article_translation_affs():
+    def validate_translated_affiliations(self, country_codes_list=None, id_error_level=None, label_error_level=None, original_error_level=None, orgname_error_level=None, country_error_level=None, country_code_error_level=None, state_error_level=None, city_error_level=None):
+        orgname_error_level = orgname_error_level or "INFO"
+        country_error_level = country_error_level or "INFO"
+        country_code_error_level = country_code_error_level or "INFO"
+        state_error_level = state_error_level or "INFO"
+        city_error_level = city_error_level or "INFO"
+
+        items = list(self.affiliations.sub_article_translation_affs())
+        total = len(items)
+        if total == 1:
+            label_error_level = "INFO"
+        for affiliation in items:
             yield from AffiliationValidation(
                 affiliation, country_codes_list
-            ).validate_translated_affiliation()
+            ).validate(
+                id_error_level, label_error_level, original_error_level, orgname_error_level, country_error_level, country_code_error_level, state_error_level, city_error_level
+            )
 
     def validate(self, data):
         """
@@ -162,19 +180,20 @@ class AffiliationValidation:
         """
         original = self.affiliation.get("original")
         error_level = error_level or "ERROR"
-        return build_response(
-            title="original",
-            parent=self.affiliation,
-            item="institution",
-            sub_item='@content-type="original"',
-            validation_type="exist",
-            is_valid=bool(original),
-            expected=_("original affiliation"),
-            obtained=original,
-            advice=_("provide the original affiliation"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not original or error_level == "INFO":
+            yield build_response(
+                title="original",
+                parent=self.affiliation,
+                item="institution",
+                sub_item='@content-type="original"',
+                validation_type="exist",
+                is_valid=bool(original),
+                expected=_("original affiliation"),
+                obtained=original,
+                advice=_("provide the original affiliation"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_orgname(self, error_level=None):
         """
@@ -192,19 +211,51 @@ class AffiliationValidation:
         """
         orgname = self.affiliation.get("orgname")
         error_level = error_level or "CRITICAL"
-        return build_response(
-            title="orgname",
-            parent=self.affiliation,
-            item="institution",
-            sub_item='@content-type="orgname"',
-            validation_type="exist",
-            is_valid=bool(orgname),
-            expected=_("orgname"),
-            obtained=orgname,
-            advice=_("provide the orgname"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not orgname or error_level == "INFO":
+            yield build_response(
+                title="orgname",
+                parent=self.affiliation,
+                item="institution",
+                sub_item='@content-type="orgname"',
+                validation_type="exist",
+                is_valid=bool(orgname),
+                expected=_("orgname"),
+                obtained=orgname,
+                advice=_("provide the orgname"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
+
+    def validate_label(self, error_level=None):
+        """
+        Validate the presence of the label affiliation content.
+
+        Parameters
+        ----------
+        error_level : str, optional
+            The level of error to be reported. Default is "CRITICAL".
+
+        Yields
+        ------
+        dict
+            A dictionary containing the validation result for the orgname affiliation.
+        """
+        label = self.affiliation.get("label")
+        error_level = error_level or "CRITICAL"
+        if not label or error_level == "INFO":
+            yield build_response(
+                title="label",
+                parent=self.affiliation,
+                item="aff",
+                sub_item="label",
+                validation_type="exist",
+                is_valid=bool(label),
+                expected=_("label"),
+                obtained=label,
+                advice=_("provide the label"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_country(self, error_level=None):
         """
@@ -222,19 +273,20 @@ class AffiliationValidation:
         """
         country = self.affiliation.get("country_name")
         error_level = error_level or "CRITICAL"
-        return build_response(
-            title="country name",
-            parent=self.affiliation,
-            item="aff",
-            sub_item="country",
-            validation_type="exist",
-            is_valid=bool(country),
-            expected=_("country name"),
-            obtained=country,
-            advice=_("provide the country name"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not country or error_level == "INFO":
+            yield build_response(
+                title="country name",
+                parent=self.affiliation,
+                item="aff",
+                sub_item="country",
+                validation_type="exist",
+                is_valid=bool(country),
+                expected=_("country name"),
+                obtained=country,
+                advice=_("provide the country name"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_country_code(self, error_level=None):
         """
@@ -259,19 +311,20 @@ class AffiliationValidation:
             )
         country_code = self.affiliation.get("country_code")
         error_level = error_level or "CRITICAL"
-        return build_response(
-            title="country code",
-            parent=self.affiliation,
-            item="country",
-            sub_item="@country",
-            validation_type="value in list",
-            is_valid=country_code in country_codes_list,
-            expected=self.country_codes_list,
-            obtained=country_code,
-            advice=_("provide a valid @country"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if (not country_code in country_codes_list) or (error_level == "INFO"):
+            yield build_response(
+                title="country code",
+                parent=self.affiliation,
+                item="country",
+                sub_item="@country",
+                validation_type="value in list",
+                is_valid=country_code in country_codes_list,
+                expected=self.country_codes_list,
+                obtained=country_code,
+                advice=_("provide a valid @country"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_state(self, error_level=None):
         """
@@ -289,19 +342,20 @@ class AffiliationValidation:
         """
         state = self.affiliation.get("state")
         error_level = error_level or "ERROR"
-        return build_response(
-            title="state",
-            parent=self.affiliation,
-            item="addr-line",
-            sub_item="state",
-            validation_type="exist",
-            is_valid=bool(state),
-            expected=_("state"),
-            obtained=state,
-            advice=_("provide the state"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not state or error_level == "INFO":
+            yield build_response(
+                title="state",
+                parent=self.affiliation,
+                item="addr-line",
+                sub_item="state",
+                validation_type="exist",
+                is_valid=bool(state),
+                expected=_("state"),
+                obtained=state,
+                advice=_("provide the state"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_city(self, error_level=None):
         """
@@ -319,19 +373,20 @@ class AffiliationValidation:
         """
         city = self.affiliation.get("city")
         error_level = error_level or "ERROR"
-        return build_response(
-            title="city",
-            parent=self.affiliation,
-            item="addr-line",
-            sub_item="city",
-            validation_type="exist",
-            is_valid=bool(city),
-            expected=_("city"),
-            obtained=city,
-            advice=_("provide the city"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not city or error_level == "INFO":
+            yield build_response(
+                title="city",
+                parent=self.affiliation,
+                item="addr-line",
+                sub_item="city",
+                validation_type="exist",
+                is_valid=bool(city),
+                expected=_("city"),
+                obtained=city,
+                advice=_("provide the city"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
     def validate_id(self, error_level=None):
         """
@@ -349,21 +404,22 @@ class AffiliationValidation:
         """
         aff_id = self.affiliation.get("id")
         error_level = error_level or "CRITICAL"
-        return build_response(
-            title="id",
-            parent=self.affiliation,
-            item="aff",
-            sub_item="@id",
-            validation_type="exist",
-            is_valid=bool(aff_id),
-            expected=_("affiliation ID"),
-            obtained=aff_id,
-            advice=_("provide the affiliation ID"),
-            data=self.affiliation,
-            error_level=error_level,
-        )
+        if not aff_id or error_level == "INFO":
+            yield build_response(
+                title="id",
+                parent=self.affiliation,
+                item="aff",
+                sub_item="@id",
+                validation_type="exist",
+                is_valid=bool(aff_id),
+                expected=_("affiliation ID"),
+                obtained=aff_id,
+                advice=_("provide the affiliation ID"),
+                data=self.affiliation,
+                error_level=error_level,
+            )
 
-    def validate_affiliation(self):
+    def validate(self, id_error_level=None, label_error_level=None, original_error_level=None, orgname_error_level=None, country_error_level=None, country_code_error_level=None, state_error_level=None, city_error_level=None):
         """
         Validate the affiliation
 
@@ -372,36 +428,11 @@ class AffiliationValidation:
         dict
             A dictionary containing the validation results for the affiliation.
         """
-        yield self.validate_main_affiliation()
-        yield self.validate_translated_affiliation()
-
-    def validate_main_affiliation(self, id_error_level=None, original_error_level=None, orgname_error_level=None, country_error_level=None, country_code_error_level=None, state_error_level=None, city_error_level=None):
-        """
-        Validate the affiliation
-
-        Yields
-        ------
-        dict
-            A dictionary containing the validation results for the affiliation.
-        """
-        if self.affiliation.get("parent_article_type") != "translation":
-            yield self.validate_id(id_error_level)
-            yield self.validate_original(original_error_level)
-            yield self.validate_orgname(orgname_error_level)
-            yield self.validate_country(country_error_level)
-            yield self.validate_country_code(country_code_error_level)
-            yield self.validate_state(state_error_level)
-            yield self.validate_city(city_error_level)
-
-    def validate_translated_affiliation(self, id_error_level=None, original_error_level=None):
-        """
-        Validate the translated affiliation
-
-        Yields
-        ------
-        dict
-            A dictionary containing the validation results for the translated affiliation.
-        """
-        if self.affiliation.get("parent_article_type") == "translation":
-            yield self.validate_id(id_error_level)
-            yield self.validate_original(original_error_level)
+        yield from self.validate_id(id_error_level)
+        yield from self.validate_label(label_error_level)
+        yield from self.validate_original(original_error_level)
+        yield from self.validate_orgname(orgname_error_level)
+        yield from self.validate_country(country_error_level)
+        yield from self.validate_country_code(country_code_error_level)
+        yield from self.validate_state(state_error_level)
+        yield from self.validate_city(city_error_level)

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -48,14 +48,10 @@ class AffiliationValidationTest(TestCase):
         obtained = list(
             AffiliationsListValidation(xml_tree, ["BR"]).validate_affiliations_list()
         )
-        expected = [
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-        ]
-        self.assertEqual(14, len(obtained))
+        self.assertEqual(0, len(obtained))
         for i, item in enumerate(obtained):
             with self.subTest(i):
-                self.assertEqual(expected[i], item["title"])
+                self.assertIsNone(item)
 
 
     def test_affiliation_without_original(self):
@@ -80,7 +76,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_original()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_original())
 
         expected = {
                 "title": "original",
@@ -114,7 +110,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
     def test_affiliations_without_orgname(self):
         self.maxDiff = None
@@ -137,7 +133,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_orgname()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_orgname())
 
         expected = {
                 "title": "orgname",
@@ -172,7 +168,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
 
     def test_affiliations_without_country(self):
@@ -197,7 +193,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_country()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_country())
 
         expected = {
                 "title": "country name",
@@ -232,7 +228,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
 
     def test_affiliations_without_country_code(self):
@@ -258,7 +254,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0], ["BR"]).validate_country_code()
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_country_code())
 
         expected = {
                 "title": "country code",
@@ -293,7 +289,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
 
     def test_affiliations_without_state(self):
@@ -318,7 +314,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_state()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_state())
 
         expected = {
                 "title": "state",
@@ -353,7 +349,7 @@ class AffiliationValidationTest(TestCase):
                     "state": None,
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
     def test_affiliations_without_city(self):
         self.maxDiff = None
@@ -377,7 +373,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_city()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_city())
 
         expected = {
                 "title": "city",
@@ -412,7 +408,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
     def test_affiliations_without_id(self):
         self.maxDiff = None
@@ -436,7 +432,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = AffiliationValidation(affiliations_list[0]).validate_id()
+        obtained = list(AffiliationValidation(affiliations_list[0]).validate_id())
 
         expected = {
                 "title": "id",
@@ -471,7 +467,7 @@ class AffiliationValidationTest(TestCase):
                     "state": "MG",
                 },
             }
-        self.assertDictEqual(expected, obtained)
+        self.assertDictEqual(expected, obtained[0])
 
     def test_validate(self):
         self.maxDiff = None
@@ -508,15 +504,7 @@ class AffiliationValidationTest(TestCase):
         xml_tree = etree.fromstring(xml)
         data = {"country_codes_list": ["BR"]}
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
-
-        expected = [
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-        ]
-        self.assertEqual(14, len(obtained))
-        for i, item in enumerate(obtained):
-            with self.subTest(i):
-                self.assertEqual(expected[i], item["title"])
+        self.assertEqual(0, len(obtained))
 
     def test_validate_affiliation_sub_article_original_only(self):
         self.maxDiff = None
@@ -551,12 +539,11 @@ class AffiliationValidationTest(TestCase):
         xml_tree = etree.fromstring(xml)
         data = {"country_codes_list": ["BR"]}
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
-
         expected = [
-            "id", "original",
-            "id", "original",
+            "orgname", "country name", "country code", "state", "city",
+            "orgname", "country name", "country code", "state", "city"
         ]
-        self.assertEqual(4, len(obtained))
+        self.assertEqual(10, len(obtained))
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertEqual(expected[i], item["title"])
@@ -607,10 +594,10 @@ class AffiliationValidationTest(TestCase):
         validation = AffiliationsListValidation(xml_tree)
         obtained = list(validation.validate(data))
         expected = [
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-            "id", "original",
+            "label", 
+            "label", "orgname", "country name", "country code", "state", "city",
         ]
-        self.assertEqual(9, len(obtained))
+        self.assertEqual(7, len(obtained))
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertEqual(expected[i], item["title"])
@@ -658,15 +645,13 @@ class AffiliationValidationTest(TestCase):
         data = {"country_codes_list": ["BR"]}
         obtained = list(AffiliationsListValidation(xml_tree).validate(data))
         expected = [
-            "id", "original", "orgname", "country name", "country code", "state", "city",
-            "id", "original",
-            "id", "original",
+            "label", 
+            "label", "orgname", "country name", "country code", "state", "city",
         ]
-        self.assertEqual(9, len(obtained))
+        self.assertEqual(7, len(obtained))
         for i, item in enumerate(obtained):
             with self.subTest(i):
                 self.assertEqual(expected[i], item["title"])
-
 
     def test_validate_affiliation_count_MNHpJQpnjvSX6pkKCg37yTJ(self):
         self.maxDiff = None


### PR DESCRIPTION
#### O que esse PR faz?
- Adiciona error_level como parâmetros de AffiliationValidation.validate_main_affiliations e validate_translated_affiliations
- Também condiciona o retorno da resposta quando há erro ou quando o error_level é INFO
- Adiciona AffiliationValidation.validate_label

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
```console
python -m unittest -v tests.sps.validation.test_aff
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

