### PR TITLE
Refactor: author notes validations

### DIFF
--- a/packtools/sps/validation/author_notes.py
+++ b/packtools/sps/validation/author_notes.py
@@ -1,0 +1,208 @@
+from packtools.sps.models.author_notes import ArticleAuthorNotes
+from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
+
+from packtools.sps.validation.utils import build_response
+from packtools.sps.validation.basefn import BaseFnValidation
+
+
+class AuthorNotesFnValidation(BaseFnValidation):
+
+    def validate_current_affiliation_attrib_type_deprecation(self):
+        if "current-aff" == self.fn_data.get("fn_type"):
+            return build_response(
+                title="unexpected current-aff",
+                parent=self.fn_data,
+                item="fn",
+                sub_item="@fn-type",
+                validation_type="unexpected",
+                is_valid=False,
+                expected="bio",
+                obtained=self.fn_data.get("fn_type"),
+                advice=f"Use '<bio>' instead of @fn-type='current-aff'",
+                data=self.fn_data,
+                error_level=self.rules["current-aff_error_level"],
+            )
+
+    def validate_contribution_attrib_type_deprecation(self):
+        if "con" == self.fn_data.get("fn_type"):
+            return build_response(
+                title="unexpected con",
+                parent=self.fn_data,
+                item="fn",
+                sub_item="@fn-type",
+                validation_type="unexpected",
+                is_valid=False,
+                expected="role",
+                obtained=self.fn_data.get("fn_type"),
+                advice=f"Use '<role>' instead of @fn-type='con'",
+                data=self.fn_data,
+                error_level=self.rules["con_error_level"],
+            )
+
+    def validate(self):
+        """
+        Execute all registered validations for the footnote.
+
+        Returns:
+            list[dict]: A list of validation responses (excluding None responses).
+        """
+        validations = [
+            self.validate_label,
+            self.validate_title,
+            self.validate_bold,
+            self.validate_type,
+            self.validate_current_affiliation_attrib_type_deprecation,
+            self.validate_contribution_attrib_type_deprecation,
+        ]
+        return [response for validate in validations if (response := validate())]
+
+
+class ArticleAuthorNotesValidation:
+    """
+    Validates groups of footnotes in an XML document.
+
+    Attributes:
+        xml_tree (ElementTree): The XML tree representing the document.
+        rules (dict): Validation rules.
+    """
+
+    def __init__(self, xml_tree, rules):
+        """
+        Initialize the FnGroupValidation object.
+
+        Args:
+            xml_tree (ElementTree): The XML tree to validate.
+            rules (dict): Validation rules.
+        """
+        self.xml_tree = xml_tree
+        self.rules = rules
+        self.dtd_version = ArticleAndSubArticles(xml_tree).main_dtd_version
+
+        xml_article = ArticleAuthorNotes(xml_tree)
+        self.article_author_notes = xml_article.article_author_notes()
+        self.sub_article_author_notes = xml_article.sub_article_author_notes()
+
+    def validate(self):
+        """
+        Validate all footnote groups in the XML document.
+
+        Yields:
+            dict: Validation results for each footnote (excluding None).
+        """
+        fn_group = self.article_author_notes
+        for corresp_data in fn_group.get("corresp_data"):
+            corresp_validator = CorrespValidation(corresp_data, self.rules)
+            for result in [
+                corresp_validator.validate_title(),
+                corresp_validator.validate_bold(),
+                corresp_validator.validate_label()
+            ]:
+                if result is not None:
+                    yield result
+
+        for fn in fn_group.get("fns"):
+            for result in self.validate_fn(fn):
+                if result is not None:
+                    yield result
+
+        for fn_group in self.sub_article_author_notes:
+            for corresp_data in fn_group.get("corresp_data"):
+                corresp_validator = CorrespValidation(corresp_data, self.rules)
+                for result in [
+                    corresp_validator.validate_title(),
+                    corresp_validator.validate_bold(),
+                    corresp_validator.validate_label()
+                ]:
+                    if result is not None:
+                        yield result
+
+            for fn in fn_group.get("fns"):
+                for result in self.validate_fn(fn):
+                    if result is not None:
+                        yield result
+
+    def validate_fn(self, fn):
+        """
+        Validate an individual footnote and update the response with context.
+
+        Args:
+            fn (dict): The footnote to validate.
+
+        Yields:
+            dict: Validation results for the footnote (excluding None).
+        """
+        validator = AuthorNotesFnValidation(fn_data=fn, rules=self.rules, dtd_version=self.dtd_version)
+        for result in validator.validate():
+            if result is not None:
+                yield result
+
+
+class CorrespValidation:
+
+    def __init__(self, corresp_data, rules):
+        """
+        Initialize the CorrespValidation object.
+
+        Args:
+            corresp_data (dict): Data related to the corresp.
+            rules (dict): Rules defining validation constraints and error levels.
+        """
+        self.corresp_data = corresp_data
+        self.rules = rules
+
+    def validate_label(self):
+        """
+        Validate the presence of the 'label' in the corresp.
+        """
+        if not self.corresp_data.get("corresp_label"):
+            return build_response(
+                title="label",
+                parent=self.corresp_data,
+                item="corresp",
+                sub_item="label",
+                validation_type="exist",
+                is_valid=False,
+                expected="corresp/label",
+                obtained=None,
+                advice=f"Check if corresp label is present and identify it with label element",
+                data=self.corresp_data,
+                error_level=self.rules["corresp_label_error_level"],
+            )
+
+    def validate_title(self):
+        """
+        Validate the presence of 'title' when 'label' is expected.
+        """
+        if self.corresp_data.get("corresp_title"):
+            return build_response(
+                title="unexpected title element",
+                parent=self.corresp_data,
+                item="corresp",
+                sub_item="unexpected title",
+                validation_type="unexpected",
+                is_valid=False,
+                expected="corresp/label",
+                obtained="corresp/title",
+                advice=f"Replace corresp/title by corresp/label",
+                data=self.corresp_data,
+                error_level=self.rules["corresp_title_error_level"],
+            )
+
+    def validate_bold(self):
+        """
+        Validate the presence of 'bold' when 'label' is expected.
+        """
+        if self.corresp_data.get("corresp_bold"):
+            return build_response(
+                title="unexpected bold element",
+                parent=self.corresp_data,
+                item="corresp",
+                sub_item="unexpected bold",
+                validation_type="unexpected",
+                is_valid=False,
+                expected="corresp/label",
+                obtained="corresp/bold",
+                advice=f"Replace corresp/bold by corresp/label",
+                data=self.corresp_data,
+                error_level=self.rules["corresp_bold_error_level"],
+            )

--- a/tests/sps/validation/test_author_notes.py
+++ b/tests/sps/validation/test_author_notes.py
@@ -1,0 +1,186 @@
+import unittest
+from lxml import etree
+from packtools.sps.validation.author_notes import ArticleAuthorNotesValidation
+
+
+class TestAuthorNotesFnValidation(unittest.TestCase):
+    def setUp(self):
+        self.rules = {
+            "corresp_bold_error_level": "CRITICAL",
+            "corresp_title_error_level": "CRITICAL",
+            "corresp_label_error_level": "WARNING",
+            "fn_bold_error_level": "CRITICAL",
+            "fn_title_error_level": "CRITICAL",
+            "fn_label_error_level": "WARNING",
+            "current-aff_error_level": "CRITICAL",
+            "con_error_level": "CRITICAL",
+            "fn_type_error_level": "CRITICAL",
+            "fn_type_expected_values": [
+                "abbr",
+                "com",
+                "coi-statement",
+                "conflict",
+                "corresp",
+                "custom",
+                "deceased",
+                "edited-by",
+                "equal",
+                "financial-disclosure",
+                "on-leave",
+                "other",
+                "participating-researchers",
+                "present-address",
+                "presented-at",
+                "presented-by",
+                "previously-at",
+                "study-group-members",
+                "supplementary-material",
+                "supported-by"
+            ]
+        }
+
+    def test_validate_current_affiliation_attrib_type_deprecation(self):
+        xml_tree = etree.fromstring('''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="pt">
+                <front>
+                    <article-meta>
+                        <author-notes>
+                            <corresp id="c01">
+                                <label>*</label>
+                            </corresp>
+                            <fn fn-type="current-aff">
+                                <label>*</label>
+                                <p>Current affiliation details.</p>
+                            </fn>
+                        </author-notes>
+                    </article-meta>
+                </front>
+            </article>
+        ''')
+        obtained = list(
+            ArticleAuthorNotesValidation(xml_tree, self.rules).validate()
+        )
+
+        self.assertEqual(len(obtained), 2)
+
+        self.assertEqual(obtained[0]["validation_type"], "value in list")
+        self.assertEqual(obtained[0]["response"], "CRITICAL")
+        self.assertEqual(obtained[0]["advice"],"Select one of ['abbr', 'com', 'coi-statement', 'conflict', "
+                                               "'corresp', 'custom', 'deceased', 'edited-by', 'equal', "
+                                               "'financial-disclosure', 'on-leave', 'other', "
+                                               "'participating-researchers', 'present-address', 'presented-at', "
+                                               "'presented-by', 'previously-at', 'study-group-members', "
+                                               "'supplementary-material', 'supported-by']")
+
+        self.assertEqual(obtained[1]["validation_type"], "unexpected")
+        self.assertEqual(obtained[1]["response"], "CRITICAL")
+        self.assertEqual(obtained[1]["advice"], "Use '<bio>' instead of @fn-type='current-aff'")
+
+    def test_validate_contribution_attrib_type_deprecation(self):
+        xml_tree = etree.fromstring('''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="pt">
+                <front>
+                    <article-meta>
+                        <author-notes>
+                            <corresp id="c01">
+                                <label>*</label>
+                            </corresp>
+                            <fn fn-type="con">
+                                <label>*</label>
+                                <p>Lead Author</p>
+                            </fn>
+                        </author-notes>
+                    </article-meta>
+                </front>
+            </article>
+        ''')
+        obtained = list(
+            ArticleAuthorNotesValidation(xml_tree, self.rules).validate()
+        )
+        self.assertEqual(len(obtained), 2)
+
+        self.assertEqual(obtained[0]["validation_type"], "value in list")
+        self.assertEqual(obtained[0]["response"], "CRITICAL")
+        self.assertEqual(obtained[0]["advice"], "Select one of ['abbr', 'com', 'coi-statement', 'conflict', "
+                                               "'corresp', 'custom', 'deceased', 'edited-by', 'equal', "
+                                               "'financial-disclosure', 'on-leave', 'other', "
+                                               "'participating-researchers', 'present-address', 'presented-at', "
+                                               "'presented-by', 'previously-at', 'study-group-members', "
+                                               "'supplementary-material', 'supported-by']")
+
+        self.assertEqual(obtained[1]["validation_type"], "unexpected")
+        self.assertEqual(obtained[1]["response"], "CRITICAL")
+        self.assertEqual(obtained[1]["advice"], "Use '<role>' instead of @fn-type='con'")
+
+    def test_validate_corresp_label_presence(self):
+        xml_tree = etree.fromstring('''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="pt">
+                <front>
+                    <article-meta>
+                        <author-notes>
+                            <corresp>
+                                <p>Corresponding author details.</p>
+                            </corresp>
+                        </author-notes>
+                    </article-meta>
+                </front>
+            </article>
+        ''')
+        obtained = list(ArticleAuthorNotesValidation(xml_tree, self.rules).validate())
+
+        # Filtrar somente as validações relacionadas a corresp/label
+        obtained = [item for item in obtained if item["item"] == "corresp" and item["sub_item"] == "label"]
+        self.assertEqual(len(obtained), 1)
+        self.assertEqual(obtained[0]["response"], "WARNING")
+        self.assertIn("Check if corresp label is present", obtained[0]["advice"])
+
+    def test_validate_corresp_title_unexpected(self):
+        def test_validate_corresp_title_unexpected(self):
+            xml_tree = etree.fromstring('''
+                <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="pt">
+                    <front>
+                        <article-meta>
+                            <author-notes>
+                                <corresp>
+                                    <title>Correspondence</title>
+                                </corresp>
+                            </author-notes>
+                        </article-meta>
+                    </front>
+                </article>
+            ''')
+            obtained = list(ArticleAuthorNotesValidation(xml_tree, self.rules).validate())
+
+            # Filtrar somente as validações relacionadas a corresp/title
+            obtained = [item for item in obtained if
+                        item["item"] == "corresp" and item["sub_item"] == "unexpected title"]
+            self.assertEqual(len(obtained), 1)
+            self.assertEqual(obtained[0]["response"], "ERROR")
+            self.assertIn("Replace corresp/title by corresp/label", obtained[0]["advice"])
+
+    def test_validate_fn_type_attribute_expected_value(self):
+        xml_tree = etree.fromstring('''
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" xml:lang="pt">
+                <front>
+                    <article-meta>
+                        <author-notes>
+                            <corresp id="c01">
+                                <label>*</label>
+                            </corresp>
+                            <fn fn-type="conflict">
+                                <label>*</label>
+                                <p>Conflict of interest statement.</p>
+                            </fn>
+                        </author-notes>
+                    </article-meta>
+                </front>
+            </article>
+        ''')
+        obtained = list(
+            ArticleAuthorNotesValidation(xml_tree, self.rules).validate()
+        )
+        self.assertEqual(len(obtained), 0)  # No errors expected
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona módulo com validações para `author_notes`, e os respectivos testes, que substitui o módulo `article_author_notes`.

#### Onde a revisão poderia começar?
NA.

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

