### PR TITLE
Feat: build ack element

### DIFF
--- a/packtools/sps/formats/sps_xml/ack.py
+++ b/packtools/sps/formats/sps_xml/ack.py
@@ -8,7 +8,7 @@ def build_ack(data):
     Args:
         data (dict): A dictionary containing acknowledgment details with the following keys:
             - "title" (str, optional): Title of the acknowledgment section.
-            - "paragraphs" (list of str, optional): A list of paragraphs for the acknowledgment.
+            - "p" (list of str, optional): A list of paragraphs for the acknowledgment.
 
     Returns:
         xml.etree.ElementTree.Element: An XML element representing the acknowledgment section.
@@ -16,7 +16,7 @@ def build_ack(data):
     Example input:
         data = {
             "title": "Acknowledgments",
-            "paragraphs": [
+            "p": [
                 "We thank the participants for their time.",
                 "Funding was provided by XYZ organization."
             ]
@@ -30,7 +30,7 @@ def build_ack(data):
         </ack>
     """
     title = data.get("title")
-    paragraphs = data.get("paragraphs")
+    paragraphs = data.get("p")
 
     if title or paragraphs:
         ack_elem = ET.Element("ack")

--- a/packtools/sps/formats/sps_xml/ack.py
+++ b/packtools/sps/formats/sps_xml/ack.py
@@ -1,0 +1,42 @@
+import xml.etree.ElementTree as ET
+
+
+def build_ack(data):
+    """
+    Builds an XML element representing the acknowledgments section.
+
+    Args:
+        data (dict): A dictionary containing acknowledgment details with the following keys:
+            - "title" (str, optional): Title of the acknowledgment section.
+            - "paragraphs" (list of str, optional): A list of paragraphs for the acknowledgment.
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the acknowledgment section.
+
+    Example input:
+        data = {
+            "title": "Acknowledgments",
+            "paragraphs": [
+                "We thank the participants for their time.",
+                "Funding was provided by XYZ organization."
+            ]
+        }
+
+    Example output:
+        <ack>
+            <title>Acknowledgments</title>
+            <p>We thank the participants for their time.</p>
+            <p>Funding was provided by XYZ organization.</p>
+        </ack>
+    """
+    title = data.get("title")
+    paragraphs = data.get("paragraphs")
+
+    if title or paragraphs:
+        ack_elem = ET.Element("ack")
+        if title:
+            ET.SubElement(ack_elem, "title").text = title
+        for paragraph in paragraphs or []:
+            ET.SubElement(ack_elem, "p").text = paragraph
+
+        return ack_elem

--- a/tests/sps/formats/sps_xml/test_ack.py
+++ b/tests/sps/formats/sps_xml/test_ack.py
@@ -1,0 +1,48 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.ack import build_ack
+
+
+class TestBuildAck(unittest.TestCase):
+    def test_build_ack(self):
+        data = {
+            "title": "Agradecimentos",
+            "paragraphs": ["Texto de agradecimento"]
+        }
+        expected_xml_str = (
+            '<ack>'
+            '<title>Agradecimentos</title>'
+            '<p>Texto de agradecimento</p>'
+            '</ack>'
+        )
+        ack_elem = build_ack(data)
+        generated_xml_str = ET.tostring(ack_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_ack_title_None(self):
+        data = {
+            "title": None,
+            "paragraphs": ["Texto de agradecimento"]
+        }
+        expected_xml_str = (
+            '<ack>'
+            '<p>Texto de agradecimento</p>'
+            '</ack>'
+        )
+        ack_elem = build_ack(data)
+        generated_xml_str = ET.tostring(ack_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_ack_paragraph_None(self):
+        data = {
+            "title": "Agradecimentos",
+            "paragraphs": None
+        }
+        expected_xml_str = (
+            '<ack>'
+            '<title>Agradecimentos</title>'
+            '</ack>'
+        )
+        ack_elem = build_ack(data)
+        generated_xml_str = ET.tostring(ack_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())

--- a/tests/sps/formats/sps_xml/test_ack.py
+++ b/tests/sps/formats/sps_xml/test_ack.py
@@ -7,7 +7,7 @@ class TestBuildAck(unittest.TestCase):
     def test_build_ack(self):
         data = {
             "title": "Agradecimentos",
-            "paragraphs": ["Texto de agradecimento"]
+            "p": ["Texto de agradecimento"]
         }
         expected_xml_str = (
             '<ack>'
@@ -22,7 +22,7 @@ class TestBuildAck(unittest.TestCase):
     def test_build_ack_title_None(self):
         data = {
             "title": None,
-            "paragraphs": ["Texto de agradecimento"]
+            "p": ["Texto de agradecimento"]
         }
         expected_xml_str = (
             '<ack>'
@@ -36,7 +36,7 @@ class TestBuildAck(unittest.TestCase):
     def test_build_ack_paragraph_None(self):
         data = {
             "title": "Agradecimentos",
-            "paragraphs": None
+            "p": None
         }
         expected_xml_str = (
             '<ack>'


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `ack`, no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_ack.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

