### PR TITLE
Fix: pubmed format

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -169,9 +169,10 @@ def xml_pubmed_article_title_pipe(xml_pubmed, xml_tree):
     </ArticleTitle>
     """
     title = get_article_titles(xml_tree)
-    if title.get("en") is not None:
+    title_text = title.get("en", {}).get("text")
+    if title_text is not None:
         el = ET.Element("ArticleTitle")
-        el.text = title.get("en")
+        el.text = title_text
         xml_pubmed.append(el)
 
 
@@ -183,9 +184,10 @@ def xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree):
     """
     main_lang = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_lang
     title = get_article_titles(xml_tree)
-    if title.get(main_lang) is not None:
+    title_text = title.get(main_lang, {}).get("text")
+    if title_text is not None:
         el = ET.Element("VernacularTitle")
-        el.text = title.get(main_lang)
+        el.text = title_text
         xml_pubmed.append(el)
 
 

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -6,13 +6,13 @@ from packtools.sps.models import (
     article_abstract,
     article_and_subarticles,
     article_authors,
-    article_citations,
     article_ids,
     article_titles,
     dates,
     front_articlemeta_issue,
     journal_meta,
     kwd_group,
+    references
 )
 
 
@@ -620,7 +620,7 @@ def xml_pubmed_citations(xml_pubmed, xml_tree):
             </Reference>
      </ReferenceList>
     """
-    refs = article_citations.ArticleCitations(xml_tree).article_citations
+    refs = references.ArticleReferences(xml_tree).article_references
     xml = xml_pubmed.find("./ReferenceList")
     for ref in refs:
         ref_el = ET.Element("Reference")


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o gerador do formato PubMed, de acordo com as melhorias implementadas nos modelos.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes.

#### Algum cenário de contexto que queira dar?
Originalmente, buscou-se corrigir a obtenção dos valores para `chapter-title` e `part-title`, visto que o primeiro é substituído pelo segundo quando a versão JATS é igual ou supeiror a 1.3. Essa regra não impacta a formatação das referências em PubMed, as quais são compostas com o valor da tag mixed-citation.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #853 

### Referências
NA.

