### PR TITLE
Feat: fig file extension

### DIFF
--- a/packtools/sps/models/fig.py
+++ b/packtools/sps/models/fig.py
@@ -52,6 +52,15 @@ class Fig:
         return []
 
     @property
+    def file_extension(self):
+        file_name = self.graphic_href
+
+        if file_name and "." in file_name:
+            return file_name.split(".")[-1]
+        return None
+
+
+    @property
     def data(self):
         return {
             "alternative_parent": "fig",
@@ -62,6 +71,7 @@ class Fig:
             "caption": self.caption_text,
             "source_attrib": self.source_attrib,
             "alternatives": self.alternative_elements,
+            "file_extension": self.file_extension
         }
 
 

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -68,6 +68,7 @@ class FigValidation:
         yield from self._validate_item("label")
         yield from self._validate_item("caption")
         yield from self.validate_content()
+        yield from self.validate_file_extension()
 
     def _validate_item(self, name):
         if not self.data.get(name):
@@ -101,4 +102,22 @@ class FigValidation:
                 advice=f"Identify the {name}",
                 data=self.data,
                 error_level=self.rules["content_error_level"],
+            )
+
+    def validate_file_extension(self):
+        file_extension = self.data.get("file_extension")
+        allowed_file_extensions = self.rules["allowed file extensions"]
+        if file_extension not in allowed_file_extensions:
+            yield build_response(
+                title="file extension",
+                parent=self.data,
+                item="fig",
+                sub_item="file extension",
+                validation_type="value in list",
+                is_valid=False,
+                expected=allowed_file_extensions,
+                obtained=file_extension,
+                advice=f"provide a file with one of the following extensions {allowed_file_extensions}",
+                data=self.data,
+                error_level=self.rules["file_extension_error_level"],
             )

--- a/packtools/sps/validation_rules/fig_rules.json
+++ b/packtools/sps/validation_rules/fig_rules.json
@@ -7,5 +7,7 @@
         "label_error_level": "CRITICAL",
         "caption_error_level": "CRITICAL",
         "content_error_level": "CRITICAL",
+        "file_extension_error_level": "CRITICAL",
+        "allowed file extensions": ["tif", "jpg", "png", "svg"]
     }
 }

--- a/tests/sps/models/test_fig.py
+++ b/tests/sps/models/test_fig.py
@@ -118,6 +118,7 @@ class FigTest(unittest.TestCase):
                 "textual-alternative",
                 "media",
             ],
+            "file_extension": "tif",
         }
         self.assertDictEqual(self.fig_obj.data, expected_data)
 
@@ -236,6 +237,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": None,
                 "parent_lang": "pt",
                 "parent_article_type": "research-article",
+                "file_extension": "tif",
             },
             {
                 "alternative_parent": "fig",
@@ -255,6 +257,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": None,
                 "parent_lang": "pt",
                 "parent_article_type": "research-article",
+                "file_extension": "tif",
             },
             {
                 "alternative_parent": "fig",
@@ -269,6 +272,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": "TRen",
                 "parent_lang": "en",
                 "parent_article_type": "translation",
+                "file_extension": "tif",
             },
             {
                 "alternative_parent": "fig",
@@ -283,6 +287,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": "TRen",
                 "parent_lang": "en",
                 "parent_article_type": "translation",
+                "file_extension": "tif",
             },
             {
                 'alternatives': [],
@@ -296,7 +301,8 @@ class ArticleFigsTest(unittest.TestCase):
                 'parent_article_type': 'supplementary-material',
                 'parent_id': 'SM1',
                 'parent_lang': 'en',
-                'source_attrib': 'Data Source: Experimental Data 2020'
+                'source_attrib': 'Data Source: Experimental Data 2020',
+                "file_extension": "tif",
             }
 
         ]
@@ -329,6 +335,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": None,
                 "parent_lang": "pt",
                 "parent_article_type": "research-article",
+                "file_extension": "tif",
             },
             {
                 "alternative_parent": "fig",
@@ -348,6 +355,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": None,
                 "parent_lang": "pt",
                 "parent_article_type": "research-article",
+                "file_extension": "tif",
             }
         ]
 
@@ -374,6 +382,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": "TRen",
                 "parent_lang": "en",
                 "parent_article_type": "translation",
+                "file_extension": "tif",
             },
             {
                 "alternative_parent": "fig",
@@ -388,6 +397,7 @@ class ArticleFigsTest(unittest.TestCase):
                 "parent_id": "TRen",
                 "parent_lang": "en",
                 "parent_article_type": "translation",
+                "file_extension": "tif",
             }
         ]
 
@@ -413,7 +423,8 @@ class ArticleFigsTest(unittest.TestCase):
                 'parent_article_type': 'supplementary-material',
                 'parent_id': 'SM1',
                 'parent_lang': 'en',
-                'source_attrib': 'Data Source: Experimental Data 2020'
+                'source_attrib': 'Data Source: Experimental Data 2020',
+                "file_extension": "tif",
             }
         ]
 

--- a/tests/sps/validation/test_fig.py
+++ b/tests/sps/validation/test_fig.py
@@ -82,7 +82,9 @@ class FigValidationTest(unittest.TestCase):
                 "label_error_level": "CRITICAL",
                 "caption_error_level": "CRITICAL",
                 "content_error_level": "CRITICAL",
-                "article_types_requires": ["research-article"]
+                "article_types_requires": ["research-article"],
+                "file_extension_error_level": "CRITICAL",
+                "allowed file extensions": ["tif", "jpg", "png", "svg"]
             }
         ).validate())
 
@@ -114,6 +116,7 @@ class FigValidationTest(unittest.TestCase):
                     "parent_id": None,
                     "parent_article_type": "research-article",
                     "parent_lang": "pt",
+                    'file_extension': 'png',
                 },
             }
         ]
@@ -151,7 +154,9 @@ class FigValidationTest(unittest.TestCase):
                 "label_error_level": "CRITICAL",
                 "caption_error_level": "CRITICAL",
                 "content_error_level": "CRITICAL",
-                "article_types_requires": ["research-article"]
+                "article_types_requires": ["research-article"],
+                "file_extension_error_level": "CRITICAL",
+                "allowed file extensions": ["tif", "jpg", "png", "svg"]
             }
         ).validate())
 
@@ -183,6 +188,7 @@ class FigValidationTest(unittest.TestCase):
                     "parent_id": None,
                     "parent_article_type": "research-article",
                     "parent_lang": "pt",
+                    'file_extension': 'png',
                 },
             }
         ]
@@ -218,7 +224,9 @@ class FigValidationTest(unittest.TestCase):
                 "label_error_level": "CRITICAL",
                 "caption_error_level": "CRITICAL",
                 "content_error_level": "CRITICAL",
-                "article_types_requires": ["research-article"]
+                "article_types_requires": ["research-article"],
+                "file_extension_error_level": "CRITICAL",
+                "allowed file extensions": ["tif", "jpg", "png", "svg"]
             }
         ).validate())
 
@@ -250,6 +258,7 @@ class FigValidationTest(unittest.TestCase):
                     "parent_id": None,
                     "parent_article_type": "research-article",
                     "parent_lang": "pt",
+                    'file_extension': 'png',
                 },
             }
         ]
@@ -284,7 +293,9 @@ class FigValidationTest(unittest.TestCase):
                 "label_error_level": "CRITICAL",
                 "caption_error_level": "CRITICAL",
                 "content_error_level": "CRITICAL",
-                "article_types_requires": ["research-article"]
+                "article_types_requires": ["research-article"],
+                "file_extension_error_level": "CRITICAL",
+                "allowed file extensions": ["tif", "jpg", "png", "svg"]
             }
         ).validate())
 
@@ -316,11 +327,116 @@ class FigValidationTest(unittest.TestCase):
                     "parent_id": None,
                     "parent_article_type": "research-article",
                     "parent_lang": "pt",
+                    'file_extension': None,
+                },
+            },
+            {
+                "title": "file extension",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "fig",
+                "sub_item": "file extension",
+                "validation_type": "value in list",
+                "response": "CRITICAL",
+                "expected_value": "one of ['tif', 'jpg', 'png', 'svg']",
+                "got_value": None,
+                "message": "Got None, expected one of ['tif', 'jpg', 'png', 'svg']",
+                "advice": "provide a file with one of the following extensions ['tif', 'jpg', 'png', 'svg']",
+                "data": {
+                    "alternative_parent": "fig",
+                    "id": "f01",
+                    "type": None,
+                    "label": "Figure 1",
+                    "graphic": None,
+                    "caption": "título da imagem",
+                    "source_attrib": None,
+                    "alternatives": [],
+                    "parent": "article",
+                    "parent_id": None,
+                    "parent_article_type": "research-article",
+                    "parent_lang": "pt",
+                    "file_extension": None
+                }
+            }
+        ]
+
+        self.assertEqual(len(obtained), 2)
+        for i, item in enumerate(expected):
+            with self.subTest(i):
+                self.assertDictEqual(item, obtained[i])
+
+    def test_fig_validation_file_extension(self):
+        self.maxDiff = None
+        xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+                     dtd-version="1.0" article-type="research-article" xml:lang="pt">
+                <body>
+                    <p>
+                        <fig fig-type="map" id="f02">
+                            <label>FIGURE 2</label>
+                            <caption>
+                                <title>Título da figura 1 em Português</title>
+                            </caption>
+                            <graphic xlink:href="1234-5678-zwy-12-04-0123-gf02.bmp"/>
+                            <attrib>Fonte: IBGE (2018)</attrib>
+                        </fig>
+                    </p>
+                </body>
+            </article>
+            """
+        )
+        obtained = list(ArticleFigValidation(
+            xml_tree,
+            {
+                "error_level": "WARNING",
+                "required_error_level": "CRITICAL",
+                "absent_error_level": "WARNING",
+                "id_error_level": "CRITICAL",
+                "label_error_level": "CRITICAL",
+                "caption_error_level": "CRITICAL",
+                "content_error_level": "CRITICAL",
+                "article_types_requires": ["research-article"],
+                "file_extension_error_level": "CRITICAL",
+                "allowed file extensions": ["tif", "jpg", "png", "svg"]
+            }
+        ).validate())
+
+        expected = [
+            {
+                "title": "file extension",
+                "parent": "article",
+                "parent_id": None,
+                "parent_article_type": "research-article",
+                "parent_lang": "pt",
+                "item": "fig",
+                "sub_item": "file extension",
+                "validation_type": "value in list",
+                "response": 'CRITICAL',
+                "expected_value": "one of ['tif', 'jpg', 'png', 'svg']",
+                'got_value': "bmp",
+                'message': "Got bmp, expected one of ['tif', 'jpg', 'png', 'svg']",
+                "advice": "provide a file with one of the following extensions ['tif', 'jpg', 'png', 'svg']",
+                "data": {
+                    'alternative_parent': 'fig',
+                    'alternatives': [],
+                    'caption': 'Título da figura 1 em Português',
+                    'file_extension': 'bmp',
+                    'graphic': '1234-5678-zwy-12-04-0123-gf02.bmp',
+                    'id': 'f02',
+                    'label': 'FIGURE 2',
+                    'parent': 'article',
+                    'parent_article_type': 'research-article',
+                    'parent_id': None,
+                    'parent_lang': 'pt',
+                    'source_attrib': 'Fonte: IBGE (2018)',
+                    'type': 'map'
                 },
             }
         ]
 
-        self.assertEqual(len(obtained), 1)
         for i, item in enumerate(expected):
             with self.subTest(i):
                 self.assertDictEqual(item, obtained[i])


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona uma validação para garantir que a extensão do arquivo informado esteja dentro da lista de extensões permitidas. Caso contrário, uma resposta de erro será gerada. Essa funcionalidade evita o uso de arquivos com formatos não suportados, garantindo a consistência e integridade dos dados processados.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Sugiro avaliar os testes:

`python3 -m unittest -v tests/sps/models/test_fig.py`
`python3 -m unittest -v tests/sps/formats/am/test_h_record.py`

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #862 

### Referências
NA.
