### PR TITLE
Feat: complements build article element

### DIFF
--- a/packtools/sps/formats/sps_xml/article.py
+++ b/packtools/sps/formats/sps_xml/article.py
@@ -1,7 +1,7 @@
 import xml.etree.ElementTree as ET
 
 
-def build_article_node(data):
+def build_article_node(data, nodes):
     """
     Builds an XML article node with the specified attributes and child elements.
 
@@ -22,18 +22,19 @@ def build_article_node(data):
 
     Example:
         Input:
-            article_data = {
+            data = {
                 "dtd-version": "1.1",
                 "specific-use": "sps-1.8",
                 "article-type": "research-article",
-                "xml:lang": "pt",
-                "children_nodes": [
-                    ET.fromstring('<front />'),
-                    ET.fromstring('<body />'),
-                    ET.fromstring('<back />'),
-                    ET.fromstring('<sub-article />')
-                ]
+                "xml:lang": "pt"
             }
+
+            nodes = [
+                ET.fromstring('<front />'),
+                ET.fromstring('<body />'),
+                ET.fromstring('<back />'),
+                ET.fromstring('<sub-article />')
+            ]
 
         Output:
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
@@ -66,8 +67,8 @@ def build_article_node(data):
     except KeyError as e:
         raise KeyError(f"{e} is required")
 
-    if list_node := data.get("children_nodes"):
-        article_elem.extend(list_node)
+    if nodes:
+        article_elem.extend(nodes)
     else:
         raise ValueError("A list of children nodes is required")
 

--- a/packtools/sps/formats/sps_xml/article.py
+++ b/packtools/sps/formats/sps_xml/article.py
@@ -1,7 +1,49 @@
 import xml.etree.ElementTree as ET
 
 
-def build_article_node(article_data: dict):
+def build_article_node(data):
+    """
+    Builds an XML article node with the specified attributes and child elements.
+
+    Args:
+        data (dict): A dictionary containing the data to build the <article> node. The keys should include:
+            - "dtd-version" (str): The DTD version for the article (required).
+            - "specific-use" (str): A specific-use attribute value, such as "sps-1.8" (required).
+            - "article-type" (str): The type of the article, e.g., "research-article" (required).
+            - "xml:lang" (str): The language of the article, e.g., "pt" (required).
+            - "children_nodes" (list of xml.etree.ElementTree.Element): A list of child elements to append to the article node (required).
+
+    Returns:
+        xml.etree.ElementTree.Element: An XML element representing the <article> node with the specified attributes and children.
+
+    Raises:
+        KeyError: If any required keys ("dtd-version", "specific-use", "article-type", "xml:lang") are missing from the input dictionary.
+        ValueError: If "children_nodes" is not provided or is empty.
+
+    Example:
+        Input:
+            article_data = {
+                "dtd-version": "1.1",
+                "specific-use": "sps-1.8",
+                "article-type": "research-article",
+                "xml:lang": "pt",
+                "children_nodes": [
+                    ET.fromstring('<front />'),
+                    ET.fromstring('<body />'),
+                    ET.fromstring('<back />'),
+                    ET.fromstring('<sub-article />')
+                ]
+            }
+
+        Output:
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+            dtd-version="1.1" specific-use="sps-1.8" article-type="research-article" xml:lang="pt">
+                <front />
+                <body />
+                <back />
+                <sub-article />
+            </article>
+    """
     namespaces = {
         "xlink": "http://www.w3.org/1999/xlink",
         "mml": "http://www.w3.org/1998/Math/MathML"
@@ -16,12 +58,17 @@ def build_article_node(article_data: dict):
         article_elem = ET.Element("article", {
             "xmlns:xlink": namespaces["xlink"],
             "xmlns:mml": namespaces["mml"],
-            "dtd-version": article_data["dtd-version"],
-            "specific-use": article_data["specific-use"],
-            "article-type": article_data["article-type"],
-            "xml:lang": article_data["xml:lang"]
+            "dtd-version": data["dtd-version"],
+            "specific-use": data["specific-use"],
+            "article-type": data["article-type"],
+            "xml:lang": data["xml:lang"]
         })
     except KeyError as e:
         raise KeyError(f"{e} is required")
+
+    if list_node := data.get("children_nodes"):
+        article_elem.extend(list_node)
+    else:
+        raise ValueError("A list of children nodes is required")
 
     return article_elem

--- a/tests/sps/formats/sps_xml/test_article.py
+++ b/tests/sps/formats/sps_xml/test_article.py
@@ -1,39 +1,43 @@
 import unittest
-from xml.etree.ElementTree import Element
+import xml.etree.ElementTree as ET
+
 
 from packtools.sps.formats.sps_xml.article import build_article_node
 
 
 class TestBuildArticleNode(unittest.TestCase):
     def test_build_article_node(self):
-        article_node = build_article_node(
-            article_data={
+        article = build_article_node(
+            data={
                 'dtd-version': '1.1',
                 'specific-use': 'sps-1.8',
                 'article-type': 'research-article',
-                'xml:lang': 'pt'
+                'xml:lang': 'pt',
+                'children_nodes': [
+                    ET.fromstring('<front />'),
+                    ET.fromstring('<body />'),
+                    ET.fromstring('<back />'),
+                    ET.fromstring('<sub-article />')
+                ]
             }
         )
 
-        self.assertIsInstance(article_node, Element)
+        expected_xml_str = (
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.1" specific-use="sps-1.8" article-type="research-article" xml:lang="pt">'
+            '<front />'
+            '<body />'
+            '<back />'
+            '<sub-article />'
+            '</article>'
+        )
+        generated_xml_str = ET.tostring(article, encoding="unicode", method="xml")
+        self.assertEqual(generated_xml_str.strip(), expected_xml_str.strip())
 
-        self.assertEqual(article_node.tag, 'article')
-
-        expected_attributes = {
-            'xmlns:xlink': 'http://www.w3.org/1999/xlink',
-            'xmlns:mml': 'http://www.w3.org/1998/Math/MathML',
-            'dtd-version': '1.1',
-            'specific-use': 'sps-1.8',
-            'article-type': 'research-article',
-            'xml:lang': 'pt'
-        }
-
-        self.assertDictEqual(article_node.attrib, expected_attributes)
-
-    def test_build_article_node_error(self):
+    def test_build_article_node_error_attribs(self):
         with self.assertRaises(KeyError) as e:
             build_article_node(
-                article_data={
+                data={
                     'specific-use': 'sps-1.8',
                     'article-type': 'research-article',
                     'xml:lang': 'pt'
@@ -41,6 +45,17 @@ class TestBuildArticleNode(unittest.TestCase):
             )
         self.assertEqual(str(e.exception), '"\'dtd-version\' is required"')
 
+    def test_build_article_node_error_children(self):
+        with self.assertRaises(ValueError) as e:
+            build_article_node(
+                data={
+                    'dtd-version': '1.1',
+                    'specific-use': 'sps-1.8',
+                    'article-type': 'research-article',
+                    'xml:lang': 'pt',
+                }
+            )
+        self.assertEqual(str(e.exception), "A list of children nodes is required")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sps/formats/sps_xml/test_article.py
+++ b/tests/sps/formats/sps_xml/test_article.py
@@ -12,14 +12,14 @@ class TestBuildArticleNode(unittest.TestCase):
                 'dtd-version': '1.1',
                 'specific-use': 'sps-1.8',
                 'article-type': 'research-article',
-                'xml:lang': 'pt',
-                'children_nodes': [
+                'xml:lang': 'pt'
+            },
+            nodes=[
                     ET.fromstring('<front />'),
                     ET.fromstring('<body />'),
                     ET.fromstring('<back />'),
                     ET.fromstring('<sub-article />')
                 ]
-            }
         )
 
         expected_xml_str = (
@@ -41,7 +41,8 @@ class TestBuildArticleNode(unittest.TestCase):
                     'specific-use': 'sps-1.8',
                     'article-type': 'research-article',
                     'xml:lang': 'pt'
-                }
+                },
+                nodes=None
             )
         self.assertEqual(str(e.exception), '"\'dtd-version\' is required"')
 
@@ -53,7 +54,8 @@ class TestBuildArticleNode(unittest.TestCase):
                     'specific-use': 'sps-1.8',
                     'article-type': 'research-article',
                     'xml:lang': 'pt',
-                }
+                },
+                nodes=None
             )
         self.assertEqual(str(e.exception), "A list of children nodes is required")
 


### PR DESCRIPTION
#### O que esse PR faz?
Complementa a função `build_article_node` para considerar os elementos filhos.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/formats/sps_xml/test_article.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

