### PR TITLE
Feat: build xml elements

### DIFF
--- a/packtools/sps/formats/sps_xml/article.py
+++ b/packtools/sps/formats/sps_xml/article.py
@@ -1,0 +1,24 @@
+import xml.etree.ElementTree as ET
+
+
+def build_article_node(article_data: dict):
+    namespaces = {
+        "xlink": "http://www.w3.org/1999/xlink",
+        "mml": "http://www.w3.org/1998/Math/MathML"
+    }
+
+    # Adiciona os namespaces
+    for prefix, uri in namespaces.items():
+        ET.register_namespace(prefix, uri)
+
+    # Cria o elemento <article>
+    article_elem = ET.Element("article", {
+        "xmlns:xlink": namespaces["xlink"],
+        "xmlns:mml": namespaces["mml"],
+        "dtd-version": article_data.get("dtd-version"),
+        "specific-use": article_data.get("specific-use"),
+        "article-type": article_data.get("article-type"),
+        "xml:lang": article_data.get("xml:lang")
+    })
+
+    return article_elem

--- a/packtools/sps/formats/sps_xml/article.py
+++ b/packtools/sps/formats/sps_xml/article.py
@@ -11,14 +11,17 @@ def build_article_node(article_data: dict):
     for prefix, uri in namespaces.items():
         ET.register_namespace(prefix, uri)
 
-    # Cria o elemento <article>
-    article_elem = ET.Element("article", {
-        "xmlns:xlink": namespaces["xlink"],
-        "xmlns:mml": namespaces["mml"],
-        "dtd-version": article_data.get("dtd-version"),
-        "specific-use": article_data.get("specific-use"),
-        "article-type": article_data.get("article-type"),
-        "xml:lang": article_data.get("xml:lang")
-    })
+    try:
+        # Cria o elemento <article>
+        article_elem = ET.Element("article", {
+            "xmlns:xlink": namespaces["xlink"],
+            "xmlns:mml": namespaces["mml"],
+            "dtd-version": article_data["dtd-version"],
+            "specific-use": article_data["specific-use"],
+            "article-type": article_data["article-type"],
+            "xml:lang": article_data["xml:lang"]
+        })
+    except KeyError as e:
+        raise KeyError(f"{e} is required")
 
     return article_elem

--- a/packtools/sps/formats/sps_xml/contrib.py
+++ b/packtools/sps/formats/sps_xml/contrib.py
@@ -1,0 +1,55 @@
+"""
+data = {
+    "contrib_type": "author",
+    "contrib_ids": {
+        "orcid": "0000-0001-8528-2091",
+        "scopus": "24771926600"
+    },
+    "surname": "Einstein",
+    "given_names": "Albert",
+    "affiliations": [
+        {"rid": "aff1", "text": "1"}
+    ]
+}
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def build_contrib_author(data):
+    # Garantir que o contrib_type seja uma string válida ou usar 'author' como padrão
+    contrib_type = data.get("contrib_type") or "author"
+
+    # Criação do elemento principal <contrib> com o tipo de contribuição
+    contrib_elem = ET.Element("contrib", attrib={"contrib-type": contrib_type})
+
+    # Adiciona os elementos <contrib-id> para ORCID e Scopus
+    for contrib_id_type, contrib_id_value in data.get('contrib_ids', {}).items():
+        if contrib_id_value:  # Verifica se o valor não é None
+            contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
+            contrib_id_elem.text = contrib_id_value
+            contrib_elem.append(contrib_id_elem)  # Usando append para adicionar ao pai
+
+    # Cria e adiciona o <name> com <surname> e <given-names>
+    name_elem = ET.Element("name")
+
+    surname_elem = ET.Element("surname")
+    surname_elem.text = data.get("surname", "")
+    name_elem.append(surname_elem)  # Adiciona <surname> ao <name>
+
+    given_names_elem = ET.Element("given-names")
+    given_names_elem.text = data.get("given_names", "")
+    name_elem.append(given_names_elem)  # Adiciona <given-names> ao <name>
+
+    contrib_elem.append(name_elem)  # Adiciona <name> ao <contrib>
+
+    # Adiciona o <xref> para afiliação, apenas se rid e text não forem None
+    for xref_data in data.get("affiliations", []):
+        rid = xref_data.get("rid")
+        text = xref_data.get("text")
+        if rid and text:
+            xref_elem = ET.Element("xref", attrib={"ref-type": "aff", "rid": rid})
+            xref_elem.text = text
+            contrib_elem.append(xref_elem)  # Adiciona <xref> ao <contrib>
+
+    return contrib_elem

--- a/packtools/sps/formats/sps_xml/contrib.py
+++ b/packtools/sps/formats/sps_xml/contrib.py
@@ -1,10 +1,8 @@
 """
 data = {
     "contrib_type": "author",
-    "contrib_ids": {
-        "orcid": "0000-0001-8528-2091",
-        "scopus": "24771926600"
-    },
+    "orcid": "0000-0001-8528-2091",
+    "scopus": "24771926600",
     "surname": "Einstein",
     "given_names": "Albert",
     "affiliations": [
@@ -19,68 +17,61 @@ import xml.etree.ElementTree as ET
 def build_contrib_author(data):
     # Garantir que o contrib_type seja uma string válida
     contrib_type = data.get("contrib_type")
-    if contrib_type is None:
-        raise KeyError("contrib-type is required")
+    if not contrib_type:
+        raise NameError("contrib-type is required")
 
     # Criação do elemento principal <contrib> com o tipo de contribuição
     contrib_elem = ET.Element("contrib", attrib={"contrib-type": contrib_type})
 
-    # Adiciona os elementos <contrib-id> para ORCID e Scopus, se existirem no dicionário
-    if 'contrib_ids' in data:
-        if data.get('contrib_ids') is None:
-            raise KeyError("contrib-id-type is required")
-        else:
-            for contrib_id_type, contrib_id_value in (data['contrib_ids'] or {}).items():
-                contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
-                contrib_id_elem.text = contrib_id_value
-                contrib_elem.append(contrib_id_elem)
+    for contrib_id_type in ("lattes", "orcid", "researchid", "scopus"):
+        contrib_id_value = data.get(contrib_id_type)
+        if contrib_id_value:
+            contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
+            contrib_id_elem.text = contrib_id_value
+            contrib_elem.append(contrib_id_elem)
 
-    if "collab" in data:
+    if data.get("collab"):
         collab_elem = ET.Element("collab")
         collab_elem.text = data["collab"]
         contrib_elem.append(collab_elem)
 
     # Cria e adiciona o <name> com <surname> e <given-names> somente se existirem no dicionário
-    if any(key in data for key in ("surname", "given_names", "prefix", "suffix")):
+
+    if any(data.get(key) for key in ("surname", "given_names", "prefix", "suffix")):
         name_elem = ET.Element("name")
 
-        if "surname" in data:  # Adiciona <surname> somente se estiver presente no dicionário
+        if data.get("surname"):  # Adiciona <surname> somente se estiver presente no dicionário
             surname_elem = ET.Element("surname")
-            surname_elem.text = data["surname"]  # Mesmo se for vazio, cria o elemento
+            surname_elem.text = data["surname"]
             name_elem.append(surname_elem)
 
-        if "given_names" in data:  # Adiciona <given-names> somente se estiver presente no dicionário
+        if data.get("given_names"):  # Adiciona <given-names> somente se estiver presente no dicionário
             given_names_elem = ET.Element("given-names")
-            given_names_elem.text = data["given_names"]  # Mesmo se for vazio, cria o elemento
+            given_names_elem.text = data["given_names"]
             name_elem.append(given_names_elem)
 
-        if "prefix" in data:  # Adiciona <prefix> somente se estiver presente no dicionário
+        if data.get("prefix"):  # Adiciona <prefix> somente se estiver presente no dicionário
             prefix_elem = ET.Element("prefix")
-            prefix_elem.text = data["prefix"]  # Mesmo se for vazio, cria o elemento
+            prefix_elem.text = data["prefix"]
             name_elem.append(prefix_elem)
 
-        if "suffix" in data:  # Adiciona <suffix> somente se estiver presente no dicionário
+        if data.get("suffix"):  # Adiciona <suffix> somente se estiver presente no dicionário
             suffix_elem = ET.Element("suffix")
-            suffix_elem.text = data["suffix"]  # Mesmo se for vazio, cria o elemento
+            suffix_elem.text = data["suffix"]
             name_elem.append(suffix_elem)
 
         contrib_elem.append(name_elem)
 
     # Adiciona o <xref> para afiliação apenas se rid ou text forem fornecidos no dicionário
-    if "affiliations" in data:
-        if data.get("affiliations") is None:
-            xref_elem = ET.Element("xref")
-            contrib_elem.append(xref_elem)
-        else:
-            for xref_data in data.get("affiliations") or []:
-                # rid é obrigatório, a ausência da chave deveria levantar exceção
-                try:
-                    xref_elem = ET.Element("xref", attrib={"ref-type": "aff", "rid": xref_data["rid"]})
-                    xref_elem.text = xref_data["text"]
-                except KeyError as e:
-                    raise KeyError(f"{e} is required")
+    for xref_data in data.get("affiliations") or []:
+        # rid é obrigatório, a ausência da chave deveria levantar exceção
+        try:
+            xref_elem = ET.Element("xref", attrib={"ref-type": "aff", "rid": xref_data["rid"]})
+            xref_elem.text = xref_data["text"]
+        except KeyError as e:
+            raise KeyError(f"{e} is required")
 
-                contrib_elem.append(xref_elem)
+        contrib_elem.append(xref_elem)
 
     return contrib_elem
 

--- a/packtools/sps/formats/sps_xml/contrib.py
+++ b/packtools/sps/formats/sps_xml/contrib.py
@@ -18,38 +18,44 @@ import xml.etree.ElementTree as ET
 
 def build_contrib_author(data):
     # Garantir que o contrib_type seja uma string válida ou usar 'author' como padrão
-    contrib_type = data.get("contrib_type") or "author"
+    contrib_type = data.get("contrib_type") or ""
 
     # Criação do elemento principal <contrib> com o tipo de contribuição
     contrib_elem = ET.Element("contrib", attrib={"contrib-type": contrib_type})
 
-    # Adiciona os elementos <contrib-id> para ORCID e Scopus
+    # Adiciona os elementos <contrib-id> para ORCID e Scopus, se existirem no dicionário
     for contrib_id_type, contrib_id_value in data.get('contrib_ids', {}).items():
-        if contrib_id_value:  # Verifica se o valor não é None
-            contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
-            contrib_id_elem.text = contrib_id_value
-            contrib_elem.append(contrib_id_elem)  # Usando append para adicionar ao pai
+        contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
+        contrib_id_elem.text = contrib_id_value
+        contrib_elem.append(contrib_id_elem)
 
-    # Cria e adiciona o <name> com <surname> e <given-names>
-    name_elem = ET.Element("name")
+    # Cria e adiciona o <name> com <surname> e <given-names> somente se existirem no dicionário
+    if "surname" in data or "given_names" in data:
+        name_elem = ET.Element("name")
 
-    surname_elem = ET.Element("surname")
-    surname_elem.text = data.get("surname", "")
-    name_elem.append(surname_elem)  # Adiciona <surname> ao <name>
+        if "surname" in data:  # Adiciona <surname> somente se estiver presente no dicionário
+            surname_elem = ET.Element("surname")
+            surname_elem.text = data.get("surname", "")  # Mesmo se for vazio, cria o elemento
+            name_elem.append(surname_elem)
 
-    given_names_elem = ET.Element("given-names")
-    given_names_elem.text = data.get("given_names", "")
-    name_elem.append(given_names_elem)  # Adiciona <given-names> ao <name>
+        if "given_names" in data:  # Adiciona <given-names> somente se estiver presente no dicionário
+            given_names_elem = ET.Element("given-names")
+            given_names_elem.text = data.get("given_names", "")  # Mesmo se for vazio, cria o elemento
+            name_elem.append(given_names_elem)
 
-    contrib_elem.append(name_elem)  # Adiciona <name> ao <contrib>
+        contrib_elem.append(name_elem)
 
-    # Adiciona o <xref> para afiliação, apenas se rid e text não forem None
+    # Adiciona o <xref> para afiliação apenas se rid ou text forem fornecidos no dicionário
     for xref_data in data.get("affiliations", []):
         rid = xref_data.get("rid")
         text = xref_data.get("text")
-        if rid and text:
-            xref_elem = ET.Element("xref", attrib={"ref-type": "aff", "rid": rid})
-            xref_elem.text = text
-            contrib_elem.append(xref_elem)  # Adiciona <xref> ao <contrib>
+        if rid is not None or text is not None:  # Certifica-se de que pelo menos um não seja None
+            xref_elem = ET.Element("xref", attrib={"ref-type": "aff"})
+            if rid is not None:
+                xref_elem.set("rid", rid)
+            if text is not None:
+                xref_elem.text = text
+            contrib_elem.append(xref_elem)
 
     return contrib_elem
+

--- a/packtools/sps/formats/sps_xml/contrib.py
+++ b/packtools/sps/formats/sps_xml/contrib.py
@@ -17,45 +17,70 @@ import xml.etree.ElementTree as ET
 
 
 def build_contrib_author(data):
-    # Garantir que o contrib_type seja uma string válida ou usar 'author' como padrão
-    contrib_type = data.get("contrib_type") or ""
+    # Garantir que o contrib_type seja uma string válida
+    contrib_type = data.get("contrib_type")
+    if contrib_type is None:
+        raise KeyError("contrib-type is required")
 
     # Criação do elemento principal <contrib> com o tipo de contribuição
     contrib_elem = ET.Element("contrib", attrib={"contrib-type": contrib_type})
 
     # Adiciona os elementos <contrib-id> para ORCID e Scopus, se existirem no dicionário
-    for contrib_id_type, contrib_id_value in data.get('contrib_ids', {}).items():
-        contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
-        contrib_id_elem.text = contrib_id_value
-        contrib_elem.append(contrib_id_elem)
+    if 'contrib_ids' in data:
+        if data.get('contrib_ids') is None:
+            raise KeyError("contrib-id-type is required")
+        else:
+            for contrib_id_type, contrib_id_value in (data['contrib_ids'] or {}).items():
+                contrib_id_elem = ET.Element("contrib-id", attrib={"contrib-id-type": contrib_id_type})
+                contrib_id_elem.text = contrib_id_value
+                contrib_elem.append(contrib_id_elem)
+
+    if "collab" in data:
+        collab_elem = ET.Element("collab")
+        collab_elem.text = data["collab"]
+        contrib_elem.append(collab_elem)
 
     # Cria e adiciona o <name> com <surname> e <given-names> somente se existirem no dicionário
-    if "surname" in data or "given_names" in data:
+    if any(key in data for key in ("surname", "given_names", "prefix", "suffix")):
         name_elem = ET.Element("name")
 
         if "surname" in data:  # Adiciona <surname> somente se estiver presente no dicionário
             surname_elem = ET.Element("surname")
-            surname_elem.text = data.get("surname", "")  # Mesmo se for vazio, cria o elemento
+            surname_elem.text = data["surname"]  # Mesmo se for vazio, cria o elemento
             name_elem.append(surname_elem)
 
         if "given_names" in data:  # Adiciona <given-names> somente se estiver presente no dicionário
             given_names_elem = ET.Element("given-names")
-            given_names_elem.text = data.get("given_names", "")  # Mesmo se for vazio, cria o elemento
+            given_names_elem.text = data["given_names"]  # Mesmo se for vazio, cria o elemento
             name_elem.append(given_names_elem)
+
+        if "prefix" in data:  # Adiciona <prefix> somente se estiver presente no dicionário
+            prefix_elem = ET.Element("prefix")
+            prefix_elem.text = data["prefix"]  # Mesmo se for vazio, cria o elemento
+            name_elem.append(prefix_elem)
+
+        if "suffix" in data:  # Adiciona <suffix> somente se estiver presente no dicionário
+            suffix_elem = ET.Element("suffix")
+            suffix_elem.text = data["suffix"]  # Mesmo se for vazio, cria o elemento
+            name_elem.append(suffix_elem)
 
         contrib_elem.append(name_elem)
 
     # Adiciona o <xref> para afiliação apenas se rid ou text forem fornecidos no dicionário
-    for xref_data in data.get("affiliations", []):
-        rid = xref_data.get("rid")
-        text = xref_data.get("text")
-        if rid is not None or text is not None:  # Certifica-se de que pelo menos um não seja None
-            xref_elem = ET.Element("xref", attrib={"ref-type": "aff"})
-            if rid is not None:
-                xref_elem.set("rid", rid)
-            if text is not None:
-                xref_elem.text = text
+    if "affiliations" in data:
+        if data.get("affiliations") is None:
+            xref_elem = ET.Element("xref")
             contrib_elem.append(xref_elem)
+        else:
+            for xref_data in data.get("affiliations") or []:
+                # rid é obrigatório, a ausência da chave deveria levantar exceção
+                try:
+                    xref_elem = ET.Element("xref", attrib={"ref-type": "aff", "rid": xref_data["rid"]})
+                    xref_elem.text = xref_data["text"]
+                except KeyError as e:
+                    raise KeyError(f"{e} is required")
+
+                contrib_elem.append(xref_elem)
 
     return contrib_elem
 

--- a/packtools/sps/formats/sps_xml/journal_meta.py
+++ b/packtools/sps/formats/sps_xml/journal_meta.py
@@ -1,0 +1,57 @@
+"""
+data = {
+    "journal_ids": {
+        "nlm-ta": "Braz J Med Biol Res",
+        "publisher-id": "bjmbr"
+    },
+    "journal_title": "Brazilian Journal of Medical and Biological Research",
+    "abbrev_journal_title": "Braz. J. Med. Biol. Res.",
+    "issn": {
+        "epub": "1414-431X",
+        "ppub": "0100-879X"
+    },
+    "publisher_name": "Associação Brasileira de Divulgação Científica"
+}
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def build_journal_meta(data):
+    # Criação do elemento principal <journal-meta>
+    journal_meta = ET.Element("journal-meta")
+
+    # Adiciona <journal-id> elementos
+    for journal_id_type, journal_id_value in data.get('journal_ids', {}).items():
+        journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
+        journal_id_elem.text = journal_id_value
+        journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
+
+    # Cria <journal-title-group> e seus elementos filhos
+    journal_title_group = ET.Element("journal-title-group")
+
+    journal_title_elem = ET.Element("journal-title")
+    journal_title_elem.text = data.get('journal_title', '')
+    journal_title_group.append(journal_title_elem)  # Adiciona <journal-title> ao <journal-title-group>
+
+    abbrev_journal_title_elem = ET.Element("abbrev-journal-title", attrib={"abbrev-type": "publisher"})
+    abbrev_journal_title_elem.text = data.get('abbrev_journal_title', '')
+    journal_title_group.append(abbrev_journal_title_elem)  # Adiciona <abbrev-journal-title> ao <journal-title-group>
+
+    journal_meta.append(journal_title_group)  # Adiciona <journal-title-group> ao <journal-meta>
+
+    # Adiciona <issn> elementos
+    for issn_type, issn_value in data.get('issn', {}).items():
+        issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
+        issn_elem.text = issn_value
+        journal_meta.append(issn_elem)  # Adiciona <issn> ao <journal-meta>
+
+    # Cria <publisher> e <publisher-name>
+    publisher_elem = ET.Element("publisher")
+    publisher_name_elem = ET.Element("publisher-name")
+    publisher_name_elem.text = data.get('publisher_name', '')
+    publisher_elem.append(publisher_name_elem)  # Adiciona <publisher-name> ao <publisher>
+
+    journal_meta.append(publisher_elem)  # Adiciona <publisher> ao <journal-meta>
+
+    return journal_meta

--- a/packtools/sps/formats/sps_xml/journal_meta.py
+++ b/packtools/sps/formats/sps_xml/journal_meta.py
@@ -21,46 +21,56 @@ def build_journal_meta(data):
     # Criação do elemento principal <journal-meta>
     journal_meta = ET.Element("journal-meta")
 
-    journal_ids = data.get("journal_ids")
-    if journal_ids == {}:
-        # Se journal_ids é um dicionário vazio, cria um <journal-id> vazio
-        journal_id_elem = ET.Element("journal-id")
-        journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
-    elif journal_ids:
-        # Adiciona <journal-id> elementos, verificando se o valor não é None
-        for journal_id_type, journal_id_value in journal_ids.items():
-            journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
-            journal_id_elem.text = journal_id_value or ""  # Se journal_id_value for None ou vazio, usa ""
+    if "journal_ids" in data:
+        journal_ids = data.get("journal_ids")
+        if journal_ids is None:
+            # Se journal_ids é um dicionário vazio, cria um <journal-id> vazio
+            journal_id_elem = ET.Element("journal-id")
             journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
+        elif journal_ids:
+            # Adiciona <journal-id> elementos, verificando se o valor não é None
+            for journal_id_type, journal_id_value in journal_ids.items():
+                journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
+                journal_id_elem.text = journal_id_value or ""  # Se journal_id_value for None ou vazio, usa ""
+                journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
 
-    # Cria <journal-title-group> e seus elementos filhos
-    journal_title_group = ET.Element("journal-title-group")
+    if 'journal_title' in data or "abbrev_journal_title" in data:
+        # Cria <journal-title-group>
+        journal_title_group = ET.Element("journal-title-group")
 
-    # Adiciona <journal-title> se o valor for None, insere string vazia
-    journal_title_elem = ET.Element("journal-title")
-    journal_title_elem.text = data.get('journal_title', '') or ''
-    journal_title_group.append(journal_title_elem)
+        if 'journal_title' in data:
+            # Adiciona <journal-title> se o valor for None, insere string vazia
+            journal_title_elem = ET.Element("journal-title")
+            journal_title_elem.text = data.get('journal_title') or ''
 
-    # Adiciona <abbrev-journal-title>, verificando se o valor não é None
-    abbrev_journal_title_elem = ET.Element("abbrev-journal-title", attrib={"abbrev-type": "publisher"})
-    abbrev_journal_title_elem.text = data.get('abbrev_journal_title', '') or ''
-    journal_title_group.append(abbrev_journal_title_elem)
+            journal_title_group.append(journal_title_elem)
 
-    # Adiciona <journal-title-group> ao <journal-meta>
-    journal_meta.append(journal_title_group)
+        if "abbrev_journal_title" in data:
+            # Adiciona <abbrev-journal-title>, verificando se o valor não é None
+            abbrev_journal_title_elem = ET.Element("abbrev-journal-title", attrib={"abbrev-type": "publisher"})
+            abbrev_journal_title_elem.text = data.get('abbrev_journal_title') or ''
 
-    # Adiciona <issn> elementos, verificando se o valor não é None
-    for issn_type, issn_value in data.get('issn', {}).items():
-        if issn_value is not None:
-            issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
-            issn_elem.text = issn_value
+            journal_title_group.append(abbrev_journal_title_elem)
+
+        # Adiciona <journal-title-group> ao <journal-meta>
+        journal_meta.append(journal_title_group)
+
+    if "issn" in data:
+        if data.get("issn") is None:
+            issn_elem = ET.Element("issn")
             journal_meta.append(issn_elem)
+        else:
+            # Adiciona <issn> elementos, verificando se o valor não é None
+            for issn_type, issn_value in (data.get('issn') or {}).items():
+                issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
+                issn_elem.text = issn_value or ""
+                journal_meta.append(issn_elem)
 
     # Cria <publisher> e <publisher-name>, insere string vazia se o valor for None
     if 'publisher_name' in data:
         publisher_elem = ET.Element("publisher")
         publisher_name_elem = ET.Element("publisher-name")
-        publisher_name_elem.text = data.get('publisher_name', '') or ''
+        publisher_name_elem.text = data.get('publisher_name') or ''
         publisher_elem.append(publisher_name_elem)
 
         journal_meta.append(publisher_elem)

--- a/packtools/sps/formats/sps_xml/journal_meta.py
+++ b/packtools/sps/formats/sps_xml/journal_meta.py
@@ -21,37 +21,48 @@ def build_journal_meta(data):
     # Criação do elemento principal <journal-meta>
     journal_meta = ET.Element("journal-meta")
 
-    # Adiciona <journal-id> elementos
-    for journal_id_type, journal_id_value in data.get('journal_ids', {}).items():
-        journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
-        journal_id_elem.text = journal_id_value
+    journal_ids = data.get("journal_ids")
+    if journal_ids == {}:
+        # Se journal_ids é um dicionário vazio, cria um <journal-id> vazio
+        journal_id_elem = ET.Element("journal-id")
         journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
+    elif journal_ids:
+        # Adiciona <journal-id> elementos, verificando se o valor não é None
+        for journal_id_type, journal_id_value in journal_ids.items():
+            journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
+            journal_id_elem.text = journal_id_value or ""  # Se journal_id_value for None ou vazio, usa ""
+            journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
 
     # Cria <journal-title-group> e seus elementos filhos
     journal_title_group = ET.Element("journal-title-group")
 
+    # Adiciona <journal-title> se o valor for None, insere string vazia
     journal_title_elem = ET.Element("journal-title")
-    journal_title_elem.text = data.get('journal_title', '')
-    journal_title_group.append(journal_title_elem)  # Adiciona <journal-title> ao <journal-title-group>
+    journal_title_elem.text = data.get('journal_title', '') or ''
+    journal_title_group.append(journal_title_elem)
 
+    # Adiciona <abbrev-journal-title>, verificando se o valor não é None
     abbrev_journal_title_elem = ET.Element("abbrev-journal-title", attrib={"abbrev-type": "publisher"})
-    abbrev_journal_title_elem.text = data.get('abbrev_journal_title', '')
-    journal_title_group.append(abbrev_journal_title_elem)  # Adiciona <abbrev-journal-title> ao <journal-title-group>
+    abbrev_journal_title_elem.text = data.get('abbrev_journal_title', '') or ''
+    journal_title_group.append(abbrev_journal_title_elem)
 
-    journal_meta.append(journal_title_group)  # Adiciona <journal-title-group> ao <journal-meta>
+    # Adiciona <journal-title-group> ao <journal-meta>
+    journal_meta.append(journal_title_group)
 
-    # Adiciona <issn> elementos
+    # Adiciona <issn> elementos, verificando se o valor não é None
     for issn_type, issn_value in data.get('issn', {}).items():
-        issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
-        issn_elem.text = issn_value
-        journal_meta.append(issn_elem)  # Adiciona <issn> ao <journal-meta>
+        if issn_value is not None:
+            issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
+            issn_elem.text = issn_value
+            journal_meta.append(issn_elem)
 
-    # Cria <publisher> e <publisher-name>
-    publisher_elem = ET.Element("publisher")
-    publisher_name_elem = ET.Element("publisher-name")
-    publisher_name_elem.text = data.get('publisher_name', '')
-    publisher_elem.append(publisher_name_elem)  # Adiciona <publisher-name> ao <publisher>
+    # Cria <publisher> e <publisher-name>, insere string vazia se o valor for None
+    if 'publisher_name' in data:
+        publisher_elem = ET.Element("publisher")
+        publisher_name_elem = ET.Element("publisher-name")
+        publisher_name_elem.text = data.get('publisher_name', '') or ''
+        publisher_elem.append(publisher_name_elem)
 
-    journal_meta.append(publisher_elem)  # Adiciona <publisher> ao <journal-meta>
+        journal_meta.append(publisher_elem)
 
     return journal_meta

--- a/packtools/sps/formats/sps_xml/journal_meta.py
+++ b/packtools/sps/formats/sps_xml/journal_meta.py
@@ -1,16 +1,12 @@
 """
 data = {
-    "journal_ids": {
-        "nlm-ta": "Braz J Med Biol Res",
-        "publisher-id": "bjmbr"
-    },
+    "journal_ids_nlm_ta": "Braz J Med Biol Res",
+    "journal_ids_publisher_id": "bjmbr",
     "journal_title": "Brazilian Journal of Medical and Biological Research",
     "abbrev_journal_title": "Braz. J. Med. Biol. Res.",
-    "issn": {
-        "epub": "1414-431X",
-        "ppub": "0100-879X"
-    },
-    "publisher_name": "Associação Brasileira de Divulgação Científica"
+    "issn_epub": "1414-431X",
+    "issn_ppub": "0100-879X",
+    "publisher_names": ["Associação Brasileira de Divulgação Científica"]
 }
 """
 
@@ -21,57 +17,51 @@ def build_journal_meta(data):
     # Criação do elemento principal <journal-meta>
     journal_meta = ET.Element("journal-meta")
 
-    if "journal_ids" in data:
-        journal_ids = data.get("journal_ids")
-        if journal_ids is None:
-            # Se journal_ids é um dicionário vazio, cria um <journal-id> vazio
-            journal_id_elem = ET.Element("journal-id")
-            journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
-        elif journal_ids:
+    for journal_id_type in ("journal_ids_nlm-ta", "journal_ids_publisher-id"):
+        journal_id_value = data.get(journal_id_type)
+        if journal_id_value:
             # Adiciona <journal-id> elementos, verificando se o valor não é None
-            for journal_id_type, journal_id_value in journal_ids.items():
-                journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
-                journal_id_elem.text = journal_id_value or ""  # Se journal_id_value for None ou vazio, usa ""
-                journal_meta.append(journal_id_elem)  # Adiciona ao <journal-meta>
+            journal_id_type = journal_id_type.replace("journal_ids_", "")
+            journal_id_elem = ET.Element("journal-id", attrib={"journal-id-type": journal_id_type})
+            journal_id_elem.text = journal_id_value
+            journal_meta.append(journal_id_elem)
 
-    if 'journal_title' in data or "abbrev_journal_title" in data:
+    if any(data.get(key) for key in ("journal_title", "abbrev_journal_title")):
         # Cria <journal-title-group>
         journal_title_group = ET.Element("journal-title-group")
 
-        if 'journal_title' in data:
-            # Adiciona <journal-title> se o valor for None, insere string vazia
+        if data.get('journal_title'):
+            # Adiciona <journal-title> se o valor não é None
             journal_title_elem = ET.Element("journal-title")
-            journal_title_elem.text = data.get('journal_title') or ''
+            journal_title_elem.text = data.get('journal_title')
 
             journal_title_group.append(journal_title_elem)
 
-        if "abbrev_journal_title" in data:
-            # Adiciona <abbrev-journal-title>, verificando se o valor não é None
+        if data.get("abbrev_journal_title"):
+            # Adiciona <abbrev-journal-title> se o valor não é None
             abbrev_journal_title_elem = ET.Element("abbrev-journal-title", attrib={"abbrev-type": "publisher"})
-            abbrev_journal_title_elem.text = data.get('abbrev_journal_title') or ''
+            abbrev_journal_title_elem.text = data.get('abbrev_journal_title')
 
             journal_title_group.append(abbrev_journal_title_elem)
 
         # Adiciona <journal-title-group> ao <journal-meta>
         journal_meta.append(journal_title_group)
 
-    if "issn" in data:
-        if data.get("issn") is None:
-            issn_elem = ET.Element("issn")
+    for issn_type in ("issn_epub", "issn_ppub"):
+        issn_value = data.get(issn_type)
+        if issn_value:
+            issn_type = issn_type.replace("issn_", "")
+            issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
+            issn_elem.text = issn_value
             journal_meta.append(issn_elem)
-        else:
-            # Adiciona <issn> elementos, verificando se o valor não é None
-            for issn_type, issn_value in (data.get('issn') or {}).items():
-                issn_elem = ET.Element("issn", attrib={"pub-type": issn_type})
-                issn_elem.text = issn_value or ""
-                journal_meta.append(issn_elem)
 
-    # Cria <publisher> e <publisher-name>, insere string vazia se o valor for None
-    if 'publisher_name' in data:
+    # Cria <publisher> e <publisher-name> se existirem no dicionáŕrio
+    if data.get('publisher_names'):
         publisher_elem = ET.Element("publisher")
-        publisher_name_elem = ET.Element("publisher-name")
-        publisher_name_elem.text = data.get('publisher_name') or ''
-        publisher_elem.append(publisher_name_elem)
+        for publisher_name in data["publisher_names"] or []:
+            publisher_name_elem = ET.Element("publisher-name")
+            publisher_name_elem.text = publisher_name
+            publisher_elem.append(publisher_name_elem)
 
         journal_meta.append(publisher_elem)
 

--- a/packtools/sps/models/v2/related_articles.py
+++ b/packtools/sps/models/v2/related_articles.py
@@ -8,8 +8,6 @@ de Foucault.
 </related-article>
 """
 
-import xml.etree.ElementTree as ET
-
 from packtools.sps.utils.xml_utils import put_parent_context, process_subtags
 
 
@@ -28,15 +26,8 @@ class RelatedArticle:
             "id": self.id,
             "related-article-type": self.related_article_type,
             "href": self.href,
-            "text": self.text,
-            "full_tag": self.full_tag
+            "text": self.text
         }
-
-    @property
-    def full_tag(self):
-        ET.register_namespace('xlink', "http://www.w3.org/1999/xlink")
-        opening_tag = ET.tostring(self.related_article_node, encoding='unicode').split('>')[0] + '>'
-        return opening_tag
 
 
 class RelatedArticlesByNode:

--- a/packtools/sps/models/v2/related_articles.py
+++ b/packtools/sps/models/v2/related_articles.py
@@ -8,6 +8,8 @@ de Foucault.
 </related-article>
 """
 
+import xml.etree.ElementTree as ET
+
 from packtools.sps.utils.xml_utils import put_parent_context, process_subtags
 
 
@@ -26,8 +28,15 @@ class RelatedArticle:
             "id": self.id,
             "related-article-type": self.related_article_type,
             "href": self.href,
-            "text": self.text
+            "text": self.text,
+            "full_tag": self.full_tag
         }
+
+    @property
+    def full_tag(self):
+        ET.register_namespace('xlink', "http://www.w3.org/1999/xlink")
+        opening_tag = ET.tostring(self.related_article_node, encoding='unicode').split('>')[0] + '>'
+        return opening_tag
 
 
 class RelatedArticlesByNode:

--- a/tests/sps/formats/sps_xml/test_article.py
+++ b/tests/sps/formats/sps_xml/test_article.py
@@ -1,0 +1,35 @@
+import unittest
+from xml.etree.ElementTree import Element
+
+from packtools.sps.formats.sps_xml.article import build_article_node
+
+
+class TestBuildArticleNode(unittest.TestCase):
+    def test_build_article_node(self):
+        article_node = build_article_node(
+            article_data={
+                'dtd-version': '1.1',
+                'specific-use': 'sps-1.8',
+                'article-type': 'research-article',
+                'xml:lang': 'pt'
+            }
+        )
+
+        self.assertIsInstance(article_node, Element)
+
+        self.assertEqual(article_node.tag, 'article')
+
+        expected_attributes = {
+            'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+            'xmlns:mml': 'http://www.w3.org/1998/Math/MathML',
+            'dtd-version': '1.1',
+            'specific-use': 'sps-1.8',
+            'article-type': 'research-article',
+            'xml:lang': 'pt'
+        }
+
+        self.assertDictEqual(article_node.attrib, expected_attributes)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/formats/sps_xml/test_article.py
+++ b/tests/sps/formats/sps_xml/test_article.py
@@ -30,6 +30,17 @@ class TestBuildArticleNode(unittest.TestCase):
 
         self.assertDictEqual(article_node.attrib, expected_attributes)
 
+    def test_build_article_node_error(self):
+        with self.assertRaises(KeyError) as e:
+            build_article_node(
+                article_data={
+                    'specific-use': 'sps-1.8',
+                    'article-type': 'research-article',
+                    'xml:lang': 'pt'
+                }
+            )
+        self.assertEqual(str(e.exception), '"\'dtd-version\' is required"')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sps/formats/sps_xml/test_contrib.py
+++ b/tests/sps/formats/sps_xml/test_contrib.py
@@ -1,6 +1,6 @@
 import unittest
 import xml.etree.ElementTree as ET
-from packtools.sps.formats.sps_xml.contrib import build_contrib_author  # Substitua 'your_module' pelo nome do seu arquivo
+from packtools.sps.formats.sps_xml.contrib import build_contrib_author
 
 
 class TestBuildContribAuthor(unittest.TestCase):
@@ -19,35 +19,34 @@ class TestBuildContribAuthor(unittest.TestCase):
                 {"rid": "aff1", "text": "1"}
             ]
         }
+        self.contrib_elem = build_contrib_author(self.valid_data)
 
-    def test_contrib_author_structure(self):
-        # Gera o XML a partir dos dados válidos
-        contrib_elem = build_contrib_author(self.valid_data)
+    def test_contrib_author_contrib_type(self):
+        # Combinação de verificação da estrutura e do valor de contrib-type
+        contrib_type = self.contrib_elem.get("contrib-type")
+        self.assertIsNotNone(contrib_type)
+        self.assertEqual(contrib_type, "author")
 
-        # Verifica se o elemento principal é <contrib> e se tem o atributo correto
-        self.assertEqual(contrib_elem.tag, "contrib")
-        self.assertEqual(contrib_elem.get("contrib-type"), "author")
-
-        # Verifica os elementos <contrib-id> para ORCID e Scopus
-        contrib_ids = contrib_elem.findall("contrib-id")
+    def test_contrib_author_ids(self):
+        contrib_ids = self.contrib_elem.findall("contrib-id")
         self.assertEqual(len(contrib_ids), 2)
         self.assertEqual(contrib_ids[0].get("contrib-id-type"), "orcid")
         self.assertEqual(contrib_ids[0].text, "0000-0001-8528-2091")
         self.assertEqual(contrib_ids[1].get("contrib-id-type"), "scopus")
         self.assertEqual(contrib_ids[1].text, "24771926600")
 
-        # Verifica os elementos <name>, <surname>, e <given-names>
-        name_elem = contrib_elem.find("name")
+    def test_contrib_author_name(self):
+        name_elem = self.contrib_elem.find("name")
         self.assertIsNotNone(name_elem)
-
         surname_elem = name_elem.find("surname")
-        self.assertEqual(surname_elem.text, "Einstein")
-
         given_names_elem = name_elem.find("given-names")
+        self.assertEqual(surname_elem.text, "Einstein")
         self.assertEqual(given_names_elem.text, "Albert")
 
-        # Verifica o <xref> para afiliação
-        xref_elem = contrib_elem.find("xref")
+    def test_contrib_author_affiliations(self):
+        xref_elems = self.contrib_elem.findall("xref")
+        self.assertEqual(len(xref_elems), 1)
+        xref_elem = xref_elems[0]
         self.assertEqual(xref_elem.get("ref-type"), "aff")
         self.assertEqual(xref_elem.get("rid"), "aff1")
         self.assertEqual(xref_elem.text, "1")
@@ -75,9 +74,12 @@ class TestBuildContribAuthor(unittest.TestCase):
         # Comparar o XML gerado com a string esperada
         self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
-    def test_contrib_author_with_null_values(self):
-        # Dados com valores nulos (None)
-        null_data = {
+
+class TestBuildContribAuthorNoneValues(unittest.TestCase):
+
+    def setUp(self):
+        # Dados de exemplo para o teste com valores nulos
+        self.valid_data = {
             "contrib_type": None,
             "contrib_ids": {
                 "orcid": None,
@@ -90,24 +92,74 @@ class TestBuildContribAuthor(unittest.TestCase):
             ]
         }
 
-        # Gera o XML a partir dos dados nulos
-        contrib_elem = build_contrib_author(null_data)
-
-        # Converte o elemento XML em uma string
+    def _build_and_compare(self, expected_xml_str):
+        """Método auxiliar para construção e comparação do XML gerado"""
+        contrib_elem = build_contrib_author(self.valid_data)
         generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
-        # String XML esperada para dados nulos
+    def test_contrib_author_with_all_null_values(self):
         expected_xml_str = (
-            '<contrib contrib-type="author">'
+            '<contrib contrib-type="">'
+            '<contrib-id contrib-id-type="orcid" />'
+            '<contrib-id contrib-id-type="scopus" />'
             '<name>'
             '<surname />'
             '<given-names />'
             '</name>'
             '</contrib>'
         )
+        self._build_and_compare(expected_xml_str)
 
-        # Verifica se o XML gerado corresponde à string esperada
-        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+    def test_contrib_author_without_contrib_id(self):
+        self.valid_data.pop("contrib_ids")
+        expected_xml_str = (
+            '<contrib contrib-type="">'
+            '<name>'
+            '<surname />'
+            '<given-names />'
+            '</name>'
+            '</contrib>'
+        )
+        self._build_and_compare(expected_xml_str)
+
+    def test_contrib_author_without_contrib_id_type(self):
+        self.valid_data["contrib_ids"].pop("orcid")
+        expected_xml_str = (
+            '<contrib contrib-type="">'
+            '<contrib-id contrib-id-type="scopus" />'
+            '<name>'
+            '<surname />'
+            '<given-names />'
+            '</name>'
+            '</contrib>'
+        )
+        self._build_and_compare(expected_xml_str)
+
+    def test_contrib_author_without_contrib_ids(self):
+        self.valid_data.pop("contrib_ids")
+        expected_xml_str = (
+            '<contrib contrib-type="">'
+            '<name>'
+            '<surname />'
+            '<given-names />'
+            '</name>'
+            '</contrib>'
+        )
+        self._build_and_compare(expected_xml_str)
+
+    def test_contrib_author_without_surname(self):
+        self.valid_data.pop("surname")
+        expected_xml_str = (
+            '<contrib contrib-type="">'
+            '<contrib-id contrib-id-type="orcid" />'
+            '<contrib-id contrib-id-type="scopus" />'
+            '<name>'
+            '<given-names />'
+            '</name>'
+            '</contrib>'
+        )
+        self._build_and_compare(expected_xml_str)
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/sps_xml/test_contrib.py
+++ b/tests/sps/formats/sps_xml/test_contrib.py
@@ -9,10 +9,8 @@ class TestBuildContribAuthor(unittest.TestCase):
         # Dados de exemplo para o teste com valores válidos
         self.valid_data = {
             "contrib_type": "author",
-            "contrib_ids": {
-                "orcid": "0000-0001-8528-2091",
-                "scopus": "24771926600"
-            },
+            "orcid": "0000-0001-8528-2091",
+            "scopus": "24771926600",
             "prefix": "Prof.",
             "surname": "Einstein",
             "given_names": "Albert",
@@ -98,10 +96,8 @@ class TestBuildContribAuthorNoneValues(unittest.TestCase):
     """
         {
             "contrib_type": None,
-            "contrib_ids": {
-                "orcid": None,
-                "scopus": None
-            },
+            "orcid": None,
+            "scopus": None,
             "surname": None,
             "given_names": None,
             "affiliations": [
@@ -115,32 +111,18 @@ class TestBuildContribAuthorNoneValues(unittest.TestCase):
             "contrib_type": None
         }
 
-        with self.assertRaises(KeyError) as e:
+        with self.assertRaises(NameError) as e:
             build_contrib_author(data)
 
-        self.assertEqual(str(e.exception), "'contrib-type is required'")
+        self.assertEqual(str(e.exception), "contrib-type is required")
 
     def test_contrib_author_contrib_ids_None(self):
         data = {
             "contrib_type": "author",
-            "contrib_ids": None
-        }
-        with self.assertRaises(KeyError) as e:
-            build_contrib_author(data)
-
-        self.assertEqual(str(e.exception), "'contrib-id-type is required'")
-
-    def test_contrib_author_contrib_ids_attrib_None(self):
-        data = {
-            "contrib_type": "author",
-            "contrib_ids": {
-                "orcid": None,
-            },
+            "scopus": None
         }
         expected_xml_str = (
-            '<contrib contrib-type="author">'
-            '<contrib-id contrib-id-type="orcid" />'
-            '</contrib>'
+            '<contrib contrib-type="author" />'
         )
         contrib_elem = build_contrib_author(data)
         generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")
@@ -153,11 +135,7 @@ class TestBuildContribAuthorNoneValues(unittest.TestCase):
             "surname": None,
         }
         expected_xml_str = (
-            '<contrib contrib-type="author">'
-            '<name>'
-            '<surname />'
-            '</name>'
-            '</contrib>'
+            '<contrib contrib-type="author" />'
         )
         contrib_elem = build_contrib_author(data)
         generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")
@@ -169,9 +147,7 @@ class TestBuildContribAuthorNoneValues(unittest.TestCase):
             "affiliations": None,
         }
         expected_xml_str = (
-            '<contrib contrib-type="author">'
-            '<xref />'
-            '</contrib>'
+            '<contrib contrib-type="author" />'
         )
         contrib_elem = build_contrib_author(data)
         generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")

--- a/tests/sps/formats/sps_xml/test_contrib.py
+++ b/tests/sps/formats/sps_xml/test_contrib.py
@@ -1,0 +1,114 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.contrib import build_contrib_author  # Substitua 'your_module' pelo nome do seu arquivo
+
+
+class TestBuildContribAuthor(unittest.TestCase):
+
+    def setUp(self):
+        # Dados de exemplo para o teste com valores válidos
+        self.valid_data = {
+            "contrib_type": "author",
+            "contrib_ids": {
+                "orcid": "0000-0001-8528-2091",
+                "scopus": "24771926600"
+            },
+            "surname": "Einstein",
+            "given_names": "Albert",
+            "affiliations": [
+                {"rid": "aff1", "text": "1"}
+            ]
+        }
+
+    def test_contrib_author_structure(self):
+        # Gera o XML a partir dos dados válidos
+        contrib_elem = build_contrib_author(self.valid_data)
+
+        # Verifica se o elemento principal é <contrib> e se tem o atributo correto
+        self.assertEqual(contrib_elem.tag, "contrib")
+        self.assertEqual(contrib_elem.get("contrib-type"), "author")
+
+        # Verifica os elementos <contrib-id> para ORCID e Scopus
+        contrib_ids = contrib_elem.findall("contrib-id")
+        self.assertEqual(len(contrib_ids), 2)
+        self.assertEqual(contrib_ids[0].get("contrib-id-type"), "orcid")
+        self.assertEqual(contrib_ids[0].text, "0000-0001-8528-2091")
+        self.assertEqual(contrib_ids[1].get("contrib-id-type"), "scopus")
+        self.assertEqual(contrib_ids[1].text, "24771926600")
+
+        # Verifica os elementos <name>, <surname>, e <given-names>
+        name_elem = contrib_elem.find("name")
+        self.assertIsNotNone(name_elem)
+
+        surname_elem = name_elem.find("surname")
+        self.assertEqual(surname_elem.text, "Einstein")
+
+        given_names_elem = name_elem.find("given-names")
+        self.assertEqual(given_names_elem.text, "Albert")
+
+        # Verifica o <xref> para afiliação
+        xref_elem = contrib_elem.find("xref")
+        self.assertEqual(xref_elem.get("ref-type"), "aff")
+        self.assertEqual(xref_elem.get("rid"), "aff1")
+        self.assertEqual(xref_elem.text, "1")
+
+    def test_contrib_author_as_string(self):
+        # Gera o XML a partir dos dados válidos
+        contrib_elem = build_contrib_author(self.valid_data)
+
+        # Converte o elemento XML em uma string
+        generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")
+
+        # String XML esperada
+        expected_xml_str = (
+            '<contrib contrib-type="author">'
+            '<contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>'
+            '<contrib-id contrib-id-type="scopus">24771926600</contrib-id>'
+            '<name>'
+            '<surname>Einstein</surname>'
+            '<given-names>Albert</given-names>'
+            '</name>'
+            '<xref ref-type="aff" rid="aff1">1</xref>'
+            '</contrib>'
+        )
+
+        # Comparar o XML gerado com a string esperada
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_contrib_author_with_null_values(self):
+        # Dados com valores nulos (None)
+        null_data = {
+            "contrib_type": None,
+            "contrib_ids": {
+                "orcid": None,
+                "scopus": None
+            },
+            "surname": None,
+            "given_names": None,
+            "affiliations": [
+                {"rid": None, "text": None}
+            ]
+        }
+
+        # Gera o XML a partir dos dados nulos
+        contrib_elem = build_contrib_author(null_data)
+
+        # Converte o elemento XML em uma string
+        generated_xml_str = ET.tostring(contrib_elem, encoding="unicode", method="xml")
+
+        # String XML esperada para dados nulos
+        expected_xml_str = (
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<surname />'
+            '<given-names />'
+            '</name>'
+            '</contrib>'
+        )
+
+        # Verifica se o XML gerado corresponde à string esperada
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/formats/sps_xml/test_journal_meta.py
+++ b/tests/sps/formats/sps_xml/test_journal_meta.py
@@ -1,0 +1,131 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.journal_meta import build_journal_meta
+
+
+class TestBuildJournalMeta(unittest.TestCase):
+
+    def setUp(self):
+        # Dados de exemplo para uso em testes
+        self.data = {
+            "journal_ids": {
+                "nlm-ta": "Braz J Med Biol Res",
+                "publisher-id": "bjmbr"
+            },
+            "journal_title": "Brazilian Journal of Medical and Biological Research",
+            "abbrev_journal_title": "Braz. J. Med. Biol. Res.",
+            "issn": {
+                "epub": "1414-431X",
+                "ppub": "0100-879X"
+            },
+            "publisher_name": "Associação Brasileira de Divulgação Científica"
+        }
+
+    def test_journal_meta_structure(self):
+        # Gera o XML a partir dos dados
+        journal_meta_elem = build_journal_meta(self.data)
+
+        # Verifica se o elemento principal é <journal-meta>
+        self.assertEqual(journal_meta_elem.tag, "journal-meta")
+
+        # Verifica se <journal-id> elementos foram criados corretamente
+        journal_ids = journal_meta_elem.findall("journal-id")
+        self.assertEqual(len(journal_ids), 2)
+        self.assertEqual(journal_ids[0].get("journal-id-type"), "nlm-ta")
+        self.assertEqual(journal_ids[0].text, "Braz J Med Biol Res")
+        self.assertEqual(journal_ids[1].get("journal-id-type"), "publisher-id")
+        self.assertEqual(journal_ids[1].text, "bjmbr")
+
+        # Verifica o grupo de títulos <journal-title-group>
+        journal_title_group = journal_meta_elem.find("journal-title-group")
+        self.assertIsNotNone(journal_title_group)
+
+        # Verifica se <journal-title> foi criado corretamente
+        journal_title = journal_title_group.find("journal-title")
+        self.assertEqual(journal_title.text, "Brazilian Journal of Medical and Biological Research")
+
+        # Verifica o título abreviado <abbrev-journal-title>
+        abbrev_title = journal_title_group.find("abbrev-journal-title")
+        self.assertEqual(abbrev_title.text, "Braz. J. Med. Biol. Res.")
+        self.assertEqual(abbrev_title.get("abbrev-type"), "publisher")
+
+        # Verifica os elementos <issn>
+        issns = journal_meta_elem.findall("issn")
+        self.assertEqual(len(issns), 2)
+        self.assertEqual(issns[0].get("pub-type"), "epub")
+        self.assertEqual(issns[0].text, "1414-431X")
+        self.assertEqual(issns[1].get("pub-type"), "ppub")
+        self.assertEqual(issns[1].text, "0100-879X")
+
+        # Verifica o elemento <publisher> e <publisher-name>
+        publisher = journal_meta_elem.find("publisher")
+        self.assertIsNotNone(publisher)
+
+        publisher_name = publisher.find("publisher-name")
+        self.assertEqual(publisher_name.text, "Associação Brasileira de Divulgação Científica")
+
+    def test_journal_meta_empty_data(self):
+        # Testa com dados vazios
+        empty_data = {
+            "journal_ids": {},
+            "journal_title": "",
+            "abbrev_journal_title": "",
+            "issn": {},
+            "publisher_name": ""
+        }
+        journal_meta_elem = build_journal_meta(empty_data)
+
+        # Verifica se os elementos principais são criados, mas sem conteúdo
+        self.assertEqual(journal_meta_elem.tag, "journal-meta")
+        self.assertEqual(len(journal_meta_elem.findall("journal-id")), 0)
+        self.assertEqual(len(journal_meta_elem.findall("issn")), 0)
+
+        # Verifica se o <journal-title-group> está presente, mas vazio
+        journal_title_group = journal_meta_elem.find("journal-title-group")
+        self.assertIsNotNone(journal_title_group)
+
+        journal_title = journal_title_group.find("journal-title")
+        self.assertEqual(journal_title.text, "")
+
+        abbrev_title = journal_title_group.find("abbrev-journal-title")
+        self.assertEqual(abbrev_title.text, "")
+        self.assertEqual(abbrev_title.get("abbrev-type"), "publisher")
+
+        # Verifica se o <publisher> foi criado, mas sem nome
+        publisher = journal_meta_elem.find("publisher")
+        self.assertIsNotNone(publisher)
+
+        publisher_name = publisher.find("publisher-name")
+        self.assertEqual(publisher_name.text, "")
+
+    def test_journal_meta_as_string(self):
+        self.maxDiff = None
+        # Gera o XML a partir dos dados
+        journal_meta_elem = build_journal_meta(self.data)
+
+        # Converte o elemento XML em uma string
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+
+        # String XML esperada
+        expected_xml_str = (
+            '<journal-meta>'
+            '<journal-id journal-id-type="nlm-ta">Braz J Med Biol Res</journal-id>'
+            '<journal-id journal-id-type="publisher-id">bjmbr</journal-id>'
+            '<journal-title-group>'
+            '<journal-title>Brazilian Journal of Medical and Biological Research</journal-title>'
+            '<abbrev-journal-title abbrev-type="publisher">Braz. J. Med. Biol. Res.</abbrev-journal-title>'
+            '</journal-title-group>'
+            '<issn pub-type="epub">1414-431X</issn>'
+            '<issn pub-type="ppub">0100-879X</issn>'
+            '<publisher>'
+            '<publisher-name>Associação Brasileira de Divulgação Científica</publisher-name>'
+            '</publisher>'
+            '</journal-meta>'
+        )
+
+        # Comparar o XML gerado com a string esperada
+        self.assertEqual(generated_xml_str, expected_xml_str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/formats/sps_xml/test_journal_meta.py
+++ b/tests/sps/formats/sps_xml/test_journal_meta.py
@@ -20,91 +20,49 @@ class TestBuildJournalMeta(unittest.TestCase):
             },
             "publisher_name": "Associação Brasileira de Divulgação Científica"
         }
+        self.journal_meta_elem = build_journal_meta(self.data)
 
     def test_journal_meta_structure(self):
-        # Gera o XML a partir dos dados
-        journal_meta_elem = build_journal_meta(self.data)
-
         # Verifica se o elemento principal é <journal-meta>
-        self.assertEqual(journal_meta_elem.tag, "journal-meta")
+        self.assertEqual(self.journal_meta_elem.tag, "journal-meta")
 
-        # Verifica se <journal-id> elementos foram criados corretamente
-        journal_ids = journal_meta_elem.findall("journal-id")
+    def test_journal_meta_journal_ids(self):
+        journal_ids = self.journal_meta_elem.findall("journal-id")
         self.assertEqual(len(journal_ids), 2)
         self.assertEqual(journal_ids[0].get("journal-id-type"), "nlm-ta")
         self.assertEqual(journal_ids[0].text, "Braz J Med Biol Res")
         self.assertEqual(journal_ids[1].get("journal-id-type"), "publisher-id")
         self.assertEqual(journal_ids[1].text, "bjmbr")
 
-        # Verifica o grupo de títulos <journal-title-group>
-        journal_title_group = journal_meta_elem.find("journal-title-group")
+    def test_journal_meta_titles(self):
+        journal_title_group = self.journal_meta_elem.find("journal-title-group")
         self.assertIsNotNone(journal_title_group)
 
-        # Verifica se <journal-title> foi criado corretamente
         journal_title = journal_title_group.find("journal-title")
         self.assertEqual(journal_title.text, "Brazilian Journal of Medical and Biological Research")
 
-        # Verifica o título abreviado <abbrev-journal-title>
         abbrev_title = journal_title_group.find("abbrev-journal-title")
         self.assertEqual(abbrev_title.text, "Braz. J. Med. Biol. Res.")
         self.assertEqual(abbrev_title.get("abbrev-type"), "publisher")
 
-        # Verifica os elementos <issn>
-        issns = journal_meta_elem.findall("issn")
+    def test_journal_meta_issn(self):
+        issns = self.journal_meta_elem.findall("issn")
         self.assertEqual(len(issns), 2)
         self.assertEqual(issns[0].get("pub-type"), "epub")
         self.assertEqual(issns[0].text, "1414-431X")
         self.assertEqual(issns[1].get("pub-type"), "ppub")
         self.assertEqual(issns[1].text, "0100-879X")
 
-        # Verifica o elemento <publisher> e <publisher-name>
-        publisher = journal_meta_elem.find("publisher")
+    def test_journal_meta_publisher(self):
+        publisher = self.journal_meta_elem.find("publisher")
         self.assertIsNotNone(publisher)
 
         publisher_name = publisher.find("publisher-name")
         self.assertEqual(publisher_name.text, "Associação Brasileira de Divulgação Científica")
 
-    def test_journal_meta_empty_data(self):
-        # Testa com dados vazios
-        empty_data = {
-            "journal_ids": {},
-            "journal_title": "",
-            "abbrev_journal_title": "",
-            "issn": {},
-            "publisher_name": ""
-        }
-        journal_meta_elem = build_journal_meta(empty_data)
-
-        # Verifica se os elementos principais são criados, mas sem conteúdo
-        self.assertEqual(journal_meta_elem.tag, "journal-meta")
-        self.assertEqual(len(journal_meta_elem.findall("journal-id")), 0)
-        self.assertEqual(len(journal_meta_elem.findall("issn")), 0)
-
-        # Verifica se o <journal-title-group> está presente, mas vazio
-        journal_title_group = journal_meta_elem.find("journal-title-group")
-        self.assertIsNotNone(journal_title_group)
-
-        journal_title = journal_title_group.find("journal-title")
-        self.assertEqual(journal_title.text, "")
-
-        abbrev_title = journal_title_group.find("abbrev-journal-title")
-        self.assertEqual(abbrev_title.text, "")
-        self.assertEqual(abbrev_title.get("abbrev-type"), "publisher")
-
-        # Verifica se o <publisher> foi criado, mas sem nome
-        publisher = journal_meta_elem.find("publisher")
-        self.assertIsNotNone(publisher)
-
-        publisher_name = publisher.find("publisher-name")
-        self.assertEqual(publisher_name.text, "")
-
     def test_journal_meta_as_string(self):
-        self.maxDiff = None
-        # Gera o XML a partir dos dados
-        journal_meta_elem = build_journal_meta(self.data)
-
-        # Converte o elemento XML em uma string
-        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        # Gera o XML a partir dos dados válidos
+        generated_xml_str = ET.tostring(self.journal_meta_elem, encoding="unicode", method="xml")
 
         # String XML esperada
         expected_xml_str = (
@@ -124,7 +82,76 @@ class TestBuildJournalMeta(unittest.TestCase):
         )
 
         # Comparar o XML gerado com a string esperada
-        self.assertEqual(generated_xml_str, expected_xml_str)
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildJournalMetaNoneValues(unittest.TestCase):
+
+    def setUp(self):
+        self.empty_data = {
+            "journal_ids": {
+                "nlm-ta": None,
+            },
+            "journal_title": "",
+            "abbrev_journal_title": "",
+            "issn": {},
+            "publisher_name": ""
+        }
+
+    def _build_and_compare(self, expected_xml_str):
+        """Método auxiliar para construção e comparação do XML gerado"""
+        journal_meta_elem = build_journal_meta(self.empty_data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_empty_data(self):
+        expected_xml_str = (
+            '<journal-meta>'
+            '<journal-id journal-id-type="nlm-ta" />'
+            '<journal-title-group>'
+            '<journal-title />'
+            '<abbrev-journal-title abbrev-type="publisher" />'
+            '</journal-title-group>'
+            '<publisher>'
+            '<publisher-name />'
+            '</publisher>'
+            '</journal-meta>'
+        )
+        self._build_and_compare(expected_xml_str)
+
+    def test_journal_meta_without_journal_ids(self):
+        self.maxDiff = None
+        # Exclui journal_ids para testar a ausência
+        self.empty_data.pop("journal_ids")
+        expected_xml_str = (
+            '<journal-meta>'
+            '<journal-title-group>'
+            '<journal-title />'
+            '<abbrev-journal-title abbrev-type="publisher" />'
+            '</journal-title-group>'
+            '<publisher>'
+            '<publisher-name />'
+            '</publisher>'
+            '</journal-meta>'
+        )
+        self._build_and_compare(expected_xml_str)
+
+    def test_journal_meta_without_issn(self):
+        # Exclui issn para testar a ausência
+        self.empty_data.pop("issn")
+        expected_xml_str = (
+            '<journal-meta>'
+            '<journal-id journal-id-type="nlm-ta" />'
+            '<journal-title-group>'
+            '<journal-title />'
+            '<abbrev-journal-title abbrev-type="publisher" />'
+            '</journal-title-group>'
+            '<publisher>'
+            '<publisher-name />'
+            '</publisher>'
+            '</journal-meta>'
+        )
+        self._build_and_compare(expected_xml_str)
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/sps_xml/test_journal_meta.py
+++ b/tests/sps/formats/sps_xml/test_journal_meta.py
@@ -98,60 +98,111 @@ class TestBuildJournalMetaNoneValues(unittest.TestCase):
             "publisher_name": ""
         }
 
-    def _build_and_compare(self, expected_xml_str):
-        """Método auxiliar para construção e comparação do XML gerado"""
-        journal_meta_elem = build_journal_meta(self.empty_data)
+    def test_journal_meta_journal_id_None(self):
+        data = {
+            "journal_ids": None
+        }
+        expected_xml_str = (
+            '<journal-meta>'
+            '<journal-id />'
+            '</journal-meta>'
+        )
+
+        journal_meta_elem = build_journal_meta(data)
         generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
         self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
-    def test_journal_meta_empty_data(self):
+    def test_journal_meta_journal_id_attrib_None(self):
+        data = {
+            "journal_ids": {
+                "nlm-ta": None,
+            },
+        }
         expected_xml_str = (
             '<journal-meta>'
             '<journal-id journal-id-type="nlm-ta" />'
-            '<journal-title-group>'
-            '<journal-title />'
-            '<abbrev-journal-title abbrev-type="publisher" />'
-            '</journal-title-group>'
-            '<publisher>'
-            '<publisher-name />'
-            '</publisher>'
             '</journal-meta>'
         )
-        self._build_and_compare(expected_xml_str)
 
-    def test_journal_meta_without_journal_ids(self):
-        self.maxDiff = None
-        # Exclui journal_ids para testar a ausência
-        self.empty_data.pop("journal_ids")
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_journal_title_None(self):
+        data = {
+            "journal_title": None,
+        }
         expected_xml_str = (
             '<journal-meta>'
             '<journal-title-group>'
             '<journal-title />'
-            '<abbrev-journal-title abbrev-type="publisher" />'
             '</journal-title-group>'
-            '<publisher>'
-            '<publisher-name />'
-            '</publisher>'
             '</journal-meta>'
         )
-        self._build_and_compare(expected_xml_str)
 
-    def test_journal_meta_without_issn(self):
-        # Exclui issn para testar a ausência
-        self.empty_data.pop("issn")
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_abbrev_journal_title_None(self):
+        data = {
+            "abbrev_journal_title": None,
+        }
         expected_xml_str = (
             '<journal-meta>'
-            '<journal-id journal-id-type="nlm-ta" />'
             '<journal-title-group>'
-            '<journal-title />'
             '<abbrev-journal-title abbrev-type="publisher" />'
             '</journal-title-group>'
-            '<publisher>'
-            '<publisher-name />'
-            '</publisher>'
             '</journal-meta>'
         )
-        self._build_and_compare(expected_xml_str)
+
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_issn_None(self):
+        data = {
+            "issn": None,
+        }
+        expected_xml_str = (
+            '<journal-meta>'
+            '<issn />'
+            '</journal-meta>'
+        )
+
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_issn_attrib_None(self):
+        data = {
+            "issn": {
+                "epub": None,
+            }
+        }
+        expected_xml_str = (
+            '<journal-meta>'
+            '<issn pub-type="epub" />'
+            '</journal-meta>'
+        )
+
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_journal_meta_publisher_name_None(self):
+        data = {
+            "publisher_name": None,
+        }
+        expected_xml_str = (
+            '<journal-meta>'
+            '<publisher><publisher-name /></publisher>'
+            '</journal-meta>'
+        )
+
+        journal_meta_elem = build_journal_meta(data)
+        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/sps_xml/test_journal_meta.py
+++ b/tests/sps/formats/sps_xml/test_journal_meta.py
@@ -8,17 +8,13 @@ class TestBuildJournalMeta(unittest.TestCase):
     def setUp(self):
         # Dados de exemplo para uso em testes
         self.data = {
-            "journal_ids": {
-                "nlm-ta": "Braz J Med Biol Res",
-                "publisher-id": "bjmbr"
-            },
+            "journal_ids_nlm-ta": "Braz J Med Biol Res",
+            "journal_ids_publisher-id": "bjmbr",
             "journal_title": "Brazilian Journal of Medical and Biological Research",
             "abbrev_journal_title": "Braz. J. Med. Biol. Res.",
-            "issn": {
-                "epub": "1414-431X",
-                "ppub": "0100-879X"
-            },
-            "publisher_name": "Associação Brasileira de Divulgação Científica"
+            "issn_epub": "1414-431X",
+            "issn_ppub": "0100-879X",
+            "publisher_names": ["Associação Brasileira de Divulgação Científica"]
         }
         self.journal_meta_elem = build_journal_meta(self.data)
 
@@ -86,42 +82,13 @@ class TestBuildJournalMeta(unittest.TestCase):
 
 
 class TestBuildJournalMetaNoneValues(unittest.TestCase):
-
-    def setUp(self):
-        self.empty_data = {
-            "journal_ids": {
-                "nlm-ta": None,
-            },
-            "journal_title": "",
-            "abbrev_journal_title": "",
-            "issn": {},
-            "publisher_name": ""
-        }
-
     def test_journal_meta_journal_id_None(self):
         data = {
-            "journal_ids": None
+            "journal_ids_nlm-ta": None,
+            "journal_ids_publisher-id": None,
         }
         expected_xml_str = (
-            '<journal-meta>'
-            '<journal-id />'
-            '</journal-meta>'
-        )
-
-        journal_meta_elem = build_journal_meta(data)
-        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
-        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
-
-    def test_journal_meta_journal_id_attrib_None(self):
-        data = {
-            "journal_ids": {
-                "nlm-ta": None,
-            },
-        }
-        expected_xml_str = (
-            '<journal-meta>'
-            '<journal-id journal-id-type="nlm-ta" />'
-            '</journal-meta>'
+            '<journal-meta />'
         )
 
         journal_meta_elem = build_journal_meta(data)
@@ -133,11 +100,7 @@ class TestBuildJournalMetaNoneValues(unittest.TestCase):
             "journal_title": None,
         }
         expected_xml_str = (
-            '<journal-meta>'
-            '<journal-title-group>'
-            '<journal-title />'
-            '</journal-title-group>'
-            '</journal-meta>'
+            '<journal-meta />'
         )
 
         journal_meta_elem = build_journal_meta(data)
@@ -149,11 +112,7 @@ class TestBuildJournalMetaNoneValues(unittest.TestCase):
             "abbrev_journal_title": None,
         }
         expected_xml_str = (
-            '<journal-meta>'
-            '<journal-title-group>'
-            '<abbrev-journal-title abbrev-type="publisher" />'
-            '</journal-title-group>'
-            '</journal-meta>'
+            '<journal-meta />'
         )
 
         journal_meta_elem = build_journal_meta(data)
@@ -162,28 +121,11 @@ class TestBuildJournalMetaNoneValues(unittest.TestCase):
 
     def test_journal_meta_issn_None(self):
         data = {
-            "issn": None,
+            "issn_epub": None,
+            "issn_ppub": None,
         }
         expected_xml_str = (
-            '<journal-meta>'
-            '<issn />'
-            '</journal-meta>'
-        )
-
-        journal_meta_elem = build_journal_meta(data)
-        generated_xml_str = ET.tostring(journal_meta_elem, encoding="unicode", method="xml")
-        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
-
-    def test_journal_meta_issn_attrib_None(self):
-        data = {
-            "issn": {
-                "epub": None,
-            }
-        }
-        expected_xml_str = (
-            '<journal-meta>'
-            '<issn pub-type="epub" />'
-            '</journal-meta>'
+            '<journal-meta />'
         )
 
         journal_meta_elem = build_journal_meta(data)
@@ -192,12 +134,10 @@ class TestBuildJournalMetaNoneValues(unittest.TestCase):
 
     def test_journal_meta_publisher_name_None(self):
         data = {
-            "publisher_name": None,
+            "publisher_names": None,
         }
         expected_xml_str = (
-            '<journal-meta>'
-            '<publisher><publisher-name /></publisher>'
-            '</journal-meta>'
+            '<journal-meta />'
         )
 
         journal_meta_elem = build_journal_meta(data)

--- a/tests/sps/models/v2/test_related_articles.py
+++ b/tests/sps/models/v2/test_related_articles.py
@@ -16,7 +16,6 @@ from packtools.sps.models.v2.related_articles import RelatedArticle, RelatedArti
 
 class RelatedArticleTest(TestCase):
     def test_related_article(self):
-        self.maxDiff = None
         xml = """
             <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <front>
@@ -38,16 +37,13 @@ class RelatedArticleTest(TestCase):
             "href": "10.1590/0101-3173.2022.v45n1.p139",
             "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                     "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                    "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
-            'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
-                        'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
+                    "da Unesp, v. 45, n. 1, p. 139-158, 2022."
         }
         self.assertDictEqual(obtained, expected)
 
 
 class RelatedArticlesByNodeTest(TestCase):
     def test_related_articles(self):
-        self.maxDiff = None
         xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="article-commentary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
@@ -77,9 +73,7 @@ class RelatedArticlesByNodeTest(TestCase):
                 "href": "10.1590/0101-3173.2022.v45n1.p139",
                 "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                         "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                        "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
-                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
-                            'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
+                        "da Unesp, v. 45, n. 1, p. 139-158, 2022."
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -104,10 +98,7 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': '',
-                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA1" '
-                            'related-article-type="corrected-article" ext-link-type="doi" '
-                            'xlink:href="10.1590/s1413-65382620000100001" />',
+                'text': ''
             },
             {
                 'ext-link-type': 'doi',
@@ -118,10 +109,7 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': '',
-                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA9" '
-                            'related-article-type="corrected-article" ext-link-type="doi" '
-                            'xlink:href="10.1590/s1413-65382620000100009" />',
+                'text': ''
             },
 
         ]
@@ -141,10 +129,7 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': '',
-                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA10" '
-                            'related-article-type="corrected-article" ext-link-type="doi" '
-                            'xlink:href="10.1590/s1413-65382620000100001" />',
+                'text': ''
             },
             {
                 'ext-link-type': 'doi',
@@ -155,10 +140,7 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': '',
-                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA18" '
-                            'related-article-type="corrected-article" ext-link-type="doi" '
-                            'xlink:href="10.1590/s1413-65382620000100009" />',
+                'text': ''
             },
 
         ]

--- a/tests/sps/models/v2/test_related_articles.py
+++ b/tests/sps/models/v2/test_related_articles.py
@@ -16,6 +16,7 @@ from packtools.sps.models.v2.related_articles import RelatedArticle, RelatedArti
 
 class RelatedArticleTest(TestCase):
     def test_related_article(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:xlink="http://www.w3.org/1999/xlink">
             <front>
@@ -37,13 +38,16 @@ class RelatedArticleTest(TestCase):
             "href": "10.1590/0101-3173.2022.v45n1.p139",
             "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                     "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                    "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                    "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+            'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                        'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
         }
         self.assertDictEqual(obtained, expected)
 
 
 class RelatedArticlesByNodeTest(TestCase):
     def test_related_articles(self):
+        self.maxDiff = None
         xml = """
             <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="article-commentary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
@@ -73,7 +77,9 @@ class RelatedArticlesByNodeTest(TestCase):
                 "href": "10.1590/0101-3173.2022.v45n1.p139",
                 "text": "Referência do artigo comentado: FREITAS, J. H. de. Cinismo e indiferenciación: la huella de "
                         "Glucksmann en <i>El coraje de la verdad</i> de Foucault. Trans/form/ação : revista de Filosofia "
-                        "da Unesp, v. 45, n. 1, p. 139-158, 2022."
+                        "da Unesp, v. 45, n. 1, p. 139-158, 2022.",
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="doi" id="A01" '
+                            'related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">',
             }
         ]
         self.assertEqual(len(obtained), 1)
@@ -98,7 +104,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA1" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -109,7 +118,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': None,
                 'parent_lang': 'pt',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA9" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]
@@ -129,7 +141,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA10" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100001" />',
             },
             {
                 'ext-link-type': 'doi',
@@ -140,7 +155,10 @@ class RelatedArticlesTest(TestCase):
                 'parent_id': "s1",
                 'parent_lang': 'en',
                 'related-article-type': 'corrected-article',
-                'text': ''
+                'text': '',
+                'full_tag': '<related-article xmlns:xlink="http://www.w3.org/1999/xlink" id="RA18" '
+                            'related-article-type="corrected-article" ext-link-type="doi" '
+                            'xlink:href="10.1590/s1413-65382620000100009" />',
             },
 
         ]


### PR DESCRIPTION
#### O que esse PR faz?
Este PR introduz três funções que geram estruturas XML usando a biblioteca `xml.etree.ElementTree`. Ele visa resolver a necessidade de criação dinâmica de elementos XML, tais como `<article>`, `<contrib>,` e `<journal-meta>`, com base em dados de entrada. 

#### Onde a revisão poderia começar?
A revisão pode começar pelos arquivos que contêm as seguintes funções:

- `build_article_node()` no arquivo `article.py`
- `build_contrib_author()` no arquivo `contrib.py`
- `build_journal_meta()` no arquivo `journal_meta.py`

#### Como este poderia ser testado manualmente?

1. Crie um script Python para importar as funções dos arquivos relevantes.

2. Forneça dados de entrada similares aos exemplos abaixo e execute as funções para gerar o XML.


Exemplo de dados para `build_article_node`:
```
article_data = {
    "dtd-version": "1.1",
    "specific-use": "research",
    "article-type": "original",
    "xml:lang": "en"
}
```
Exemplo de dados para `build_contrib_author`:

```
data = {
    "contrib_type": "author",
    "contrib_ids": {
        "orcid": "0000-0001-8528-2091",
        "scopus": "24771926600"
    },
    "surname": "Einstein",
    "given_names": "Albert",
    "affiliations": [
        {"rid": "aff1", "text": "1"}
    ]
}
```
Exemplo de dados para `build_journal_meta`:

```
data = {
    "journal_ids": {
        "nlm-ta": "Braz J Med Biol Res",
        "publisher-id": "bjmbr"
    },
    "journal_title": "Brazilian Journal of Medical and Biological Research",
    "abbrev_journal_title": "Braz. J. Med. Biol. Res.",
    "issn": {
        "epub": "1414-431X",
        "ppub": "0100-879X"
    },
    "publisher_name": "Associação Brasileira de Divulgação Científica"
}
```
3. Verifique a saída XML gerada pelas funções, certificando-se de que todos os elementos foram corretamente criados e formatados.

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA
