### PR TITLE
Modifica packtools.sps.models.v2.aff e modifica validações de afiliações 

### DIFF
--- a/packtools/sps/models/v2/aff.py
+++ b/packtools/sps/models/v2/aff.py
@@ -65,17 +65,17 @@ class Affiliation:
     @property
     def data(self):
         return {
-            "city": self.city,
-            "country_code": self.country_code,
-            "country_name": self.country,
-            "email": self.email,
             "id": self.aff_id,
             "label": self.label,
+            "original": self.original,
+            "orgname": self.orgname,
             "orgdiv1": self.orgdiv1,
             "orgdiv2": self.orgdiv2,
-            "orgname": self.orgname,
-            "original": self.original,
+            "country_name": self.country,
+            "country_code": self.country_code,
             "state": self.state
+            "city": self.city,
+            "email": self.email,
         }
 
     def _get_institution_info(self, inst_type):
@@ -126,6 +126,12 @@ class ArticleAffiliations:
     def sub_article_translation_affs(self):
         for node in self.xml_tree.xpath(".//sub-article[@article-type='translation']"):
             yield from Affiliations(node).affiliations()
+
+    def sub_article_translation_affs_by_lang(self):
+        langs = {}
+        for node in self.xml_tree.xpath(".//sub-article[@article-type='translation']"):
+            langs[node.get("{http://www.w3.org/XML/1998/namespace}lang")] = Affiliations(node).affiliations()
+        return langs
 
     def sub_article_non_translation_affs(self):
         for node in self.xml_tree.xpath(".//sub-article[@article-type!='translation']"):

--- a/packtools/sps/models/v2/aff.py
+++ b/packtools/sps/models/v2/aff.py
@@ -73,7 +73,7 @@ class Affiliation:
             "orgdiv2": self.orgdiv2,
             "country_name": self.country,
             "country_code": self.country_code,
-            "state": self.state
+            "state": self.state,
             "city": self.city,
             "email": self.email,
         }

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -94,7 +94,7 @@ class AffiliationsValidation:
         article_count = len(article_list)
 
         for lang, items in self.translation_affs_by_lang.items():
-            sub_article_count = len(items)
+            sub_article_count = len(list(items))
             if article_count == sub_article_count:
                 continue
 

--- a/packtools/sps/validation/exceptions.py
+++ b/packtools/sps/validation/exceptions.py
@@ -16,7 +16,7 @@ class ValidationArticleAndSubArticlesHasInvalidLanguage(ValidationArticleDataErr
     ...
 
 
-class AffiliationValidationValidateCountryCodeException(Exception):
+class AffiliationCountryCodeListNotProvidedException(Exception):
     ...
 
 

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -1,6 +1,6 @@
 from packtools.sps.models.article_dates import ArticleDates
 
-from packtools.sps.validation.aff import AffiliationsListValidation
+from packtools.sps.validation.aff import AffiliationsValidation
 from packtools.sps.validation.article_abstract import (
     HighlightsValidation,
     VisualAbstractsValidation,
@@ -59,16 +59,12 @@ from packtools.sps.validation.journal_meta import (
 def validate_affiliations(xmltree, params):
     country_codes_list = params["country_codes_list"]
 
-    # FIXME acesso a country_codes_list dentro das classes e métodos
-    validator = AffiliationsListValidation(xmltree, country_codes_list)
-    
-    aff_rules = params["aff_rules"]
-    aff_rules["country_codes_list"] = country_codes_list
+    validator = AffiliationsValidation(xmltree, country_codes_list)
 
+    aff_rules = params["aff_rules"]
     yield from validator.validate_main_affiliations(**aff_rules)
 
     translated_aff_rules = params["translated_aff_rules"]
-    translated_aff_rules["country_codes_list"] = country_codes_list
     yield from validator.validate_translated_affiliations(**translated_aff_rules)
 
 

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -3,10 +3,10 @@ from unittest import TestCase
 
 from lxml import etree
 
-from packtools.sps.models.aff import Affiliation
+from packtools.sps.models.v2.aff import ArticleAffiliations
 from packtools.sps.validation.aff import (
     AffiliationValidation,
-    AffiliationsListValidation,
+    AffiliationsValidation,
 )
 from packtools.sps.utils import xml_utils
 
@@ -46,7 +46,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         obtained = list(
-            AffiliationsListValidation(xml_tree, ["BR"]).validate_affiliations_list()
+            AffiliationsValidation(xml_tree, ["BR"]).validate_main_affiliations()
         )
         self.assertEqual(0, len(obtained))
         for i, item in enumerate(obtained):
@@ -75,8 +75,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_original())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_original())
 
         expected = {
                 "title": "original",
@@ -132,8 +132,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_orgname())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_orgname())
 
         expected = {
                 "title": "orgname",
@@ -192,8 +192,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_country())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_country())
 
         expected = {
                 "title": "country name",
@@ -253,7 +253,7 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
         obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_country_code())
 
         expected = {
@@ -266,9 +266,9 @@ class AffiliationValidationTest(TestCase):
                 "sub_item": "@country",
                 "validation_type": "value in list",
                 "response": "CRITICAL",
-                "expected_value": ["BR"],
+                "expected_value": 'one of ["BR"]',
                 "got_value": None,
-                "message": "Got None, expected ['BR']",
+                "message": "Got None, expected one of ['BR']",
                 "advice": "provide a valid @country",
                 "data": {
                     "city": "Belo Horizonte",
@@ -313,8 +313,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_state())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_state())
 
         expected = {
                 "title": "state",
@@ -372,8 +372,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_city())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_city())
 
         expected = {
                 "title": "city",
@@ -431,8 +431,8 @@ class AffiliationValidationTest(TestCase):
         """
 
         xml_tree = etree.fromstring(xml)
-        affiliations_list = list(Affiliation(xml_tree).affiliation_list)
-        obtained = list(AffiliationValidation(affiliations_list[0]).validate_id())
+        affiliations_list = list(ArticleAffiliations(xml_tree).article_affs())
+        obtained = list(AffiliationValidation(affiliations_list[0], ["BR"]).validate_id())
 
         expected = {
                 "title": "id",
@@ -503,7 +503,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         data = {"country_codes_list": ["BR"]}
-        obtained = list(AffiliationsListValidation(xml_tree).validate(data))
+        obtained = list(AffiliationsValidation(xml_tree, ["BR"]).validate_main_affiliations(data))
         self.assertEqual(0, len(obtained))
 
     def test_validate_affiliation_sub_article_original_only(self):
@@ -538,7 +538,7 @@ class AffiliationValidationTest(TestCase):
 
         xml_tree = etree.fromstring(xml)
         data = {"country_codes_list": ["BR"]}
-        obtained = list(AffiliationsListValidation(xml_tree).validate(data))
+        obtained = list(AffiliationsValidation(xml_tree, ["BR"]).validate_translated_affiliations(data))
         expected = [
             "orgname", "country name", "country code", "state", "city",
             "orgname", "country name", "country code", "state", "city"
@@ -548,13 +548,13 @@ class AffiliationValidationTest(TestCase):
             with self.subTest(i):
                 self.assertEqual(expected[i], item["title"])
 
-    def test_validate_affiliation_count_article_vs_sub_article(self):
+    def test_validate_affiliation_count(self):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/samples/1518-8787-rsp-56-79.xml")
         obtained = list(
-            AffiliationsListValidation(
-                xml_tree
-            ).validate_affiliation_count_article_vs_sub_article()
+            AffiliationsValidation(
+                xml_tree, ["BR"]
+            ).validate_affiliation_count()
         )
         expected = [
             {
@@ -591,7 +591,7 @@ class AffiliationValidationTest(TestCase):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/bak/2176-4573-bak-p58270.xml")
         data = {"country_codes_list": ["BR"]}
-        validation = AffiliationsListValidation(xml_tree)
+        validation = AffiliationsValidation(xml_tree, ["BR"])
         obtained = list(validation.validate(data))
         expected = [
             "label", 
@@ -607,9 +607,9 @@ class AffiliationValidationTest(TestCase):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/bak/2176-4573-bak-p58270.xml")
         obtained = list(
-            AffiliationsListValidation(
-                xml_tree
-            ).validate_affiliation_count_article_vs_sub_article()
+            AffiliationsValidation(
+                xml_tree, ["BR"]
+            ).validate_affiliation_count()
         )
         expected = [
             {
@@ -643,7 +643,7 @@ class AffiliationValidationTest(TestCase):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/sub-article_translation_with_sub-article_reply/MNHpJQpnjvSX6pkKCg37yTJ.xml")
         data = {"country_codes_list": ["BR"]}
-        obtained = list(AffiliationsListValidation(xml_tree).validate(data))
+        obtained = list(AffiliationsValidation(xml_tree, ["BR"]).validate(data))
         expected = [
             "label", 
             "label", "orgname", "country name", "country code", "state", "city",
@@ -657,9 +657,9 @@ class AffiliationValidationTest(TestCase):
         self.maxDiff = None
         xml_tree = xml_utils.get_xml_tree("tests/fixtures/htmlgenerator/sub-article_translation_with_sub-article_reply/MNHpJQpnjvSX6pkKCg37yTJ.xml")
         obtained = list(
-            AffiliationsListValidation(
-                xml_tree
-            ).validate_affiliation_count_article_vs_sub_article()
+            AffiliationsValidation(
+                xml_tree, ["BR"]
+            ).validate_affiliation_count()
         )
         expected = [
             {


### PR DESCRIPTION
#### O que esse PR faz?
Revisa as validações de aff
- melhoria em nomes de classes, métodos, exceções
- passa a considerar obrigatório country_code_list como parâmetro de `__init__`, que seria mais fácil do que completar como parâmetro em vários métodos onde estava ausente
- elimina os métodos que validate e validate_affiliation_list por suprimir os parâmetros dos métodos chamados, sendo úteis somente se fossem ser usados com  os valores default dos métodos chamados. Sendo assim, melhor chamar diretamente os métodos.
- corrige o método que verifica a quantidade de aff em article-meta e sub-articles. Há 3 testes e todos testam a mesma situação de que os valores estão corretos. **É necessário adicionar testes para artigos que contém **mais de um** sub-article e testes para quando somente há article sem sub-article**. **Nota:** a função `zip` corta os valores excedentes. Faça o teste `zip("123", "ab")` e `zip("123", "abxy")`
- Foi alterado o expected de country_code. Quando está correto, o valor de expected é o próprio valor obtido, caso contrário, foi adicionado `'one of '` diante da lista de código de países
- foram corrigidos apenas alguns testes. Será necessário executar e corrigir os demais

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando 
```console
python -m unittest -v  tests.sps.validation.test_aff
```

#### Algum cenário de contexto que queira dar?
Revisar os testes com erros e falhas e adicionar testes para validate_affiliation_count com os casos de artigo sem sub-article e artigo que tem 2 sub-article de tradução.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

