### PR TITLE
Reescreve as validações de related-article

### DIFF
--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -32,85 +32,12 @@ class RelatedArticlesValidation:
                 'error_level': 'ERROR'  # Default error level for validations
             }
         """
-        self.related_articles = [
-            related for related in RelatedItems(xmltree).related_articles
-        ]
-        self.article_type = ArticleAndSubArticles(xmltree).main_article_type
+        self.validator = FulltextValidation(Fulltext(xmltree.find(".")), params)
         self.params = params or {}
         self.error_level = self.params.get("error_level", "ERROR")
 
-    def validate_related_article_types(self):
-        """
-        Validate if article type matches related article types from correspondence list.
-
-        Returns
-        -------
-        generator
-            Yields validation results for each related article
-        """
-        correspondence_list = self.params.get("correspondence_list")
-        if not correspondence_list:
-            raise ValidationRelatedArticleException(
-                "Validation requires 'correspondence_list' parameter with article type and related article types"
-            )
-
-        expected_values = None
-        for item in correspondence_list:
-            if isinstance(item, dict) and item.get("article-type") == self.article_type:
-                expected_values = item["related-article-types"]
-                break
-
-        if expected_values:
-            for related_article in self.related_articles:
-                obtained_type = related_article.get("related-article-type")
-                is_valid = obtained_type in expected_values
-
-                yield build_response(
-                    title="Related article type",
-                    parent=related_article,
-                    item="related-article",
-                    sub_item="related-article-type",
-                    validation_type="match",
-                    is_valid=is_valid,
-                    expected=expected_values,
-                    obtained=obtained_type,
-                    advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-                    f"{obtained_type}, provide one of the following items: {expected_values}",
-                    data=related_article,
-                    error_level=self.error_level,
-                )
-
-    def validate_related_article_doi(self):
-        """
-        Validate if related articles have DOIs.
-
-        Returns
-        -------
-        generator
-            Yields validation results for each related article's DOI
-        """
-        for related_article in self.related_articles:
-            doi = related_article.get("href")
-            is_valid = doi is not None
-            expected = (
-                doi if doi else "A valid DOI or URI for related-article/@xlink:href"
-            )
-
-            yield build_response(
-                title="Related article doi",
-                parent=related_article,
-                item="related-article",
-                sub_item="xlink:href",
-                validation_type="exist",
-                is_valid=is_valid,
-                expected=expected,
-                obtained=doi,
-                advice=f'Provide a valid DOI for <related-article ext-link-type="doi" '
-                f'id="{related_article.get("id")}" related-article-type='
-                f'"{related_article.get("related-article-type")}" />',
-                data=related_article,
-                error_level=self.error_level,
-            )
+    def validate(self):
+        yield from self.validator.validate()
 
 
 class RelatedArticleValidation:

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -1,6 +1,4 @@
-from packtools.sps.models.related_articles import RelatedItems, Fulltext
-from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
-from packtools.sps.validation.exceptions import ValidationRelatedArticleException
+from packtools.sps.models.related_articles import Fulltext
 from packtools.sps.validation.utils import (
     build_response,
     is_valid_url_format,
@@ -10,28 +8,6 @@ from packtools.sps.validation.utils import (
 
 class RelatedArticlesValidation:
     def __init__(self, xmltree, params=None):
-        """Initialize with xmltree and validation parameters
-
-        Parameters
-        ----------
-        xmltree : etree
-            XML tree to be validated
-        params : dict, optional
-            Dictionary containing validation parameters:
-            {
-                'correspondence_list': [
-                    {
-                        'article-type': 'correction',
-                        'related-article-types': ['corrected-article']
-                    },
-                    {
-                        'article-type': 'retraction',
-                        'related-article-types': ['retracted-article']
-                    }
-                ],
-                'error_level': 'ERROR'  # Default error level for validations
-            }
-        """
         self.validator = FulltextValidation(Fulltext(xmltree.find(".")), params)
         self.params = params or {}
         self.error_level = self.params.get("error_level", "ERROR")

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -1,138 +1,107 @@
-from packtools.sps.models import (
-    related_articles,
-    article_and_subarticles
-)
-
+from packtools.sps.models.related_articles import RelatedItems
+from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.validation.exceptions import ValidationRelatedArticleException
-from packtools.sps.validation.utils import format_response
+from packtools.sps.validation.utils import build_response
 
 
 class RelatedArticlesValidation:
-    def __init__(self, xmltree):
-        self.related_articles = [related for related in related_articles.RelatedItems(xmltree).related_articles]
-        self.article_type = article_and_subarticles.ArticleAndSubArticles(xmltree).main_article_type
+    def __init__(self, xmltree, params=None):
+        """Initialize with xmltree and validation parameters
 
-    def related_articles_matches_article_type_validation(self, correspondence_list=None, error_level="ERROR"):
+        Parameters
+        ----------
+        xmltree : etree
+            XML tree to be validated
+        params : dict, optional
+            Dictionary containing validation parameters:
+            {
+                'correspondence_list': [
+                    {
+                        'article-type': 'correction',
+                        'related-article-types': ['corrected-article']
+                    },
+                    {
+                        'article-type': 'retraction',
+                        'related-article-types': ['retracted-article']
+                    }
+                ],
+                'error_level': 'ERROR'  # Default error level for validations
+            }
         """
-        Check whether the article type attribute of the article matches the options provided in a standard list.
+        self.related_articles = [
+            related for related in RelatedItems(xmltree).related_articles
+        ]
+        self.article_type = ArticleAndSubArticles(xmltree).main_article_type
+        self.params = params or {}
+        self.error_level = self.params.get('error_level', 'ERROR')
 
-        XML input
-        ---------
-        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-        article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-        <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
-        </article>
-
-        Params
-        ------
-        correspondence_list : list of dict, such as:
-            [
-                {
-                    'article-type': 'correction',
-                    'related-article-types': ['corrected-article']
-                },
-                {
-                    'article-type': 'retraction',
-                    'related-article-types': ['retracted-article']
-                }, ...
-            ]
+    def validate_related_article_types(self):
+        """
+        Validate if article type matches related article types from correspondence list.
 
         Returns
         -------
-        list of dict
-            A list of dictionaries, such as:
-            [
-                {
-                    'title': 'Related article type validation',
-                    'xpath': './article[@article-type] .//related-article[@related-article-type]',
-                    'validation_type': 'match',
-                    'response': 'OK',
-                    'expected_value': ['corrected-article'],
-                    'got_value': 'corrected-article',
-                    'message': 'Got corrected-article, expected one of the following items: ['corrected-article'],
-                    'advice': None
-                }, ...
-            ]
+        generator
+            Yields validation results for each related article
         """
+        correspondence_list = self.params.get('correspondence_list')
         if not correspondence_list:
-            raise ValidationRelatedArticleException("Function requires a list of dictionary with article type and related article types")
+            raise ValidationRelatedArticleException(
+                "Validation requires 'correspondence_list' parameter with article type and related article types"
+            )
 
-        expected_values_for_related_article_type = None
+        expected_values = None
         for item in correspondence_list:
             if isinstance(item, dict) and item.get('article-type') == self.article_type:
-                expected_values_for_related_article_type = item['related-article-types']
+                expected_values = item['related-article-types']
                 break
 
-        if expected_values_for_related_article_type:
+        if expected_values:
             for related_article in self.related_articles:
-                obtained_related_article = related_article.get('related-article-type')
-                is_valid = obtained_related_article in expected_values_for_related_article_type
-                yield format_response(
+                obtained_type = related_article.get('related-article-type')
+                is_valid = obtained_type in expected_values
+
+                yield build_response(
                     title='Related article type validation',
-                    parent=related_article.get("parent"),
-                    parent_id=related_article.get("parent_id"),
-                    parent_article_type=related_article.get("parent_article_type"),
-                    parent_lang=related_article.get("parent_lang"),
+                    parent=related_article,
                     item='related-article',
                     sub_item='related-article-type',
                     validation_type='match',
                     is_valid=is_valid,
-                    expected=expected_values_for_related_article_type,
-                    obtained=obtained_related_article,
+                    expected=expected_values,
+                    obtained=obtained_type,
                     advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-                           f"{obtained_related_article}, provide one of the following items: "
-                           f"{expected_values_for_related_article_type}",
+                          f"{obtained_type}, provide one of the following items: {expected_values}",
                     data=related_article,
-                    error_level=error_level
+                    error_level=self.error_level
                 )
 
-    def related_articles_doi(self, error_level="ERROR"):
+    def validate_related_article_doi(self):
         """
-        Checks if there is a DOI for related articles.
-
-        XML input
-        ---------
-        <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink"
-        article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-        <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
-        </article>
+        Validate if related articles have DOIs.
 
         Returns
         -------
-        list of dict
-            A list of dictionaries, such as:
-            [
-                {
-                    'title': 'Related article doi validation',
-                    'xpath': './/related-article/@xLink:href',
-                    'validation_type': 'exist',
-                    'response': 'OK',
-                    'expected_value': '10.1590/1808-057x202090350',
-                    'got_value': '10.1590/1808-057x202090350',
-                    'message': 'Got 10.1590/1808-057x202090350, expected 10.1590/1808-057x202090350',
-                    'advice': None
-                },...
-            ]
+        generator
+            Yields validation results for each related article's DOI
         """
-
         for related_article in self.related_articles:
             doi = related_article.get('href')
             is_valid = doi is not None
-            expected_value = doi if doi else 'A valid DOI or URI for related-article/@xlink:href'
-            yield format_response(
+            expected = doi if doi else 'A valid DOI or URI for related-article/@xlink:href'
+
+            yield build_response(
                 title='Related article doi validation',
-                parent=related_article.get("parent"),
-                parent_id=related_article.get("parent_id"),
-                parent_article_type=related_article.get("parent_article_type"),
-                parent_lang=related_article.get("parent_lang"),
+                parent=related_article,
                 item='related-article',
                 sub_item='xlink:href',
                 validation_type='exist',
                 is_valid=is_valid,
-                expected=expected_value,
+                expected=expected,
                 obtained=doi,
-                advice=f'Provide a valid DOI for <related-article ext-link-type="doi" id="{related_article.get("id")}" '
-                       f'related-article-type="{related_article.get("related-article-type")}" /> ',
+                advice=f'Provide a valid DOI for <related-article ext-link-type="doi" '
+                      f'id="{related_article.get("id")}" related-article-type='
+                      f'"{related_article.get("related-article-type")}" />',
                 data=related_article,
-                error_level=error_level
+                error_level=self.error_level
             )

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -1,7 +1,11 @@
 from packtools.sps.models.related_articles import RelatedItems
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.validation.exceptions import ValidationRelatedArticleException
-from packtools.sps.validation.utils import build_response, is_valid_url_format, validate_doi_format
+from packtools.sps.validation.utils import (
+    build_response,
+    is_valid_url_format,
+    validate_doi_format,
+)
 
 
 class RelatedArticlesValidation:
@@ -33,7 +37,7 @@ class RelatedArticlesValidation:
         ]
         self.article_type = ArticleAndSubArticles(xmltree).main_article_type
         self.params = params or {}
-        self.error_level = self.params.get('error_level', 'ERROR')
+        self.error_level = self.params.get("error_level", "ERROR")
 
     def validate_related_article_types(self):
         """
@@ -44,7 +48,7 @@ class RelatedArticlesValidation:
         generator
             Yields validation results for each related article
         """
-        correspondence_list = self.params.get('correspondence_list')
+        correspondence_list = self.params.get("correspondence_list")
         if not correspondence_list:
             raise ValidationRelatedArticleException(
                 "Validation requires 'correspondence_list' parameter with article type and related article types"
@@ -52,28 +56,28 @@ class RelatedArticlesValidation:
 
         expected_values = None
         for item in correspondence_list:
-            if isinstance(item, dict) and item.get('article-type') == self.article_type:
-                expected_values = item['related-article-types']
+            if isinstance(item, dict) and item.get("article-type") == self.article_type:
+                expected_values = item["related-article-types"]
                 break
 
         if expected_values:
             for related_article in self.related_articles:
-                obtained_type = related_article.get('related-article-type')
+                obtained_type = related_article.get("related-article-type")
                 is_valid = obtained_type in expected_values
 
                 yield build_response(
-                    title='Related article type validation',
+                    title="Related article type validation",
                     parent=related_article,
-                    item='related-article',
-                    sub_item='related-article-type',
-                    validation_type='match',
+                    item="related-article",
+                    sub_item="related-article-type",
+                    validation_type="match",
                     is_valid=is_valid,
                     expected=expected_values,
                     obtained=obtained_type,
                     advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-                          f"{obtained_type}, provide one of the following items: {expected_values}",
+                    f"{obtained_type}, provide one of the following items: {expected_values}",
                     data=related_article,
-                    error_level=self.error_level
+                    error_level=self.error_level,
                 )
 
     def validate_related_article_doi(self):
@@ -86,24 +90,26 @@ class RelatedArticlesValidation:
             Yields validation results for each related article's DOI
         """
         for related_article in self.related_articles:
-            doi = related_article.get('href')
+            doi = related_article.get("href")
             is_valid = doi is not None
-            expected = doi if doi else 'A valid DOI or URI for related-article/@xlink:href'
+            expected = (
+                doi if doi else "A valid DOI or URI for related-article/@xlink:href"
+            )
 
             yield build_response(
-                title='Related article doi validation',
+                title="Related article doi validation",
                 parent=related_article,
-                item='related-article',
-                sub_item='xlink:href',
-                validation_type='exist',
+                item="related-article",
+                sub_item="xlink:href",
+                validation_type="exist",
                 is_valid=is_valid,
                 expected=expected,
                 obtained=doi,
                 advice=f'Provide a valid DOI for <related-article ext-link-type="doi" '
-                      f'id="{related_article.get("id")}" related-article-type='
-                      f'"{related_article.get("related-article-type")}" />',
+                f'id="{related_article.get("id")}" related-article-type='
+                f'"{related_article.get("related-article-type")}" />',
                 data=related_article,
-                error_level=self.error_level
+                error_level=self.error_level,
             )
 
 
@@ -133,191 +139,207 @@ class RelatedArticleValidation:
             }
         """
         self.related_article = related_article
-        self.article_type = related_article.get("original_article_type") or related_article.get('parent_article_type')
+        self.article_type = related_article.get(
+            "original_article_type"
+        ) or related_article.get("parent_article_type")
         self.related_article_type = related_article.get("related-article-type")
 
         self.params = params or {}
-        self.valid_ext_link_types = self.params.get('ext_link_types', ['doi', "uri"])
-        _related = (
-            self.params.get('article-types-and-related-article-types', {}).get(self.article_type, {})
+        self.valid_ext_link_types = self.params.get("ext_link_types", ["doi", "uri"])
+        _related = self.params.get("article-types-and-related-article-types", {}).get(
+            self.article_type, {}
         )
-        self.required_related_article_types = _related.get("required_related_article_types") or []
-        self.acceptable_related_article_types = _related.get("acceptable_related_article_types") or []
+        self.required_related_article_types = (
+            _related.get("required_related_article_types") or []
+        )
+        self.acceptable_related_article_types = (
+            _related.get("acceptable_related_article_types") or []
+        )
 
     def _get_error_level(self, validation_type):
         """
         Get error level for specific validation type from params
-        
+
         Parameters
         ----------
         validation_type : str
             Type of validation being performed
-            
+
         Returns
         -------
         str
             Error level for the validation type
         """
-        error_level_key = f'{validation_type}_error_level'
-        return self.params.get(error_level_key, 'CRITICAL')
+        error_level_key = f"{validation_type}_error_level"
+        return self.params.get(error_level_key, "CRITICAL")
 
     def validate_type(self):
         """Validate if related article type matches main article type"""
-        expected_values = self.required_related_article_types + self.acceptable_related_article_types
+        expected_values = (
+            self.required_related_article_types + self.acceptable_related_article_types
+        )
 
-        obtained_type = self.related_article.get('related-article-type')
+        obtained_type = self.related_article.get("related-article-type")
 
         if not expected_values:
             return build_response(
-                title='Related article type validation',
+                title="Related article type validation",
                 parent=self.related_article,
-                item='related-article',
-                sub_item='related-article-type',
-                validation_type='match',
+                item="related-article",
+                sub_item="related-article-type",
+                validation_type="match",
                 is_valid=False,
                 expected=expected_values,
                 obtained=obtained_type,
                 advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-                      f"{obtained_type}, provide one of the following items: {expected_values}",
+                f"{obtained_type}, provide one of the following items: {expected_values}",
                 data=self.related_article,
-                error_level=self._get_error_level('type')
+                error_level=self._get_error_level("type"),
             )
 
         is_valid = obtained_type in expected_values
 
         return build_response(
-            title='Related article type validation',
+            title="Related article type validation",
             parent=self.related_article,
-            item='related-article',
-            sub_item='related-article-type',
-            validation_type='match',
+            item="related-article",
+            sub_item="related-article-type",
+            validation_type="match",
             is_valid=is_valid,
             expected=expected_values,
             obtained=obtained_type,
             advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-                  f"{obtained_type}, provide one of the following items: {expected_values}",
+            f"{obtained_type}, provide one of the following items: {expected_values}",
             data=self.related_article,
-            error_level=self._get_error_level('type')
+            error_level=self._get_error_level("type"),
         )
 
     def validate_ext_link_type(self):
         """Validate if related article has valid ext-link-type"""
-        ext_link_type = self.related_article.get('ext-link-type')
+        ext_link_type = self.related_article.get("ext-link-type")
         is_valid = ext_link_type in self.valid_ext_link_types
 
         return build_response(
-            title='Related article ext-link-type validation',
+            title="Related article ext-link-type validation",
             parent=self.related_article,
-            item='related-article',
-            sub_item='ext-link-type',
-            validation_type='match',
+            item="related-article",
+            sub_item="ext-link-type",
+            validation_type="match",
             is_valid=is_valid,
             expected=self.valid_ext_link_types,
             obtained=ext_link_type,
             advice=f'The ext-link-type should be one of {self.valid_ext_link_types} for related article with id="{self.related_article.get("id")}"',
             data=self.related_article,
-            error_level=self._get_error_level('ext_link_type')
+            error_level=self._get_error_level("ext_link_type"),
         )
 
     def validate_uri(self):
         """Validate if related article has valid link (URI)"""
-        ext_link_type = self.related_article.get('ext-link-type')
+        ext_link_type = self.related_article.get("ext-link-type")
         if not ext_link_type == "uri":
             return
 
-        link = self.related_article.get('href')
+        link = self.related_article.get("href")
         if not link:
             return build_response(
-                title='Related article link validation',
+                title="Related article link validation",
                 parent=self.related_article,
-                item='related-article',
-                sub_item='xlink:href',
-                validation_type='exist',
+                item="related-article",
+                sub_item="xlink:href",
+                validation_type="exist",
                 is_valid=False,
                 expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
                 obtained=link,
                 advice=f'Provide a valid {ext_link_type.upper() if ext_link_type else "link"} for <related-article '
-                      f'id="{self.related_article.get("id")}" />',
+                f'id="{self.related_article.get("id")}" />',
                 data=self.related_article,
-                error_level=self._get_error_level('uri')
+                error_level=self._get_error_level("uri"),
             )
 
         is_valid = is_valid_url_format(link)
-        expected = 'A valid URI format (e.g., http://example.com)'
-        
+        expected = "A valid URI format (e.g., http://example.com)"
+
         return build_response(
-            title='Related article link validation',
+            title="Related article link validation",
             parent=self.related_article,
-            item='related-article',
-            sub_item='xlink:href',
-            validation_type='format',
+            item="related-article",
+            sub_item="xlink:href",
+            validation_type="format",
             is_valid=is_valid,
             expected=expected,
             obtained=link,
-            advice=None if is_valid else f'Invalid {ext_link_type.upper()} format for link: {link}',
+            advice=(
+                None
+                if is_valid
+                else f"Invalid {ext_link_type.upper()} format for link: {link}"
+            ),
             data=self.related_article,
-            error_level=self._get_error_level('uri_format')
+            error_level=self._get_error_level("uri_format"),
         )
 
     def validate_doi(self):
         """Validate if related article has valid DOI"""
-        ext_link_type = self.related_article.get('ext-link-type')
+        ext_link_type = self.related_article.get("ext-link-type")
         if not ext_link_type == "doi":
             return
 
-        link = self.related_article.get('href')
+        link = self.related_article.get("href")
         if not link:
             return build_response(
-                title='Related article doi validation',
+                title="Related article doi validation",
                 parent=self.related_article,
-                item='related-article',
-                sub_item='xlink:href',
-                validation_type='exist',
+                item="related-article",
+                sub_item="xlink:href",
+                validation_type="exist",
                 is_valid=False,
                 expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
                 obtained=link,
                 advice=f'Provide a valid {ext_link_type.upper() if ext_link_type else "link"} for <related-article '
-                      f'id="{self.related_article.get("id")}" />',
+                f'id="{self.related_article.get("id")}" />',
                 data=self.related_article,
-                error_level=self.params.get("doi_error_level")
+                error_level=self.params.get("doi_error_level"),
             )
 
         valid = validate_doi_format(link)
         is_valid = valid and valid.get("valido")
-        expected = 'A valid DOI'
+        expected = "A valid DOI"
 
         return build_response(
-            title='Related article doi validation',
+            title="Related article doi validation",
             parent=self.related_article,
-            item='related-article',
-            sub_item='xlink:href',
-            validation_type='format',
+            item="related-article",
+            sub_item="xlink:href",
+            validation_type="format",
             is_valid=is_valid,
             expected=expected,
             obtained=link,
-            advice=None if is_valid else f'Invalid {ext_link_type.upper()} format for link: {link}',
+            advice=(
+                None
+                if is_valid
+                else f"Invalid {ext_link_type.upper()} format for link: {link}"
+            ),
             data=self.related_article,
-            error_level=self.params.get("doi_format_error_level")
+            error_level=self.params.get("doi_format_error_level"),
         )
 
     def validate_id_presence(self):
         """Validate if related article has an ID"""
-        related_id = self.related_article.get('id')
-        is_valid = related_id is not None and related_id.strip() != ''
-        expected = 'A non-empty ID'
+        related_id = self.related_article.get("id")
+        is_valid = related_id is not None and related_id.strip() != ""
+        expected = "A non-empty ID"
 
         return build_response(
-            title='Related article id validation',
+            title="Related article id validation",
             parent=self.related_article,
-            item='related-article',
-            sub_item='id',
-            validation_type='exist',
+            item="related-article",
+            sub_item="id",
+            validation_type="exist",
             is_valid=is_valid,
             expected=expected,
             obtained=related_id,
-            advice='Each related-article element must have a unique id attribute',
+            advice="Each related-article element must have a unique id attribute",
             data=self.related_article,
-            error_level=self._get_error_level('id')
+            error_level=self._get_error_level("id"),
         )
 
     def validate(self):
@@ -326,6 +348,6 @@ class RelatedArticleValidation:
             self.validate_type(),
             self.validate_ext_link_type(),
             self.validate_doi() or self.validate_uri(),
-            self.validate_id_presence()
+            self.validate_id_presence(),
         ]
         return [v for v in validations if v is not None]

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -1,7 +1,7 @@
 from packtools.sps.models.related_articles import RelatedItems
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.validation.exceptions import ValidationRelatedArticleException
-from packtools.sps.validation.utils import build_response
+from packtools.sps.validation.utils import build_response, is_valid_url_format, validate_doi_format
 
 
 class RelatedArticlesValidation:
@@ -105,3 +105,227 @@ class RelatedArticlesValidation:
                 data=related_article,
                 error_level=self.error_level
             )
+
+
+class RelatedArticleValidation:
+    """Validates a single related-article element"""
+
+    def __init__(self, related_article, params=None):
+        """
+        Parameters
+        ----------
+        related_article : dict
+            Dictionary with related article data including parent_article_type
+        params : dict, optional
+            Dictionary with validation parameters:
+            {
+                'correspondence_list': [...],
+                'ext_link_types': ['doi', 'uri'],
+                'requires_related_article': ['correction', 'retraction', ...],
+                'requirement_error_level': 'ERROR',
+                'type_error_level': 'ERROR',
+                'ext_link_type_error_level': 'ERROR',
+                'uri_error_level': 'ERROR',
+                'uri_format_error_level': 'ERROR',
+                'doi_error_level': 'ERROR',
+                'doi_format_error_level': 'ERROR',
+                'id_error_level': 'ERROR'
+            }
+        """
+        self.related_article = related_article
+        self.article_type = related_article.get("original_article_type") or related_article.get('parent_article_type')
+        self.related_article_type = related_article.get("related-article-type")
+
+        self.params = params or {}
+        self.valid_ext_link_types = self.params.get('ext_link_types', ['doi', "uri"])
+        _related = (
+            self.params.get('article-types-and-related-article-types', {}).get(self.article_type, {})
+        )
+        self.required_related_article_types = _related.get("required_related_article_types") or []
+        self.acceptable_related_article_types = _related.get("acceptable_related_article_types") or []
+
+    def _get_error_level(self, validation_type):
+        """
+        Get error level for specific validation type from params
+        
+        Parameters
+        ----------
+        validation_type : str
+            Type of validation being performed
+            
+        Returns
+        -------
+        str
+            Error level for the validation type
+        """
+        error_level_key = f'{validation_type}_error_level'
+        return self.params.get(error_level_key, 'CRITICAL')
+
+    def validate_type(self):
+        """Validate if related article type matches main article type"""
+        expected_values = self.required_related_article_types + self.acceptable_related_article_types
+
+        obtained_type = self.related_article.get('related-article-type')
+
+        if not expected_values:
+            return build_response(
+                title='Related article type validation',
+                parent=self.related_article,
+                item='related-article',
+                sub_item='related-article-type',
+                validation_type='match',
+                is_valid=False,
+                expected=expected_values,
+                obtained=obtained_type,
+                advice=f"The article-type: {self.article_type} does not match the related-article-type: "
+                      f"{obtained_type}, provide one of the following items: {expected_values}",
+                data=self.related_article,
+                error_level=self._get_error_level('type')
+            )
+
+        is_valid = obtained_type in expected_values
+
+        return build_response(
+            title='Related article type validation',
+            parent=self.related_article,
+            item='related-article',
+            sub_item='related-article-type',
+            validation_type='match',
+            is_valid=is_valid,
+            expected=expected_values,
+            obtained=obtained_type,
+            advice=f"The article-type: {self.article_type} does not match the related-article-type: "
+                  f"{obtained_type}, provide one of the following items: {expected_values}",
+            data=self.related_article,
+            error_level=self._get_error_level('type')
+        )
+
+    def validate_ext_link_type(self):
+        """Validate if related article has valid ext-link-type"""
+        ext_link_type = self.related_article.get('ext-link-type')
+        is_valid = ext_link_type in self.valid_ext_link_types
+
+        return build_response(
+            title='Related article ext-link-type validation',
+            parent=self.related_article,
+            item='related-article',
+            sub_item='ext-link-type',
+            validation_type='match',
+            is_valid=is_valid,
+            expected=self.valid_ext_link_types,
+            obtained=ext_link_type,
+            advice=f'The ext-link-type should be one of {self.valid_ext_link_types} for related article with id="{self.related_article.get("id")}"',
+            data=self.related_article,
+            error_level=self._get_error_level('ext_link_type')
+        )
+
+    def validate_uri(self):
+        """Validate if related article has valid link (URI)"""
+        ext_link_type = self.related_article.get('ext-link-type')
+        if not ext_link_type == "uri":
+            return
+
+        link = self.related_article.get('href')
+        if not link:
+            return build_response(
+                title='Related article link validation',
+                parent=self.related_article,
+                item='related-article',
+                sub_item='xlink:href',
+                validation_type='exist',
+                is_valid=False,
+                expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
+                obtained=link,
+                advice=f'Provide a valid {ext_link_type.upper() if ext_link_type else "link"} for <related-article '
+                      f'id="{self.related_article.get("id")}" />',
+                data=self.related_article,
+                error_level=self._get_error_level('uri')
+            )
+
+        is_valid = is_valid_url_format(link)
+        expected = 'A valid URI format (e.g., http://example.com)'
+        
+        return build_response(
+            title='Related article link validation',
+            parent=self.related_article,
+            item='related-article',
+            sub_item='xlink:href',
+            validation_type='format',
+            is_valid=is_valid,
+            expected=expected,
+            obtained=link,
+            advice=None if is_valid else f'Invalid {ext_link_type.upper()} format for link: {link}',
+            data=self.related_article,
+            error_level=self._get_error_level('uri_format')
+        )
+
+    def validate_doi(self):
+        """Validate if related article has valid DOI"""
+        ext_link_type = self.related_article.get('ext-link-type')
+        if not ext_link_type == "doi":
+            return
+
+        link = self.related_article.get('href')
+        if not link:
+            return build_response(
+                title='Related article doi validation',
+                parent=self.related_article,
+                item='related-article',
+                sub_item='xlink:href',
+                validation_type='exist',
+                is_valid=False,
+                expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
+                obtained=link,
+                advice=f'Provide a valid {ext_link_type.upper() if ext_link_type else "link"} for <related-article '
+                      f'id="{self.related_article.get("id")}" />',
+                data=self.related_article,
+                error_level=self.params.get("doi_error_level")
+            )
+
+        valid = validate_doi_format(link)
+        is_valid = valid and valid.get("valido")
+        expected = 'A valid DOI'
+
+        return build_response(
+            title='Related article doi validation',
+            parent=self.related_article,
+            item='related-article',
+            sub_item='xlink:href',
+            validation_type='format',
+            is_valid=is_valid,
+            expected=expected,
+            obtained=link,
+            advice=None if is_valid else f'Invalid {ext_link_type.upper()} format for link: {link}',
+            data=self.related_article,
+            error_level=self.params.get("doi_format_error_level")
+        )
+
+    def validate_id_presence(self):
+        """Validate if related article has an ID"""
+        related_id = self.related_article.get('id')
+        is_valid = related_id is not None and related_id.strip() != ''
+        expected = 'A non-empty ID'
+
+        return build_response(
+            title='Related article id validation',
+            parent=self.related_article,
+            item='related-article',
+            sub_item='id',
+            validation_type='exist',
+            is_valid=is_valid,
+            expected=expected,
+            obtained=related_id,
+            advice='Each related-article element must have a unique id attribute',
+            data=self.related_article,
+            error_level=self._get_error_level('id')
+        )
+
+    def validate(self):
+        """Run all validations"""
+        validations = [
+            self.validate_type(),
+            self.validate_ext_link_type(),
+            self.validate_doi() or self.validate_uri(),
+            self.validate_id_presence()
+        ]
+        return [v for v in validations if v is not None]

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -1,4 +1,4 @@
-from packtools.sps.models.related_articles import RelatedItems
+from packtools.sps.models.related_articles import RelatedItems, Fulltext
 from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.validation.exceptions import ValidationRelatedArticleException
 from packtools.sps.validation.utils import (
@@ -66,7 +66,7 @@ class RelatedArticlesValidation:
                 is_valid = obtained_type in expected_values
 
                 yield build_response(
-                    title="Related article type validation",
+                    title="Related article type",
                     parent=related_article,
                     item="related-article",
                     sub_item="related-article-type",
@@ -97,7 +97,7 @@ class RelatedArticlesValidation:
             )
 
             yield build_response(
-                title="Related article doi validation",
+                title="Related article doi",
                 parent=related_article,
                 item="related-article",
                 sub_item="xlink:href",
@@ -183,7 +183,7 @@ class RelatedArticleValidation:
 
         if not expected_values:
             return build_response(
-                title="Related article type validation",
+                title="Related article type",
                 parent=self.related_article,
                 item="related-article",
                 sub_item="related-article-type",
@@ -198,40 +198,41 @@ class RelatedArticleValidation:
             )
 
         is_valid = obtained_type in expected_values
-
-        return build_response(
-            title="Related article type validation",
-            parent=self.related_article,
-            item="related-article",
-            sub_item="related-article-type",
-            validation_type="match",
-            is_valid=is_valid,
-            expected=expected_values,
-            obtained=obtained_type,
-            advice=f"The article-type: {self.article_type} does not match the related-article-type: "
-            f"{obtained_type}, provide one of the following items: {expected_values}",
-            data=self.related_article,
-            error_level=self._get_error_level("type"),
-        )
+        if not is_valid:
+            return build_response(
+                title="Related article type",
+                parent=self.related_article,
+                item="related-article",
+                sub_item="related-article-type",
+                validation_type="match",
+                is_valid=is_valid,
+                expected=expected_values,
+                obtained=obtained_type,
+                advice=f"The article-type: {self.article_type} does not match the related-article-type: "
+                f"{obtained_type}, provide one of the following items: {expected_values}",
+                data=self.related_article,
+                error_level=self._get_error_level("type"),
+            )
 
     def validate_ext_link_type(self):
         """Validate if related article has valid ext-link-type"""
         ext_link_type = self.related_article.get("ext-link-type")
         is_valid = ext_link_type in self.valid_ext_link_types
 
-        return build_response(
-            title="Related article ext-link-type validation",
-            parent=self.related_article,
-            item="related-article",
-            sub_item="ext-link-type",
-            validation_type="match",
-            is_valid=is_valid,
-            expected=self.valid_ext_link_types,
-            obtained=ext_link_type,
-            advice=f'The ext-link-type should be one of {self.valid_ext_link_types} for related article with id="{self.related_article.get("id")}"',
-            data=self.related_article,
-            error_level=self._get_error_level("ext_link_type"),
-        )
+        if not is_valid:
+            return build_response(
+                title="Related article ext-link-type",
+                parent=self.related_article,
+                item="related-article",
+                sub_item="ext-link-type",
+                validation_type="match",
+                is_valid=is_valid,
+                expected=self.valid_ext_link_types,
+                obtained=ext_link_type,
+                advice=f'The ext-link-type should be one of {self.valid_ext_link_types} for related article with id="{self.related_article.get("id")}"',
+                data=self.related_article,
+                error_level=self._get_error_level("ext_link_type"),
+            )
 
     def validate_uri(self):
         """Validate if related article has valid link (URI)"""
@@ -242,7 +243,7 @@ class RelatedArticleValidation:
         link = self.related_article.get("href")
         if not link:
             return build_response(
-                title="Related article link validation",
+                title="Related article link",
                 parent=self.related_article,
                 item="related-article",
                 sub_item="xlink:href",
@@ -259,23 +260,24 @@ class RelatedArticleValidation:
         is_valid = is_valid_url_format(link)
         expected = "A valid URI format (e.g., http://example.com)"
 
-        return build_response(
-            title="Related article link validation",
-            parent=self.related_article,
-            item="related-article",
-            sub_item="xlink:href",
-            validation_type="format",
-            is_valid=is_valid,
-            expected=expected,
-            obtained=link,
-            advice=(
-                None
-                if is_valid
-                else f"Invalid {ext_link_type.upper()} format for link: {link}"
-            ),
-            data=self.related_article,
-            error_level=self._get_error_level("uri_format"),
-        )
+        if not is_valid:
+            return build_response(
+                title="Related article link",
+                parent=self.related_article,
+                item="related-article",
+                sub_item="xlink:href",
+                validation_type="format",
+                is_valid=is_valid,
+                expected=expected,
+                obtained=link,
+                advice=(
+                    None
+                    if is_valid
+                    else f"Invalid {ext_link_type.upper()} format for link: {link}"
+                ),
+                data=self.related_article,
+                error_level=self._get_error_level("uri_format"),
+            )
 
     def validate_doi(self):
         """Validate if related article has valid DOI"""
@@ -286,7 +288,7 @@ class RelatedArticleValidation:
         link = self.related_article.get("href")
         if not link:
             return build_response(
-                title="Related article doi validation",
+                title="Related article doi",
                 parent=self.related_article,
                 item="related-article",
                 sub_item="xlink:href",
@@ -304,23 +306,24 @@ class RelatedArticleValidation:
         is_valid = valid and valid.get("valido")
         expected = "A valid DOI"
 
-        return build_response(
-            title="Related article doi validation",
-            parent=self.related_article,
-            item="related-article",
-            sub_item="xlink:href",
-            validation_type="format",
-            is_valid=is_valid,
-            expected=expected,
-            obtained=link,
-            advice=(
-                None
-                if is_valid
-                else f"Invalid {ext_link_type.upper()} format for link: {link}"
-            ),
-            data=self.related_article,
-            error_level=self.params.get("doi_format_error_level"),
-        )
+        if not is_valid:
+            return build_response(
+                title="Related article doi",
+                parent=self.related_article,
+                item="related-article",
+                sub_item="xlink:href",
+                validation_type="format",
+                is_valid=is_valid,
+                expected=expected,
+                obtained=link,
+                advice=(
+                    None
+                    if is_valid
+                    else f"Invalid {ext_link_type.upper()} format for link: {link}"
+                ),
+                data=self.related_article,
+                error_level=self.params.get("doi_format_error_level"),
+            )
 
     def validate_id_presence(self):
         """Validate if related article has an ID"""
@@ -328,19 +331,20 @@ class RelatedArticleValidation:
         is_valid = related_id is not None and related_id.strip() != ""
         expected = "A non-empty ID"
 
-        return build_response(
-            title="Related article id validation",
-            parent=self.related_article,
-            item="related-article",
-            sub_item="id",
-            validation_type="exist",
-            is_valid=is_valid,
-            expected=expected,
-            obtained=related_id,
-            advice="Each related-article element must have a unique id attribute",
-            data=self.related_article,
-            error_level=self._get_error_level("id"),
-        )
+        if not is_valid:
+            return build_response(
+                title="Related article id",
+                parent=self.related_article,
+                item="related-article",
+                sub_item="id",
+                validation_type="exist",
+                is_valid=is_valid,
+                expected=expected,
+                obtained=related_id,
+                advice="Each related-article element must have a unique id attribute",
+                data=self.related_article,
+                error_level=self._get_error_level("id"),
+            )
 
     def validate(self):
         """Run all validations"""
@@ -351,3 +355,105 @@ class RelatedArticleValidation:
             self.validate_id_presence(),
         ]
         return [v for v in validations if v is not None]
+
+
+class FulltextValidation:
+    """Validates related articles in a Fulltext instance"""
+
+    def __init__(self, fulltext, params=None):
+        """
+        Initialize with a Fulltext instance and validation parameters
+
+        Parameters
+        ----------
+        fulltext : Fulltext
+            Fulltext instance to validate
+        params : dict, optional
+            Dictionary with validation parameters
+        """
+        self.fulltext = fulltext
+        self.params = params or {}
+        self._set_article_rules()
+
+    def _set_article_rules(self):
+        """Set article rules from params"""
+        article_rules = self.params.get("article-types-and-related-article-types", {})
+        article_config = article_rules.get(
+            self.fulltext.parent_data["parent_article_type"], {}
+        )
+        self.required_types = article_config.get("required_related_article_types", [])
+        self.acceptable_types = article_config.get(
+            "acceptable_related_article_types", []
+        )
+
+    def _get_error_level(self, validation_type):
+        """Get error level for specific validation type"""
+        error_level_key = f"{validation_type}_error_level"
+        return self.params.get(error_level_key, "CRITICAL")
+
+    def validate_presence_of_required_related_articles(self):
+        """
+        Validate if required related articles are present
+
+        Returns
+        -------
+        dict or None
+            Validation result if article type requires related articles,
+            None otherwise
+        """
+        if not self.required_types:
+            return None
+
+        # Get all related-article-types present in the document
+        found_types = {
+            related.get("related-article-type")
+            for related in self.fulltext.related_articles
+        }
+
+        # Check if any required type is missing
+        missing_types = set(self.required_types) - found_types
+
+        if missing_types:
+            error_level = self._get_error_level("requirement")
+            return build_response(
+                title="Required related articles",
+                parent=self.fulltext.parent_data,
+                item="related-article",
+                sub_item=None,
+                validation_type="match",
+                is_valid=False,
+                expected=self.required_types,
+                obtained=list(found_types),
+                advice=f'Article type "{self.fulltext.parent_data["parent_article_type"]}" '
+                f"requires related articles of types: {list(missing_types)}",
+                data={
+                    "article_type": self.fulltext.parent_data["parent_article_type"],
+                    "missing_types": list(missing_types),
+                },
+                error_level=error_level,
+            )
+
+        return None
+
+    def validate(self):
+        """
+        Validate each related article
+
+        Returns
+        -------
+        list
+            List of validation results
+        """
+        # First check if required related articles are present
+        if presence_result := self.validate_presence_of_required_related_articles():
+            yield presence_result
+
+        # Then validate each related article
+        for related in self.fulltext.related_articles:
+            validator = RelatedArticleValidation(related, self.params)
+            yield from validator.validate()
+
+        # Validate each sub-article
+        for subtext in self.fulltext.fulltexts:
+            validator = FulltextValidation(subtext, self.params)
+            yield from validator.validate()

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -1,4 +1,5 @@
 import urllib.parse
+import re
 
 import requests
 from langdetect import detect
@@ -106,3 +107,55 @@ def is_valid_url_format(text):
         return bool(parsed_url.scheme) and bool(parsed_url.netloc)
     except ValueError:
         return False
+
+
+def validate_doi_format(doi):
+    """
+    Valida o formato de um DOI (Digital Object Identifier)
+
+    Regras de validação:
+    1. Deve começar com "10."
+    2. Após o "10.", deve ter 4 ou 5 dígitos
+    3. Deve ter uma barra (/) após os dígitos
+    4. Deve ter caracteres alfanuméricos após a barra
+    5. Pode conter hífens e pontos após a barra
+    6. Não deve conter espaços
+
+    Args:
+        doi (str): O DOI a ser validado
+
+    Returns:
+        Dict[str, Union[bool, str]]: Dicionário contendo status de validação e mensagem
+    """
+    # Verifica se o input é uma string e não está vazio
+    if not isinstance(doi, str) or not doi:
+        return {
+            "valido": False,
+            "mensagem": "DOI deve ser uma string não vazia"
+        }
+
+    # Remove possíveis espaços em branco
+    doi = doi.strip()
+
+    # Regex para validar o formato do DOI
+    doi_regex = r'^10\.\d{4,5}\/[a-zA-Z0-9./-]+$'
+
+    # Testa o formato básico
+    if not re.match(doi_regex, doi):
+        return {
+            "valido": False,
+            "mensagem": "Formato de DOI inválido. Deve seguir o padrão: 10.XXXX/string-alfanumérica"
+        }
+
+    # Verifica se não há caracteres especiais inválidos após a barra
+    sufixo = doi.split('/')[1]
+    if not re.match(r'^[a-zA-Z0-9./-]+$', sufixo):
+        return {
+            "valido": False,
+            "mensagem": "O sufixo do DOI contém caracteres inválidos"
+        }
+
+    return {
+        "valido": True,
+        "mensagem": "DOI válido"
+    }

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -41,7 +41,7 @@ from packtools.sps.validation.metadata_langs import MetadataLanguagesValidation
 # from packtools.sps.validation.erratum import xValidation
 # from packtools.sps.validation.peer_review import xValidation
 # from packtools.sps.validation.preprint import xValidation
-# from packtools.sps.validation.related_articles import xValidation
+from packtools.sps.validation.related_articles import RelatedArticlesValidation
 
 # completar
 # from packtools.sps.validation.media import xValidation
@@ -305,7 +305,7 @@ def validate_bibliographic_strip(xmltree, params):
 
 def validate_funding_data(xmltree, params):
     funding_data_rules = params["funding_data_rules"]
-    validator = FundingGroupValidation(xmltree)
+    validator = FundingGroupValidation(xmltree, funding_data_rules)
     yield from validator.validate_required_award_ids()
 
 
@@ -347,4 +347,8 @@ def validate_metadata_languages(xmltree, params):
     validator = MetadataLanguagesValidation(xmltree)
     yield from validator.validate(params["metadata_languages_rules"]["error_level"])
 
+
+def validate_related_articles(xmltree, params):
+    validator = RelatedArticlesValidation(xmltree, params["related_articles_rules"])
+    yield from validator.validate(["error_level"])
 

--- a/packtools/sps/validation/xml_validator.py
+++ b/packtools/sps/validation/xml_validator.py
@@ -80,3 +80,7 @@ def validate_xml_content(xmltree, rules):
         "group": "article_references",
         "items": xml_validations.validate_references(xmltree, params),
     }
+    yield {
+        "group": "related_articles",
+        "items": xml_validations.validate_related_articles(xmltree, params),
+    }

--- a/packtools/sps/validation_rules/related_article_rules.json
+++ b/packtools/sps/validation_rules/related_article_rules.json
@@ -1,41 +1,128 @@
 {
     "related_article_rules": {
+        "required_related_articles_error_level": "CRITICAL",
+        "type_error_level": "CRITICAL",
+        "ext_link_type_error_level": "CRITICAL",
+        "uri_error_level": "CRITICAL",
+        "uri_format_error_level": "CRITICAL",
+        "doi_error_level": "CRITICAL",
+        "doi_format_error_level": "CRITICAL",
+        "id_error_level": "CRITICAL",
         "ext_link_type_list": [
             "doi",
             "uri"
         ],
-        "related_article_type_list": [
-            "corrected-article",
-            "correction-forward",
-            "retracted-article",
-            "retraction-forward",
-            "retracted-article",
-            "partial-retraction",
-            "article",
-            "addendum",
-            "commentary-article",
-            "commentary",
-            "article",
-            "letter",
-            "peer-reviewed-material",
-            "reviewer-report",
-            "preprint"
-        ],
-        "article_type_correspondence_list": [
-            {"article-type": "addendum", "related_article_type_list": ["article"]},
-            {"article-type": "article-commentary", "related_article_type_list": ["commentary"]},
-            {"article-type": "correction", "related_article_type_list": ["corrected-article"]},
-            {"article-type": "partial-retraction", "related_article_type_list": ["retracted-article"]},
-            {"article-type": "retraction", "related_article_type_list": ["retracted-article"]},
-            {"article-type": "reviewer-report", "related_article_type_list": ["peer-reviewed-material"]}
-        ],
         "required_history_events": {
             "preprint": "preprint",
             "correction-forward": "corrected"
+        },
+        "article-types-and-related-article-types": {
+            "correction": {
+                "required_related_article_types": ["corrected-article"],
+                "acceptable_related_article_types": []
+            },
+            "research-article": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary",
+                    "reviewer-report",
+                    "preprint"
+                ]
+            },
+            "review-article": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary",
+                    "reviewer-report",
+                    "preprint"
+                ]
+            },
+            "case-report": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary",
+                    "reviewer-report",
+                    "preprint"
+                ]
+            },
+            "brief-report": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary",
+                    "reviewer-report",
+                    "preprint"
+                ]
+            },
+            "data-article": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary",
+                    "reviewer-report",
+                    "preprint"
+                ]
+            },
+            "retraction": {
+                "required_related_article_types": ["retracted-article"],
+                "acceptable_related_article_types": []
+            },
+            "partial-retraction": {
+                "required_related_article_types": ["retracted-article"],
+                "acceptable_related_article_types": []
+            },
+            "addendum": {
+                "required_related_article_types": ["article"],
+                "acceptable_related_article_types": []
+            },
+            "article-commentary": {
+                "required_related_article_types": ["commentary-article"],
+                "acceptable_related_article_types": []
+            },
+            "letter": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": ["article", "letter"]
+            },
+            "reply": {
+                "required_related_article_types": ["letter"],
+                "acceptable_related_article_types": []
+            },
+            "editorial": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": [
+                    "correction-forward",
+                    "retraction-forward",
+                    "partial-retraction",
+                    "addendum",
+                    "commentary"
+                ]
+            },
+            "reviewer-report": {
+                "required_related_article_types": ["peer-reviewed-material"],
+                "acceptable_related_article_types": []
+            },
+            "preprint": {
+                "required_related_article_types": [],
+                "acceptable_related_article_types": ["article"]
+            }
         }
-
     }
-
 }
-
-            

--- a/tests/sps/models/test_related_articles.py
+++ b/tests/sps/models/test_related_articles.py
@@ -1,18 +1,17 @@
-import unittest
+from unittest import TestCase
 from io import BytesIO
 
 from lxml import etree
-from packtools.sps.models.related_articles import RelatedItems
+from packtools.sps.models.related_articles import RelatedItems, Fulltext
 
 
 def create_xml_tree(xml_content):
     return etree.parse(BytesIO(xml_content.encode("utf-8")))
 
 
-class TestArticleRelatedItems(unittest.TestCase):
+class TestArticleRelatedItems(TestCase):
     def setUp(self):
         xml = (
-            '<?xml version="1.0" encoding="utf-8"?>'
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">'
             "<front>"
             "<article-meta>"
@@ -29,7 +28,6 @@ class TestArticleRelatedItems(unittest.TestCase):
         xml = '<related-article ext-link-type="doi" id="A01" related-article-type="commentary-article" xlink:href="10.1590/0101-3173.2022.v45n1.p139">Referência do artigo comentado: FREITAS, J. H. de. <italic>Some italic text</italic> Sample text <bold>Journal Name</bold>: additional details</related-article>'
         self.assertEqual(len(items), 1)
         item = items[0]
-        print(item)
         self.assertEqual(item["id"], "A01")
         self.assertEqual(item["ext-link-type"], "doi")
         self.assertEqual(item["related-article-type"], "commentary-article")
@@ -43,10 +41,9 @@ class TestArticleRelatedItems(unittest.TestCase):
         self.assertEqual(item.get("parent_article_type"), "research-article")
 
 
-class TestSubArticleRelatedItems(unittest.TestCase):
+class TestSubArticleRelatedItems(TestCase):
     def setUp(self):
         xml = (
-            '<?xml version="1.0" encoding="utf-8"?>'
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">'
             '<sub-article article-type="translation" xml:lang="es" id="tr1">'
             "<front-stub>"
@@ -74,10 +71,9 @@ class TestSubArticleRelatedItems(unittest.TestCase):
         self.assertEqual(item.get("parent_article_type"), "translation")
 
 
-class TestMultipleRelatedItems(unittest.TestCase):
+class TestMultipleRelatedItems(TestCase):
     def setUp(self):
         xml = (
-            '<?xml version="1.0" encoding="utf-8"?>'
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en">'
             "<front>"
             "<article-meta>"
@@ -119,10 +115,9 @@ class TestMultipleRelatedItems(unittest.TestCase):
         self.assertEqual(items[2].get("parent_article_type"), "translation")
 
 
-class TestNoRelatedItems(unittest.TestCase):
+class TestNoRelatedItems(TestCase):
     def setUp(self):
         xml = (
-            '<?xml version="1.0" encoding="utf-8"?>'
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">'
             "<front>"
             "<article-meta>"
@@ -138,5 +133,176 @@ class TestNoRelatedItems(unittest.TestCase):
         self.assertEqual(len(items), 0)
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestFulltextMainArticle(TestCase):
+    """Tests for basic article with related-articles and sub-articles"""
+    
+    def setUp(self):
+        xml = '''
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en" id="a1">
+            <front>
+                <article-meta>
+                    <related-article related-article-type="correction-forward" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/123456789" 
+                                   id="ra1">Some text</related-article>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="pt" id="s1">
+                <front-stub>
+                    <related-article related-article-type="correction-forward"
+                                   ext-link-type="doi"
+                                   id="ra2">Translation related</related-article>
+                </front-stub>
+            </sub-article>
+            <sub-article article-type="reviewer-report" xml:lang="es" id="s2">
+                <front-stub>
+                    <related-article related-article-type="reviewer-report-of"
+                                   ext-link-type="doi"
+                                   id="ra3">Text related</related-article>
+                </front-stub>
+            </sub-article>
+        </article>'''
+        self.fulltext = Fulltext(etree.fromstring(xml).find("."))
+
+    def test_parent_data(self):
+        expected = {
+            'parent': 'article',
+            'parent_id': 'a1',
+            'parent_article_type': 'research-article',
+            'parent_lang': 'en',
+            'original_article_type': None
+        }
+        self.assertEqual(self.fulltext.parent_data, expected)
+
+    def test_related_articles(self):
+        related = list(self.fulltext.related_articles)
+        self.assertEqual(len(related), 1)
+        
+        article = related[0]
+        self.assertEqual(article['related-article-type'], 'correction-forward')
+        self.assertEqual(article['ext-link-type'], 'doi')
+        self.assertEqual(article['href'], '10.1590/123456789')
+        self.assertEqual(article['id'], 'ra1')
+        self.assertEqual(article['text'], 'Some text')
+        self.assertIn('xml', article)
+        self.assertIsNone(article['original_article_type'])
+
+    def test_fulltexts(self):
+        sub_articles = list(self.fulltext.fulltexts)
+        self.assertEqual(len(sub_articles), 2)
+        
+        # Test translation sub-article
+        translation = sub_articles[0]
+        self.assertEqual(translation.parent_data['parent_article_type'], 'translation')
+        self.assertEqual(translation.parent_data['parent_lang'], 'pt')
+        self.assertEqual(translation.parent_data['original_article_type'], 'research-article')
+        
+        # Test reviewer-report sub-article
+        reviewer_report = sub_articles[1]
+        self.assertEqual(reviewer_report.parent_data['parent_article_type'], 'reviewer-report')
+        self.assertEqual(reviewer_report.parent_data['parent_lang'], 'es')
+        self.assertIsNone(reviewer_report.parent_data['original_article_type'])
+
+
+class TestFulltextTranslation(TestCase):
+    """Tests for translation sub-article with original_article_type parameter"""
+    
+    def setUp(self):
+        xml = '''
+        <sub-article article-type="translation" xml:lang="es" id="s1">
+            <front-stub>
+                <related-article related-article-type="translation-of" 
+                               ext-link-type="doi" 
+                               id="ra1">Translation note</related-article>
+            </front-stub>
+            <body>
+                <related-article related-article-type="corrected-article"
+                               ext-link-type="doi"
+                               id="ra2">Body related</related-article>
+            </body>
+        </sub-article>'''
+        self.fulltext = Fulltext(etree.fromstring(xml), original_article_type="research-article")
+
+    def test_parent_data_with_translation(self):
+        expected = {
+            'parent': 'sub-article',
+            'parent_id': 's1',
+            'parent_article_type': 'translation',
+            'parent_lang': 'es',
+            'original_article_type': 'research-article'
+        }
+        self.assertEqual(self.fulltext.parent_data, expected)
+
+    def test_related_articles_in_translation(self):
+        related = list(self.fulltext.related_articles)
+        self.assertEqual(len(related), 2)
+        
+        # Map related articles by id
+        articles = {r['id']: r for r in related}
+        
+        # Check front-stub related article
+        front = articles['ra1']
+        self.assertEqual(front['related-article-type'], 'translation-of')
+        self.assertEqual(front['text'], 'Translation note')
+        self.assertEqual(front['original_article_type'], 'research-article')
+        
+        # Check body related article
+        body = articles['ra2']
+        self.assertEqual(body['related-article-type'], 'corrected-article')
+        self.assertEqual(body['text'], 'Body related')
+        self.assertEqual(body['original_article_type'], 'research-article')
+
+
+class TestFulltextNestedStructure(TestCase):
+    """Tests for complex nested structure with multiple sub-articles"""
+    
+    def setUp(self):
+        xml = '''
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en" id="main">
+            <front>
+                <related-article id="ra1">Main article</related-article>
+            </front>
+            <sub-article article-type="translation" xml:lang="pt" id="trans1">
+                <front-stub>
+                    <related-article id="ra2">Translation 1</related-article>
+                </front-stub>
+                <sub-article article-type="reviewer-report" id="abs1">
+                    <front-stub>
+                        <related-article id="ra3">Nested reviewer-report</related-article>
+                    </front-stub>
+                </sub-article>
+            </sub-article>
+        </article>'''
+        self.fulltext = Fulltext(etree.fromstring(xml))
+
+    def test_nested_structure(self):
+        # Test main article
+        main_related = list(self.fulltext.related_articles)
+        self.assertEqual(len(main_related), 1)
+        self.assertEqual(main_related[0]['text'], 'Main article')
+        
+        # Test first level sub-articles
+        level1_articles = list(self.fulltext.fulltexts)
+        self.assertEqual(len(level1_articles), 1)
+        
+        translation = level1_articles[0]
+        self.assertEqual(translation.parent_data['parent_article_type'], 'translation')
+        self.assertEqual(translation.parent_data['original_article_type'], 'research-article')
+        
+        # Test translation related articles
+        trans_related = list(translation.related_articles)
+        self.assertEqual(len(trans_related), 1)
+        self.assertEqual(trans_related[0]['text'], 'Translation 1')
+        
+        # Test nested reviewer-report
+        nested_articles = list(translation.fulltexts)
+        self.assertEqual(len(nested_articles), 1)
+        
+        reviewer_report = nested_articles[0]
+        self.assertEqual(reviewer_report.parent_data['parent_article_type'], 'reviewer-report')
+        self.assertIsNone(reviewer_report.parent_data['original_article_type'])
+        
+        # Test reviewer-report related articles
+        abs_related = list(reviewer_report.related_articles)
+        self.assertEqual(len(abs_related), 1)
+        self.assertEqual(abs_related[0]['text'], 'Nested reviewer-report')

--- a/tests/sps/models/test_related_articles.py
+++ b/tests/sps/models/test_related_articles.py
@@ -135,9 +135,9 @@ class TestNoRelatedItems(TestCase):
 
 class TestFulltextMainArticle(TestCase):
     """Tests for basic article with related-articles and sub-articles"""
-    
+
     def setUp(self):
-        xml = '''
+        xml = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en" id="a1">
             <front>
                 <article-meta>
@@ -161,54 +161,58 @@ class TestFulltextMainArticle(TestCase):
                                    id="ra3">Text related</related-article>
                 </front-stub>
             </sub-article>
-        </article>'''
+        </article>"""
         self.fulltext = Fulltext(etree.fromstring(xml).find("."))
 
     def test_parent_data(self):
         expected = {
-            'parent': 'article',
-            'parent_id': 'a1',
-            'parent_article_type': 'research-article',
-            'parent_lang': 'en',
-            'original_article_type': None
+            "parent": "article",
+            "parent_id": "a1",
+            "parent_article_type": "research-article",
+            "parent_lang": "en",
+            "original_article_type": None,
         }
         self.assertEqual(self.fulltext.parent_data, expected)
 
     def test_related_articles(self):
         related = list(self.fulltext.related_articles)
         self.assertEqual(len(related), 1)
-        
+
         article = related[0]
-        self.assertEqual(article['related-article-type'], 'correction-forward')
-        self.assertEqual(article['ext-link-type'], 'doi')
-        self.assertEqual(article['href'], '10.1590/123456789')
-        self.assertEqual(article['id'], 'ra1')
-        self.assertEqual(article['text'], 'Some text')
-        self.assertIn('xml', article)
-        self.assertIsNone(article['original_article_type'])
+        self.assertEqual(article["related-article-type"], "correction-forward")
+        self.assertEqual(article["ext-link-type"], "doi")
+        self.assertEqual(article["href"], "10.1590/123456789")
+        self.assertEqual(article["id"], "ra1")
+        self.assertEqual(article["text"], "Some text")
+        self.assertIn("xml", article)
+        self.assertIsNone(article["original_article_type"])
 
     def test_fulltexts(self):
         sub_articles = list(self.fulltext.fulltexts)
         self.assertEqual(len(sub_articles), 2)
-        
+
         # Test translation sub-article
         translation = sub_articles[0]
-        self.assertEqual(translation.parent_data['parent_article_type'], 'translation')
-        self.assertEqual(translation.parent_data['parent_lang'], 'pt')
-        self.assertEqual(translation.parent_data['original_article_type'], 'research-article')
-        
+        self.assertEqual(translation.parent_data["parent_article_type"], "translation")
+        self.assertEqual(translation.parent_data["parent_lang"], "pt")
+        self.assertEqual(
+            translation.parent_data["original_article_type"], "research-article"
+        )
+
         # Test reviewer-report sub-article
         reviewer_report = sub_articles[1]
-        self.assertEqual(reviewer_report.parent_data['parent_article_type'], 'reviewer-report')
-        self.assertEqual(reviewer_report.parent_data['parent_lang'], 'es')
-        self.assertIsNone(reviewer_report.parent_data['original_article_type'])
+        self.assertEqual(
+            reviewer_report.parent_data["parent_article_type"], "reviewer-report"
+        )
+        self.assertEqual(reviewer_report.parent_data["parent_lang"], "es")
+        self.assertIsNone(reviewer_report.parent_data["original_article_type"])
 
 
 class TestFulltextTranslation(TestCase):
     """Tests for translation sub-article with original_article_type parameter"""
-    
+
     def setUp(self):
-        xml = '''
+        xml = """
         <sub-article article-type="translation" xml:lang="es" id="s1">
             <front-stub>
                 <related-article related-article-type="translation-of" 
@@ -220,44 +224,46 @@ class TestFulltextTranslation(TestCase):
                                ext-link-type="doi"
                                id="ra2">Body related</related-article>
             </body>
-        </sub-article>'''
-        self.fulltext = Fulltext(etree.fromstring(xml), original_article_type="research-article")
+        </sub-article>"""
+        self.fulltext = Fulltext(
+            etree.fromstring(xml), original_article_type="research-article"
+        )
 
     def test_parent_data_with_translation(self):
         expected = {
-            'parent': 'sub-article',
-            'parent_id': 's1',
-            'parent_article_type': 'translation',
-            'parent_lang': 'es',
-            'original_article_type': 'research-article'
+            "parent": "sub-article",
+            "parent_id": "s1",
+            "parent_article_type": "translation",
+            "parent_lang": "es",
+            "original_article_type": "research-article",
         }
         self.assertEqual(self.fulltext.parent_data, expected)
 
     def test_related_articles_in_translation(self):
         related = list(self.fulltext.related_articles)
         self.assertEqual(len(related), 2)
-        
+
         # Map related articles by id
-        articles = {r['id']: r for r in related}
-        
+        articles = {r["id"]: r for r in related}
+
         # Check front-stub related article
-        front = articles['ra1']
-        self.assertEqual(front['related-article-type'], 'translation-of')
-        self.assertEqual(front['text'], 'Translation note')
-        self.assertEqual(front['original_article_type'], 'research-article')
-        
+        front = articles["ra1"]
+        self.assertEqual(front["related-article-type"], "translation-of")
+        self.assertEqual(front["text"], "Translation note")
+        self.assertEqual(front["original_article_type"], "research-article")
+
         # Check body related article
-        body = articles['ra2']
-        self.assertEqual(body['related-article-type'], 'corrected-article')
-        self.assertEqual(body['text'], 'Body related')
-        self.assertEqual(body['original_article_type'], 'research-article')
+        body = articles["ra2"]
+        self.assertEqual(body["related-article-type"], "corrected-article")
+        self.assertEqual(body["text"], "Body related")
+        self.assertEqual(body["original_article_type"], "research-article")
 
 
 class TestFulltextNestedStructure(TestCase):
     """Tests for complex nested structure with multiple sub-articles"""
-    
+
     def setUp(self):
-        xml = '''
+        xml = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="en" id="main">
             <front>
                 <related-article id="ra1">Main article</related-article>
@@ -272,37 +278,41 @@ class TestFulltextNestedStructure(TestCase):
                     </front-stub>
                 </sub-article>
             </sub-article>
-        </article>'''
+        </article>"""
         self.fulltext = Fulltext(etree.fromstring(xml))
 
     def test_nested_structure(self):
         # Test main article
         main_related = list(self.fulltext.related_articles)
         self.assertEqual(len(main_related), 1)
-        self.assertEqual(main_related[0]['text'], 'Main article')
-        
+        self.assertEqual(main_related[0]["text"], "Main article")
+
         # Test first level sub-articles
         level1_articles = list(self.fulltext.fulltexts)
         self.assertEqual(len(level1_articles), 1)
-        
+
         translation = level1_articles[0]
-        self.assertEqual(translation.parent_data['parent_article_type'], 'translation')
-        self.assertEqual(translation.parent_data['original_article_type'], 'research-article')
-        
+        self.assertEqual(translation.parent_data["parent_article_type"], "translation")
+        self.assertEqual(
+            translation.parent_data["original_article_type"], "research-article"
+        )
+
         # Test translation related articles
         trans_related = list(translation.related_articles)
         self.assertEqual(len(trans_related), 1)
-        self.assertEqual(trans_related[0]['text'], 'Translation 1')
-        
+        self.assertEqual(trans_related[0]["text"], "Translation 1")
+
         # Test nested reviewer-report
         nested_articles = list(translation.fulltexts)
         self.assertEqual(len(nested_articles), 1)
-        
+
         reviewer_report = nested_articles[0]
-        self.assertEqual(reviewer_report.parent_data['parent_article_type'], 'reviewer-report')
-        self.assertIsNone(reviewer_report.parent_data['original_article_type'])
-        
+        self.assertEqual(
+            reviewer_report.parent_data["parent_article_type"], "reviewer-report"
+        )
+        self.assertIsNone(reviewer_report.parent_data["original_article_type"])
+
         # Test reviewer-report related articles
         abs_related = list(reviewer_report.related_articles)
         self.assertEqual(len(abs_related), 1)
-        self.assertEqual(abs_related[0]['text'], 'Nested reviewer-report')
+        self.assertEqual(abs_related[0]["text"], "Nested reviewer-report")

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -1,9 +1,10 @@
 from unittest import TestCase, skip
 from lxml import etree
-
+from packtools.sps.models.related_articles import Fulltext
 from packtools.sps.validation.related_articles import (
     RelatedArticlesValidation,
     RelatedArticleValidation,
+    FulltextValidation,
 )
 
 
@@ -32,7 +33,6 @@ class RelatedArticlesValidationTest(TestCase):
         }
         validator = RelatedArticlesValidation(xmltree, params)
         result = list(validator.validate_related_article_types())[0]
-
         self.assertEqual(result["response"], "OK")
         self.assertEqual(result["got_value"], "corrected-article")
         self.assertEqual(result["expected_value"], ["corrected-article"])
@@ -256,10 +256,7 @@ class TestRelatedArticleTypeValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_type()
 
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "corrected-article")
-        self.assertEqual(result["expected_value"], ["corrected-article"])
-        self.assertIsNone(result["advice"])
+        self.assertIsNone(result)
 
     def test_validate_type_no_match(self):
         self.base_article.update(
@@ -294,10 +291,7 @@ class TestRelatedArticleLinkValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_doi()
 
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "10.1590/example")
-        self.assertEqual(result["expected_value"], "A valid DOI")
-        self.assertIsNone(result["advice"])
+        self.assertIsNone(result)
 
     def test_validate_uri_link_valid(self):
         self.base_article.update(
@@ -306,12 +300,7 @@ class TestRelatedArticleLinkValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_uri()
 
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "http://example.com/article")
-        self.assertEqual(
-            result["expected_value"], "A valid URI format (e.g., http://example.com)"
-        )
-        self.assertIsNone(result["advice"])
+        self.assertIsNone(result)
 
     def test_validate_uri_link_invalid(self):
         self.base_article.update({"ext-link-type": "uri", "href": "invalid-uri"})
@@ -351,20 +340,14 @@ class TestRelatedArticleExtLinkTypeValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_ext_link_type()
 
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "doi")
-        self.assertEqual(result["expected_value"], ["doi", "uri"])
-        self.assertIsNone(result["advice"])
+        self.assertIsNone(result)
 
     def test_validate_ext_link_type_uri(self):
         self.base_article["ext-link-type"] = "uri"
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_ext_link_type()
 
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "uri")
-        self.assertEqual(result["expected_value"], ["doi", "uri"])
-        self.assertIsNone(result["advice"])
+        self.assertIsNone(result)
 
     def test_validate_ext_link_type_invalid(self):
         self.base_article["ext-link-type"] = "url"
@@ -395,8 +378,7 @@ class TestRelatedArticleFullValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         results = validator.validate()
 
-        self.assertEqual(len(results), 4)  # All validations should run
-        self.assertTrue(all(r["response"] == "OK" for r in results))
+        self.assertEqual(len(results), 0)
 
     def test_validate_all_pass_uri(self):
         self.base_article.update(
@@ -405,8 +387,7 @@ class TestRelatedArticleFullValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         results = validator.validate()
 
-        self.assertEqual(len(results), 4)
-        self.assertTrue(all(r["response"] == "OK" for r in results))
+        self.assertEqual(len(results), 0)
 
     def test_validate_all_with_errors(self):
         self.base_article.update(
@@ -450,7 +431,7 @@ class TestRelatedArticleValidation(BaseRelatedArticleTest):
     def test_validate_type_response(self):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_type()
-        self.assertEqual(result["response"], "OK")
+        self.assertIsNone(result)
 
     def test_validate_uri_existence(self):
         self.base_article["ext-link-type"] = "uri"
@@ -476,6 +457,238 @@ class TestRelatedArticleValidation(BaseRelatedArticleTest):
         validator = RelatedArticleValidation(self.base_article, self.params)
         result = validator.validate_doi()
         self.assertEqual(result["response"], "CRICRI")
+
+
+class BaseFulltextValidationTest(TestCase):
+    """Base test class with common setup for validation tests"""
+
+    def setUp(self):
+        self.params = {
+            "ext_link_type_list": ["doi", "uri"],
+            "article-types-and-related-article-types": {
+                "correction": {
+                    "required_related_article_types": ["corrected-article"],
+                    "acceptable_related_article_types": [],
+                },
+                "research-article": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                    ],
+                },
+            },
+        }
+
+
+class TestMissingRequiredArticle(BaseFulltextValidationTest):
+    """Test case for missing required related article"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="correction" xml:lang="en" id="a1">
+            <front><article-meta></article-meta></front>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml).find("."))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_missing_required(self):
+        results = list(self.validator.validate())
+        self.assertEqual(len(results), 1)
+
+        result = results[0]
+        self.assertEqual(result["response"], "CRITICAL")
+        self.assertEqual(result["validation_type"], "match")
+        self.assertEqual(result["title"], "Required related articles")
+        self.assertIn("corrected-article", result["expected_value"])
+        self.assertEqual(result["got_value"], [])
+
+
+class TestOptionalArticle(BaseFulltextValidationTest):
+    """Test case for article with optional related articles"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="research-article" xml:lang="en" id="a1">
+            <front><article-meta></article-meta></front>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_optional_missing(self):
+        results = list(self.validator.validate())
+        self.assertEqual(len(results), 0)
+
+
+class TestNestedValidation(BaseFulltextValidationTest):
+    """Test case for nested structure with sub-articles"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="research-article" xml:lang="en" id="a1">
+            <front>
+                <article-meta>
+                    <related-article related-article-type="correction-forward" 
+                                   ext-link-type="doi" 
+                                   id="ra1">Main text</related-article>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="pt" id="s1">
+                <front-stub>
+                    <related-article related-article-type="other-type" 
+                                   ext-link-type="doi" 
+                                   id="ra2">Translation text</related-article>
+                </front-stub>
+            </sub-article>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_nested_validation(self):
+        results = list(self.validator.validate())
+
+        # Find errors in translation sub-article
+        translation_errors = [
+            r
+            for r in results
+            if r["parent_article_type"] == "translation" and r["response"] == "CRITICAL"
+        ]
+
+        self.assertEqual(len(translation_errors), 1)
+        error = translation_errors[0]
+        self.assertEqual(error["validation_type"], "match")
+        self.assertIn("correction-forward", error["expected_value"])
+
+
+class TestValidStructure(BaseFulltextValidationTest):
+    """Test case for valid structure with all required articles"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="correction" xml:lang="en" id="a1">
+            <front>
+                <article-meta>
+                    <related-article related-article-type="corrected-article" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/dois"
+                                   id="ra1">Correction text</related-article>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="pt" id="s1">
+                <front-stub>
+                    <related-article related-article-type="corrected-article" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/dois"
+                                   id="ra2">Translation text</related-article>
+                </front-stub>
+            </sub-article>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml).find("."))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_valid_structure(self):
+        results = list(self.validator.validate())
+        print(results)
+        errors = [r for r in results if r["response"] != "OK"]
+        self.assertEqual(len(errors), 0)
+
+
+class TestMultipleSubArticles(BaseFulltextValidationTest):
+    """Test case for multiple sub-articles with different requirements"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="research-article" xml:lang="en" id="a1">
+            <front>
+                <article-meta>
+                    <related-article related-article-type="correction-forward" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/xxxx"
+                                   id="ra1">Main text</related-article>
+                </article-meta>
+            </front>
+            <sub-article article-type="translation" xml:lang="es" id="s1">
+                <front-stub>
+                    <related-article related-article-type="correction-forward" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/xxxx"
+                                   id="ra2">Spanish translation</related-article>
+                </front-stub>
+            </sub-article>
+            <sub-article article-type="translation" xml:lang="pt" id="s2">
+                <front-stub>
+                    <related-article related-article-type="other-type" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1590/xxxx"
+                                   id="ra3">Portuguese translation</related-article>
+                </front-stub>
+            </sub-article>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_multiple_sub_articles(self):
+        results = list(self.validator.validate())
+
+        # First sub-article should be valid
+        spanish_errors = [
+            r for r in results if r["parent_id"] == "s1" and r["response"] != "OK"
+        ]
+        self.assertEqual(len(spanish_errors), 0)
+
+        # Second sub-article should have error
+        portuguese_errors = [
+            r
+            for r in results
+            if r["parent_id"] == "s2" and r["response"] == "CRITICAL"
+        ]
+        self.assertEqual(len(portuguese_errors), 1)
+
+
+class TestOriginalArticleType(BaseFulltextValidationTest):
+    """Test case for original_article_type inheritance"""
+
+    def setUp(self):
+        super().setUp()
+        xml = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink"  article-type="research-article" xml:lang="en" id="a1">
+            <sub-article article-type="translation" xml:lang="pt" id="s1">
+                <front-stub>
+                    <related-article related-article-type="correction-forward" 
+                                   ext-link-type="doi" 
+                                   id="ra1">Translation</related-article>
+                </front-stub>
+                <sub-article article-type="abstract" id="s2">
+                    <front-stub>
+                        <related-article related-article-type="abstract-of" 
+                                       ext-link-type="doi" 
+                                       id="ra2">Abstract</related-article>
+                    </front-stub>
+                </sub-article>
+            </sub-article>
+        </article>"""
+
+        self.fulltext = Fulltext(etree.fromstring(xml))
+        self.validator = FulltextValidation(self.fulltext, self.params)
+
+    def test_original_article_type_inheritance(self):
+        results = list(self.validator.validate())
+
+        translation_data = [r for r in results if r["parent_id"] == "s1"][0]
+
+        self.assertEqual(
+            translation_data["data"].get("original_article_type"), "research-article"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -1,4 +1,6 @@
 from unittest import TestCase, skip
+from unittest.mock import Mock, patch
+
 from lxml import etree
 from packtools.sps.models.related_articles import Fulltext
 from packtools.sps.validation.related_articles import (
@@ -6,112 +8,6 @@ from packtools.sps.validation.related_articles import (
     RelatedArticleValidation,
     FulltextValidation,
 )
-
-
-class RelatedArticlesValidationTest(TestCase):
-    def test_validate_related_article_types_match(self):
-        xmltree = etree.fromstring(
-            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="correction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
-            </front>
-            </article>"""
-        )
-        params = {
-            "correspondence_list": [
-                {
-                    "article-type": "correction",
-                    "related-article-types": ["corrected-article"],
-                },
-                {
-                    "article-type": "retraction",
-                    "related-article-types": ["retracted-article"],
-                },
-            ],
-            "error_level": "ERROR",
-        }
-        validator = RelatedArticlesValidation(xmltree, params)
-        result = list(validator.validate_related_article_types())[0]
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "corrected-article")
-        self.assertEqual(result["expected_value"], ["corrected-article"])
-        self.assertIsNone(result["advice"])
-        self.assertEqual(result["parent_article_type"], "correction")
-
-    def test_validate_related_article_types_not_match(self):
-        xmltree = etree.fromstring(
-            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="retraction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <related-article ext-link-type="doi" id="ra1" related-article-type="retraction-forward" xlink:href="10.1590/1808-057x202090350"/>
-            </front>
-            </article>"""
-        )
-        params = {
-            "correspondence_list": [
-                {
-                    "article-type": "correction",
-                    "related-article-types": ["corrected-article"],
-                },
-                {
-                    "article-type": "retraction",
-                    "related-article-types": ["retracted-article", "article-retracted"],
-                },
-            ],
-            "error_level": "ERROR",
-        }
-        validator = RelatedArticlesValidation(xmltree, params)
-        result = list(validator.validate_related_article_types())[0]
-
-        self.assertEqual(result["response"], "ERROR")
-        self.assertEqual(result["got_value"], "retraction-forward")
-        self.assertEqual(
-            result["expected_value"], ["retracted-article", "article-retracted"]
-        )
-        self.assertTrue(result["advice"].startswith("The article-type: retraction"))
-        self.assertEqual(result["parent_article_type"], "retraction")
-
-    def test_validate_related_article_doi_exists(self):
-        xmltree = etree.fromstring(
-            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
-            </front>
-            </article>"""
-        )
-        validator = RelatedArticlesValidation(xmltree, {"error_level": "ERROR"})
-        result = list(validator.validate_related_article_doi())[0]
-
-        self.assertEqual(result["response"], "OK")
-        self.assertEqual(result["got_value"], "10.1590/1808-057x202090350")
-        self.assertEqual(result["expected_value"], "10.1590/1808-057x202090350")
-        self.assertIsNone(result["advice"])
-        self.assertEqual(result["parent_article_type"], "correction-forward")
-        self.assertEqual(result["validation_type"], "exist")
-
-    def test_validate_related_article_doi_not_exists(self):
-        xmltree = etree.fromstring(
-            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
-            article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
-            <front>
-            <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" />
-            </front>
-            </article>"""
-        )
-        validator = RelatedArticlesValidation(xmltree, {"error_level": "ERROR"})
-        result = list(validator.validate_related_article_doi())[0]
-
-        self.assertEqual(result["response"], "ERROR")
-        self.assertIsNone(result["got_value"])
-        self.assertEqual(
-            result["expected_value"],
-            "A valid DOI or URI for related-article/@xlink:href",
-        )
-        self.assertTrue(result["advice"].startswith("Provide a valid DOI"))
-        self.assertEqual(result["parent_article_type"], "correction-forward")
-        self.assertEqual(result["validation_type"], "exist")
 
 
 class BaseRelatedArticleTest(TestCase):
@@ -236,6 +132,144 @@ class BaseRelatedArticleTest(TestCase):
                 },
             },
         }
+
+
+class TestRelatedArticlesValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        
+        self.xml = '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction">
+                <front>
+                    <related-article related-article-type="corrected-article"/>
+                </front>
+            </article>'''
+        
+        self.xmltree = etree.fromstring(self.xml)
+
+    @patch('packtools.sps.validation.related_articles.FulltextValidation')
+    @patch('packtools.sps.validation.related_articles.Fulltext')
+    def test_initialization(self, mock_fulltext, mock_validation):
+        """Test if classes are properly initialized"""
+        # Arrange
+        mock_fulltext_instance = Mock()
+        mock_fulltext.return_value = mock_fulltext_instance
+        
+        mock_validation_instance = Mock()
+        mock_validation.return_value = mock_validation_instance
+
+        # Act
+        validator = RelatedArticlesValidation(self.xmltree, self.params)
+
+        # Assert
+        mock_fulltext.assert_called_once_with(self.xmltree.find("."))
+        mock_validation.assert_called_once_with(mock_fulltext_instance, self.params)
+        self.assertEqual(validator.params, self.params)
+        self.assertEqual(validator.error_level, 'ERROR')
+
+    @patch('packtools.sps.validation.related_articles.FulltextValidation')
+    @patch('packtools.sps.validation.related_articles.Fulltext')
+    def test_initialization_default_params(self, mock_fulltext, mock_validation):
+        """Test initialization with default parameters"""
+        # Act
+        validator = RelatedArticlesValidation(self.xmltree)
+
+        # Assert
+        self.assertEqual(validator.params, {})
+        self.assertEqual(validator.error_level, 'ERROR')
+
+    @patch('packtools.sps.validation.related_articles.FulltextValidation')
+    @patch('packtools.sps.validation.related_articles.Fulltext')
+    def test_validate_method_calls(self, mock_fulltext, mock_validation):
+        """Test if validate method properly calls FulltextValidation.validate"""
+        # Arrange
+        mock_validation_instance = Mock()
+        mock_validation.return_value = mock_validation_instance
+        
+        expected_results = [{'result': 1}, {'result': 2}]
+        mock_validation_instance.validate.return_value = iter(expected_results)
+
+        # Act
+        validator = RelatedArticlesValidation(self.xmltree, self.params)
+        results = list(validator.validate())
+
+        # Assert
+        mock_validation_instance.validate.assert_called_once()
+        self.assertEqual(results, expected_results)
+
+    def test_integration_with_real_xml(self):
+        """Test integration with real XML document"""
+        # Arrange
+        xml = '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction">
+                <front>
+                    <related-article related-article-type="corrected-article" 
+                                   ext-link-type="doi" 
+                                   xlink:href="10.1000/xyz123"/>
+                </front>
+            </article>'''
+        xmltree = etree.fromstring(xml)
+
+        # Act
+        validator = RelatedArticlesValidation(xmltree, self.params)
+        results = list(validator.validate())
+
+        # Assert
+        self.assertTrue(len(results) > 0)
+        for result in results:
+            self.assertIn('response', result)
+            self.assertIn('validation_type', result)
+
+    def test_multiple_related_articles(self):
+        """Test validation with multiple related articles"""
+        # Arrange
+        xml = '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction">
+                <front>
+                    <related-article related-article-type="corrected-article" id="ra1"/>
+                    <related-article related-article-type="corrected-article" id="ra2"/>
+                </front>
+            </article>'''
+        xmltree = etree.fromstring(xml)
+
+        # Act
+        validator = RelatedArticlesValidation(xmltree, self.params)
+        results = list(validator.validate())
+
+        # Assert
+        self.assertTrue(len(results) > 0)
+        ids = [r.get('data', {}).get('id') for r in results if 'data' in r]
+        self.assertTrue(len(set(ids)) > 1)  # Should have multiple unique IDs
+
+    def test_error_level_inheritance(self):
+        """Test if error_level is properly inherited from params"""
+        # Test with custom error level
+        params = self.params.copy()
+        params['error_level'] = 'CUSTOM_ERROR'
+        validator = RelatedArticlesValidation(self.xmltree, params)
+        self.assertEqual(validator.error_level, 'CUSTOM_ERROR')
+
+        # Test with default error level
+        validator = RelatedArticlesValidation(self.xmltree, {})
+        self.assertEqual(validator.error_level, 'ERROR')
+
+    def test_empty_document(self):
+        """Test validation with empty document"""
+        # Arrange
+        xml = '''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction">
+                <front></front>
+            </article>'''
+        xmltree = etree.fromstring(xml)
+
+        # Act
+        validator = RelatedArticlesValidation(xmltree, self.params)
+        results = list(validator.validate())
+
+        # Assert
+        self.assertTrue(len(results) > 0)
+        error_results = [r for r in results if r['response'] != 'OK']
+        self.assertTrue(len(error_results) > 0)
 
 
 class TestRelatedArticleTypeValidation(BaseRelatedArticleTest):

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -1,29 +1,22 @@
-import unittest
-from unittest import skip
-
+from unittest import TestCase
 from lxml import etree
 
 from packtools.sps.validation.related_articles import RelatedArticlesValidation
 
 
-class RelatedArticlesValidationTest(unittest.TestCase):
-
-    @skip("Teste pendente de correção e/ou ajuste")
-    def test_related_articles_matches_article_type_validation_match(self):
+class RelatedArticlesValidationTest(TestCase):
+    def test_validate_related_article_types_match(self):
         self.maxDiff = None
         xmltree = etree.fromstring(
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>
-
-            """
+            </article>'''
         )
-        obtained = list(RelatedArticlesValidation(xmltree).related_articles_matches_article_type_validation(
-            [
+        params = {
+            'correspondence_list': [
                 {
                     'article-type': 'correction',
                     'related-article-types': ['corrected-article']
@@ -32,8 +25,11 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'article-type': 'retraction',
                     'related-article-types': ['retracted-article']
                 }
-            ]
-        ))
+            ],
+            'error_level': 'ERROR'
+        }
+        validator = RelatedArticlesValidation(xmltree, params)
+        obtained = list(validator.validate_related_article_types())
 
         expected = [
             {
@@ -67,21 +63,18 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
-    def test_related_articles_matches_article_type_validation_not_match(self):
+    def test_validate_related_article_types_not_match(self):
         self.maxDiff = None
         xmltree = etree.fromstring(
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="retraction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="retraction-forward" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>
-
-            """
+            </article>'''
         )
-        obtained = list(RelatedArticlesValidation(xmltree).related_articles_matches_article_type_validation(
-            [
+        params = {
+            'correspondence_list': [
                 {
                     'article-type': 'correction',
                     'related-article-types': ['corrected-article']
@@ -90,8 +83,11 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                     'article-type': 'retraction',
                     'related-article-types': ['retracted-article', 'article-retracted']
                 }
-            ]
-        ))
+            ],
+            'error_level': 'ERROR'
+        }
+        validator = RelatedArticlesValidation(xmltree, params)
+        obtained = list(validator.validate_related_article_types())
 
         expected = [
             {
@@ -108,7 +104,7 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                 'got_value': 'retraction-forward',
                 'message': "Got retraction-forward, expected ['retracted-article', 'article-retracted']",
                 'advice': "The article-type: retraction does not match the related-article-type: retraction-forward, "
-                          "provide one of the following items: ['retracted-article', 'article-retracted']",
+                         "provide one of the following items: ['retracted-article', 'article-retracted']",
                 'data': {
                     'parent': 'article',
                     'parent_article_type': 'retraction',
@@ -126,20 +122,18 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
-    def test_related_articles_has_doi(self):
+    def test_validate_related_article_doi_exists(self):
         self.maxDiff = None
         xmltree = etree.fromstring(
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>
-
-            """
+            </article>'''
         )
-        obtained = list(RelatedArticlesValidation(xmltree).related_articles_doi())
+        validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
+        obtained = list(validator.validate_related_article_doi())
 
         expected = [
             {
@@ -173,20 +167,18 @@ class RelatedArticlesValidationTest(unittest.TestCase):
             with self.subTest(i):
                 self.assertDictEqual(obtained[i], item)
 
-    def test_related_articles_does_not_have_doi(self):
+    def test_validate_related_article_doi_not_exists(self):
         self.maxDiff = None
         xmltree = etree.fromstring(
-            """
-            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" />
             </front>
-            </article>
-
-            """
+            </article>'''
         )
-        obtained = list(RelatedArticlesValidation(xmltree).related_articles_doi())
+        validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
+        obtained = list(validator.validate_related_article_doi())
 
         expected = [
             {
@@ -203,7 +195,7 @@ class RelatedArticlesValidationTest(unittest.TestCase):
                 'got_value': None,
                 'message': 'Got None, expected A valid DOI or URI for related-article/@xlink:href',
                 'advice': 'Provide a valid DOI for <related-article ext-link-type="doi" id="ra1" '
-                          'related-article-type="corrected-article" /> ',
+                         'related-article-type="corrected-article" />',
                 'data': {
                     'parent': 'article',
                     'parent_article_type': 'correction-forward',

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -1,110 +1,482 @@
-from unittest import TestCase
+from unittest import TestCase, skip
 from lxml import etree
 
-from packtools.sps.validation.related_articles import RelatedArticlesValidation
+from packtools.sps.validation.related_articles import (
+    RelatedArticlesValidation,
+    RelatedArticleValidation,
+)
 
 
 class RelatedArticlesValidationTest(TestCase):
     def test_validate_related_article_types_match(self):
         xmltree = etree.fromstring(
-            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>'''
+            </article>"""
         )
         params = {
-            'correspondence_list': [
+            "correspondence_list": [
                 {
-                    'article-type': 'correction',
-                    'related-article-types': ['corrected-article']
+                    "article-type": "correction",
+                    "related-article-types": ["corrected-article"],
                 },
                 {
-                    'article-type': 'retraction',
-                    'related-article-types': ['retracted-article']
-                }
+                    "article-type": "retraction",
+                    "related-article-types": ["retracted-article"],
+                },
             ],
-            'error_level': 'ERROR'
+            "error_level": "ERROR",
         }
         validator = RelatedArticlesValidation(xmltree, params)
         result = list(validator.validate_related_article_types())[0]
 
-        self.assertEqual(result['response'], 'OK')
-        self.assertEqual(result['got_value'], 'corrected-article')
-        self.assertEqual(result['expected_value'], ['corrected-article'])
-        self.assertIsNone(result['advice'])
-        self.assertEqual(result['parent_article_type'], 'correction')
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "corrected-article")
+        self.assertEqual(result["expected_value"], ["corrected-article"])
+        self.assertIsNone(result["advice"])
+        self.assertEqual(result["parent_article_type"], "correction")
 
     def test_validate_related_article_types_not_match(self):
         xmltree = etree.fromstring(
-            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="retraction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="retraction-forward" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>'''
+            </article>"""
         )
         params = {
-            'correspondence_list': [
+            "correspondence_list": [
                 {
-                    'article-type': 'correction',
-                    'related-article-types': ['corrected-article']
+                    "article-type": "correction",
+                    "related-article-types": ["corrected-article"],
                 },
                 {
-                    'article-type': 'retraction',
-                    'related-article-types': ['retracted-article', 'article-retracted']
-                }
+                    "article-type": "retraction",
+                    "related-article-types": ["retracted-article", "article-retracted"],
+                },
             ],
-            'error_level': 'ERROR'
+            "error_level": "ERROR",
         }
         validator = RelatedArticlesValidation(xmltree, params)
         result = list(validator.validate_related_article_types())[0]
 
-        self.assertEqual(result['response'], 'ERROR')
-        self.assertEqual(result['got_value'], 'retraction-forward')
-        self.assertEqual(result['expected_value'], ['retracted-article', 'article-retracted'])
-        self.assertTrue(result['advice'].startswith('The article-type: retraction'))
-        self.assertEqual(result['parent_article_type'], 'retraction')
+        self.assertEqual(result["response"], "ERROR")
+        self.assertEqual(result["got_value"], "retraction-forward")
+        self.assertEqual(
+            result["expected_value"], ["retracted-article", "article-retracted"]
+        )
+        self.assertTrue(result["advice"].startswith("The article-type: retraction"))
+        self.assertEqual(result["parent_article_type"], "retraction")
 
     def test_validate_related_article_doi_exists(self):
         xmltree = etree.fromstring(
-            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.1590/1808-057x202090350"/>
             </front>
-            </article>'''
+            </article>"""
         )
-        validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
+        validator = RelatedArticlesValidation(xmltree, {"error_level": "ERROR"})
         result = list(validator.validate_related_article_doi())[0]
 
-        self.assertEqual(result['response'], 'OK')
-        self.assertEqual(result['got_value'], '10.1590/1808-057x202090350')
-        self.assertEqual(result['expected_value'], '10.1590/1808-057x202090350')
-        self.assertIsNone(result['advice'])
-        self.assertEqual(result['parent_article_type'], 'correction-forward')
-        self.assertEqual(result['validation_type'], 'exist')
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "10.1590/1808-057x202090350")
+        self.assertEqual(result["expected_value"], "10.1590/1808-057x202090350")
+        self.assertIsNone(result["advice"])
+        self.assertEqual(result["parent_article_type"], "correction-forward")
+        self.assertEqual(result["validation_type"], "exist")
 
     def test_validate_related_article_doi_not_exists(self):
         xmltree = etree.fromstring(
-            '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
+            """<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
             <front>
             <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" />
             </front>
-            </article>'''
+            </article>"""
         )
-        validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
+        validator = RelatedArticlesValidation(xmltree, {"error_level": "ERROR"})
         result = list(validator.validate_related_article_doi())[0]
 
-        self.assertEqual(result['response'], 'ERROR')
-        self.assertIsNone(result['got_value'])
-        self.assertEqual(result['expected_value'], 'A valid DOI or URI for related-article/@xlink:href')
-        self.assertTrue(result['advice'].startswith('Provide a valid DOI'))
-        self.assertEqual(result['parent_article_type'], 'correction-forward')
-        self.assertEqual(result['validation_type'], 'exist')
+        self.assertEqual(result["response"], "ERROR")
+        self.assertIsNone(result["got_value"])
+        self.assertEqual(
+            result["expected_value"],
+            "A valid DOI or URI for related-article/@xlink:href",
+        )
+        self.assertTrue(result["advice"].startswith("Provide a valid DOI"))
+        self.assertEqual(result["parent_article_type"], "correction-forward")
+        self.assertEqual(result["validation_type"], "exist")
 
 
-if __name__ == '__main__':
+class BaseRelatedArticleTest(TestCase):
+    """Base test class with common setup"""
+
+    def setUp(self):
+        self.params = {
+            "requirement_error_level": "CRICRI",
+            "type_error_level": "CRICRI",
+            "ext_link_type_error_level": "CRICRI",
+            "uri_error_level": "CRICRI",
+            "uri_format_error_level": "CRICRI",
+            "doi_error_level": "CRICRI",
+            "doi_format_error_level": "CRICRI",
+            "id_error_level": "CRICRI",
+            "article-types-and-related-article-types": {
+                "correction": {
+                    "required_related_article_types": ["corrected-article"],
+                    "acceptable_related_article_types": [],
+                },
+                "research-article": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                        "reviewer-report",
+                        "preprint",
+                    ],
+                },
+                "review-article": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                        "reviewer-report",
+                        "preprint",
+                    ],
+                },
+                "case-report": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                        "reviewer-report",
+                        "preprint",
+                    ],
+                },
+                "brief-report": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                        "reviewer-report",
+                        "preprint",
+                    ],
+                },
+                "data-article": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                        "reviewer-report",
+                        "preprint",
+                    ],
+                },
+                "retraction": {
+                    "required_related_article_types": ["retracted-article"],
+                    "acceptable_related_article_types": [],
+                },
+                "partial-retraction": {
+                    "required_related_article_types": ["retracted-article"],
+                    "acceptable_related_article_types": [],
+                },
+                "addendum": {
+                    "required_related_article_types": ["article"],
+                    "acceptable_related_article_types": [],
+                },
+                "article-commentary": {
+                    "required_related_article_types": ["commentary-article"],
+                    "acceptable_related_article_types": [],
+                },
+                "letter": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": ["article", "letter"],
+                },
+                "reply": {
+                    "required_related_article_types": ["letter"],
+                    "acceptable_related_article_types": [],
+                },
+                "editorial": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": [
+                        "correction-forward",
+                        "retraction-forward",
+                        "partial-retraction",
+                        "addendum",
+                        "commentary",
+                    ],
+                },
+                "reviewer-report": {
+                    "required_related_article_types": ["peer-reviewed-material"],
+                    "acceptable_related_article_types": [],
+                },
+                "preprint": {
+                    "required_related_article_types": [],
+                    "acceptable_related_article_types": ["article"],
+                },
+            },
+        }
+
+
+class TestRelatedArticleTypeValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        self.base_article = {
+            "parent": "article",
+            "parent_article_type": "correction",
+            "parent_id": None,
+            "parent_lang": "en",
+            "ext-link-type": "doi",
+            "href": "10.1590/1808-057x202090350",
+            "id": "ra1",
+            "related-article-type": "corrected-article",
+        }
+
+    def test_validate_type_match(self):
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_type()
+
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "corrected-article")
+        self.assertEqual(result["expected_value"], ["corrected-article"])
+        self.assertIsNone(result["advice"])
+
+    def test_validate_type_no_match(self):
+        self.base_article.update(
+            {
+                "parent_article_type": "retraction",
+                "related-article-type": "corrected-article",
+            }
+        )
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_type()
+
+        self.assertEqual(result["response"], "CRICRI")
+        self.assertEqual(result["got_value"], "corrected-article")
+        self.assertEqual(result["expected_value"], ["retracted-article"])
+        self.assertTrue(result["advice"].startswith("The article-type: retraction"))
+
+
+class TestRelatedArticleLinkValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        self.base_article = {
+            "parent": "article",
+            "parent_article_type": "correction",
+            "parent_id": None,
+            "parent_lang": "en",
+            "ext-link-type": "doi",
+            "href": "10.1590/example",
+            "id": "ra1",
+        }
+
+    def test_validate_doi_link(self):
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_doi()
+
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "10.1590/example")
+        self.assertEqual(result["expected_value"], "A valid DOI")
+        self.assertIsNone(result["advice"])
+
+    def test_validate_uri_link_valid(self):
+        self.base_article.update(
+            {"ext-link-type": "uri", "href": "http://example.com/article"}
+        )
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_uri()
+
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "http://example.com/article")
+        self.assertEqual(
+            result["expected_value"], "A valid URI format (e.g., http://example.com)"
+        )
+        self.assertIsNone(result["advice"])
+
+    def test_validate_uri_link_invalid(self):
+        self.base_article.update({"ext-link-type": "uri", "href": "invalid-uri"})
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_uri()
+
+        self.assertEqual(result["response"], "CRICRI")
+        self.assertEqual(result["got_value"], "invalid-uri")
+        self.assertEqual(
+            result["expected_value"], "A valid URI format (e.g., http://example.com)"
+        )
+        self.assertTrue(result["advice"].startswith("Invalid URI format"))
+
+    def test_validate_link_missing(self):
+        del self.base_article["href"]
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_doi()
+
+        self.assertEqual(result["response"], "CRICRI")
+        self.assertIsNone(result["got_value"])
+        self.assertEqual(result["expected_value"], "A valid DOI")
+        self.assertTrue(result["advice"].startswith("Provide a valid DOI"))
+
+
+class TestRelatedArticleExtLinkTypeValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        self.base_article = {
+            "parent": "article",
+            "parent_article_type": "correction",
+            "ext-link-type": "doi",
+            "href": "10.1590/example",
+            "id": "ra1",
+        }
+
+    def test_validate_ext_link_type_doi(self):
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_ext_link_type()
+
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "doi")
+        self.assertEqual(result["expected_value"], ["doi", "uri"])
+        self.assertIsNone(result["advice"])
+
+    def test_validate_ext_link_type_uri(self):
+        self.base_article["ext-link-type"] = "uri"
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_ext_link_type()
+
+        self.assertEqual(result["response"], "OK")
+        self.assertEqual(result["got_value"], "uri")
+        self.assertEqual(result["expected_value"], ["doi", "uri"])
+        self.assertIsNone(result["advice"])
+
+    def test_validate_ext_link_type_invalid(self):
+        self.base_article["ext-link-type"] = "url"
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_ext_link_type()
+
+        self.assertEqual(result["response"], "CRICRI")
+        self.assertEqual(result["got_value"], "url")
+        self.assertEqual(result["expected_value"], ["doi", "uri"])
+        self.assertTrue(result["advice"].startswith("The ext-link-type"))
+
+
+class TestRelatedArticleFullValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        self.base_article = {
+            "parent": "article",
+            "parent_article_type": "correction",
+            "parent_id": None,
+            "parent_lang": "en",
+            "ext-link-type": "doi",
+            "href": "10.1590/example",
+            "id": "ra1",
+            "related-article-type": "corrected-article",
+        }
+
+    def test_validate_all_pass_doi(self):
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        results = validator.validate()
+
+        self.assertEqual(len(results), 4)  # All validations should run
+        self.assertTrue(all(r["response"] == "OK" for r in results))
+
+    def test_validate_all_pass_uri(self):
+        self.base_article.update(
+            {"ext-link-type": "uri", "href": "http://example.com/article"}
+        )
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        results = validator.validate()
+
+        self.assertEqual(len(results), 4)
+        self.assertTrue(all(r["response"] == "OK" for r in results))
+
+    def test_validate_all_with_errors(self):
+        self.base_article.update(
+            {
+                "ext-link-type": "url",
+                "href": "invalid-uri",
+                "related-article-type": "invalid-type",
+            }
+        )
+
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        results = validator.validate()
+
+        error_count = sum(1 for r in results if r["response"] == "CRICRI")
+        self.assertGreater(error_count, 0)
+
+
+class TestRelatedArticleValidation(BaseRelatedArticleTest):
+    def setUp(self):
+        super().setUp()
+        self.base_article = {
+            "parent": "article",
+            "parent_article_type": "correction",
+            "ext-link-type": "doi",
+            "href": "10.1590/example",
+            "id": "ra1",
+            "related-article-type": "corrected-article",
+        }
+
+    def test_get_error_level_default(self):
+        validator = RelatedArticleValidation(self.base_article, {})
+        error_level = validator._get_error_level("any_type")
+        self.assertEqual(error_level, "CRITICAL")
+
+    def test_get_error_level_custom(self):
+        params = {"custom_error_level": "CUSTOM"}
+        validator = RelatedArticleValidation(self.base_article, params)
+        error_level = validator._get_error_level("custom")
+        self.assertEqual(error_level, "CUSTOM")
+
+    def test_validate_type_response(self):
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_type()
+        self.assertEqual(result["response"], "OK")
+
+    def test_validate_uri_existence(self):
+        self.base_article["ext-link-type"] = "uri"
+        del self.base_article["href"]
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_uri()
+        self.assertEqual(result["response"], "CRICRI")
+
+    def test_validate_uri_format(self):
+        self.base_article.update({"ext-link-type": "uri", "href": "invalid-uri"})
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_uri()
+        self.assertEqual(result["response"], "CRICRI")
+
+    def test_validate_doi_existence(self):
+        del self.base_article["href"]
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_doi()
+        self.assertEqual(result["response"], "CRICRI")
+
+    def test_validate_doi_format(self):
+        self.base_article["href"] = "invalid-doi"
+        validator = RelatedArticleValidation(self.base_article, self.params)
+        result = validator.validate_doi()
+        self.assertEqual(result["response"], "CRICRI")
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_related_articles.py
+++ b/tests/sps/validation/test_related_articles.py
@@ -6,7 +6,6 @@ from packtools.sps.validation.related_articles import RelatedArticlesValidation
 
 class RelatedArticlesValidationTest(TestCase):
     def test_validate_related_article_types_match(self):
-        self.maxDiff = None
         xmltree = etree.fromstring(
             '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
@@ -29,42 +28,15 @@ class RelatedArticlesValidationTest(TestCase):
             'error_level': 'ERROR'
         }
         validator = RelatedArticlesValidation(xmltree, params)
-        obtained = list(validator.validate_related_article_types())
+        result = list(validator.validate_related_article_types())[0]
 
-        expected = [
-            {
-                'title': 'Related article type validation',
-                'parent': 'article',
-                'parent_article_type': 'correction',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'item': 'related-article',
-                'sub_item': 'related-article-type',
-                'validation_type': 'match',
-                'response': 'OK',
-                'expected_value': ['corrected-article'],
-                'got_value': 'corrected-article',
-                'message': "Got corrected-article, expected ['corrected-article']",
-                'advice': None,
-                'data': {
-                    'parent': 'article',
-                    'parent_article_type': 'correction',
-                    'parent_id': None,
-                    'parent_lang': 'en',
-                    'ext-link-type': 'doi',
-                    'href': '10.1590/1808-057x202090350',
-                    'id': 'ra1',
-                    'related-article-type': 'corrected-article'
-                }
-            }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(result['response'], 'OK')
+        self.assertEqual(result['got_value'], 'corrected-article')
+        self.assertEqual(result['expected_value'], ['corrected-article'])
+        self.assertIsNone(result['advice'])
+        self.assertEqual(result['parent_article_type'], 'correction')
 
     def test_validate_related_article_types_not_match(self):
-        self.maxDiff = None
         xmltree = etree.fromstring(
             '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="retraction" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
@@ -87,43 +59,15 @@ class RelatedArticlesValidationTest(TestCase):
             'error_level': 'ERROR'
         }
         validator = RelatedArticlesValidation(xmltree, params)
-        obtained = list(validator.validate_related_article_types())
+        result = list(validator.validate_related_article_types())[0]
 
-        expected = [
-            {
-                'title': 'Related article type validation',
-                'parent': 'article',
-                'parent_article_type': 'retraction',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'item': 'related-article',
-                'sub_item': 'related-article-type',
-                'validation_type': 'match',
-                'response': 'ERROR',
-                'expected_value': ['retracted-article', 'article-retracted'],
-                'got_value': 'retraction-forward',
-                'message': "Got retraction-forward, expected ['retracted-article', 'article-retracted']",
-                'advice': "The article-type: retraction does not match the related-article-type: retraction-forward, "
-                         "provide one of the following items: ['retracted-article', 'article-retracted']",
-                'data': {
-                    'parent': 'article',
-                    'parent_article_type': 'retraction',
-                    'parent_id': None,
-                    'parent_lang': 'en',
-                    'ext-link-type': 'doi',
-                    'href': '10.1590/1808-057x202090350',
-                    'id': 'ra1',
-                    'related-article-type': 'retraction-forward'
-                }
-            }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(result['response'], 'ERROR')
+        self.assertEqual(result['got_value'], 'retraction-forward')
+        self.assertEqual(result['expected_value'], ['retracted-article', 'article-retracted'])
+        self.assertTrue(result['advice'].startswith('The article-type: retraction'))
+        self.assertEqual(result['parent_article_type'], 'retraction')
 
     def test_validate_related_article_doi_exists(self):
-        self.maxDiff = None
         xmltree = etree.fromstring(
             '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
@@ -133,42 +77,16 @@ class RelatedArticlesValidationTest(TestCase):
             </article>'''
         )
         validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
-        obtained = list(validator.validate_related_article_doi())
+        result = list(validator.validate_related_article_doi())[0]
 
-        expected = [
-            {
-                'title': 'Related article doi validation',
-                'parent': 'article',
-                'parent_article_type': 'correction-forward',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'item': 'related-article',
-                'sub_item': 'xlink:href',
-                'validation_type': 'exist',
-                'response': 'OK',
-                'expected_value': '10.1590/1808-057x202090350',
-                'got_value': '10.1590/1808-057x202090350',
-                'message': 'Got 10.1590/1808-057x202090350, expected 10.1590/1808-057x202090350',
-                'advice': None,
-                'data': {
-                    'parent': 'article',
-                    'parent_article_type': 'correction-forward',
-                    'parent_id': None,
-                    'parent_lang': 'en',
-                    'ext-link-type': 'doi',
-                    'href': '10.1590/1808-057x202090350',
-                    'id': 'ra1',
-                    'related-article-type': 'corrected-article'
-                }
-            }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(result['response'], 'OK')
+        self.assertEqual(result['got_value'], '10.1590/1808-057x202090350')
+        self.assertEqual(result['expected_value'], '10.1590/1808-057x202090350')
+        self.assertIsNone(result['advice'])
+        self.assertEqual(result['parent_article_type'], 'correction-forward')
+        self.assertEqual(result['validation_type'], 'exist')
 
     def test_validate_related_article_doi_not_exists(self):
-        self.maxDiff = None
         xmltree = etree.fromstring(
             '''<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" 
             article-type="correction-forward" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
@@ -178,39 +96,14 @@ class RelatedArticlesValidationTest(TestCase):
             </article>'''
         )
         validator = RelatedArticlesValidation(xmltree, {'error_level': 'ERROR'})
-        obtained = list(validator.validate_related_article_doi())
+        result = list(validator.validate_related_article_doi())[0]
 
-        expected = [
-            {
-                'title': 'Related article doi validation',
-                'parent': 'article',
-                'parent_article_type': 'correction-forward',
-                'parent_id': None,
-                'parent_lang': 'en',
-                'item': 'related-article',
-                'sub_item': 'xlink:href',
-                'validation_type': 'exist',
-                'response': 'ERROR',
-                'expected_value': 'A valid DOI or URI for related-article/@xlink:href',
-                'got_value': None,
-                'message': 'Got None, expected A valid DOI or URI for related-article/@xlink:href',
-                'advice': 'Provide a valid DOI for <related-article ext-link-type="doi" id="ra1" '
-                         'related-article-type="corrected-article" />',
-                'data': {
-                    'parent': 'article',
-                    'parent_article_type': 'correction-forward',
-                    'parent_id': None,
-                    'parent_lang': 'en',
-                    'ext-link-type': 'doi',
-                    'id': 'ra1',
-                    'related-article-type': 'corrected-article'
-                }
-            }
-        ]
-
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(obtained[i], item)
+        self.assertEqual(result['response'], 'ERROR')
+        self.assertIsNone(result['got_value'])
+        self.assertEqual(result['expected_value'], 'A valid DOI or URI for related-article/@xlink:href')
+        self.assertTrue(result['advice'].startswith('Provide a valid DOI'))
+        self.assertEqual(result['parent_article_type'], 'correction-forward')
+        self.assertEqual(result['validation_type'], 'exist')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### O que esse PR faz?
Reescreve as validações de related-article, para considerar a necessidade de agrupar os related-article por article e sub-article, pois para alguns `@article-type` há um `relate-article` com `@related-article-type` obrigatório, por exemplo, 'correction' e 'corrected-article'. 
O modelo RelatedItems não atendia a demanda. Foi mantido, mas foi criado Fulltext.
Foi necessário criar:
- FulltextValidation para contextualizar as validações de article e sub-article.
- RelatedArticleValidation para validações individuais
- Reescrever RelatedArticlesValidation que passou a usar FulltextValidation

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

```console
python -m unittest -v  tests/sps/models/test_related_articles.py
```

```console
python -m unittest -v  tests/sps/validation/test_related_articles.py
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

