### PR TITLE
Corrige a validação de dados de financiamento

### DIFF
--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -150,12 +150,26 @@ class FundingGroup:
         return items
 
     @property
+    def award_ids(self):
+        items = []
+        for node in self._xmltree.xpath(".//funding-group/award-group/award-id"):
+            if node.text:
+                items.append(node.text)
+        return items
+
+    @property
     def funding_statement(self):
         """
         De acordo com https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt-br/latest/tagset/elemento-funding-statement.html?highlight=funding-statement
         <funding-statement> ocorre zero ou uma vez.
         """
         return self._xmltree.findtext(".//funding-group/funding-statement")
+
+    @property
+    def funding_statement_data(self):
+        node = self._xmltree.find(".//funding-group/funding-statement")
+        if node is not None:
+            return self._process_paragraph_node(node)
 
     @property
     def principal_award_recipients(self):

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -1,23 +1,7 @@
 import logging
-
 from packtools.sps.utils import xml_utils
 
 logger = logging.getLogger(__name__)
-
-
-def _looks_like_institution_name(text, special_chars):
-    """
-    Checks whether all characters in text are alphanumeric, spaces or belong to the list of characters considered valid
-     in composing the name of the funding source.
-
-    Example: special_chars = ['.', ',', '-']
-
-    In other words, it checks whether a text is, potentially, the name of a funding source.
-    """
-    for char in text:
-        if not (char.isalpha() or char.isspace() or char in special_chars):
-            return False
-    return True
 
 
 def _looks_like_award_id(text):
@@ -79,26 +63,23 @@ class FundingGroup:
 
     def __init__(self, xmltree, params=None):
         self._xmltree = xmltree
-        self.params = params or {
-            "special_chars_funding": [".", ","],
-            "special_chars_award_id": ["/", ".", "-"],
-        }
+        self.params = params or {"special_chars_award_id": ["/", ".", "-"]}
 
     def _process_paragraph_node(self, node):
         """
-        Process a single paragraph node to extract funding sources and award IDs.
+        Process a single paragraph node to extract award IDs.
 
         Parameters
         ----------
         node : lxml.etree.Element
             The paragraph node to process
+
         Returns
         -------
         dict
-            Dictionary containing fn-type, extracted funding sources, award IDs and original text
+            Dictionary containing extracted award IDs and original text
         """
         text = xml_utils.node_plain_text(node)
-        funding_sources = []
         award_ids = []
 
         if has_digit(text):
@@ -110,18 +91,42 @@ class FundingGroup:
 
         return {"look-like-award-id": award_ids, "text": text}
 
-    def fn_financial_information(self):
+    @property
+    def financial_disclosure(self):
+        """
+        Extract financial disclosure information from fn nodes.
+        Returns a list of dictionaries containing award IDs and text found in financial-disclosure notes.
+        """
         items = []
-        for fn_type in ("financial-disclosure", "supported-by"):
-            for nodes in self._xmltree.xpath(f".//fn-group/fn[@fn-type='{fn_type}']"):
-                for node in nodes.xpath("p"):
-                    node_data = self._process_paragraph_node(node)
-                    node_data["fn-type"] = fn_type
-                    items.append(node_data)
+        for nodes in self._xmltree.xpath(
+            ".//fn-group/fn[@fn-type='financial-disclosure']"
+        ):
+            for node in nodes.xpath("p"):
+                node_data = self._process_paragraph_node(node)
+                node_data["fn-type"] = "financial-disclosure"
+                items.append(node_data)
+        return items
+
+    @property
+    def supported_by(self):
+        """
+        Extract supported-by information from fn nodes.
+        Returns a list of dictionaries containing award IDs and text found in supported-by notes.
+        """
+        items = []
+        for nodes in self._xmltree.xpath(".//fn-group/fn[@fn-type='supported-by']"):
+            for node in nodes.xpath("p"):
+                node_data = self._process_paragraph_node(node)
+                node_data["fn-type"] = "supported-by"
+                items.append(node_data)
         return items
 
     @property
     def award_groups(self):
+        """
+        Extract award groups information from funding-group.
+        Returns a list of dictionaries containing funding sources and award IDs.
+        """
         items = []
         for node in self._xmltree.xpath(".//funding-group/award-group"):
             d = {
@@ -199,55 +204,19 @@ class FundingGroup:
         """
         Extracts various financial and funding-related information from the XML for validation purposes.
 
-        This function processes the XML to retrieve information about the article type, language,
-        and financial details, which are essential for validating the completeness and correctness
-        of funding information in scientific articles.
-
-        Parameters
-        ----------
-        funding_special_chars : list, optional
-            List of special characters considered valid in the names of funding sources.
-        award_id_special_chars : list, optional
-            List of special characters considered valid in award IDs.
-
         Returns
         -------
         dict
-            A dictionary containing various pieces of extracted information for validation purposes,
-            such as article type, language, financial information, award groups, funding sources,
-            funding statement, principal award recipients, and acknowledgments. This data is used
-            to ensure that the article's funding information meets required standards and includes
-            all necessary details.
+            A dictionary containing various pieces of extracted information for validation purposes.
         """
         return {
-            # Type of the article, obtained from the "article-type" attribute in the XML root element.
             "article_type": self.article_type,
-            # Language of the article, obtained from the "lang" attribute in the XML namespace.
             "article_lang": self.article_lang,
-            # Possible financial information extracted from the financial footnote group.
-            "fn_financial_information": self.fn_financial_information(),
-            # Award groups, containing funding sources and award IDs.
+            "financial_disclosure": self.financial_disclosure,
+            "supported_by": self.supported_by,
             "award_groups": self.award_groups,
-            # Funding sources listed in "award-groups".
             "funding_sources": self.funding_sources,
-            # Funding information obtained in "funding-statement".
             "funding_statement": self.funding_statement,
-            # Principal award recipients obtained in "principal-award-recipient".
             "principal_award_recipients": self.principal_award_recipients,
-            # Funding information obtained in "ack".
             "ack": self.ack,
         }
-
-    @property
-    def data(self):
-        if self.award_groups:
-            _data = []
-            for item in self.award_groups:
-                award_id = item.get("award-id")
-                funding_source = item.get("funding-source")
-                if award_id and funding_source:
-                    for aid in award_id:
-                        _data.append(
-                            {"award-id": aid, "funding-source": funding_source}
-                        )
-            return _data

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -179,7 +179,7 @@ class FundingGroup:
         items = []
         for ack in self._xmltree.xpath(".//back//ack"):
             item = {"title": ack.findtext("title"), "p": []}
-            for node in nodes.xpath("p"):
+            for node in ack.xpath("p"):
                 node_data = self._process_paragraph_node(node)
                 item["p"].append(node_data)
             items.append(item)

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -200,7 +200,8 @@ class FundingGroup:
             "{http://www.w3.org/XML/1998/namespace}lang"
         )
 
-    def extract_funding_data(self):
+    @property
+    def data(self):
         """
         Extracts various financial and funding-related information from the XML for validation purposes.
 

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -17,7 +17,6 @@ class FundingGroupValidation:
     params : dict
         Dictionary containing parameters for validation:
         - special_chars_award_id: List of special characters allowed in award IDs
-        - callable_validation: Function to validate award IDs format
         - error_level: Error level for validation messages ("ERROR" or "WARNING")
     """
 
@@ -25,7 +24,6 @@ class FundingGroupValidation:
         self.xml_tree = xml_tree
         self.params = {
             "special_chars_award_id": ["/", ".", "-"],
-            "callable_validation": _callable_extern_validate_default,
             "error_level": "ERROR",
         }
         self.params.update(params or {})

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -9,7 +9,7 @@ def _callable_extern_validate_default(award_id):
 class FundingGroupValidation:
     """
     Validation class for funding information in XML documents.
-    
+
     Parameters
     ----------
     xml_tree : lxml.etree.Element
@@ -20,21 +20,22 @@ class FundingGroupValidation:
         - callable_validation: Function to validate award IDs format
         - error_level: Error level for validation messages ("ERROR" or "WARNING")
     """
+
     def __init__(self, xml_tree, params=None):
         self.xml_tree = xml_tree
         self.params = {
-            'special_chars_award_id': ['/', '.', '-'],
-            'callable_validation': _callable_extern_validate_default,
-            'error_level': "ERROR"
+            "special_chars_award_id": ["/", ".", "-"],
+            "callable_validation": _callable_extern_validate_default,
+            "error_level": "ERROR",
         }
         self.params.update(params or {})
 
         self.funding = FundingGroup(xml_tree, self.params)
-        
+
     def validate_required_award_ids(self):
         """
         Validates the existence of funding sources and award IDs.
-        
+
         Yields
         ------
         dict
@@ -68,7 +69,9 @@ class FundingGroupValidation:
                         errors.append(item)
             if funding_statement_data := self.funding.funding_statement_data:
                 if funding_statement_data.get("look-like-award-id"):
-                    funding_statement_data["context"] = "funding-group/funding-statement"
+                    funding_statement_data["context"] = (
+                        "funding-group/funding-statement"
+                    )
                     errors.append(funding_statement_data)
 
             for error in errors:
@@ -79,10 +82,14 @@ class FundingGroupValidation:
                     sub_item="award-id",
                     validation_type="exist",
                     is_valid=False,
-                    expected='award-id and funding-source in award-group',
+                    expected="award-id and funding-source in award-group",
                     obtained=None,
-                    advice='Found `{}` in `{}` ({}). Check it is a project contract. Add award-id ({}) in funding-group/award-group with respectives funding-source'.format(
-                        error['look-like-award-id'], error['text'], error['context'], error['look-like-award-id']),
+                    advice="Found `{}` in `{}` ({}). Check it is a project contract. Add award-id ({}) in funding-group/award-group with respectives funding-source".format(
+                        error["look-like-award-id"],
+                        error["text"],
+                        error["context"],
+                        error["look-like-award-id"],
+                    ),
                     data=error,
-                    error_level=self.params['error_level'],
+                    error_level=self.params["error_level"],
                 )

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -305,13 +305,8 @@ def validate_bibliographic_strip(xmltree, params):
 
 def validate_funding_data(xmltree, params):
     funding_data_rules = params["funding_data_rules"]
-
-    # FIXME o nome do método não está condizendo com o que está fazendo, que é validar source + award-id; usar verbo para o método
-    # TODO a classe deve ter um método que identifique se nos elementos fn e ack há algum número que possa ser do número do contrato e que não esteja identificado como award-id
     validator = FundingGroupValidation(xmltree)
-    yield from validator.funding_sources_exist_validation(
-        error_level=funding_data_rules["error_level"],
-    )
+    yield from validator.validate_required_award_ids()
 
 
 def validate_journal_meta(xmltree, params):

--- a/packtools/sps/validation_rules/funding_data_rules.json
+++ b/packtools/sps/validation_rules/funding_data_rules.json
@@ -1,5 +1,6 @@
 {
     "funding_data_rules": {
+        "special_chars_award_id": ["/", ".", "-"],
         "error_level": "CRITICAL"
     }
 }

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -249,7 +249,7 @@ class FundingTest(TestCase):
 
     def test_extract_funding_data(self):
         self.maxDiff = None
-        obtained = self.funding.extract_funding_data()
+        obtained = self.funding.data
         
         # Verify the structure exists
         self.assertIn('article_type', obtained)

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -77,13 +77,12 @@ class FundingTest(TestCase):
         """
         xml_tree = etree.fromstring(xml)
         params = {
-            'special_chars_funding': ['.', ','],
             'special_chars_award_id': ['/', '.', '-']
         }
         self.funding = funding_group.FundingGroup(xml_tree, params)
         self.funding_no_params = funding_group.FundingGroup(xml_tree)
 
-    def test_fn_financial_information(self):
+    def test_financial_disclosure(self):
         self.maxDiff = None
         expected = [
             {
@@ -130,7 +129,14 @@ class FundingTest(TestCase):
                 'fn-type': 'financial-disclosure',
                 'look-like-award-id': ['0001.'],
                 'text': 'Finance code 0001.'
-            },
+            }
+        ]
+        obtained = self.funding.financial_disclosure
+        self.assertEqual(expected, obtained)
+
+    def test_supported_by(self):
+        self.maxDiff = None
+        expected = [
             {
                 'fn-type': 'supported-by',
                 'look-like-award-id': [],
@@ -142,7 +148,7 @@ class FundingTest(TestCase):
                 'text': 'Número 123.456-7'
             }
         ]
-        obtained = self.funding.fn_financial_information()
+        obtained = self.funding.supported_by
         self.assertEqual(expected, obtained)
 
     def test_award_groups(self):
@@ -219,51 +225,12 @@ class FundingTest(TestCase):
         obtained = self.funding.ack
         self.assertEqual(expected, obtained)
 
-    def test_extract_funding_data(self):
-        self.maxDiff = None
-        obtained = self.funding.extract_funding_data()
-        
-        # Verify the structure exists
-        self.assertIn('article_type', obtained)
-        self.assertIn('article_lang', obtained)
-        self.assertIn('fn_financial_information', obtained)
-        self.assertIn('award_groups', obtained)
-        self.assertIn('funding_sources', obtained)
-        self.assertIn('funding_statement', obtained)
-        self.assertIn('principal_award_recipients', obtained)
-        self.assertIn('ack', obtained)
-        
-        # Verify some key values
-        self.assertEqual('research-article', obtained['article_type'])
-        self.assertEqual('en', obtained['article_lang'])
-        
-    def test_data(self):
-        self.maxDiff = None
-        expected = [
-            {"award-id": "2019JJ40269", "funding-source": ["Natural Science Foundation of Hunan Province"]},
-            {"award-id": "2020CFB547", "funding-source": ["Hubei Provincial Natural Science Foundation of China"]}
-        ]
-        obtained = self.funding.data
-        self.assertListEqual(expected, obtained)
-
-    def test__looks_like_institution_name_success(self):
-        self.assertTrue(funding_group._looks_like_institution_name(
-            "Natural Science, Foundation of-Hunan Province.",
-            ['.', ',', '-']
-        ))
-
-    def test__looks_like_institution_name_fail(self):
-        self.assertFalse(funding_group._looks_like_institution_name(
-            "Natural Science Foundation 1 of Hunan Province",
-            ['.', ',', '-']
-        ))
-
-    def test__looks_like_award_id_success(self):
+    def test_looks_like_award_id_success(self):
         self.assertTrue(funding_group._looks_like_award_id(
             "123.456.789-0"
         ))
 
-    def test__looks_like_award_id_fail(self):
+    def test_looks_like_award_id_fail(self):
         self.assertFalse(funding_group._looks_like_award_id(
             "doi.org.//123.456.789-0"
         ))
@@ -279,3 +246,22 @@ class FundingTest(TestCase):
             'text': 'Grant No: 303625/2019-8'
         }
         self.assertEqual(expected, result)
+
+    def test_extract_funding_data(self):
+        self.maxDiff = None
+        obtained = self.funding.extract_funding_data()
+        
+        # Verify the structure exists
+        self.assertIn('article_type', obtained)
+        self.assertIn('article_lang', obtained)
+        self.assertIn('financial_disclosure', obtained)
+        self.assertIn('supported_by', obtained)
+        self.assertIn('award_groups', obtained)
+        self.assertIn('funding_sources', obtained)
+        self.assertIn('funding_statement', obtained)
+        self.assertIn('principal_award_recipients', obtained)
+        self.assertIn('ack', obtained)
+        
+        # Verify some key values
+        self.assertEqual('research-article', obtained['article_type'])
+        self.assertEqual('en', obtained['article_lang'])

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -93,7 +93,12 @@ class FundingTest(TestCase):
         </article>
         """
         xml_tree = etree.fromstring(xml)
-        self.funding = funding_group.FundingGroup(xml_tree)
+        params = {
+            'special_chars_funding': ['.', ','],
+            'special_chars_award_id': ['/', '.', '-']
+        }
+        self.funding = funding_group.FundingGroup(xml_tree, params)
+        self.funding_no_params = funding_group.FundingGroup(xml_tree)
 
     def test_fn_financial_information(self):
         self.maxDiff = None
@@ -118,10 +123,7 @@ class FundingTest(TestCase):
             }
         ]
 
-        obtained = self.funding.fn_financial_information(
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        )
+        obtained = self.funding.fn_financial_information()
         self.assertEqual(expected, obtained)
 
     def test_award_groups(self):
@@ -269,10 +271,7 @@ class FundingTest(TestCase):
                 }
             ]
         }
-        obtained = self.funding.extract_funding_data(
-            funding_special_chars=['.', ','],
-            award_id_special_chars=['/', '.', '-']
-        )
+        obtained = self.funding.extract_funding_data()
         self.assertEqual(expected, obtained)
 
     def test_data(self):

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -76,9 +76,7 @@ class FundingTest(TestCase):
         </article>
         """
         xml_tree = etree.fromstring(xml)
-        params = {
-            'special_chars_award_id': ['/', '.', '-']
-        }
+        params = {"special_chars_award_id": ["/", ".", "-"]}
         self.funding = funding_group.FundingGroup(xml_tree, params)
         self.funding_no_params = funding_group.FundingGroup(xml_tree)
 
@@ -86,50 +84,50 @@ class FundingTest(TestCase):
         self.maxDiff = None
         expected = [
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': 'Conselho Nacional de Desenvolvimento Científico e Tecnológico'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "Conselho Nacional de Desenvolvimento Científico e Tecnológico",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': '[https://doi.org/10.13039/501100003593]'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "[https://doi.org/10.13039/501100003593]",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': ['303625/2019-8'],
-                'text': 'Grant No: 303625/2019-8'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": ["303625/2019-8"],
+                "text": "Grant No: 303625/2019-8",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': 'Fundação de Amparo à Pesquisa do Estado de São Paulo'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "Fundação de Amparo à Pesquisa do Estado de São Paulo",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': '[https://doi.org/10.13039/501100001807]'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "[https://doi.org/10.13039/501100001807]",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': ['2016/17640-0'],
-                'text': 'Grant No: 2016/17640-0'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": ["2016/17640-0"],
+                "text": "Grant No: 2016/17640-0",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': 'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': [],
-                'text': '[https://doi.org/10.13039/501100002322]'
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": [],
+                "text": "[https://doi.org/10.13039/501100002322]",
             },
             {
-                'fn-type': 'financial-disclosure',
-                'look-like-award-id': ['0001.'],
-                'text': 'Finance code 0001.'
-            }
+                "fn-type": "financial-disclosure",
+                "look-like-award-id": ["0001."],
+                "text": "Finance code 0001.",
+            },
         ]
         obtained = self.funding.financial_disclosure
         self.assertEqual(expected, obtained)
@@ -138,15 +136,15 @@ class FundingTest(TestCase):
         self.maxDiff = None
         expected = [
             {
-                'fn-type': 'supported-by',
-                'look-like-award-id': [],
-                'text': 'Conselho Nacional de Desenvolvimento Científico e Tecnológico'
+                "fn-type": "supported-by",
+                "look-like-award-id": [],
+                "text": "Conselho Nacional de Desenvolvimento Científico e Tecnológico",
             },
             {
-                'fn-type': 'supported-by',
-                'look-like-award-id': ['123.456-7'],
-                'text': 'Número 123.456-7'
-            }
+                "fn-type": "supported-by",
+                "look-like-award-id": ["123.456-7"],
+                "text": "Número 123.456-7",
+            },
         ]
         obtained = self.funding.supported_by
         self.assertEqual(expected, obtained)
@@ -155,12 +153,14 @@ class FundingTest(TestCase):
         expected = [
             {
                 "award-id": ["2019JJ40269"],
-                "funding-source": ["Natural Science Foundation of Hunan Province"]
+                "funding-source": ["Natural Science Foundation of Hunan Province"],
             },
             {
                 "award-id": ["2020CFB547"],
-                "funding-source": ["Hubei Provincial Natural Science Foundation of China"]
-            }
+                "funding-source": [
+                    "Hubei Provincial Natural Science Foundation of China"
+                ],
+            },
         ]
         obtained = self.funding.award_groups
         self.assertEqual(expected, obtained)
@@ -168,35 +168,28 @@ class FundingTest(TestCase):
     def test_funding_sources(self):
         expected = [
             "Natural Science Foundation of Hunan Province",
-            "Hubei Provincial Natural Science Foundation of China"
+            "Hubei Provincial Natural Science Foundation of China",
         ]
         obtained = self.funding.funding_sources
         self.assertEqual(expected, obtained)
 
     def test_funding_statement(self):
-        expected = "Natural Science Foundation of Hunan Province Grant No. 2019JJ40269 Hubei Provincial Natural Science " \
-                   "Foundation of China Grant No. 2020CFB547"
+        expected = (
+            "Natural Science Foundation of Hunan Province Grant No. 2019JJ40269 Hubei Provincial Natural Science "
+            "Foundation of China Grant No. 2020CFB547"
+        )
         obtained = self.funding.funding_statement
         self.assertEqual(expected, obtained)
 
     def test_principal_award_recipients(self):
-        expected = [
-            "Stanford",
-            "Berkeley"
-        ]
+        expected = ["Stanford", "Berkeley"]
         obtained = self.funding.principal_award_recipients
         self.assertEqual(expected, obtained)
 
     def test_principal_investigators(self):
         expected = [
-            {
-                "given-names": 'Sharon R.',
-                "surname": 'Kaufman'
-            },
-            {
-                "given-names": 'João',
-                "surname": 'Silva'
-            }
+            {"given-names": "Sharon R.", "surname": "Kaufman"},
+            {"given-names": "João", "surname": "Silva"},
         ]
         obtained = self.funding.principal_investigators
         self.assertEqual(expected, obtained)
@@ -205,63 +198,59 @@ class FundingTest(TestCase):
         self.maxDiff = None
         expected = [
             {
-                "title": 'Acknowledgments',
+                "title": "Acknowledgments",
                 "p": [
                     {
                         "look-like-award-id": [],
-                        "text": "Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and Anesthesiology, RJ, Brazil, provided important support for this research."
+                        "text": "Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and Anesthesiology, RJ, Brazil, provided important support for this research.",
                     },
                     {
                         "look-like-award-id": [],
-                        "text": "This study was funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment (CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil."
+                        "text": "This study was funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment (CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil.",
                     },
                     {
                         "look-like-award-id": ["10-14"],
-                        "text": "This study was presented as a poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 November 2018, Belém do Pará, Brazil."
-                    }
-                ]
+                        "text": "This study was presented as a poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 November 2018, Belém do Pará, Brazil.",
+                    },
+                ],
             }
         ]
         obtained = self.funding.ack
         self.assertEqual(expected, obtained)
 
     def test_looks_like_award_id_success(self):
-        self.assertTrue(funding_group._looks_like_award_id(
-            "123.456.789-0"
-        ))
+        self.assertTrue(funding_group._looks_like_award_id("123.456.789-0"))
 
     def test_looks_like_award_id_fail(self):
-        self.assertFalse(funding_group._looks_like_award_id(
-            "doi.org.//123.456.789-0"
-        ))
+        self.assertFalse(funding_group._looks_like_award_id("doi.org.//123.456.789-0"))
 
     def test_process_paragraph_node(self):
         """Test the internal _process_paragraph_node method"""
-        xml = '<p>Grant No: 303625/2019-8</p>'
+        xml = "<p>Grant No: 303625/2019-8</p>"
         node = etree.fromstring(xml)
-        
+
         result = self.funding._process_paragraph_node(node)
         expected = {
-            'look-like-award-id': ['303625/2019-8'],
-            'text': 'Grant No: 303625/2019-8'
+            "look-like-award-id": ["303625/2019-8"],
+            "text": "Grant No: 303625/2019-8",
         }
         self.assertEqual(expected, result)
 
     def test_extract_funding_data(self):
         self.maxDiff = None
         obtained = self.funding.data
-        
+
         # Verify the structure exists
-        self.assertIn('article_type', obtained)
-        self.assertIn('article_lang', obtained)
-        self.assertIn('financial_disclosure', obtained)
-        self.assertIn('supported_by', obtained)
-        self.assertIn('award_groups', obtained)
-        self.assertIn('funding_sources', obtained)
-        self.assertIn('funding_statement', obtained)
-        self.assertIn('principal_award_recipients', obtained)
-        self.assertIn('ack', obtained)
-        
+        self.assertIn("article_type", obtained)
+        self.assertIn("article_lang", obtained)
+        self.assertIn("financial_disclosure", obtained)
+        self.assertIn("supported_by", obtained)
+        self.assertIn("award_groups", obtained)
+        self.assertIn("funding_sources", obtained)
+        self.assertIn("funding_statement", obtained)
+        self.assertIn("principal_award_recipients", obtained)
+        self.assertIn("ack", obtained)
+
         # Verify some key values
-        self.assertEqual('research-article', obtained['article_type'])
-        self.assertEqual('en', obtained['article_lang'])
+        self.assertEqual("research-article", obtained["article_type"])
+        self.assertEqual("en", obtained["article_lang"])

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
-
 from lxml import etree
-
 from packtools.sps.models import funding_group
 
 
@@ -53,26 +51,13 @@ class FundingTest(TestCase):
         <fn fn-type="financial-disclosure">
         <label>Funding</label>
         <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-        <p>
-        [
-        <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.13039/501100003593">https://doi.org/10.13039/501100003593</ext-link>
-        ]
-        </p>
+        <p>[<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.13039/501100003593">https://doi.org/10.13039/501100003593</ext-link>]</p>
         <p>Grant No: 303625/2019-8</p>
         <p>Fundação de Amparo à Pesquisa do Estado de São Paulo</p>
-        <p>
-        [
-        <ext-link ext-link-type="uri" xlink:href="https://doi.org/10.13039/501100001807">https://doi.org/10.13039/501100001807</ext-link>
-        ]
-        </p>
+        <p>[<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.13039/501100001807">https://doi.org/10.13039/501100001807</ext-link>]</p>
         <p>Grant No: 2016/17640-0</p>
         <p>Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.</p>
-        <p>
-        [
-        <ext-link ext-link-type="uri" 
-        xlink:href="https://doi.org/10.13039/501100002322">https://doi.org/10.13039/501100002322</ext-link>
-        ]
-        </p>
+        <p>[<ext-link ext-link-type="uri" xlink:href="https://doi.org/10.13039/501100002322">https://doi.org/10.13039/501100002322</ext-link>]</p>
         <p>Finance code 0001.</p>
         </fn>
         <fn fn-type="other">
@@ -84,9 +69,7 @@ class FundingTest(TestCase):
         </fn>
         <fn fn-type="supported-by">
         <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-        <p>
-        Número 123.456-7
-        </p>
+        <p>Número 123.456-7</p>
         </fn>
         </fn-group>
         </back>
@@ -105,24 +88,60 @@ class FundingTest(TestCase):
         expected = [
             {
                 'fn-type': 'financial-disclosure',
-                'look-like-funding-source': [
-                    'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
-                    'Fundação de Amparo à Pesquisa do Estado de São Paulo',
-                    'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.'
-                ],
-                'look-like-award-id': [
-                    '303625/2019-8',
-                    '2016/17640-0',
-                    '0001.'
-                ]
+                'look-like-award-id': [],
+                'text': 'Conselho Nacional de Desenvolvimento Científico e Tecnológico'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': [],
+                'text': '[https://doi.org/10.13039/501100003593]'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': ['303625/2019-8'],
+                'text': 'Grant No: 303625/2019-8'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': [],
+                'text': 'Fundação de Amparo à Pesquisa do Estado de São Paulo'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': [],
+                'text': '[https://doi.org/10.13039/501100001807]'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': ['2016/17640-0'],
+                'text': 'Grant No: 2016/17640-0'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': [],
+                'text': 'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': [],
+                'text': '[https://doi.org/10.13039/501100002322]'
+            },
+            {
+                'fn-type': 'financial-disclosure',
+                'look-like-award-id': ['0001.'],
+                'text': 'Finance code 0001.'
             },
             {
                 'fn-type': 'supported-by',
-                'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'],
+                'look-like-award-id': [],
+                'text': 'Conselho Nacional de Desenvolvimento Científico e Tecnológico'
+            },
+            {
+                'fn-type': 'supported-by',
                 'look-like-award-id': ['123.456-7'],
+                'text': 'Número 123.456-7'
             }
         ]
-
         obtained = self.funding.fn_financial_information()
         self.assertEqual(expected, obtained)
 
@@ -181,16 +200,51 @@ class FundingTest(TestCase):
         expected = [
             {
                 "title": 'Acknowledgments',
-                "text": 'Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and '
-                        'Anesthesiology, RJ, Brazil, provided important support for this research. This study was '
-                        'funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment ('
-                        'CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil. This study was presented as a '
-                        'poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 '
-                        'November 2018, Belém do Pará, Brazil.'
+                "p": [
+                    {
+                        "look-like-award-id": [],
+                        "text": "Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and Anesthesiology, RJ, Brazil, provided important support for this research."
+                    },
+                    {
+                        "look-like-award-id": [],
+                        "text": "This study was funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment (CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil."
+                    },
+                    {
+                        "look-like-award-id": ["10-14"],
+                        "text": "This study was presented as a poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 November 2018, Belém do Pará, Brazil."
+                    }
+                ]
             }
         ]
         obtained = self.funding.ack
         self.assertEqual(expected, obtained)
+
+    def test_extract_funding_data(self):
+        self.maxDiff = None
+        obtained = self.funding.extract_funding_data()
+        
+        # Verify the structure exists
+        self.assertIn('article_type', obtained)
+        self.assertIn('article_lang', obtained)
+        self.assertIn('fn_financial_information', obtained)
+        self.assertIn('award_groups', obtained)
+        self.assertIn('funding_sources', obtained)
+        self.assertIn('funding_statement', obtained)
+        self.assertIn('principal_award_recipients', obtained)
+        self.assertIn('ack', obtained)
+        
+        # Verify some key values
+        self.assertEqual('research-article', obtained['article_type'])
+        self.assertEqual('en', obtained['article_lang'])
+        
+    def test_data(self):
+        self.maxDiff = None
+        expected = [
+            {"award-id": "2019JJ40269", "funding-source": ["Natural Science Foundation of Hunan Province"]},
+            {"award-id": "2020CFB547", "funding-source": ["Hubei Provincial Natural Science Foundation of China"]}
+        ]
+        obtained = self.funding.data
+        self.assertListEqual(expected, obtained)
 
     def test__looks_like_institution_name_success(self):
         self.assertTrue(funding_group._looks_like_institution_name(
@@ -214,71 +268,14 @@ class FundingTest(TestCase):
             "doi.org.//123.456.789-0"
         ))
 
-    def test_extract_funding_data(self):
-        self.maxDiff = None
+    def test_process_paragraph_node(self):
+        """Test the internal _process_paragraph_node method"""
+        xml = '<p>Grant No: 303625/2019-8</p>'
+        node = etree.fromstring(xml)
+        
+        result = self.funding._process_paragraph_node(node)
         expected = {
-            "article_type": "research-article",
-            "article_lang": "en",
-            "fn_financial_information": [
-                {
-                    'fn-type': 'financial-disclosure',
-                    'look-like-funding-source': [
-                        'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
-                        'Fundação de Amparo à Pesquisa do Estado de São Paulo',
-                        'Coordenação de Aperfeiçoamento de Pessoal de Nível Superior.'
-                    ],
-                    'look-like-award-id': [
-                        '303625/2019-8',
-                        '2016/17640-0',
-                        '0001.'
-                    ]
-                },
-                {
-                    'fn-type': 'supported-by',
-                    'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico'],
-                    'look-like-award-id': ['123.456-7'],
-                }
-            ],
-            "award_groups": [
-                {
-                    "award-id": ["2019JJ40269"],
-                    "funding-source": ["Natural Science Foundation of Hunan Province"]
-                },
-                {
-                    "award-id": ["2020CFB547"],
-                    "funding-source": ["Hubei Provincial Natural Science Foundation of China"]
-                }
-            ],
-            "funding_sources": [
-                "Natural Science Foundation of Hunan Province",
-                "Hubei Provincial Natural Science Foundation of China"
-            ],
-            "funding_statement": "Natural Science Foundation of Hunan Province Grant No. 2019JJ40269 Hubei Provincial "
-                                 "Natural Science Foundation of China Grant No. 2020CFB547",
-            "principal_award_recipients": [
-                "Stanford",
-                "Berkeley"
-            ],
-            "ack": [
-                {
-                    "title": 'Acknowledgments',
-                    "text": 'Federal University of Rio de Janeiro (UFRJ), School of Medicine, Department of Surgery and '
-                            'Anesthesiology, RJ, Brazil, provided important support for this research. This study was '
-                            'funded by the Hospital Municipal Conde Modesto Leal, Center of Diagnostic and Treatment ('
-                            'CDT), Municipal Secretariat of Health, Maricá, RJ, Brazil. This study was presented as a '
-                            'poster presentation at the Brazilian Congress of Anesthesiology CBA Annual Meeting 10-14 '
-                            'November 2018, Belém do Pará, Brazil.'
-                }
-            ]
+            'look-like-award-id': ['303625/2019-8'],
+            'text': 'Grant No: 303625/2019-8'
         }
-        obtained = self.funding.extract_funding_data()
-        self.assertEqual(expected, obtained)
-
-    def test_data(self):
-        self.maxDiff = None
-        expected = [
-            {"award-id": "2019JJ40269", "funding-source": ["Natural Science Foundation of Hunan Province"]},
-            {"award-id": "2020CFB547", "funding-source": ["Hubei Provincial Natural Science Foundation of China"]}
-        ]
-        obtained = self.funding.data
-        self.assertListEqual(expected, obtained)
+        self.assertEqual(expected, result)

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -1,172 +1,241 @@
 import unittest
+from lxml import etree
 
-from packtools.sps.utils.xml_utils import get_xml_tree
 from packtools.sps.validation.funding_group import FundingGroupValidation
 
 
-def callable_validation_success(award_id):
-    """Função auxiliar para simular validação bem-sucedida de award_id"""
-    return True
+class TestFundingValidationBase(unittest.TestCase):
+    """Classe base para testes de FundingGroupValidation"""
+    params = {
+        'special_chars_award_id': ['/', '.', '-'],
+        'callable_validation': lambda x: True,
+        'error_level': "ERROR"
+    }
 
 
-def callable_validation_fail(award_id):
-    """Função auxiliar para simular validação falha de award_id"""
-    return False
-
-
-class FundingGroupValidationTest(unittest.TestCase):
-    def test_funding_sources_exist_validation_empty_xml(self):
-        """Testa validação quando não há informações de funding no XML"""
-        xml_str = """
+class TestEmptyXML(TestFundingValidationBase):
+    """Testa casos com XML vazio ou sem informações de funding"""
+    def setUp(self):
+        xml = """
             <article article-type="research-article" xml:lang="pt">
                 <front><article-meta></article-meta></front>
+                <back></back>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).funding_sources_exist_validation())
-        self.assertEqual([], obtained)
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
 
-    def test_funding_sources_exist_validation_with_award_group(self):
-        """Testa validação com award-group contendo funding_source e award_id"""
-        xml_str = """
+    def test_no_award_ids(self):
+        results = list(self.validator.validate_required_award_ids())
+        self.assertEqual(len(results), 0)
+
+
+class TestProperAwardGroup(TestFundingValidationBase):
+    """Testa casos com award-id corretamente em award-group"""
+    def setUp(self):
+        xml = """
             <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
                             <award-group>
-                                <funding-source>Natural Science Foundation</funding-source>
-                                <award-id>2019JJ40269</award-id>
+                                <funding-source>CNPq</funding-source>
+                                <award-id>123.456-7</award-id>
                             </award-group>
                         </funding-group>
                     </article-meta>
                 </front>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        validator = FundingGroupValidation(xml_tree)
-        obtained = list(validator.funding_sources_exist_validation())
-        
-        self.assertEqual(len(obtained), 1)
-        result = obtained[0]
-        
-        # Verifica campos básicos
-        self.assertEqual(result['title'], 'Funding source element validation')
-        self.assertEqual(result['item'], 'award-group')
-        self.assertEqual(result['sub_item'], 'funding-source')
-        self.assertEqual(result['response'], 'OK')
-        
-        # Verifica a estrutura de dados
-        data = result['data']
-        self.assertEqual(data['article_type'], 'research-article')
-        self.assertEqual(data['article_lang'], 'pt')
-        self.assertEqual(len(data['award_groups']), 1)
-        self.assertEqual(data['award_groups'][0]['funding-source'], ['Natural Science Foundation'])
-        self.assertEqual(data['award_groups'][0]['award-id'], ['2019JJ40269'])
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
 
-    def test_funding_sources_exist_validation_with_financial_disclosure(self):
-        """Testa validação com fn-type='financial-disclosure'"""
-        xml_str = """
+    def test_proper_award_group(self):
+        results = list(self.validator.validate_required_award_ids())
+        self.assertEqual(len(results), 0)
+
+
+class TestAwardInAck(TestFundingValidationBase):
+    """Testa casos com award ID em acknowledgments"""
+    def setUp(self):
+        xml = """
+            <article article-type="research-article" xml:lang="pt">
+                <back>
+                    <ack>
+                        <title>Acknowledgments</title>
+                        <p>Project funded by grant 123.456-7</p>
+                    </ack>
+                </back>
+            </article>
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
+
+    def test_award_in_ack(self):
+        results = list(self.validator.validate_required_award_ids())
+        print(results)
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result['data']['context'], 'ack')
+        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+
+
+class TestAwardInFinancialDisclosure(TestFundingValidationBase):
+    """Testa casos com award ID em financial disclosure"""
+    def setUp(self):
+        xml = """
             <article article-type="research-article" xml:lang="pt">
                 <back>
                     <fn-group>
                         <fn fn-type="financial-disclosure">
-                            <p>Research Foundation</p>
-                            <p>Grant No: 123-456</p>
+                            <p>Grant: 123.456-7</p>
                         </fn>
                     </fn-group>
                 </back>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        params = {
-            'special_chars_award_id': ['-']
-        }
-        validator = FundingGroupValidation(xml_tree, params)
-        obtained = list(validator.funding_sources_exist_validation())
-        
-        self.assertEqual(len(obtained), 1)
-        result = obtained[0]
-        
-        # Verifica campos específicos de financial-disclosure
-        self.assertEqual(result['item'], 'fn')
-        self.assertEqual(result['sub_item'], "@fn-type='financial-disclosure'")
-        self.assertEqual('Research Foundation Grant No: 123-456', result['data']['financial_disclosure'][0]['text'])
-        self.assertEqual('123-456', result['data']['financial_disclosure'][0]['look-like-award-id'])
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
 
-    def test_award_id_format_validation_success(self):
-        """Testa validação bem-sucedida de formato de award_id"""
-        xml_str = """
+    def test_award_in_financial_disclosure(self):
+        results = list(self.validator.validate_required_award_ids())
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result['data']['context'], "fn[@fn-type='financial-disclosure']")
+        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+
+
+class TestAwardInSupportedBy(TestFundingValidationBase):
+    """Testa casos com award ID em supported-by"""
+    def setUp(self):
+        xml = """
+            <article article-type="research-article" xml:lang="pt">
+                <back>
+                    <fn-group>
+                        <fn fn-type="supported-by">
+                            <p>Support: 123.456-7</p>
+                        </fn>
+                    </fn-group>
+                </back>
+            </article>
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
+
+    def test_award_in_supported_by(self):
+        results = list(self.validator.validate_required_award_ids())
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result['data']['context'], "fn[@fn-type='supported-by']")
+        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+
+
+class TestAwardInFundingStatement(TestFundingValidationBase):
+    """Testa casos com award ID em funding-statement"""
+    def setUp(self):
+        xml = """
             <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
-                            <award-group>
-                                <funding-source>Foundation</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
+                            <funding-statement>Project 123.456-7</funding-statement>
                         </funding-group>
                     </article-meta>
                 </front>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        params = {
-            'callable_validation': callable_validation_success
-        }
-        validator = FundingGroupValidation(xml_tree, params)
-        obtained = list(validator.award_id_format_validation())
-        
-        self.assertEqual(len(obtained), 1)
-        result = obtained[0]
-        self.assertEqual(result['response'], 'OK')
-        self.assertEqual(result['got_value'], '2019JJ40269')
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
 
-    def test_award_id_format_validation_fail(self):
-        """Testa falha na validação de formato de award_id"""
-        xml_str = """
+    def test_award_in_funding_statement(self):
+        results = list(self.validator.validate_required_award_ids())
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result['data']['context'], "funding-group/funding-statement")
+        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+
+
+class TestAwardInAllLocations(TestFundingValidationBase):
+    """Testa casos com award IDs em todos os locais possíveis"""
+    def setUp(self):
+        xml = """
             <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
-                            <award-group>
-                                <funding-source>Foundation</funding-source>
-                                <award-id>invalid-format</award-id>
-                            </award-group>
+                            <funding-statement>Project 123.456-7</funding-statement>
                         </funding-group>
                     </article-meta>
                 </front>
+                <back>
+                    <ack>
+                        <p>Project 234.567-8</p>
+                    </ack>
+                    <fn-group>
+                        <fn fn-type="financial-disclosure">
+                            <p>Grant: 345.678-9</p>
+                        </fn>
+                        <fn fn-type="supported-by">
+                            <p>Support: 456.789-0</p>
+                        </fn>
+                    </fn-group>
+                </back>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        params = {
-            'callable_validation': callable_validation_fail,
-            'error_level': "ERROR"
-        }
-        validator = FundingGroupValidation(xml_tree, params)
-        obtained = list(validator.award_id_format_validation())
-        
-        self.assertEqual(len(obtained), 1)
-        result = obtained[0]
-        self.assertEqual(result['response'], 'ERROR')
-        self.assertEqual(result['got_value'], 'invalid-format')
-        self.assertEqual(result['expected_value'], 'a valid value for award id')
+        """
+        self.xml_tree = etree.fromstring(xml)
+        self.validator = FundingGroupValidation(self.xml_tree, self.params)
 
-    def test_award_id_format_validation_no_award_id(self):
-        """Testa validação quando não há award_id no XML"""
-        xml_str = """
+    def test_awards_in_all_locations(self):
+        results = list(self.validator.validate_required_award_ids())
+        
+        # Verifica número total de resultados
+        self.assertEqual(len(results), 4)
+        
+        # Verifica se encontrou award IDs em todos os contextos
+        contexts = {r['data']['context'] for r in results}
+        self.assertEqual(len(contexts), 4)
+        
+        # Verifica cada contexto específico
+        self.assertIn('funding-group/funding-statement', contexts)
+        self.assertIn('ack', contexts)
+        self.assertIn("fn[@fn-type='financial-disclosure']", contexts)
+        self.assertIn("fn[@fn-type='supported-by']", contexts)
+        
+        # Verifica os award IDs encontrados
+        award_ids = set()
+        for r in results:
+            award_ids.update(r['data']['look-like-award-id'])
+        
+        expected_ids = {'123.456-7', '234.567-8', '345.678-9', '456.789-0'}
+        self.assertEqual(award_ids, expected_ids)
+
+
+class TestErrorLevels(TestFundingValidationBase):
+    """Testa diferentes níveis de erro"""
+    def setUp(self):
+        self.xml = """
             <article article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Foundation</funding-source>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
+                <back>
+                    <ack><p>Project 123.456-7</p></ack>
+                </back>
             </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        validator = FundingGroupValidation(xml_tree)
-        obtained = list(validator.award_id_format_validation())
-        self.assertEqual([], obtained)
+        """
+        self.xml_tree = etree.fromstring(self.xml)
+
+    def test_warning_level(self):
+        params = dict(self.params)
+        params['error_level'] = 'WARNING'
+        validator = FundingGroupValidation(self.xml_tree, params)
+        results = list(validator.validate_required_award_ids())
+        self.assertEqual(results[0]['response'], 'WARNING')
+
+    def test_info_level(self):
+        params = dict(self.params)
+        params['error_level'] = 'INFO'
+        validator = FundingGroupValidation(self.xml_tree, params)
+        results = list(validator.validate_required_award_ids())
+        self.assertEqual(results[0]['response'], 'INFO')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -6,15 +6,17 @@ from packtools.sps.validation.funding_group import FundingGroupValidation
 
 class TestFundingValidationBase(unittest.TestCase):
     """Classe base para testes de FundingGroupValidation"""
+
     params = {
-        'special_chars_award_id': ['/', '.', '-'],
-        'callable_validation': lambda x: True,
-        'error_level': "ERROR"
+        "special_chars_award_id": ["/", ".", "-"],
+        "callable_validation": lambda x: True,
+        "error_level": "ERROR",
     }
 
 
 class TestEmptyXML(TestFundingValidationBase):
     """Testa casos com XML vazio ou sem informações de funding"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -32,6 +34,7 @@ class TestEmptyXML(TestFundingValidationBase):
 
 class TestProperAwardGroup(TestFundingValidationBase):
     """Testa casos com award-id corretamente em award-group"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -57,6 +60,7 @@ class TestProperAwardGroup(TestFundingValidationBase):
 
 class TestAwardInAck(TestFundingValidationBase):
     """Testa casos com award ID em acknowledgments"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -76,12 +80,13 @@ class TestAwardInAck(TestFundingValidationBase):
         print(results)
         self.assertEqual(len(results), 1)
         result = results[0]
-        self.assertEqual(result['data']['context'], 'ack')
-        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+        self.assertEqual(result["data"]["context"], "ack")
+        self.assertIn("123.456-7", str(result["data"]["look-like-award-id"]))
 
 
 class TestAwardInFinancialDisclosure(TestFundingValidationBase):
     """Testa casos com award ID em financial disclosure"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -101,12 +106,15 @@ class TestAwardInFinancialDisclosure(TestFundingValidationBase):
         results = list(self.validator.validate_required_award_ids())
         self.assertEqual(len(results), 1)
         result = results[0]
-        self.assertEqual(result['data']['context'], "fn[@fn-type='financial-disclosure']")
-        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+        self.assertEqual(
+            result["data"]["context"], "fn[@fn-type='financial-disclosure']"
+        )
+        self.assertIn("123.456-7", str(result["data"]["look-like-award-id"]))
 
 
 class TestAwardInSupportedBy(TestFundingValidationBase):
     """Testa casos com award ID em supported-by"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -126,12 +134,13 @@ class TestAwardInSupportedBy(TestFundingValidationBase):
         results = list(self.validator.validate_required_award_ids())
         self.assertEqual(len(results), 1)
         result = results[0]
-        self.assertEqual(result['data']['context'], "fn[@fn-type='supported-by']")
-        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+        self.assertEqual(result["data"]["context"], "fn[@fn-type='supported-by']")
+        self.assertIn("123.456-7", str(result["data"]["look-like-award-id"]))
 
 
 class TestAwardInFundingStatement(TestFundingValidationBase):
     """Testa casos com award ID em funding-statement"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -151,12 +160,13 @@ class TestAwardInFundingStatement(TestFundingValidationBase):
         results = list(self.validator.validate_required_award_ids())
         self.assertEqual(len(results), 1)
         result = results[0]
-        self.assertEqual(result['data']['context'], "funding-group/funding-statement")
-        self.assertIn('123.456-7', str(result['data']['look-like-award-id']))
+        self.assertEqual(result["data"]["context"], "funding-group/funding-statement")
+        self.assertIn("123.456-7", str(result["data"]["look-like-award-id"]))
 
 
 class TestAwardInAllLocations(TestFundingValidationBase):
     """Testa casos com award IDs em todos os locais possíveis"""
+
     def setUp(self):
         xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -187,31 +197,32 @@ class TestAwardInAllLocations(TestFundingValidationBase):
 
     def test_awards_in_all_locations(self):
         results = list(self.validator.validate_required_award_ids())
-        
+
         # Verifica número total de resultados
         self.assertEqual(len(results), 4)
-        
+
         # Verifica se encontrou award IDs em todos os contextos
-        contexts = {r['data']['context'] for r in results}
+        contexts = {r["data"]["context"] for r in results}
         self.assertEqual(len(contexts), 4)
-        
+
         # Verifica cada contexto específico
-        self.assertIn('funding-group/funding-statement', contexts)
-        self.assertIn('ack', contexts)
+        self.assertIn("funding-group/funding-statement", contexts)
+        self.assertIn("ack", contexts)
         self.assertIn("fn[@fn-type='financial-disclosure']", contexts)
         self.assertIn("fn[@fn-type='supported-by']", contexts)
-        
+
         # Verifica os award IDs encontrados
         award_ids = set()
         for r in results:
-            award_ids.update(r['data']['look-like-award-id'])
-        
-        expected_ids = {'123.456-7', '234.567-8', '345.678-9', '456.789-0'}
+            award_ids.update(r["data"]["look-like-award-id"])
+
+        expected_ids = {"123.456-7", "234.567-8", "345.678-9", "456.789-0"}
         self.assertEqual(award_ids, expected_ids)
 
 
 class TestErrorLevels(TestFundingValidationBase):
     """Testa diferentes níveis de erro"""
+
     def setUp(self):
         self.xml = """
             <article article-type="research-article" xml:lang="pt">
@@ -224,18 +235,18 @@ class TestErrorLevels(TestFundingValidationBase):
 
     def test_warning_level(self):
         params = dict(self.params)
-        params['error_level'] = 'WARNING'
+        params["error_level"] = "WARNING"
         validator = FundingGroupValidation(self.xml_tree, params)
         results = list(validator.validate_required_award_ids())
-        self.assertEqual(results[0]['response'], 'WARNING')
+        self.assertEqual(results[0]["response"], "WARNING")
 
     def test_info_level(self):
         params = dict(self.params)
-        params['error_level'] = 'INFO'
+        params["error_level"] = "INFO"
         validator = FundingGroupValidation(self.xml_tree, params)
         results = list(validator.validate_required_award_ids())
-        self.assertEqual(results[0]['response'], 'INFO')
+        self.assertEqual(results[0]["response"], "INFO")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_funding_group.py
+++ b/tests/sps/validation/test_funding_group.py
@@ -5,44 +5,36 @@ from packtools.sps.validation.funding_group import FundingGroupValidation
 
 
 def callable_validation_success(award_id):
+    """Função auxiliar para simular validação bem-sucedida de award_id"""
     return True
 
 
 def callable_validation_fail(award_id):
+    """Função auxiliar para simular validação falha de award_id"""
     return False
 
 
 class FundingGroupValidationTest(unittest.TestCase):
-    def test_funding_sources_validation_success_without_funding_information(self):
-        self.maxDiff = None
+    def test_funding_sources_exist_validation_empty_xml(self):
+        """Testa validação quando não há informações de funding no XML"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        
-                    </article-meta>
-                </front>
+            <article article-type="research-article" xml:lang="pt">
+                <front><article-meta></article-meta></front>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree, special_chars_funding=['.', ','],
-                                               special_chars_award_id=['/', '.',
-                                                                       '-']).funding_sources_exist_validation())
+        obtained = list(FundingGroupValidation(xml_tree).funding_sources_exist_validation())
+        self.assertEqual([], obtained)
 
-        self.assertListEqual([], obtained)
-
-    def test_funding_sources_validation_success_2_funding_1_award_in_funding_group(self):
-        self.maxDiff = None
+    def test_funding_sources_exist_validation_with_award_group(self):
+        """Testa validação com award-group contendo funding_source e award_id"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
                             <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <funding-source>Natural Science Foundation</funding-source>
                                 <award-id>2019JJ40269</award-id>
                             </award-group>
                         </funding-group>
@@ -51,906 +43,66 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'funding-source',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '2 values for funding source and 1 values for award id',
-                'got_value': '2 values for funding source and 1 values for award id',
-                'message': 'Got 2 values for funding source and 1 values for award id, expected at least 1 value for '
-                           'funding source and at least 1 value for award id',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': [
-                                'Natural Science Foundation of Hunan Province',
-                                'Hubei Provincial Natural Science Foundation of China'
-                            ]
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [
-                        'Natural Science Foundation of Hunan Province',
-                        'Hubei Provincial Natural Science Foundation of China'
-                    ],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        validator = FundingGroupValidation(xml_tree)
+        obtained = list(validator.funding_sources_exist_validation())
+        
+        self.assertEqual(len(obtained), 1)
+        result = obtained[0]
+        
+        # Verifica campos básicos
+        self.assertEqual(result['title'], 'Funding source element validation')
+        self.assertEqual(result['item'], 'award-group')
+        self.assertEqual(result['sub_item'], 'funding-source')
+        self.assertEqual(result['response'], 'OK')
+        
+        # Verifica a estrutura de dados
+        data = result['data']
+        self.assertEqual(data['article_type'], 'research-article')
+        self.assertEqual(data['article_lang'], 'pt')
+        self.assertEqual(len(data['award_groups']), 1)
+        self.assertEqual(data['award_groups'][0]['funding-source'], ['Natural Science Foundation'])
+        self.assertEqual(data['award_groups'][0]['award-id'], ['2019JJ40269'])
 
-    def test_funding_sources_validation_success_2_funding_1_award_in_fn_group_financial_disclosure(self):
-        self.maxDiff = None
+    def test_funding_sources_exist_validation_with_financial_disclosure(self):
+        """Testa validação com fn-type='financial-disclosure'"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <article article-type="research-article" xml:lang="pt">
                 <back>
                     <fn-group>
                         <fn fn-type="financial-disclosure">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                            <p>Grant No: 303625/2019-8</p>
-                            <p>Fundação de Amparo à Pesquisa do Estado de São Paulo</p>
-                            <p>Grant No: 2016/17640-0</p>
+                            <p>Research Foundation</p>
+                            <p>Grant No: 123-456</p>
                         </fn>
                     </fn-group>
                 </back>
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='financial-disclosure'",
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '2 values that look like funding source and 2 values that look like award id',
-                'got_value': '2 values that look like funding source and 2 values that look like award id',
-                'message': 'Got 2 values that look like funding source and 2 values that look like award id, '
-                           'expected at least 1 value for funding source and at least 1 value for award id',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'financial-disclosure',
-                            'look-like-award-id': [
-                                '303625/2019-8',
-                                '2016/17640-0'
-                            ],
-                            'look-like-funding-source': [
-                                'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
-                                'Fundação de Amparo à Pesquisa do Estado de São Paulo'
-                            ]
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_success_2_funding_1_award_in_fn_group_supported_by(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="supported-by">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                            <p>Grant No: 303625/2019-8</p>
-                            <p>Fundação de Amparo à Pesquisa do Estado de São Paulo</p>
-                            <p>Grant No: 2016/17640-0</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='supported-by'",
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '2 values that look like funding source and 2 values that look like award id',
-                'got_value': '2 values that look like funding source and 2 values that look like award id',
-                'message': 'Got 2 values that look like funding source and 2 values that look like award id, '
-                           'expected at least 1 value for funding source',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'supported-by',
-                            'look-like-award-id': [
-                                '303625/2019-8',
-                                '2016/17640-0'
-                            ],
-                            'look-like-funding-source': [
-                                'Conselho Nacional de Desenvolvimento Científico e Tecnológico',
-                                'Fundação de Amparo à Pesquisa do Estado de São Paulo'
-                            ]
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_success_1_funding_2_award_in_funding_group(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                                <award-id>2020CFB547</award-id>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'funding-source',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '1 values for funding source and 2 values for award id',
-                'got_value': '1 values for funding source and 2 values for award id',
-                'message': 'Got 1 values for funding source and 2 values for award id, expected at least 1 value for '
-                           'funding source and at least 1 value for award id',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269', '2020CFB547'],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': ['Natural Science Foundation of Hunan Province'],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_success_1_funding_2_award_in_fn_group_financial_disclosure(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="financial-disclosure">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                            <p>Grant No: 303625/2019-8</p>
-                            <p>Grant No: 2016/17640-0</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='financial-disclosure'",
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '1 values that look like funding source and 2 values that look like award id',
-                'got_value': '1 values that look like funding source and 2 values that look like award id',
-                'message': 'Got 1 values that look like funding source and 2 values that look like award id, '
-                           'expected at least 1 value for funding source and at least 1 value for award id',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'financial-disclosure',
-                            'look-like-award-id': ['303625/2019-8', '2016/17640-0'],
-                            'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico']
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []},
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_success_1_funding_2_award_in_fn_group_supported_by(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="supported-by">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                            <p>Grant No: 303625/2019-8</p>
-                            <p>Grant No: 2016/17640-0</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='supported-by'",
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '1 values that look like funding source and 2 values that look like award id',
-                'got_value': '1 values that look like funding source and 2 values that look like award id',
-                'message': 'Got 1 values that look like funding source and 2 values that look like award id, '
-                           'expected at least 1 value for funding source',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'supported-by',
-                            'look-like-award-id': ['303625/2019-8', '2016/17640-0'],
-                            'look-like-funding-source': [
-                                'Conselho Nacional de Desenvolvimento Científico e Tecnológico'
-                            ]
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_0_award_in_funding_group(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'funding-source',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '0 values for funding source and 0 values for award id',
-                'message': 'Got 0 values for funding source and 0 values for award id, expected at least 1 value for '
-                           'funding source and at least 1 value for award id',
-                'advice': 'Provide values for award id and funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': [],
-                            'funding-source': []
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []},
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_0_award_in_fn_group_financial_disclosure(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="financial-disclosure">
-
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='financial-disclosure'",
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '0 values that look like funding source and 0 values that look like award id',
-                'message': 'Got 0 values that look like funding source and 0 values that look like award id, '
-                           'expected at least 1 value for funding source and at least 1 value for award id',
-                'advice': 'Provide values for award id and funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'financial-disclosure',
-                            'look-like-award-id': [],
-                            'look-like-funding-source': []
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_0_award_in_fn_group_supported_by(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="supported-by">
-
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='supported-by'",
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source',
-                'got_value': '0 values that look like funding source and 0 values that look like award id',
-                'message': 'Got 0 values that look like funding source and 0 values that look like award id, '
-                           'expected at least 1 value for funding source',
-                'advice': 'Provide value for funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'supported-by',
-                            'look-like-award-id': [],
-                            'look-like-funding-source': []
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_1_funding_0_award_in_funding_group(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'funding-source',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '1 values for funding source and 0 values for award id',
-                'message': 'Got 1 values for funding source and 0 values for award id, expected at least 1 value for '
-                           'funding source and at least 1 value for award id',
-                'advice': 'Provide value for award id or move funding source to <fn fn-type="supported-by">',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': [],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': ['Natural Science Foundation of Hunan Province'],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_1_funding_0_award_in_fn_group_financial_disclosure(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="financial-disclosure">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='financial-disclosure'",
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '1 values that look like funding source and 0 values that look like award id',
-                'message': 'Got 1 values that look like funding source and 0 values that look like award id, '
-                           'expected at least 1 value for funding source and at least 1 value for award id',
-                'advice': 'Provide value for award id or move funding source to <fn fn-type="supported-by">',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'financial-disclosure',
-                            'look-like-award-id': [],
-                            'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico']
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_1_funding_0_award_in_fn_group_supported_by(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="supported-by">
-                            <p>Conselho Nacional de Desenvolvimento Científico e Tecnológico</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='supported-by'",
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '1 values that look like funding source and 0 values that look like award id',
-                'got_value': '1 values that look like funding source and 0 values that look like award id',
-                'message': 'Got 1 values that look like funding source and 0 values that look like award id, '
-                           'expected at least 1 value for funding source',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'supported-by',
-                            'look-like-award-id': [],
-                            'look-like-funding-source': ['Conselho Nacional de Desenvolvimento Científico e Tecnológico']
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_1_award_in_funding_group(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-                        <funding-group>
-                            <award-group>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                        </funding-group>
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'funding-source',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '0 values for funding source and 1 values for award id',
-                'message': 'Got 0 values for funding source and 1 values for award id, expected at least 1 value for '
-                           'funding source and at least 1 value for award id',
-                'advice': 'Provide value for funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': []
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []},
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_1_award_in_fn_group_financial_disclosure(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="financial-disclosure">
-                            <p>Grant No: 2016/17640-0</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='financial-disclosure'",
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source and at least 1 value for award id',
-                'got_value': '0 values that look like funding source and 1 values that look like award id',
-                'message': 'Got 0 values that look like funding source and 1 values that look like award id, '
-                           'expected at least 1 value for funding source and at least 1 value for award id',
-                'advice': 'Provide value for funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'financial-disclosure',
-                            'look-like-award-id': ['2016/17640-0'],
-                            'look-like-funding-source': []
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []},
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
-
-    def test_funding_sources_validation_fail_0_funding_1_award_in_fn_group_supported_by(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <back>
-                    <fn-group>
-                        <fn fn-type="supported-by">
-                            <p>Grant No: 2016/17640-0</p>
-                        </fn>
-                    </fn-group>
-                </back>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(
-            xml_tree,
-            special_chars_funding=['.', ','],
-            special_chars_award_id=['/', '.', '-']
-        ).funding_sources_exist_validation())
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'fn',
-                'sub_item': "@fn-type='supported-by'",
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'at least 1 value for funding source',
-                'got_value': '0 values that look like funding source and 1 values that look like award id',
-                'message': 'Got 0 values that look like funding source and 1 values that look like award id, '
-                           'expected at least 1 value for funding source',
-                'advice': 'Provide value for funding source',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [],
-                    'fn_financial_information': [
-                        {
-                            'fn-type': 'supported-by',
-                            'look-like-award-id': ['2016/17640-0'],
-                            'look-like-funding-source': []
-                        }
-                    ],
-                    'funding_sources': [],
-                    'funding_statement': None,
-                    'principal_award_recipients': []},
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        params = {
+            'special_chars_award_id': ['-']
+        }
+        validator = FundingGroupValidation(xml_tree, params)
+        obtained = list(validator.funding_sources_exist_validation())
+        
+        self.assertEqual(len(obtained), 1)
+        result = obtained[0]
+        
+        # Verifica campos específicos de financial-disclosure
+        self.assertEqual(result['item'], 'fn')
+        self.assertEqual(result['sub_item'], "@fn-type='financial-disclosure'")
+        self.assertEqual('Research Foundation Grant No: 123-456', result['data']['financial_disclosure'][0]['text'])
+        self.assertEqual('123-456', result['data']['financial_disclosure'][0]['look-like-award-id'])
 
     def test_award_id_format_validation_success(self):
-        self.maxDiff = None
+        """Testa validação bem-sucedida de formato de award_id"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
                             <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
+                                <funding-source>Foundation</funding-source>
                                 <award-id>2019JJ40269</award-id>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
                             </award-group>
                         </funding-group>
                     </article-meta>
@@ -958,102 +110,27 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_success))
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'award-id',
-                'validation_type': 'format',
-                'response': 'OK',
-                'expected_value': '2019JJ40269',
-                'got_value': '2019JJ40269',
-                'message': 'Got 2019JJ40269, expected 2019JJ40269',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        },
-                        {
-                            'award-id': ['2020CFB547'],
-                            'funding-source': ['Hubei Provincial Natural Science Foundation of China']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [
-                        'Natural Science Foundation of Hunan Province',
-                        'Hubei Provincial Natural Science Foundation of China'
-                    ],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            },
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'award-id',
-                'validation_type': 'format',
-                'response': 'OK',
-                'expected_value': '2020CFB547',
-                'got_value': '2020CFB547',
-                'message': 'Got 2020CFB547, expected 2020CFB547',
-                'advice': None,
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        },
-                        {
-                            'award-id': ['2020CFB547'],
-                            'funding-source': ['Hubei Provincial Natural Science Foundation of China']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [
-                        'Natural Science Foundation of Hunan Province',
-                        'Hubei Provincial Natural Science Foundation of China'
-                    ],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        params = {
+            'callable_validation': callable_validation_success
+        }
+        validator = FundingGroupValidation(xml_tree, params)
+        obtained = list(validator.award_id_format_validation())
+        
+        self.assertEqual(len(obtained), 1)
+        result = obtained[0]
+        self.assertEqual(result['response'], 'OK')
+        self.assertEqual(result['got_value'], '2019JJ40269')
 
     def test_award_id_format_validation_fail(self):
-        self.maxDiff = None
+        """Testa falha na validação de formato de award_id"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
                             <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                                <award-id>2019JJ40269</award-id>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
-                                <award-id>2020CFB547</award-id>
+                                <funding-source>Foundation</funding-source>
+                                <award-id>invalid-format</award-id>
                             </award-group>
                         </funding-group>
                     </article-meta>
@@ -1061,116 +138,28 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail))
-        expected = [
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'award-id',
-                'validation_type': 'format',
-                'response': 'ERROR',
-                'expected_value': 'a valid value for award id',
-                'got_value': '2019JJ40269',
-                'message': 'Got 2019JJ40269, expected a valid value for award id',
-                'advice': 'Provide a valid value for award id',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        },
-                        {
-                            'award-id': ['2020CFB547'],
-                            'funding-source': ['Hubei Provincial Natural Science Foundation of China']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [
-                        'Natural Science Foundation of Hunan Province',
-                        'Hubei Provincial Natural Science Foundation of China'
-                    ],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            },
-            {
-                'title': 'Funding source element validation',
-                'parent': 'article',
-                'parent_article_type': "research-article",
-                'parent_id': None,
-                'parent_lang': "pt",
-                'item': 'award-group',
-                'sub_item': 'award-id',
-                'validation_type': 'format',
-                'response': 'ERROR',
-                'expected_value': 'a valid value for award id',
-                'got_value': '2020CFB547',
-                'message': 'Got 2020CFB547, expected a valid value for award id',
-                'advice': 'Provide a valid value for award id',
-                'data': {
-                    'ack': [],
-                    'article_lang': "pt",
-                    'article_type': "research-article",
-                    'award_groups': [
-                        {
-                            'award-id': ['2019JJ40269'],
-                            'funding-source': ['Natural Science Foundation of Hunan Province']
-                        },
-                        {
-                            'award-id': ['2020CFB547'],
-                            'funding-source': ['Hubei Provincial Natural Science Foundation of China']
-                        }
-                    ],
-                    'fn_financial_information': [],
-                    'funding_sources': [
-                        'Natural Science Foundation of Hunan Province',
-                        'Hubei Provincial Natural Science Foundation of China'
-                    ],
-                    'funding_statement': None,
-                    'principal_award_recipients': []
-                },
-            }
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        params = {
+            'callable_validation': callable_validation_fail,
+            'error_level': "ERROR"
+        }
+        validator = FundingGroupValidation(xml_tree, params)
+        obtained = list(validator.award_id_format_validation())
+        
+        self.assertEqual(len(obtained), 1)
+        result = obtained[0]
+        self.assertEqual(result['response'], 'ERROR')
+        self.assertEqual(result['got_value'], 'invalid-format')
+        self.assertEqual(result['expected_value'], 'a valid value for award id')
 
-    def test_award_id_format_validation_fail_without_funding_group(self):
-        self.maxDiff = None
+    def test_award_id_format_validation_no_award_id(self):
+        """Testa validação quando não há award_id no XML"""
         xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
-                <front>
-                    <article-meta>
-
-                    </article-meta>
-                </front>
-            </article>
-            """
-        xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail))
-        self.assertEqual([], obtained)
-
-    def test_award_id_format_validation_fail_without_award_id(self):
-        self.maxDiff = None
-        xml_str = """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-            dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <article article-type="research-article" xml:lang="pt">
                 <front>
                     <article-meta>
                         <funding-group>
                             <award-group>
-                                <funding-source>Natural Science Foundation of Hunan Province</funding-source>
-                            </award-group>
-                            <award-group>
-                                <funding-source>Hubei Provincial Natural Science Foundation of China</funding-source>
+                                <funding-source>Foundation</funding-source>
                             </award-group>
                         </funding-group>
                     </article-meta>
@@ -1178,8 +167,6 @@ class FundingGroupValidationTest(unittest.TestCase):
             </article>
             """
         xml_tree = get_xml_tree(xml_str)
-        obtained = list(FundingGroupValidation(xml_tree).award_id_format_validation(callable_validation_fail))
+        validator = FundingGroupValidation(xml_tree)
+        obtained = list(validator.award_id_format_validation())
         self.assertEqual([], obtained)
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a validação de dados de financiamento: É obrigatório haver award-id se há "números" em ack, funding-statement, fn. É comum que os produtores de XML, não identifiquem apropriadamente award-id, por haver uma variedade de elementos para identificar financiamento. No entanto, os dados mais relevantes é o de número de contrato que prova que a pesquisa teve um financiamento. 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python -m unittest -v  tests/sps/models/test_funding_group.py
```

```console
python -m unittest -v  tests/sps/validation/test_funding_group.py
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
