### PR TITLE
Feat: build trans abstract element

### DIFF
--- a/packtools/sps/formats/sps_xml/abstract.py
+++ b/packtools/sps/formats/sps_xml/abstract.py
@@ -1,29 +1,94 @@
-"""
-example of structured abstract:
-data = {
-            "title": "Resumo",
-            "secs": [
-                {
-                    "title": "Objetivo",
-                    "p": "Verificar a sensibilidade e especificidade ..."
-                },
-                {
-                    "title": "Métodos",
-                    "p": "Durante quatro meses foram selecionados ..."
-                }
-            ]
-        }
-"""
-
 import xml.etree.ElementTree as ET
 
 
 def build_abstract(data):
-    abstract_elem = ET.Element("abstract")
+    """
+    Builds a structured abstract XML element.
 
+    Args:
+        data (dict): A dictionary containing the abstract details with the following keys:
+            - "title" (str): The title of the abstract (required).
+            - "lang" (str or None): The language of the abstract, used for translation (optional).
+            - "secs" (list): A list of sections, each represented as a dictionary with:
+                - "title" (str): Title of the section (optional).
+                - "p" (str): Paragraph content of the section (optional).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the abstract.
+
+    Raises:
+        ValueError: If "title" is missing.
+
+    Example:
+        Input:
+            data = {
+                "title": "Resumo",
+                "lang": None,
+                "secs": [
+                    {"title": "Objetivo", "p": "Verificar a sensibilidade ..."},
+                    {"title": "Métodos", "p": "Durante quatro meses ..."}
+                ]
+            }
+        Output:
+            <abstract>
+                <title>Resumo</title>
+                <sec>
+                    <title>Objetivo</title>
+                    <p>Verificar a sensibilidade ...</p>
+                </sec>
+                <sec>
+                    <title>Métodos</title>
+                    <p>Durante quatro meses ...</p>
+                </sec>
+            </abstract>
+    """
+    abstract_elem = ET.Element("abstract")
+    return build_abstract_content(data, abstract_elem)
+
+
+def build_trans_abstract(data):
+    """
+    Builds a translated abstract XML element.
+
+    Args:
+        data (dict): A dictionary containing the abstract details with the following keys:
+            - "title" (str): The title of the abstract (required).
+            - "lang" (str): The language of the translated abstract (required).
+            - "secs" (list): A list of sections (optional). See `build_abstract` for structure.
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the translated abstract.
+
+    Raises:
+        ValueError: If "lang" or "title" is missing.
+
+    Example:
+        See `build_abstract` for input/output examples.
+    """
+    if not (lang := data.get("lang")):
+        raise ValueError("Lang is required")
+
+    abstract_elem = ET.Element("trans-abstract", attrib={"xml:lang": lang})
+    return build_abstract_content(data, abstract_elem)
+
+
+def build_abstract_content(data, abstract_elem):
+    """
+    Helper function to build the content of an abstract or translated abstract.
+
+    Args:
+        data (dict): Abstract content details. See `build_abstract` for structure.
+        abstract_elem (xml.etree.ElementTree.Element): The root element for the abstract.
+
+    Returns:
+        xml.etree.ElementTree.Element: The updated abstract element with content.
+
+    Raises:
+        ValueError: If "title" is missing.
+    """
     title_text = data.get("title")
     if not title_text:
-        raise ValueError(f"title is required")
+        raise ValueError("title is required")
 
     title_elem = ET.Element("title")
     title_elem.text = title_text
@@ -55,18 +120,44 @@ def build_abstract(data):
     return abstract_elem
 
 
-"""
-example of visual abstract
-data = {
-            "title": "Visual Abstract",
-            "fig_id": "vf01",
-            "caption": "Título",
-            "href": "1234-5678-zwy-12-04-0123-vs01.tif"
-        }
-"""
-
-
 def build_visual_abstract(data):
+    """
+    Builds a visual abstract XML element.
+
+    Args:
+        data (dict): A dictionary containing the visual abstract details with the following keys:
+            - "title" (str): The title of the abstract (required).
+            - "fig_id" (str): Unique identifier for the figure (required).
+            - "caption" (str): Caption for the figure (optional).
+            - "href" (str): Path or URL to the graphical representation (optional).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the visual abstract.
+
+    Raises:
+        ValueError: If "title" or "fig_id" is missing.
+
+    Example:
+        Input:
+            data = {
+                "title": "Visual Abstract",
+                "fig_id": "vf01",
+                "caption": "Título",
+                "href": "1234-5678-zwy-12-04-0123-vs01.tif"
+            }
+        Output:
+            <abstract abstract-type="graphical">
+                <title>Visual Abstract</title>
+                <p>
+                    <fig id="vf01">
+                        <caption>
+                            <title>Título</title>
+                        </caption>
+                        <graphic xlink:href="1234-5678-zwy-12-04-0123-vs01.tif" />
+                    </fig>
+                </p>
+            </abstract>
+    """
     abstract_elem = ET.Element("abstract", attrib={"abstract-type": "graphical"})
 
     title_text = data.get("title")

--- a/packtools/sps/formats/sps_xml/abstract.py
+++ b/packtools/sps/formats/sps_xml/abstract.py
@@ -43,7 +43,7 @@ def build_abstract(data):
             </abstract>
     """
     abstract_elem = ET.Element("abstract")
-    return build_abstract_content(data, abstract_elem)
+    return _build_abstract_content(data, abstract_elem)
 
 
 def build_trans_abstract(data):
@@ -69,10 +69,10 @@ def build_trans_abstract(data):
         raise ValueError("Lang is required")
 
     abstract_elem = ET.Element("trans-abstract", attrib={"xml:lang": lang})
-    return build_abstract_content(data, abstract_elem)
+    return _build_abstract_content(data, abstract_elem)
 
 
-def build_abstract_content(data, abstract_elem):
+def _build_abstract_content(data, abstract_elem):
     """
     Helper function to build the content of an abstract or translated abstract.
 
@@ -190,5 +190,30 @@ def build_visual_abstract(data):
 
     p_elem.append(fig_elem)
     abstract_elem.append(p_elem)
+
+    return abstract_elem
+
+
+def build_highlights(data):
+    """
+    data = {
+        "title": "Highlights",
+        "highlights": [
+            "highlight 1",
+            "highlight 2",
+            "highlight 3",
+        ]
+    }
+    """
+    abstract_elem = ET.Element("abstract", attrib={"abstract-type": "key-points"})
+
+    title_text = data.get("title")
+    if not title_text:
+        raise ValueError(f"title is required")
+
+    ET.SubElement(abstract_elem,"title").text = title_text
+
+    for highlight in (data.get("highlights") or []):
+        ET.SubElement(abstract_elem, "p").text = highlight
 
     return abstract_elem

--- a/packtools/sps/formats/sps_xml/abstract.py
+++ b/packtools/sps/formats/sps_xml/abstract.py
@@ -196,14 +196,36 @@ def build_visual_abstract(data):
 
 def build_highlights(data):
     """
-    data = {
-        "title": "Highlights",
-        "highlights": [
-            "highlight 1",
-            "highlight 2",
-            "highlight 3",
-        ]
-    }
+    Builds a highlights abstract XML element.
+
+    Args:
+        data (dict): A dictionary containing the details for the highlights abstract with the following keys:
+            - "title" (str): The title of the abstract (required).
+            - "highlights" (list of str): A list of highlight points to include in the abstract (optional).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the highlights abstract.
+
+    Raises:
+        ValueError: If the "title" key is missing or empty.
+
+    Example:
+        Input:
+            data = {
+                "title": "Highlights",
+                "highlights": [
+                    "Highlight 1",
+                    "Highlight 2",
+                    "Highlight 3",
+                ]
+            }
+        Output:
+            <abstract abstract-type="key-points">
+                <title>Highlights</title>
+                <p>Highlight 1</p>
+                <p>Highlight 2</p>
+                <p>Highlight 3</p>
+            </abstract>
     """
     abstract_elem = ET.Element("abstract", attrib={"abstract-type": "key-points"})
 

--- a/tests/sps/formats/sps_xml/test_abstract.py
+++ b/tests/sps/formats/sps_xml/test_abstract.py
@@ -1,6 +1,6 @@
 import unittest
 import xml.etree.ElementTree as ET
-from packtools.sps.formats.sps_xml.abstract import build_abstract, build_visual_abstract, build_trans_abstract
+from packtools.sps.formats.sps_xml.abstract import build_abstract, build_visual_abstract, build_trans_abstract, build_highlights
 
 
 class TestBuildStructuredAbstractTitle(unittest.TestCase):
@@ -289,5 +289,65 @@ class TestBuildTransAbstractTitle(unittest.TestCase):
             '</trans-abstract>'
         )
         abstract_elem = build_trans_abstract(data)
+        generated_xml_str = ET.tostring(abstract_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildHighlightTitle(unittest.TestCase):
+    def test_build_highlight_title(self):
+        data = {
+            "title": "Highlights",
+        }
+        expected_xml_str = (
+            '<abstract abstract-type="key-points">'
+            '<title>Highlights</title>'
+            '</abstract>'
+        )
+        abstract_elem = build_highlights(data)
+        generated_xml_str = ET.tostring(abstract_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_highlight_title_None(self):
+        data = {
+            "title": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_highlights(data)
+        self.assertEqual(str(e.exception), "title is required")
+
+
+class TestBuildHighlightItems(unittest.TestCase):
+    def test_build_highlight_items(self):
+        data = {
+            "title": "Highlights",
+            "highlights": [
+                "highlight 1",
+                "highlight 2",
+                "highlight 3",
+            ]
+        }
+        expected_xml_str = (
+            '<abstract abstract-type="key-points">'
+            '<title>Highlights</title>'
+            '<p>highlight 1</p>'
+            '<p>highlight 2</p>'
+            '<p>highlight 3</p>'
+            '</abstract>'
+        )
+        abstract_elem = build_highlights(data)
+        generated_xml_str = ET.tostring(abstract_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_highlight_items_None(self):
+        data = {
+            "title": "Highlights",
+            "highlights": None
+        }
+        expected_xml_str = (
+            '<abstract abstract-type="key-points">'
+            '<title>Highlights</title>'
+            '</abstract>'
+        )
+        abstract_elem = build_highlights(data)
         generated_xml_str = ET.tostring(abstract_elem, encoding="unicode", method="xml")
         self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())

--- a/tests/sps/formats/sps_xml/test_abstract.py
+++ b/tests/sps/formats/sps_xml/test_abstract.py
@@ -1,6 +1,6 @@
 import unittest
 import xml.etree.ElementTree as ET
-from packtools.sps.formats.sps_xml.abstract import build_abstract, build_visual_abstract
+from packtools.sps.formats.sps_xml.abstract import build_abstract, build_visual_abstract, build_trans_abstract
 
 
 class TestBuildStructuredAbstractTitle(unittest.TestCase):
@@ -259,3 +259,35 @@ class TestBuildVisualAbstractHref(unittest.TestCase):
         self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
 
+class TestBuildTransAbstractTitle(unittest.TestCase):
+    def test_build_structured_abstract_title(self):
+        data = {
+            "title": "Resumo",
+            "lang": "pt",
+            "secs": [
+                {
+                    "title": "Objetivo",
+                    "p": "Verificar a sensibilidade e especificidade ..."
+                },
+                {
+                    "title": "Métodos",
+                    "p": "Durante quatro meses foram selecionados ..."
+                }
+            ]
+        }
+        expected_xml_str = (
+            '<trans-abstract xml:lang="pt">'
+            '<title>Resumo</title>'
+            '<sec>'
+            '<title>Objetivo</title>'
+            '<p>Verificar a sensibilidade e especificidade ...</p>'
+            '</sec>'
+            '<sec>'
+            '<title>Métodos</title>'
+            '<p>Durante quatro meses foram selecionados ...</p>'
+            '</sec>'
+            '</trans-abstract>'
+        )
+        abstract_elem = build_trans_abstract(data)
+        generated_xml_str = ET.tostring(abstract_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())


### PR DESCRIPTION
#### O que esse PR faz?
Adapta o módulo `abstract` para permitir a geração do elemento `trans-abstract`.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_abstract.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

