### PR TITLE
Feat: build back element

### DIFF
--- a/packtools/sps/formats/sps_xml/back.py
+++ b/packtools/sps/formats/sps_xml/back.py
@@ -1,20 +1,34 @@
-"""
-    node = {
-        element: [<Element>,...],
-        ...
-    }
-
-"""
-
 import xml.etree.ElementTree as ET
 
+def build_back(nodes):
+    """
+    Constructs an XML 'back' element and populates it with child elements.
 
-def build_back(node):
-    if not node:
+    This function takes a list of lists, where each sublist contains XML elements,
+    and appends all these elements as children of a newly created 'back' element.
+
+    Args:
+        nodes (list of list of xml.etree.ElementTree.Element):
+            A list of lists containing 'Element' objects to be added as children of the 'back' element.
+
+    Returns:
+        xml.etree.ElementTree.Element:
+            An XML 'back' element with the provided child elements appended.
+
+    Raises:
+        ValueError: If the input 'nodes' list is empty.
+
+    Example:
+        nodes = [
+            [<Element>, <Element>],
+            [<Element>]
+        ]
+    """
+    if not nodes:
         raise ValueError("A list of child elements is required.")
 
     back_elem = ET.Element("back")
-    for element_name, element_list in node.items():
+    for element_list in nodes:
         back_elem.extend(element_list)
 
     return back_elem

--- a/packtools/sps/formats/sps_xml/back.py
+++ b/packtools/sps/formats/sps_xml/back.py
@@ -1,0 +1,20 @@
+"""
+    node = {
+        element: [<Element>,...],
+        ...
+    }
+
+"""
+
+import xml.etree.ElementTree as ET
+
+
+def build_back(node):
+    if not node:
+        raise ValueError("A list of child elements is required.")
+
+    back_elem = ET.Element("back")
+    for element_name, element_list in node.items():
+        back_elem.extend(element_list)
+
+    return back_elem

--- a/tests/sps/formats/sps_xml/test_back.py
+++ b/tests/sps/formats/sps_xml/test_back.py
@@ -6,8 +6,8 @@ from packtools.sps.formats.sps_xml.back import build_back
 class TestBuildBack(unittest.TestCase):
     def test_build_back(self):
         self.maxDiff = None
-        node = {
-            "ack": [
+        node = [
+            [
                 ET.fromstring(
                     '<ack>'
                     '<title>Acknowledgments</title>'
@@ -16,7 +16,7 @@ class TestBuildBack(unittest.TestCase):
                     '</ack>'
                 )
             ],
-            "ref-list": [
+            [
                 ET.fromstring(
                     '<ref-list>'
                     '<title>References</title>'
@@ -40,7 +40,7 @@ class TestBuildBack(unittest.TestCase):
                     '</ref-list>'
                 )
             ]
-        }
+        ]
         expected_xml_str = (
             '<back>'
             '<ack>'
@@ -75,7 +75,7 @@ class TestBuildBack(unittest.TestCase):
         self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
     def test_build_back_None(self):
-        node = {}
+        node = []
         with self.assertRaises(ValueError) as e:
             build_back(node)
         self.assertEqual(str(e.exception), "A list of child elements is required.")

--- a/tests/sps/formats/sps_xml/test_back.py
+++ b/tests/sps/formats/sps_xml/test_back.py
@@ -1,0 +1,81 @@
+import unittest
+import xml.etree.ElementTree as ET
+from packtools.sps.formats.sps_xml.back import build_back
+
+
+class TestBuildBack(unittest.TestCase):
+    def test_build_back(self):
+        self.maxDiff = None
+        node = {
+            "ack": [
+                ET.fromstring(
+                    '<ack>'
+                    '<title>Acknowledgments</title>'
+                    '<p>Federal University of Rio de Janeiro (UFRJ), School of Medicine,...</p>'
+                    '<p>This study was funded by the Hospital Municipal Conde Modesto Leal...</p>'
+                    '</ack>'
+                )
+            ],
+            "ref-list": [
+                ET.fromstring(
+                    '<ref-list>'
+                    '<title>References</title>'
+                    '<ref id="B1">'
+                    '<label>1</label>'
+                    '<mixed-citation>Goldberg DS, McGee SJ. Pain as a global public health priority. BMC Public Health. 2011;11:770.</mixed-citation>'
+                    '<element-citation publication-type="journal">'
+                    '<person-group person-group-type="author">'
+                    '<name>'
+                    '<surname>Goldberg</surname>'
+                    '<given-names>DS</given-names>'
+                    '</name>'
+                    '</person-group>'
+                    '<article-title>Pain as a global public health priority</article-title>'
+                    '<source>BMC Public Health</source>'
+                    '<volume>11</volume>'
+                    '<year>2011</year>'
+                    '<fpage>770</fpage>'
+                    '</element-citation>'
+                    '</ref>'
+                    '</ref-list>'
+                )
+            ]
+        }
+        expected_xml_str = (
+            '<back>'
+            '<ack>'
+            '<title>Acknowledgments</title>'
+            '<p>Federal University of Rio de Janeiro (UFRJ), School of Medicine,...</p>'
+            '<p>This study was funded by the Hospital Municipal Conde Modesto Leal...</p>'
+            '</ack>'
+            '<ref-list>'
+            '<title>References</title>'
+            '<ref id="B1">'
+            '<label>1</label>'
+            '<mixed-citation>Goldberg DS, McGee SJ. Pain as a global public health priority. BMC Public Health. 2011;11:770.</mixed-citation>'
+            '<element-citation publication-type="journal">'
+            '<person-group person-group-type="author">'
+            '<name>'
+            '<surname>Goldberg</surname>'
+            '<given-names>DS</given-names>'
+            '</name>'
+            '</person-group>'
+            '<article-title>Pain as a global public health priority</article-title>'
+            '<source>BMC Public Health</source>'
+            '<volume>11</volume>'
+            '<year>2011</year>'
+            '<fpage>770</fpage>'
+            '</element-citation>'
+            '</ref>'
+            '</ref-list>'
+            '</back>'
+        )
+        back_elem = build_back(node)
+        generated_xml_str = ET.tostring(back_elem, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
+
+    def test_build_back_None(self):
+        node = {}
+        with self.assertRaises(ValueError) as e:
+            build_back(node)
+        self.assertEqual(str(e.exception), "A list of child elements is required.")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona função para a criação do elemento `back`, no formato xml.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_back.py
`
#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

