### PR TITLE
Feat: build disp-formula element

### DIFF
--- a/packtools/sps/formats/sps_xml/disp_formula.py
+++ b/packtools/sps/formats/sps_xml/disp_formula.py
@@ -1,0 +1,40 @@
+"""
+data = {
+    "formula-id": "e01",
+    "label": "(1)",
+    "codification": "mml:math",
+    "codification-id": "m1",
+    "formula": "<mml:mrow><mml:msub><mml:mi>q</mml:mi><mml:mi>c</mml:mi></mml:msub><mml:mo>=</mml:mo><mml:mi>h</mml:mi>
+    <mml:mrow><mml:mo>(</mml:mo><mml:mrow><mml:mi>T</mml:mi><mml:mo>−</mml:mo><mml:msub><mml:mi>T</mml:mi><mml:mn>0
+    </mml:mn></mml:msub></mml:mrow><mml:mo>)</mml:mo></mml:mrow></mml:mrow></mml:math>",
+    "alternative-link": "0103-507X-rbti-26-02-0089-ee10.svg"
+}
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def build_disp_formula(data):
+    required_fields = ["formula-id", "codification", "codification-id", "formula"]
+    missing_fields = [field for field in required_fields if not data.get(field)]
+
+    if missing_fields:
+        raise ValueError(f"Missing required fields: {', '.join(missing_fields)}")
+
+    disp_formula_elem = ET.Element("disp-formula", attrib={"id": data["formula-id"]})
+
+    if label := data.get("label"):
+        label_elem = ET.SubElement(disp_formula_elem, "label")
+        label_elem.text = label
+
+    codification_elem = ET.Element(data["codification"], attrib={"id": data["codification-id"]})
+    codification_elem.text = data["formula"]
+
+    if alternative_link := data.get("alternative-link"):
+        alternative_elem = ET.SubElement(disp_formula_elem, "alternatives")
+        alternative_elem.append(codification_elem)
+        ET.SubElement(alternative_elem, "graphic", attrib={"xlink:href": alternative_link})
+    else:
+        disp_formula_elem.append(codification_elem)
+
+    return disp_formula_elem

--- a/packtools/sps/formats/sps_xml/disp_formula.py
+++ b/packtools/sps/formats/sps_xml/disp_formula.py
@@ -29,15 +29,17 @@ def build_formula(data):
 
     """
     for cod_type in ("mml:math", "tex-math", "graphic"):
-        if (cod_value := data.get(cod_type)) and (cod_id := data.get("id")):
+        if cod_value := data.get(cod_type):
+            cod_id = data.get("id")
             break
     else:
-        raise ValueError(f"A valid codification type and ID are required.")
+        raise ValueError("A valid codification type is required.")
 
+    attributes = {}
     if cod_type == "graphic":
-        attributes = {"xlink:href": cod_value, "id": cod_id}
-    else:
-        attributes = {"id": cod_id}
+        attributes["xlink:href"] = cod_value
+    elif cod_id:
+        attributes["id"] = cod_id
 
     formula_elem = ET.Element(cod_type, attrib=attributes)
 

--- a/packtools/sps/formats/sps_xml/disp_formula.py
+++ b/packtools/sps/formats/sps_xml/disp_formula.py
@@ -3,10 +3,30 @@ import xml.etree.ElementTree as ET
 
 def build_formula(data):
     """
-    data = {
-        "mml:math": "fórmula no formato mml",
-        "id": "m1"
-    }
+    Builds an XML element for a formula representation.
+
+    Args:
+        data (dict): A dictionary containing formula details with the following keys:
+            - "mml:math" (str): Formula in MathML format (optional).
+            - "tex-math" (str): Formula in TeX format (optional).
+            - "graphic" (str): Path to a graphical representation of the formula (optional).
+            - "id" (str): Unique identifier for the formula (required).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the formula.
+
+    Raises:
+        ValueError: If neither a valid formula representation nor an "id" is provided.
+
+    Example input:
+        data = {
+            "mml:math": "fórmula no formato mml",
+            "id": "m1"
+        }
+
+    Example output:
+        <mml:math id="m1">fórmula no formato mml</mml:math>
+
     """
     for cod_type in ("mml:math", "tex-math", "graphic"):
         if (cod_value := data.get(cod_type)) and (cod_id := data.get("id")):
@@ -29,24 +49,50 @@ def build_formula(data):
 
 def build_disp_formula(data):
     """
-    data = {
-        "formula-id": "e01",
-        "label": "(1)",
-        "formulas": [
-            {
-                "mml:math": "fórmula no formato mml",
-                "id": "m1"
-            },
-            {
-                "tex-math": "fórmula no formato tex",
-                "id": "t1"
-            },
-            {
-                "graphic": "0103-507X-rbti-26-02-0089-ee10.svg",
-                "id": "g1"
-            }
-        ]
-    }
+    Builds an XML element for a display formula, including its label and alternative representations.
+
+    Args:
+        data (dict): A dictionary containing details of the display formula with the following keys:
+            - "formula-id" (str): Unique identifier for the display formula (required).
+            - "label" (str): Label associated with the formula, e.g., "(1)" (optional).
+            - "formulas" (list): A list of dictionaries, each representing a formula in one of the formats
+              (see `build_formula` for the format details). At least one formula representation is required.
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the display formula.
+
+    Raises:
+        ValueError: If "formula-id" is missing or if no formulas are provided.
+
+    Example input:
+        data = {
+            "formula-id": "e01",
+            "label": "(1)",
+            "formulas": [
+                {
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
+                },
+                {
+                    "tex-math": "fórmula no formato tex",
+                    "id": "t1"
+                },
+                {
+                    "graphic": "0103-507X-rbti-26-02-0089-ee10.svg",
+                    "id": "g1"
+                }
+            ]
+        }
+
+    Example output:
+        <disp-formula id="e01">
+            <label>(1)</label>
+            <alternatives>
+                <mml:math id="m1">fórmula no formato mml</mml:math>
+                <tex-math id="t1">fórmula no formato tex</tex-math>
+                <graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" id="g1" />
+            </alternatives>
+        </disp-formula>
     """
     # build disp-formula
     if not (formula_id := data.get("formula-id")):

--- a/packtools/sps/formats/sps_xml/disp_formula.py
+++ b/packtools/sps/formats/sps_xml/disp_formula.py
@@ -4,35 +4,25 @@ import xml.etree.ElementTree as ET
 def build_formula(data):
     """
     data = {
-        "codification": "mml:math",
-        "id": "m1",
-        "text": "fórmula no formato mml"
+        "mml:math": "fórmula no formato mml",
+        "id": "m1"
     }
     """
-    required_fields = ("codification", "id", "text")
-    missing_fields = [field for field in required_fields if not data.get(field)]
-
-    if missing_fields:
-        raise ValueError(f"Missing required fields: {', '.join(missing_fields)}")
-
-    codification = data["codification"]
-    formula_id = data["id"]
-    formula_text = data["text"]
-
-    valid_codifications = ("mml:math", "tex-math", "graphic")
-
-    if codification not in valid_codifications:
-        raise KeyError(f"Invalid codification. Expected values are: {', '.join(valid_codifications)}")
-
-    if codification == "graphic":
-        attributes = {"xlink:href": formula_text, "id": formula_id}
+    for cod_type in ("mml:math", "tex-math", "graphic"):
+        if (cod_value := data.get(cod_type)) and (cod_id := data.get("id")):
+            break
     else:
-        attributes = {"id": formula_id}
+        raise ValueError(f"A valid codification type and ID are required.")
 
-    formula_elem = ET.Element(codification, attrib=attributes)
+    if cod_type == "graphic":
+        attributes = {"xlink:href": cod_value, "id": cod_id}
+    else:
+        attributes = {"id": cod_id}
 
-    if codification != "graphic":
-        formula_elem.text = formula_text
+    formula_elem = ET.Element(cod_type, attrib=attributes)
+
+    if cod_type != "graphic":
+        formula_elem.text = cod_value
 
     return formula_elem
 
@@ -44,19 +34,16 @@ def build_disp_formula(data):
         "label": "(1)",
         "formulas": [
             {
-                "codification": "mml:math",
-                "id": "m1",
-                "text": "fórmula no formato mml"
+                "mml:math": "fórmula no formato mml",
+                "id": "m1"
             },
             {
-                "codification": "tex-math",
-                "id": "t1",
-                "text": "fórmula no formato tex"
+                "tex-math": "fórmula no formato tex",
+                "id": "t1"
             },
             {
-                "codification": "graphic",
-                "id": "g1",
-                "text": "0103-507X-rbti-26-02-0089-ee10.svg"
+                "graphic": "0103-507X-rbti-26-02-0089-ee10.svg",
+                "id": "g1"
             }
         ]
     }

--- a/tests/sps/formats/sps_xml/test_disp_formula.py
+++ b/tests/sps/formats/sps_xml/test_disp_formula.py
@@ -10,9 +10,8 @@ class TestBuildDispFormulaId(unittest.TestCase):
             "formula-id": "e01",
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
                 }
             ]
         }
@@ -30,9 +29,8 @@ class TestBuildDispFormulaId(unittest.TestCase):
             "formula-id": None,
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
                 }
             ]
         }
@@ -48,9 +46,8 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
             "label": "(1)",
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
                 }
             ]
         }
@@ -70,9 +67,8 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
             "label": None,
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
                 }
             ]
         }
@@ -103,15 +99,14 @@ class TestBuildDispFormula(unittest.TestCase):
             "label": "(1)",
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": None,
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": None
                 }
             ]
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: id")
+        self.assertEqual(str(e.exception), "A valid codification type and ID are required.")
 
     def test_build_disp_formula_formula_None(self):
         data = {
@@ -119,15 +114,14 @@ class TestBuildDispFormula(unittest.TestCase):
             "label": "(1)",
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": None
+                    "mml:math": None,
+                    "id": "m1"
                 }
             ]
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: text")
+        self.assertEqual(str(e.exception), "A valid codification type and ID are required.")
 
 
 class TestBuildDispFormulaAlternatives(unittest.TestCase):
@@ -137,19 +131,16 @@ class TestBuildDispFormulaAlternatives(unittest.TestCase):
             "label": "(1)",
             "formulas": [
                 {
-                    "codification": "mml:math",
-                    "id": "m1",
-                    "text": "fórmula no formato mml"
+                    "mml:math": "fórmula no formato mml",
+                    "id": "m1"
                 },
                 {
-                    "codification": "tex-math",
-                    "id": "t1",
-                    "text": "fórmula no formato tex"
+                    "tex-math": "fórmula no formato tex",
+                    "id": "t1"
                 },
                 {
-                    "codification": "graphic",
-                    "id": "g1",
-                    "text": "0103-507X-rbti-26-02-0089-ee10.svg"
+                    "graphic": "0103-507X-rbti-26-02-0089-ee10.svg",
+                    "id": "g1"
                 }
             ]
         }

--- a/tests/sps/formats/sps_xml/test_disp_formula.py
+++ b/tests/sps/formats/sps_xml/test_disp_formula.py
@@ -96,7 +96,6 @@ class TestBuildDispFormula(unittest.TestCase):
     def test_build_disp_formula_codification_id_None(self):
         data = {
             "formula-id": "e01",
-            "label": "(1)",
             "formulas": [
                 {
                     "mml:math": "fórmula no formato mml",
@@ -104,9 +103,14 @@ class TestBuildDispFormula(unittest.TestCase):
                 }
             ]
         }
-        with self.assertRaises(ValueError) as e:
-            build_disp_formula(data)
-        self.assertEqual(str(e.exception), "A valid codification type and ID are required.")
+        expected_xml_str = (
+            '<disp-formula id="e01">'
+            '<mml:math>fórmula no formato mml</mml:math>'
+            '</disp-formula>'
+        )
+        disp_formula_elem = build_disp_formula(data)
+        generated_xml_str = ET.tostring(disp_formula_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
     def test_build_disp_formula_formula_None(self):
         data = {
@@ -121,11 +125,12 @@ class TestBuildDispFormula(unittest.TestCase):
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "A valid codification type and ID are required.")
+        self.assertEqual(str(e.exception), "A valid codification type is required.")
 
 
 class TestBuildDispFormulaAlternatives(unittest.TestCase):
     def test_build_disp_formula_alternatives(self):
+        self.maxDiff = None
         data = {
             "formula-id": "e01",
             "label": "(1)",
@@ -139,8 +144,7 @@ class TestBuildDispFormulaAlternatives(unittest.TestCase):
                     "id": "t1"
                 },
                 {
-                    "graphic": "0103-507X-rbti-26-02-0089-ee10.svg",
-                    "id": "g1"
+                    "graphic": "0103-507X-rbti-26-02-0089-ee10.svg"
                 }
             ]
         }
@@ -150,7 +154,7 @@ class TestBuildDispFormulaAlternatives(unittest.TestCase):
             '<alternatives>'
             '<mml:math id="m1">fórmula no formato mml</mml:math>'
             '<tex-math id="t1">fórmula no formato tex</tex-math>'
-            '<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" id="g1" />'
+            '<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" />'
             '</alternatives>'
             '</disp-formula>'
         )

--- a/tests/sps/formats/sps_xml/test_disp_formula.py
+++ b/tests/sps/formats/sps_xml/test_disp_formula.py
@@ -8,13 +8,17 @@ class TestBuildDispFormulaId(unittest.TestCase):
     def test_build_disp_formula_id(self):
         data = {
             "formula-id": "e01",
-            "codification": "mml:math",
-            "codification-id": "m1",
-            "formula": "codificação da fórmula"
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": "fórmula no formato mml"
+                }
+            ]
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
-            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '<mml:math id="m1">fórmula no formato mml</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -24,13 +28,17 @@ class TestBuildDispFormulaId(unittest.TestCase):
     def test_build_disp_formula_id_None(self):
         data = {
             "formula-id": None,
-            "codification": "mml:math",
-            "codification-id": "m1",
-            "formula": "codificação da fórmula"
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": "fórmula no formato mml"
+                }
+            ]
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: formula-id")
+        self.assertEqual(str(e.exception), "formula-id is required")
 
 
 class TestBuildDispFormulaLabel(unittest.TestCase):
@@ -38,14 +46,18 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
         data = {
             "formula-id": "e01",
             "label": "(1)",
-            "codification": "mml:math",
-            "codification-id": "m1",
-            "formula": "codificação da fórmula"
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": "fórmula no formato mml"
+                }
+            ]
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
             '<label>(1)</label>'
-            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '<mml:math id="m1">fórmula no formato mml</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -56,13 +68,17 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
         data = {
             "formula-id": "e01",
             "label": None,
-            "codification": "mml:math",
-            "codification-id": "m1",
-            "formula": "codificação da fórmula"
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": "fórmula no formato mml"
+                }
+            ]
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
-            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '<mml:math id="m1">fórmula no formato mml</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -74,51 +90,76 @@ class TestBuildDispFormula(unittest.TestCase):
     def test_build_disp_formula_codification_None(self):
         data = {
             "formula-id": "e01",
-            "codification": None,
-            "codification-id": "m1",
-            "formula": "codificação da fórmula"
+            "label": "(1)",
+            "formulas": None
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: codification")
+        self.assertEqual(str(e.exception), "At least one representation of the formula is required")
 
     def test_build_disp_formula_codification_id_None(self):
         data = {
             "formula-id": "e01",
-            "codification": "tex-math",
-            "codification-id": None,
-            "formula": "codificação da fórmula"
+            "label": "(1)",
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": None,
+                    "text": "fórmula no formato mml"
+                }
+            ]
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: codification-id")
+        self.assertEqual(str(e.exception), "Missing required fields: id")
 
     def test_build_disp_formula_formula_None(self):
         data = {
             "formula-id": "e01",
-            "codification": "tex-math",
-            "codification-id":"m1",
-            "formula": None
+            "label": "(1)",
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": None
+                }
+            ]
         }
         with self.assertRaises(ValueError) as e:
             build_disp_formula(data)
-        self.assertEqual(str(e.exception), "Missing required fields: formula")
+        self.assertEqual(str(e.exception), "Missing required fields: text")
 
 
 class TestBuildDispFormulaAlternatives(unittest.TestCase):
     def test_build_disp_formula_alternatives(self):
         data = {
             "formula-id": "e01",
-            "codification": "tex-math",
-            "codification-id": "m1",
-            "formula": "codificação da fórmula",
-            "alternative-link": "0103-507X-rbti-26-02-0089-ee10.svg"
+            "label": "(1)",
+            "formulas": [
+                {
+                    "codification": "mml:math",
+                    "id": "m1",
+                    "text": "fórmula no formato mml"
+                },
+                {
+                    "codification": "tex-math",
+                    "id": "t1",
+                    "text": "fórmula no formato tex"
+                },
+                {
+                    "codification": "graphic",
+                    "id": "g1",
+                    "text": "0103-507X-rbti-26-02-0089-ee10.svg"
+                }
+            ]
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
+            '<label>(1)</label>'
             '<alternatives>'
-            '<tex-math id="m1">codificação da fórmula</tex-math>'
-            '<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" />'
+            '<mml:math id="m1">fórmula no formato mml</mml:math>'
+            '<tex-math id="t1">fórmula no formato tex</tex-math>'
+            '<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" id="g1" />'
             '</alternatives>'
             '</disp-formula>'
         )

--- a/tests/sps/formats/sps_xml/test_disp_formula.py
+++ b/tests/sps/formats/sps_xml/test_disp_formula.py
@@ -1,0 +1,127 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.disp_formula import build_disp_formula
+
+
+
+class TestBuildDispFormulaId(unittest.TestCase):
+    def test_build_disp_formula_id(self):
+        data = {
+            "formula-id": "e01",
+            "codification": "mml:math",
+            "codification-id": "m1",
+            "formula": "codificação da fórmula"
+        }
+        expected_xml_str = (
+            '<disp-formula id="e01">'
+            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '</disp-formula>'
+        )
+        disp_formula_elem = build_disp_formula(data)
+        generated_xml_str = ET.tostring(disp_formula_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_disp_formula_id_None(self):
+        data = {
+            "formula-id": None,
+            "codification": "mml:math",
+            "codification-id": "m1",
+            "formula": "codificação da fórmula"
+        }
+        with self.assertRaises(ValueError) as e:
+            build_disp_formula(data)
+        self.assertEqual(str(e.exception), "Missing required fields: formula-id")
+
+
+class TestBuildDispFormulaLabel(unittest.TestCase):
+    def test_build_disp_formula_label(self):
+        data = {
+            "formula-id": "e01",
+            "label": "(1)",
+            "codification": "mml:math",
+            "codification-id": "m1",
+            "formula": "codificação da fórmula"
+        }
+        expected_xml_str = (
+            '<disp-formula id="e01">'
+            '<label>(1)</label>'
+            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '</disp-formula>'
+        )
+        disp_formula_elem = build_disp_formula(data)
+        generated_xml_str = ET.tostring(disp_formula_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_disp_formula_label_None(self):
+        data = {
+            "formula-id": "e01",
+            "label": None,
+            "codification": "mml:math",
+            "codification-id": "m1",
+            "formula": "codificação da fórmula"
+        }
+        expected_xml_str = (
+            '<disp-formula id="e01">'
+            '<mml:math id="m1">codificação da fórmula</mml:math>'
+            '</disp-formula>'
+        )
+        disp_formula_elem = build_disp_formula(data)
+        generated_xml_str = ET.tostring(disp_formula_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildDispFormula(unittest.TestCase):
+    def test_build_disp_formula_codification_None(self):
+        data = {
+            "formula-id": "e01",
+            "codification": None,
+            "codification-id": "m1",
+            "formula": "codificação da fórmula"
+        }
+        with self.assertRaises(ValueError) as e:
+            build_disp_formula(data)
+        self.assertEqual(str(e.exception), "Missing required fields: codification")
+
+    def test_build_disp_formula_codification_id_None(self):
+        data = {
+            "formula-id": "e01",
+            "codification": "tex-math",
+            "codification-id": None,
+            "formula": "codificação da fórmula"
+        }
+        with self.assertRaises(ValueError) as e:
+            build_disp_formula(data)
+        self.assertEqual(str(e.exception), "Missing required fields: codification-id")
+
+    def test_build_disp_formula_formula_None(self):
+        data = {
+            "formula-id": "e01",
+            "codification": "tex-math",
+            "codification-id":"m1",
+            "formula": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_disp_formula(data)
+        self.assertEqual(str(e.exception), "Missing required fields: formula")
+
+
+class TestBuildDispFormulaAlternatives(unittest.TestCase):
+    def test_build_disp_formula_alternatives(self):
+        data = {
+            "formula-id": "e01",
+            "codification": "tex-math",
+            "codification-id": "m1",
+            "formula": "codificação da fórmula",
+            "alternative-link": "0103-507X-rbti-26-02-0089-ee10.svg"
+        }
+        expected_xml_str = (
+            '<disp-formula id="e01">'
+            '<alternatives>'
+            '<tex-math id="m1">codificação da fórmula</tex-math>'
+            '<graphic xlink:href="0103-507X-rbti-26-02-0089-ee10.svg" />'
+            '</alternatives>'
+            '</disp-formula>'
+        )
+        disp_formula_elem = build_disp_formula(data)
+        generated_xml_str = ET.tostring(disp_formula_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `disp-formula` no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_disp_formula.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

