### PR TITLE
Feat: build table wrap element

### DIFF
--- a/packtools/sps/formats/sps_xml/table_wrap.py
+++ b/packtools/sps/formats/sps_xml/table_wrap.py
@@ -10,35 +10,100 @@ data = {
             "fn-label": "*",
             "fn-p": "text"
         }
+    ],
+    "tables": [
+        {
+            "graphic": "nomedaimagemdatabela.svg",
+            "id": "g1"
+        },
+        {
+            "table": "codificação da tabela"
+        }
     ]
 }
 
 obs.:
     - nota de tabela não tem o atributo 'fn-type'
     - o atributo 'id' é obrigatório
+    - pode existir um único 'table' e muitos 'graphic' em 'table-wrap'
 """
 
 import xml.etree.ElementTree as ET
 
 
+def build_table(data):
+    """
+    Creates an XML element representing a table or graphic based on the input dictionary.
+
+    Parameters:
+    data (dict): Dictionary with keys:
+        - "graphic" (str, optional): Path or name of the image file if type is graphic.
+        - "table" (str, optional): Content of the table if type is table.
+        - "id" (str, optional): Identifier for the element.
+
+    Returns:
+    ET.Element: An XML element with the specified attributes and content.
+
+    Raises:
+    ValueError: If neither "table" nor "graphic" are provided in the data.
+    """
+    for table_type in ("table", "graphic"):
+        if table_value := data.get(table_type):
+            table_id = data.get("id")
+            break
+    else:
+        raise ValueError("A valid codification type ('table' or 'graphic') is required.")
+
+    # Define attributes based on type and presence of id
+    attributes = {"xlink:href": table_value} if table_type == "graphic" else {}
+    if table_id:
+        attributes["id"] = table_id
+
+    # Create the XML element with attributes
+    table_elem = ET.Element(table_type, attrib=attributes)
+
+    # Add text content if it's a table
+    if table_type == "table":
+        table_elem.text = table_value
+
+    return table_elem
+
+
 def build_table_wrap(data):
-    table_id = data.get("table-wrap-id")
-    if not table_id:
+    """
+    Creates a table-wrap XML element with optional label, caption, footnotes, and table representations.
+
+    Parameters:
+    data (dict): Dictionary with keys:
+        - "table-wrap-id" (str): Required identifier for the table-wrap element.
+        - "label" (str, optional): Label text for the table-wrap.
+        - "caption-title" (str, optional): Title text for the caption.
+        - "caption-p" (list of str, optional): Paragraphs for the caption.
+        - "fns" (list of dict, optional): Footnotes, each requiring "fn-id" and optionally "fn-label" and "fn-p".
+        - "tables" (list of dict): List of table data, with at least one item required.
+
+    Returns:
+    ET.Element: An XML element with the constructed structure.
+
+    Raises:
+    ValueError: If required keys are missing or data is malformed.
+    """
+    if not (table_id := data.get("table-wrap-id")):
         raise ValueError("Attrib table-wrap-id is required")
 
     # build table_wrap
-    table_elem = ET.Element("table-wrap", attrib={"id": table_id})
+    table_wrap_elem = ET.Element("table-wrap", attrib={"id": table_id})
 
     # add label
     if label := data.get("label"):
-        label_elem = ET.SubElement(table_elem, "label")
+        label_elem = ET.SubElement(table_wrap_elem, "label")
         label_elem.text = label
 
     # add caption
     caption = data.get("caption-title")
     paragraphs = data.get("caption-p")
     if caption or paragraphs:
-        caption_elem = ET.SubElement(table_elem, "caption")
+        caption_elem = ET.SubElement(table_wrap_elem, "caption")
         if caption:
             title_elem = ET.SubElement(caption_elem, "title")
             title_elem.text = caption
@@ -49,7 +114,7 @@ def build_table_wrap(data):
 
     # add footnotes
     if fns := data.get("fns"):
-        table_wrap_foot_elem = ET.SubElement(table_elem, "table-wrap-foot")
+        table_wrap_foot_elem = ET.SubElement(table_wrap_elem, "table-wrap-foot")
         for fn in fns:
             if not (fn_id := fn.get("fn-id")):
                 raise ValueError("fn-id is required")
@@ -63,4 +128,16 @@ def build_table_wrap(data):
                 p_elem = ET.SubElement(fn_elem, "p")
                 p_elem.text = p
 
-    return table_elem
+    if not (tables := data.get("tables", [])):
+        raise ValueError("At least one representation of the table is required")
+
+    if len(tables) == 1:
+        # add one table
+        table_wrap_elem.append(build_table(tables[0]))
+    else:
+        # add alternatives (many tables)
+        alternatives_elem = ET.SubElement(table_wrap_elem, "alternatives")
+        for table in tables:
+            alternatives_elem.append(build_table(table))
+
+    return table_wrap_elem

--- a/packtools/sps/formats/sps_xml/table_wrap.py
+++ b/packtools/sps/formats/sps_xml/table_wrap.py
@@ -1,0 +1,66 @@
+"""
+data = {
+    "table-wrap-id": "t01",
+    "label": "Table 1",
+    "caption-title": "Título da tabela",
+    "caption-p": ["Deaths Among Patients..."],
+    "fns": [
+        {
+            "fn-id": "fn01",
+            "fn-label": "*",
+            "fn-p": "text"
+        }
+    ]
+}
+
+obs.:
+    - nota de tabela não tem o atributo 'fn-type'
+    - o atributo 'id' é obrigatório
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def build_table_wrap(data):
+    table_id = data.get("table-wrap-id")
+    if not table_id:
+        raise ValueError("Attrib table-wrap-id is required")
+
+    # build table_wrap
+    table_elem = ET.Element("table-wrap", attrib={"id": table_id})
+
+    # add label
+    if label := data.get("label"):
+        label_elem = ET.SubElement(table_elem, "label")
+        label_elem.text = label
+
+    # add caption
+    caption = data.get("caption-title")
+    paragraphs = data.get("caption-p")
+    if caption or paragraphs:
+        caption_elem = ET.SubElement(table_elem, "caption")
+        if caption:
+            title_elem = ET.SubElement(caption_elem, "title")
+            title_elem.text = caption
+
+        for paragraph in (paragraphs or []):
+            paragraph_elem = ET.SubElement(caption_elem, "p")
+            paragraph_elem.text = paragraph
+
+    # add footnotes
+    if fns := data.get("fns"):
+        table_wrap_foot_elem = ET.SubElement(table_elem, "table-wrap-foot")
+        for fn in fns:
+            if not (fn_id := fn.get("fn-id")):
+                raise ValueError("fn-id is required")
+            fn_elem = ET.SubElement(table_wrap_foot_elem, "fn", attrib={"id": fn_id})
+
+            if label := fn.get("fn-label"):
+                label_elem = ET.SubElement(fn_elem, "label")
+                label_elem.text = label
+
+            if p := fn.get("fn-p"):
+                p_elem = ET.SubElement(fn_elem, "p")
+                p_elem.text = p
+
+    return table_elem

--- a/packtools/sps/formats/sps_xml/table_wrap.py
+++ b/packtools/sps/formats/sps_xml/table_wrap.py
@@ -1,32 +1,7 @@
-"""
-data = {
-    "table-wrap-id": "t01",
-    "label": "Table 1",
-    "caption-title": "Título da tabela",
-    "caption-p": ["Deaths Among Patients..."],
-    "fns": [
-        {
-            "fn-id": "fn01",
-            "fn-label": "*",
-            "fn-p": "text"
-        }
-    ],
-    "tables": [
-        {
-            "graphic": "nomedaimagemdatabela.svg",
-            "id": "g1"
-        },
-        {
-            "table": "codificação da tabela"
-        }
-    ]
-}
-
-obs.:
-    - nota de tabela não tem o atributo 'fn-type'
-    - o atributo 'id' é obrigatório
-    - pode existir um único 'table' e muitos 'graphic' em 'table-wrap'
-"""
+# obs.:
+#    - nota de tabela não tem o atributo 'fn-type'
+#    - o atributo 'id' é obrigatório
+#    - pode existir um único 'table' e muitos 'graphic' em 'table-wrap'
 
 import xml.etree.ElementTree as ET
 
@@ -46,6 +21,15 @@ def build_table(data):
 
     Raises:
     ValueError: If neither "table" nor "graphic" are provided in the data.
+
+    Example input:
+        data = {
+            "graphic": "nomedaimagemdatabela.svg",
+            "id": "g1"
+        }
+
+    Example output:
+        <graphic xlink:href="nomedaimagemdatabela.svg" id="g1" />
     """
     for table_type in ("table", "graphic"):
         if table_value := data.get(table_type):
@@ -87,6 +71,49 @@ def build_table_wrap(data):
 
     Raises:
     ValueError: If required keys are missing or data is malformed.
+
+    Example input:
+        data = {
+            "table-wrap-id": "t01",
+            "label": "Table 1",
+            "caption-title": "Título da tabela",
+            "caption-p": ["Deaths Among Patients..."],
+            "fns": [
+                {
+                    "fn-id": "fn01",
+                    "fn-label": "*",
+                    "fn-p": "text"
+                }
+            ],
+            "tables": [
+                {
+                    "graphic": "nomedaimagemdatabela.svg",
+                    "id": "g1"
+                },
+                {
+                    "table": "codificação da tabela"
+                }
+            ]
+        }
+
+    Example output:
+        <table-wrap id="t01">
+            <label>Table 1</label>
+            <caption>
+                <title>Título da tabela</title>
+                <p>Deaths Among Patients...</p>
+            </caption>
+            <table-wrap-foot>
+                <fn id="fn01">
+                    <label>*</label>
+                    <p>text</p>
+                </fn>
+            </table-wrap-foot>
+            <alternatives>
+                <graphic xlink:href="nomedaimagemdatabela.svg" id="g1" />
+                <table>codificação da tabela</table>
+            </alternatives>
+        </table-wrap>
     """
     if not (table_id := data.get("table-wrap-id")):
         raise ValueError("Attrib table-wrap-id is required")

--- a/tests/sps/formats/sps_xml/test_table_wrap.py
+++ b/tests/sps/formats/sps_xml/test_table_wrap.py
@@ -1,0 +1,154 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.table_wrap import build_table_wrap
+
+
+class TestBuildTableId(unittest.TestCase):
+
+    def test_build_table_wrap_without_id(self):
+        data = {
+            "table-wrap-id": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_table_wrap(data)
+        self.assertEqual(str(e.exception), "Attrib table-wrap-id is required")
+
+
+class TestBuildTableLabel(unittest.TestCase):
+
+    def test_build_table_wrap_label(self):
+        data = {
+            "table-wrap-id": "t01",
+            "label": "Table 1",
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<label>Table 1</label>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_table_wrap_label_None(self):
+        data = {
+            "table-wrap-id": "t01",
+            "label": None
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01" />'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildTableCaption(unittest.TestCase):
+
+    def test_build_table_wrap_caption(self):
+        data = {
+            "table-wrap-id": "t01",
+            "caption-title": "Título da tabela",
+            "caption-p": ["Deaths Among Patients..."],
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<caption>'
+            '<title>Título da tabela</title>'
+            '<p>Deaths Among Patients...</p>'
+            '</caption>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_table_wrap_caption_title_None(self):
+        data = {
+            "table-wrap-id": "t01",
+            "caption-title": None,
+            "caption-p": ["Deaths Among Patients..."],
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<caption>'
+            '<p>Deaths Among Patients...</p>'
+            '</caption>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_table_wrap_caption_p_None(self):
+        data = {
+            "table-wrap-id": "t01",
+            "caption-title": "Título da tabela",
+            "caption-p": None
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<caption>'
+            '<title>Título da tabela</title>'
+            '</caption>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildTableFootnotes(unittest.TestCase):
+
+    def test_build_table_wrap_footnotes_id(self):
+        data = {
+            "table-wrap-id": "t01",
+            "fns": [
+                {
+                    "fn-id": None
+                }
+            ]
+        }
+        with self.assertRaises(ValueError) as e:
+            build_table_wrap(data)
+        self.assertEqual(str(e.exception), "fn-id is required")
+
+    def test_build_table_wrap_footnotes_None(self):
+        data = {
+            "table-wrap-id": "t01",
+            "fns": None
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01" />'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_table_wrap_footnotes_sub_elements_None(self):
+        data = {
+            "table-wrap-id": "t01",
+            "fns": [
+                {
+                    "fn-id": "fn01",
+                    "fn-label": None
+                }
+            ]
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<table-wrap-foot>'
+            '<fn id="fn01" />'
+            '</table-wrap-foot>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())

--- a/tests/sps/formats/sps_xml/test_table_wrap.py
+++ b/tests/sps/formats/sps_xml/test_table_wrap.py
@@ -3,11 +3,30 @@ import xml.etree.ElementTree as ET
 from packtools.sps.formats.sps_xml.table_wrap import build_table_wrap
 
 
-class TestBuildTableId(unittest.TestCase):
+class TestBuildTableExceptions(unittest.TestCase):
+
+    def test_build_table_wrap_without_table(self):
+        data = {
+            "table-wrap-id": "t01",
+            "tables": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_table_wrap(data)
+        self.assertEqual(str(e.exception), "At least one representation of the table is required")
+
+    def test_build_table_wrap_codification_invalid(self):
+        data = {
+            "table-wrap-id": "t01",
+            "tables": [{"formula": "codificação da formula"}]
+        }
+        with self.assertRaises(ValueError) as e:
+            build_table_wrap(data)
+        self.assertEqual(str(e.exception), "A valid codification type ('table' or 'graphic') is required.")
 
     def test_build_table_wrap_without_id(self):
         data = {
-            "table-wrap-id": None
+            "table-wrap-id": None,
+            "tables": [{"table": "codificação da tabela"}]
         }
         with self.assertRaises(ValueError) as e:
             build_table_wrap(data)
@@ -20,10 +39,12 @@ class TestBuildTableLabel(unittest.TestCase):
         data = {
             "table-wrap-id": "t01",
             "label": "Table 1",
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
             '<table-wrap id="t01">'
             '<label>Table 1</label>'
+            '<table>codificação da tabela</table>'
             '</table-wrap>'
         )
 
@@ -34,10 +55,13 @@ class TestBuildTableLabel(unittest.TestCase):
     def test_build_table_wrap_label_None(self):
         data = {
             "table-wrap-id": "t01",
-            "label": None
+            "label": None,
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
-            '<table-wrap id="t01" />'
+            '<table-wrap id="t01">'
+            '<table>codificação da tabela</table>'
+            '</table-wrap>'
         )
 
         table_elem = build_table_wrap(data)
@@ -52,6 +76,7 @@ class TestBuildTableCaption(unittest.TestCase):
             "table-wrap-id": "t01",
             "caption-title": "Título da tabela",
             "caption-p": ["Deaths Among Patients..."],
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
             '<table-wrap id="t01">'
@@ -59,6 +84,7 @@ class TestBuildTableCaption(unittest.TestCase):
             '<title>Título da tabela</title>'
             '<p>Deaths Among Patients...</p>'
             '</caption>'
+            '<table>codificação da tabela</table>'
             '</table-wrap>'
         )
 
@@ -71,12 +97,14 @@ class TestBuildTableCaption(unittest.TestCase):
             "table-wrap-id": "t01",
             "caption-title": None,
             "caption-p": ["Deaths Among Patients..."],
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
             '<table-wrap id="t01">'
             '<caption>'
             '<p>Deaths Among Patients...</p>'
             '</caption>'
+            '<table>codificação da tabela</table>'
             '</table-wrap>'
         )
 
@@ -88,13 +116,15 @@ class TestBuildTableCaption(unittest.TestCase):
         data = {
             "table-wrap-id": "t01",
             "caption-title": "Título da tabela",
-            "caption-p": None
+            "caption-p": None,
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
             '<table-wrap id="t01">'
             '<caption>'
             '<title>Título da tabela</title>'
             '</caption>'
+            '<table>codificação da tabela</table>'
             '</table-wrap>'
         )
 
@@ -108,11 +138,8 @@ class TestBuildTableFootnotes(unittest.TestCase):
     def test_build_table_wrap_footnotes_id(self):
         data = {
             "table-wrap-id": "t01",
-            "fns": [
-                {
-                    "fn-id": None
-                }
-            ]
+            "fns": [{"fn-id": None}],
+            "tables": [{"table": "codificação da tabela"}]
         }
         with self.assertRaises(ValueError) as e:
             build_table_wrap(data)
@@ -121,10 +148,13 @@ class TestBuildTableFootnotes(unittest.TestCase):
     def test_build_table_wrap_footnotes_None(self):
         data = {
             "table-wrap-id": "t01",
-            "fns": None
+            "fns": None,
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
-            '<table-wrap id="t01" />'
+            '<table-wrap id="t01">'
+            '<table>codificação da tabela</table>'
+            '</table-wrap>'
         )
 
         table_elem = build_table_wrap(data)
@@ -139,13 +169,44 @@ class TestBuildTableFootnotes(unittest.TestCase):
                     "fn-id": "fn01",
                     "fn-label": None
                 }
-            ]
+            ],
+            "tables": [{"table": "codificação da tabela"}]
         }
         expected_xml_str = (
             '<table-wrap id="t01">'
             '<table-wrap-foot>'
             '<fn id="fn01" />'
             '</table-wrap-foot>'
+            '<table>codificação da tabela</table>'
+            '</table-wrap>'
+        )
+
+        table_elem = build_table_wrap(data)
+        generated_xml_str = ET.tostring(table_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildTableAlternatives(unittest.TestCase):
+
+    def test_build_table_wrap_alternatives(self):
+        data = {
+            "table-wrap-id": "t01",
+            "tables": [
+                {
+                    "graphic": "nomedaimagemdatabela.svg",
+                    "id": "g1"
+                },
+                {
+                    "table": "codificação da tabela"
+                }
+            ]
+        }
+        expected_xml_str = (
+            '<table-wrap id="t01">'
+            '<alternatives>'
+            '<graphic xlink:href="nomedaimagemdatabela.svg" id="g1" />'
+            '<table>codificação da tabela</table>'
+            '</alternatives>'
             '</table-wrap>'
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para gerar o elemento `table-wrap` no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_table_wrap.py
`
#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

