### PR TITLE
Feat: build funding group element

### DIFF
--- a/packtools/sps/formats/sps_xml/funding_group.py
+++ b/packtools/sps/formats/sps_xml/funding_group.py
@@ -1,0 +1,62 @@
+import xml.etree.ElementTree as ET
+
+
+def build_funding_group(data):
+    """
+    Builds an XML element representing a funding group.
+
+    Args:
+        data (dict): A dictionary containing funding information with the following structure:
+            - "award-group" (list): A list of dictionaries, each representing an award group with:
+                - "funding-source" (list): A list of funding sources (strings) (required).
+                - "award-id" (list): A list of award IDs (strings) (required).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the funding group.
+
+    Raises:
+        ValueError: If any award group does not include at least one funding source and one award ID.
+
+    Example input:
+        data = {
+            "award-group": [
+                {
+                    "funding-source": ["CNPq"],
+                    "award-id": ["00001", "00002"]
+                },
+                {
+                    "funding-source": ["CNPq", "FAPESP"],
+                    "award-id": ["#09/06953-4"]
+                }
+            ]
+        }
+
+    Example output:
+        <funding-group>
+            <award-group>
+                <funding-source>CNPq</funding-source>
+                <award-id>00001</award-id>
+                <award-id>00002</award-id>
+            </award-group>
+            <award-group>
+                <funding-source>CNPq</funding-source>
+                <funding-source>FAPESP</funding-source>
+                <award-id>#09/06953-4</award-id>
+            </award-group>
+        </funding-group>
+    """
+
+    if award_groups := data.get("award-group"):
+        funding_group_elem = ET.Element("funding-group")
+
+        for award_group in award_groups:
+            if not (funding_sources := award_group.get("funding-source")) or not (award_ids := award_group.get("award-id")):
+                raise ValueError("At least one funding-source and one award-id are required")
+
+            award_group_elem = ET.SubElement(funding_group_elem, "award-group")
+            for funding_source in funding_sources:
+                ET.SubElement(award_group_elem, "funding-source").text = funding_source
+            for award_id in award_ids:
+                ET.SubElement(award_group_elem, "award-id").text = award_id
+
+        return funding_group_elem

--- a/tests/sps/formats/sps_xml/test_funding_group.py
+++ b/tests/sps/formats/sps_xml/test_funding_group.py
@@ -1,0 +1,74 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.funding_group import build_funding_group
+
+
+class TestBuildFundingGroup(unittest.TestCase):
+    def test_build_funding_group(self):
+        data = {
+            "award-group": [
+                {
+                    "funding-source": ["CNPq"],
+                    "award-id": ["00001", "00002"]
+                },
+                {
+                    "funding-source": ["CNPq", "FAPESP"],
+                    "award-id": ["#09/06953-4"]
+                }
+            ]
+        }
+        expected_xml_str = (
+            '<funding-group>'
+            '<award-group>'
+            '<funding-source>CNPq</funding-source>'
+            '<award-id>00001</award-id>'
+            '<award-id>00002</award-id>'
+            '</award-group>'
+            '<award-group>'
+            '<funding-source>CNPq</funding-source>'
+            '<funding-source>FAPESP</funding-source>'
+            '<award-id>#09/06953-4</award-id>'
+            '</award-group>'
+            '</funding-group>'
+        )
+        fn_group_elem = build_funding_group(data)
+        generated_xml_str = ET.tostring(fn_group_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+
+class TestBuildFundingGroupNone(unittest.TestCase):
+    def test_build_funding_group_funding_source_None(self):
+        data = {
+            "award-group": [
+                {
+                    "funding-source": None,
+                    "award-id": ["00001", "00002"]
+                }
+            ]
+        }
+        with self.assertRaises(ValueError) as e:
+            build_funding_group(data)
+
+        self.assertEqual(str(e.exception), "At least one funding-source and one award-id are required")
+
+    def test_build_funding_group_award_id_None(self):
+        data = {
+            "award-group": [
+                {
+                    "funding-source": ["CNPq"],
+                    "award-id": None
+                }
+            ]
+        }
+        with self.assertRaises(ValueError) as e:
+            build_funding_group(data)
+
+        self.assertEqual(str(e.exception), "At least one funding-source and one award-id are required")
+
+    def test_build_funding_group_award_group_None(self):
+        data = {
+            "award-group": None
+        }
+
+        fn_group_elem = build_funding_group(data)
+        self.assertIsNone(fn_group_elem)


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `funding-group` no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_funding_group.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

