### PR TITLE
Feat: build ref list element

### DIFF
--- a/packtools/sps/formats/sps_xml/ref_list.py
+++ b/packtools/sps/formats/sps_xml/ref_list.py
@@ -1,0 +1,43 @@
+import xml.etree.ElementTree as ET
+
+from packtools.sps.formats.sps_xml.ref import build_ref
+
+
+def build_ref_list(data):
+    """
+    Constructs an XML "ref-list" element using provided reference data.
+
+    Parameters:
+        data (dict): A dictionary containing:
+            - "title" (str): The title of the reference list (required).
+            - "ref-list-node" (list, optional): A list of prebuilt XML elements to include as references.
+            - "ref-list-dict" (list, optional): A list of dictionaries used to construct references
+                                                using the 'build_ref' function.
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML "ref-list" element containing the title and references.
+
+    Raises:
+        ValueError: If "title" is missing or neither "ref-list-node" nor "ref-list-dict" is provided.
+
+    Example:
+        data = {
+            "title": "References",
+            "ref-list-node": [<Element>, <Element>],  # List of prebuilt XML elements (optional)
+            "ref-list-dict": [ref_dict, ref_dict]    # List of dictionaries to build references (optional)
+        }
+    """
+    if not (title := data.get("title")):
+        raise ValueError("Title is required")
+
+    ref_list_elem = ET.Element("ref-list")
+    ET.SubElement(ref_list_elem, "title").text = title
+
+    if list_node := data.get("ref-list-node"):
+        ref_list_elem.extend(list_node)
+    elif list_dict := data.get("ref-list-dict"):
+        ref_list_elem.extend(list(build_ref(ref) for ref in list_dict))
+    else:
+        raise ValueError("A list of references is required")
+
+    return ref_list_elem

--- a/tests/sps/formats/sps_xml/test_ref_list.py
+++ b/tests/sps/formats/sps_xml/test_ref_list.py
@@ -1,0 +1,89 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.ref_list import build_ref_list
+
+
+class TestBuildRefList(unittest.TestCase):
+    def test_build_ref_list_by_node(self):
+        data = {
+           "title": "References",
+           "ref-list-node": [
+               ET.fromstring(
+                   '<ref id="B1">'
+                   '<label>1</label>'
+                   '<element-citation publication-type="journal" />'
+                   '</ref>'
+               ),
+               ET.fromstring(
+                   '<ref id="B2">'
+                   '<label>2</label>'
+                   '<element-citation publication-type="journal" />'
+                   '</ref>'
+               )
+           ]
+        }
+        expected_xml_str = (
+            '<ref-list>'
+            '<title>References</title>'
+            '<ref id="B1">'
+            '<label>1</label>'
+            '<element-citation publication-type="journal" />'
+            '</ref>'
+            '<ref id="B2">'
+            '<label>2</label>'
+            '<element-citation publication-type="journal" />'
+            '</ref>'
+            '</ref-list>'
+        )
+        ref_list_elem = build_ref_list(data)
+        generated_xml_str = ET.tostring(ref_list_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_ref_list_by_dict(self):
+        data = {
+           "title": "References",
+           "ref-list-dict": [
+               {
+                   "ref-id": "B1",
+                   "label": "1",
+                   "publication-type": "journal"
+               },
+               {
+                   "ref-id": "B2",
+                   "label": "2",
+                   "publication-type": "journal",
+               }
+           ]
+        }
+        expected_xml_str = (
+            '<ref-list>'
+            '<title>References</title>'
+            '<ref id="B1">'
+            '<label>1</label>'
+            '<element-citation publication-type="journal" />'
+            '</ref>'
+            '<ref id="B2">'
+            '<label>2</label>'
+            '<element-citation publication-type="journal" />'
+            '</ref>'
+            '</ref-list>'
+        )
+        ref_list_elem = build_ref_list(data)
+        generated_xml_str = ET.tostring(ref_list_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_ref_list_None(self):
+        data = {
+           "title": "References"
+        }
+        with self.assertRaises(ValueError) as e:
+            build_ref_list(data)
+        self.assertEqual(str(e.exception), "A list of references is required")
+
+    def test_build_ref_list_title_None(self):
+        data = {
+           "title": None
+        }
+        with self.assertRaises(ValueError) as e:
+            build_ref_list(data)
+        self.assertEqual(str(e.exception), "Title is required")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `ref-list`, no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro a avaliação dos testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_ref_list.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

