### PR TITLE
Corrige contrib_name

### DIFF
--- a/packtools/sps/models/article_contribs.py
+++ b/packtools/sps/models/article_contribs.py
@@ -40,7 +40,7 @@ class Contrib:
     def contrib_name(self):
         name = self.node.find("name")
         if name is not None:
-            return {item.tag: item.text for item in name}
+            return {item.tag: item.text for item in name if item.text}
 
     @property
     def contrib_full_name(self):

--- a/tests/sps/models/test_article_contribs.py
+++ b/tests/sps/models/test_article_contribs.py
@@ -754,6 +754,7 @@ class ArticleContribTest(TestCase):
                     {
                         'city': None,
                         'country_name': None,
+                        'country_code': None,
                         'email': None,
                         'id': 'aff4',
                         'label': 'a',
@@ -769,7 +770,6 @@ class ArticleContribTest(TestCase):
                     }
                 ]
             }
-
         ]
 
         for i, item in enumerate(expected):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige contrib_name e teste de Contrib

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
```python 
python3 -m unittest tests.sps.models.test_article_contribs.ArticleContribTest
```

#### Algum cenário de contexto que queira dar?
Artigo do error:
[article_teste.zip](https://github.com/user-attachments/files/18121691/article_teste.zip)

```console
INFO 2024-12-13 05:24:02,407 xmlsps 498560 138744031330432 load article article/fixtures/article_teste.xml None
ERROR 2024-12-13 05:24:02,702 models 498560 138744031330432 sequence item 3: expected str instance, NoneType found
Traceback (most recent call last):
  File "/home/samuelv/Desktop/scielo/core/core/article/sources/xmlsps.py", line 96, in load_article
    create_or_update_researchers(xmltree=xmltree, user=user, item=pid_v3)
  File "/home/samuelv/Desktop/scielo/core/core/article/sources/xmlsps.py", line 341, in create_or_update_researchers
    for author in authors:
  File "/home/samuelv/Desktop/scielo/core/.venv/lib/python3.12/site-packages/packtools/sps/models/article_contribs.py", line 125, in contribs
    for contrib in ContribGroup(contrib_group).contribs:
  File "/home/samuelv/Desktop/scielo/core/.venv/lib/python3.12/site-packages/packtools/sps/models/article_contribs.py", line 111, in contribs
    yield contrib.data
          ^^^^^^^^^^^^
  File "/home/samuelv/Desktop/scielo/core/.venv/lib/python3.12/site-packages/packtools/sps/models/article_contribs.py", line 92, in data
    self.contrib_full_name,
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/samuelv/Desktop/scielo/core/.venv/lib/python3.12/site-packages/packtools/sps/models/article_contribs.py", line 50, in contrib_full_name
    return' '.join(name.get(part, '') for part in name_parts).strip()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 3: expected str instance, NoneType found
```

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

