### PR TITLE
Feat validate original components

### DIFF
--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -131,6 +131,15 @@ class AffiliationValidation:
 
         self.affiliation = affiliation
         self.params = params
+        self.original = self.affiliation.get("original")
+        self.original_components = {
+            "orgname": self.affiliation.get("orgname"),
+            "orgdiv1": self.affiliation.get("orgdiv1"),
+            "orgdiv2": self.affiliation.get("orgdiv2"),
+            "country_name": self.affiliation.get("country_name"),
+            "state": self.affiliation.get("state"),
+            "city": self.affiliation.get("city")
+        }
 
         default_min_similarity = {
             "original": 0.5,

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -454,6 +454,40 @@ class AffiliationValidation:
             error_level=self.params["original_error_level"]
         )
 
+    def validate_orgname_components_value(self):
+        original_component_words = list({
+            re.sub(r'[^\w\s]+$', '', word)
+            for value in self.original_components.values()
+            for word in value.split() if word
+        })
+        original_component_words.sort()
+
+        words_not_found = list({
+            re.sub(r'[^\w\s]+$', '', word)
+            for word in self.original.split()
+            if re.sub(r'[^\w\s]+$', '', word) not in original_component_words
+        })
+        words_not_found.sort()
+
+        is_valid = len(words_not_found) == 0
+
+        yield build_response(
+            title="original",
+            parent=self.affiliation,
+            item="institution",
+            sub_item='@content-type="original"',
+            validation_type="exist",
+            is_valid=is_valid,
+            expected="original affiliation",
+            obtained=self.original,
+            advice=f'Mark the complete original affiliation text with <institution content-type="original"> '
+                   f'in <aff> and add missing words in components: {words_not_found}.',
+            data=self.affiliation,
+            error_level=self.params["original_error_level"]
+        )
+
+
+
     def validate(self):
         """
         Validate all aspects of the affiliation.
@@ -473,3 +507,4 @@ class AffiliationValidation:
         yield from self.validate_country_code()
         yield from self.validate_state()
         yield from self.validate_city()
+        yield from self.validate_orgname_composition()

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -428,6 +428,32 @@ class AffiliationValidation:
                 data=items,
             )
 
+    def validate_orgname_components(self):
+        if not self.original:
+            return
+
+        component_not_found = [
+            key for key, value in self.original_components.items()
+            if value and not any(word in self.original for word in value.split())
+        ]
+
+        is_valid = len(component_not_found) == 0
+
+        yield build_response(
+            title="original",
+            parent=self.affiliation,
+            item="institution",
+            sub_item='@content-type="original"',
+            validation_type="exist",
+            is_valid=is_valid,
+            expected="original affiliation",
+            obtained=self.original,
+            advice=f'Mark the complete original affiliation text with <institution content-type="original"> '
+                   f'in <aff> and add missing components: {component_not_found}.',
+            data=self.affiliation,
+            error_level=self.params["original_error_level"]
+        )
+
     def validate(self):
         """
         Validate all aspects of the affiliation.

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 from difflib import SequenceMatcher
 

--- a/tests/sps/validation/test_aff.py
+++ b/tests/sps/validation/test_aff.py
@@ -119,17 +119,19 @@ class AffiliationValidationTest(TestCase):
         obtained = list(self.validator.validate_city())
         self.assertEqual(1, len(obtained))
 
-    def test_validate_orgname_components(self):
-        obtained = list(AffiliationValidation(self.complete_aff, PARAMS).validate_orgname_components())[0]
+    def test_validate_original_aff_components(self):
+        obtained = list(AffiliationValidation(self.complete_aff, PARAMS).validate_original_aff_components())[0]
         self.assertEqual(obtained["got_value"], "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil")
-        self.assertEqual(obtained["advice"], 'Mark the complete original affiliation text with <institution content-type="original"> '
-                                             'in <aff> and add missing components: [\'orgdiv1\', \'orgdiv2\'].')
+        self.assertEqual(obtained["advice"], 'Mark the complete original affiliation with '
+                                             '<institution content-type="original"> in <aff> and '
+                                             'add Divisão 1 (orgdiv1), Divisão 2 (orgdiv2) in <institution content-type="original">')
 
-    def test_validate_orgname_components_value(self):
-        obtained = list(AffiliationValidation(self.complete_aff_modified, PARAMS).validate_orgname_components_value())[0]
+    def test_validate_original_aff_components_value(self):
+        self.maxDiff = None
+        obtained = list(AffiliationValidation(self.complete_aff_modified, PARAMS).validate_original_aff_components_value())[0]
         self.assertEqual(obtained["got_value"], "Secretaria Municipal de Saúde de Belo Horizonte. Belo Horizonte, MG, Brasil")
-        self.assertEqual(obtained["advice"], 'Mark the complete original affiliation text with <institution content-type="original"> '
-                                             'in <aff> and add missing words in components: [\'Municipal\', \'Saúde\', \'Secretaria\', \'de\'].')
+        self.assertEqual(obtained["advice"], 'Mark the complete original affiliation with <institution content-type="original"> '
+                                             'in <aff> and add missing words: [\'Secretaria\', \'Municipal\', \'de\', \'Saúde\', \'de\'].')
 
 
 class TestAffiliationValidationCompare(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Valida se os componentes de `aff` estão presentes no `original` e se todas as palavras em `original` estão em algum sub-elemento (componente) de `aff`, com destaque para as palavras que não entraram em nenhum sub-elemento.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
Avaliar os testes.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #896 

### Referências
NA.

