### PR TITLE
Feat: build front element

### DIFF
--- a/packtools/sps/formats/sps_xml/front.py
+++ b/packtools/sps/formats/sps_xml/front.py
@@ -1,0 +1,34 @@
+import xml.etree.ElementTree as ET
+
+
+def build_front(node):
+    """
+    Constructs an XML "front" element by combining "journal-meta" and "article-meta" sub-elements.
+
+    Parameters:
+        node (dict): A dictionary-like object containing the keys "journal-meta" and "article-meta",
+                     which should map to XML elements.
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element named "front" that contains the "journal-meta"
+                                       and "article-meta" elements as its children.
+
+    Raises:
+        ValueError: If either "journal-meta" or "article-meta" is missing in the input node.
+
+    Example:
+        node = {
+            "journal-meta": <Element>,
+            "article-meta": <Element>
+        }
+    """
+    journal_meta = node.get("journal-meta")
+    article_meta = node.get("article-meta")
+    if journal_meta is None or article_meta is None:
+        raise ValueError("journal-meta and article-meta nodes are required.")
+
+    front = ET.Element("front")
+    front.append(journal_meta)
+    front.append(article_meta)
+
+    return front

--- a/tests/sps/formats/sps_xml/test_front.py
+++ b/tests/sps/formats/sps_xml/test_front.py
@@ -1,0 +1,92 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.front import build_front
+
+
+class TestBuildFront(unittest.TestCase):
+    def test_build_front(self):
+        self.maxDiff = None
+        node = {
+            "journal-meta": ET.fromstring(
+                '<journal-meta>'
+                '<journal-id journal-id-type="nlm-ta">Braz J Med Biol Res</journal-id>'
+                '<journal-id journal-id-type="publisher-id">bjmbr</journal-id>'
+                '<journal-title-group>'
+                '<journal-title>Brazilian Journal of Medical and Biological Research</journal-title>'
+                '<abbrev-journal-title abbrev-type="publisher">Braz. J. Med. Biol. Res.</abbrev-journal-title>'
+                '</journal-title-group>'
+                '<issn pub-type="epub">1414-431X</issn>'
+                '<issn pub-type="ppub">0100-879X</issn>'
+                '<publisher>'
+                '<publisher-name>Associação Brasileira de Divulgação Científica</publisher-name>'
+                '</publisher>'
+                '</journal-meta>'
+            ),
+            "article-meta": ET.fromstring(
+                '<article-meta>'
+                '<article-id pub-id-type="doi">10.1016/j.bjane.2019.01.003</article-id>'
+                '<article-id pub-id-type="other">00603</article-id>'
+                '</article-meta>'
+            )
+        }
+        expected_xml_str = (
+            '<front>'
+                '<journal-meta>'
+                    '<journal-id journal-id-type="nlm-ta">Braz J Med Biol Res</journal-id>'
+                    '<journal-id journal-id-type="publisher-id">bjmbr</journal-id>'
+                    '<journal-title-group>'
+                        '<journal-title>Brazilian Journal of Medical and Biological Research</journal-title>'
+                        '<abbrev-journal-title abbrev-type="publisher">Braz. J. Med. Biol. Res.</abbrev-journal-title>'
+                    '</journal-title-group>'
+                    '<issn pub-type="epub">1414-431X</issn>'
+                    '<issn pub-type="ppub">0100-879X</issn>'
+                    '<publisher>'
+                        '<publisher-name>Associação Brasileira de Divulgação Científica</publisher-name>'
+                    '</publisher>'
+                '</journal-meta>'
+                '<article-meta>'
+                    '<article-id pub-id-type="doi">10.1016/j.bjane.2019.01.003</article-id>'
+                    '<article-id pub-id-type="other">00603</article-id>'
+                '</article-meta>'
+            '</front>'
+        )
+        aff_elem = build_front(node)
+        generated_xml_str = ET.tostring(aff_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_front_journal_meta_None(self):
+        node = {
+            "journal-meta": None,
+            "article-meta": ET.fromstring(
+                '<article-meta>'
+                '<article-id pub-id-type="doi">10.1016/j.bjane.2019.01.003</article-id>'
+                '<article-id pub-id-type="other">00603</article-id>'
+                '</article-meta>'
+            )
+        }
+        with self.assertRaises(ValueError) as e:
+            build_front(node)
+        self.assertEqual(str(e.exception), "journal-meta and article-meta nodes are required.")
+
+    def test_build_front_article_meta_None(self):
+        node = {
+            "journal-meta": ET.fromstring(
+                '<journal-meta>'
+                '<journal-id journal-id-type="nlm-ta">Braz J Med Biol Res</journal-id>'
+                '<journal-id journal-id-type="publisher-id">bjmbr</journal-id>'
+                '<journal-title-group>'
+                '<journal-title>Brazilian Journal of Medical and Biological Research</journal-title>'
+                '<abbrev-journal-title abbrev-type="publisher">Braz. J. Med. Biol. Res.</abbrev-journal-title>'
+                '</journal-title-group>'
+                '<issn pub-type="epub">1414-431X</issn>'
+                '<issn pub-type="ppub">0100-879X</issn>'
+                '<publisher>'
+                '<publisher-name>Associação Brasileira de Divulgação Científica</publisher-name>'
+                '</publisher>'
+                '</journal-meta>'
+            ),
+            "article-meta": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_front(node)
+        self.assertEqual(str(e.exception), "journal-meta and article-meta nodes are required.")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `front`, no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_front.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

