### PR TITLE
Feat: supplementary material validation

### DIFF
--- a/packtools/sps/models/accessibility_data.py
+++ b/packtools/sps/models/accessibility_data.py
@@ -63,4 +63,5 @@ class AccessibilityData:
             "transcript": self.transcript,
             "content_type": self.content_type,
             "speakers": self.speaker_data,
+            "tag": self.node.tag,
         }

--- a/packtools/sps/models/accessibility_data.py
+++ b/packtools/sps/models/accessibility_data.py
@@ -1,53 +1,66 @@
 import re
+from xml.etree.ElementTree import Element
 
 class AccessibilityData:
-    def __init__(self, node):
+    def __init__(self, node: Element):
         self.node = node
 
-    def get_alt_text(self):
+    @property
+    def alt_text(self):
         """Obtém o texto alternativo (<alt-text>) do XML."""
         alt_text_node = self.node.find("alt-text")
-        return alt_text_node.text.strip() if alt_text_node is not None else None
+        return alt_text_node.text.strip() if alt_text_node is not None and alt_text_node.text else None
 
-    def get_long_desc(self):
-        """Obtém a descrição longa (<long-desc>) do XML."""
+    @property
+    def long_desc(self):
+        """Obtém a descrição longa (<long-desc>) do XML, removendo espaços extras."""
         long_desc_node = self.node.find("long-desc")
-        if long_desc_node is not None:
-            return " ".join(long_desc_node.text.split())  # Remove espaços extras e quebras de linha
+        if long_desc_node is not None and long_desc_node.text:
+            return " ".join(long_desc_node.text.split())  # Remove espaços extras
         return None
 
-    def get_transcript(self):
-        """Obtém todo o texto dentro de <sec sec-type='transcript'>, incluindo <speaker> e <speech>, removendo espaços extras."""
+    @property
+    def transcript(self):
+        """Obtém o texto dentro de <sec sec-type='transcript'>, removendo espaços extras."""
         transcript_node = self.node.find(".//sec[@sec-type='transcript']")
         if transcript_node is not None:
             text = " ".join(transcript_node.itertext()).strip()
-            return re.sub(r'\s+', ' ', text)
+            return re.sub(r'\s+', ' ', text) if text else None
         return None
 
-    def get_content_type(self):
+    @property
+    def content_type(self):
         """Obtém o atributo @content-type do elemento."""
         return self.node.get("content-type")
 
-    def get_speaker_data(self):
-        """Obtém o conteúdo de <speaker> e <speech> dentro da transcrição, se existir."""
-        speakers = self.node.findall(".//speaker")
-        speech_blocks = self.node.findall(".//speech")
+    @property
+    def speaker_data(self):
+        """Obtém os dados de <speaker> e <speech> dentro de transcrição."""
+        transcript_node = self.node.find(".//sec[@sec-type='transcript']")
+        if transcript_node is None:
+            return None
 
-        speaker_data = []
-        for speaker, speech in zip(speakers, speech_blocks):
-            speaker_data.append({
-                "speaker": speaker.text.strip() if speaker is not None else None,
-                "speech": speech.text.strip() if speech is not None else None
-            })
+        speakers = []
+        current_speaker = None
 
-        return speaker_data if speaker_data else None
+        for element in transcript_node:
+            if element.tag == "speaker" and element.text:
+                current_speaker = element.text.strip()
+            elif element.tag == "speech" and element.text:
+                speakers.append({
+                    "speaker": current_speaker,
+                    "speech": " ".join(element.text.split())
+                })
 
-    def extract_data(self):
+        return speakers if speakers else None
+
+    @property
+    def data(self):
         """Retorna um dicionário com todos os dados extraídos do XML."""
         return {
-            "alt_text": self.get_alt_text(),
-            "long_desc": self.get_long_desc(),
-            "transcript": self.get_transcript(),
-            "content_type": self.get_content_type(),
-            "speakers": self.get_speaker_data(),
+            "alt_text": self.alt_text,
+            "long_desc": self.long_desc,
+            "transcript": self.transcript,
+            "content_type": self.content_type,
+            "speakers": self.speaker_data,
         }

--- a/packtools/sps/models/accessibility_data.py
+++ b/packtools/sps/models/accessibility_data.py
@@ -1,58 +1,62 @@
 import re
-from xml.etree.ElementTree import Element
 
 class AccessibilityData:
-    def __init__(self, node: Element):
+    def __init__(self, node):
         self.node = node
 
     @property
     def alt_text(self):
         """Obtém o texto alternativo (<alt-text>) do XML."""
-        alt_text_node = self.node.find("alt-text")
-        return alt_text_node.text.strip() if alt_text_node is not None and alt_text_node.text else None
+        if self.node is not None:
+            alt_text_node = self.node.find("alt-text")
+            return alt_text_node.text.strip() if alt_text_node is not None and alt_text_node.text else None
 
     @property
     def long_desc(self):
         """Obtém a descrição longa (<long-desc>) do XML, removendo espaços extras."""
-        long_desc_node = self.node.find("long-desc")
-        if long_desc_node is not None and long_desc_node.text:
-            return " ".join(long_desc_node.text.split())  # Remove espaços extras
-        return None
+        if self.node is not None:
+            long_desc_node = self.node.find("long-desc")
+            if long_desc_node is not None and long_desc_node.text:
+                return " ".join(long_desc_node.text.split())  # Remove espaços extras
+            return None
 
     @property
     def transcript(self):
         """Obtém o texto dentro de <sec sec-type='transcript'>, removendo espaços extras."""
-        transcript_node = self.node.find(".//sec[@sec-type='transcript']")
-        if transcript_node is not None:
-            text = " ".join(transcript_node.itertext()).strip()
-            return re.sub(r'\s+', ' ', text) if text else None
-        return None
+        if self.node is not None:
+            transcript_node = self.node.find(".//sec[@sec-type='transcript']")
+            if transcript_node is not None:
+                text = " ".join(transcript_node.itertext()).strip()
+                return re.sub(r'\s+', ' ', text) if text else None
+            return None
 
     @property
     def content_type(self):
         """Obtém o atributo @content-type do elemento."""
-        return self.node.get("content-type")
+        if self.node is not None:
+            return self.node.get("content-type")
 
     @property
     def speaker_data(self):
         """Obtém os dados de <speaker> e <speech> dentro de transcrição."""
-        transcript_node = self.node.find(".//sec[@sec-type='transcript']")
-        if transcript_node is None:
-            return None
+        if self.node is not None:
+            transcript_node = self.node.find(".//sec[@sec-type='transcript']")
+            if transcript_node is None:
+                return None
 
-        speakers = []
-        current_speaker = None
+            speakers = []
+            current_speaker = None
 
-        for element in transcript_node:
-            if element.tag == "speaker" and element.text:
-                current_speaker = element.text.strip()
-            elif element.tag == "speech" and element.text:
-                speakers.append({
-                    "speaker": current_speaker,
-                    "speech": " ".join(element.text.split())
-                })
+            for element in transcript_node:
+                if element.tag == "speaker" and element.text:
+                    current_speaker = element.text.strip()
+                elif element.tag == "speech" and element.text:
+                    speakers.append({
+                        "speaker": current_speaker,
+                        "speech": " ".join(element.text.split())
+                    })
 
-        return speakers if speakers else None
+            return speakers if speakers else None
 
     @property
     def data(self):

--- a/packtools/sps/models/accessibility_data.py
+++ b/packtools/sps/models/accessibility_data.py
@@ -1,0 +1,53 @@
+import re
+
+class AccessibilityData:
+    def __init__(self, node):
+        self.node = node
+
+    def get_alt_text(self):
+        """Obtém o texto alternativo (<alt-text>) do XML."""
+        alt_text_node = self.node.find("alt-text")
+        return alt_text_node.text.strip() if alt_text_node is not None else None
+
+    def get_long_desc(self):
+        """Obtém a descrição longa (<long-desc>) do XML."""
+        long_desc_node = self.node.find("long-desc")
+        if long_desc_node is not None:
+            return " ".join(long_desc_node.text.split())  # Remove espaços extras e quebras de linha
+        return None
+
+    def get_transcript(self):
+        """Obtém todo o texto dentro de <sec sec-type='transcript'>, incluindo <speaker> e <speech>, removendo espaços extras."""
+        transcript_node = self.node.find(".//sec[@sec-type='transcript']")
+        if transcript_node is not None:
+            text = " ".join(transcript_node.itertext()).strip()
+            return re.sub(r'\s+', ' ', text)
+        return None
+
+    def get_content_type(self):
+        """Obtém o atributo @content-type do elemento."""
+        return self.node.get("content-type")
+
+    def get_speaker_data(self):
+        """Obtém o conteúdo de <speaker> e <speech> dentro da transcrição, se existir."""
+        speakers = self.node.findall(".//speaker")
+        speech_blocks = self.node.findall(".//speech")
+
+        speaker_data = []
+        for speaker, speech in zip(speakers, speech_blocks):
+            speaker_data.append({
+                "speaker": speaker.text.strip() if speaker is not None else None,
+                "speech": speech.text.strip() if speech is not None else None
+            })
+
+        return speaker_data if speaker_data else None
+
+    def extract_data(self):
+        """Retorna um dicionário com todos os dados extraídos do XML."""
+        return {
+            "alt_text": self.get_alt_text(),
+            "long_desc": self.get_long_desc(),
+            "transcript": self.get_transcript(),
+            "content_type": self.get_content_type(),
+            "speakers": self.get_speaker_data(),
+        }

--- a/packtools/sps/models/app_group.py
+++ b/packtools/sps/models/app_group.py
@@ -1,21 +1,16 @@
+from packtools.sps.models.label_and_caption import LabelAndCaption
 from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
 
 
-class App:
-    def __init__(self, node):
-        self.node = node
-
+class App(LabelAndCaption):
     @property
-    def app_id(self):
+    def id(self):
         return self.node.get("id")
 
     @property
-    def app_label(self):
-        return self.node.findtext("label")
-
-    @property
     def data(self):
-        return {"app_id": self.app_id, "app_label": self.app_label}
+        base_data = super().data or {}
+        return {**base_data, "id": self.id}
 
 
 class AppGroup:

--- a/packtools/sps/models/article_and_subarticles.py
+++ b/packtools/sps/models/article_and_subarticles.py
@@ -123,7 +123,7 @@ class ArticleAndSubArticles:
 
     @property
     def article(self):
-        node = self.xmltree.find(".//article-meta")
+        node = self.xmltree.find(".")
         if node is not None:
             yield node
 

--- a/packtools/sps/models/graphic.py
+++ b/packtools/sps/models/graphic.py
@@ -1,0 +1,8 @@
+from packtools.sps.models.visual_resource_base import VisualResourceBase
+
+
+class Graphic(VisualResourceBase):
+    pass
+
+class InlineGraphic(Graphic):
+    pass

--- a/packtools/sps/models/graphic.py
+++ b/packtools/sps/models/graphic.py
@@ -1,4 +1,4 @@
-from packtools.sps.models.visual_resource_base import VisualResourceBase
+from packtools.sps.models.visual_resource_base import VisualResourceBase, XmlVisualResource
 
 
 class Graphic(VisualResourceBase):
@@ -6,3 +6,6 @@ class Graphic(VisualResourceBase):
 
 class InlineGraphic(Graphic):
     pass
+
+class XmlGraphic(XmlVisualResource):
+    RESOURCE_TYPES = [("graphic", Graphic), ("inline-graphic", InlineGraphic)]

--- a/packtools/sps/models/label_and_caption.py
+++ b/packtools/sps/models/label_and_caption.py
@@ -1,0 +1,25 @@
+class LabelAndCaption:
+    def __init__(self, node):
+        self.node = node
+        self.id = node.get("id")
+        self.label = node.findtext("label")
+
+    @property
+    def caption(self):
+        caption_element = self.node.find(".//caption")
+        if caption_element is not None:
+            return caption_element.xpath("string()").strip()
+
+    @property
+    def data(self):
+        return {
+            "id": self.id,
+            "label": self.label,
+            "caption": self.caption
+        }
+
+    @property
+    def xml(self):
+        if self.id:
+            return f'<{self.node.tag} id="{self.id}">'
+        return f'<{self.node.tag}>'

--- a/packtools/sps/models/label_and_caption.py
+++ b/packtools/sps/models/label_and_caption.py
@@ -1,25 +1,22 @@
 class LabelAndCaption:
     def __init__(self, node):
         self.node = node
-        self.id = node.get("id")
-        self.label = node.findtext("label")
+        self.label = self.node.findtext("label")
+        self.attrib = node.findtext("attrib")
 
     @property
     def caption(self):
-        caption_element = self.node.find(".//caption")
+        """Garante que a captura de caption sempre funcione"""
+        caption_element = self.node.find("caption")
         if caption_element is not None:
-            return caption_element.xpath("string()").strip()
+            return "".join(caption_element.itertext()).strip()  # Melhor que XPath "string()"
+        return None
 
     @property
     def data(self):
+        """Garante que label, caption e attrib sejam extraídos corretamente"""
         return {
-            "id": self.id,
             "label": self.label,
-            "caption": self.caption
+            "caption": self.caption,
+            "attrib": self.attrib if self.attrib else None,  # Inclui fonte, se existir
         }
-
-    @property
-    def xml(self):
-        if self.id:
-            return f'<{self.node.tag} id="{self.id}">'
-        return f'<{self.node.tag}>'

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -1,12 +1,8 @@
-from packtools.sps.models.article_and_subarticles import Fulltext
-from packtools.sps.models.accessibility_data import AccessibilityData
+from packtools.sps.models.label_and_caption import LabelAndCaption
+from packtools.sps.models.visual_resource_base import VisualResourceBase
 
 
-class Media:
-    def __init__(self, node):
-        self.node = node
-        self.accessibility = AccessibilityData(node)
-
+class BaseMedia(VisualResourceBase):
     @property
     def mimetype(self):
         return self.node.get("mimetype")
@@ -16,38 +12,31 @@ class Media:
         return self.node.get("mime-subtype")
 
     @property
-    def media_type(self):
-        return self.node.tag if self.node is not None else None
+    def data(self):
+        base_data = super().data
 
-    @property
-    def xlink_href(self):
-        return self.node.get("{http://www.w3.org/1999/xlink}href")
+        media_data = {
+            "mimetype": self.mimetype,
+            "mime_subtype": self.mime_subtype,
+        }
+
+        combined_data = {**base_data, **media_data}
+        return combined_data
+
+
+class Media(BaseMedia, LabelAndCaption):
+    def __init__(self, node):
+        BaseMedia.__init__(self, node)  # Chama o __init__ de BaseMedia
+        LabelAndCaption.__init__(self, node)  # Chama o __init__ de LabelAndCaption
 
     @property
     def data(self):
-        """Combina os dados de mídia com os dados de acessibilidade extraídos do XML."""
-        data = {
-            "mimetype": self.mimetype,
-            "mime_subtype": self.mime_subtype,
-            "media_type": self.media_type,
-            "xlink_href": self.xlink_href,
-        }
-        data.update(self.accessibility.data)  # Adiciona os dados de acessibilidade extraídos
-        return data
+        base_data = BaseMedia.data.fget(self)
+        label_caption_data = LabelAndCaption.data.fget(self)
+
+        return {**base_data, **label_caption_data}
 
 
-class XmlMedias:
-    def __init__(self, xml_tree):
-        self.xml_tree = xml_tree
 
-    @property
-    def items(self):
-        media_list = []
-        # TODO sub-article está sendo considerado em duplicidade
-        for node in self.xml_tree.xpath(". | sub-article"):
-            full_text = Fulltext(node)
-            for media_node in full_text.node.xpath(".//media | .//graphic"):
-                media_data = Media(media_node).data
-                media_data.update(full_text.attribs_parent_prefixed)
-                media_list.append(media_data)
-        return media_list
+class InlineMedia(BaseMedia):
+    pass

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -32,7 +32,7 @@ class Media:
             "media_type": self.media_type,
             "xlink_href": self.xlink_href,
         }
-        data.update(self.accessibility.extract_data())  # Adiciona os dados de acessibilidade extraídos
+        data.update(self.accessibility.data)  # Adiciona os dados de acessibilidade extraídos
         return data
 
 
@@ -46,7 +46,7 @@ class XmlMedias:
         # TODO sub-article está sendo considerado em duplicidade
         for node in self.xml_tree.xpath(". | sub-article"):
             full_text = Fulltext(node)
-            for media_node in full_text.node.xpath(".//media"):
+            for media_node in full_text.node.xpath(".//media | .//graphic"):
                 media_data = Media(media_node).data
                 media_data.update(full_text.attribs_parent_prefixed)
                 media_list.append(media_data)

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -1,3 +1,4 @@
+from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.label_and_caption import LabelAndCaption
 from packtools.sps.models.visual_resource_base import VisualResourceBase
 
@@ -31,12 +32,28 @@ class Media(BaseMedia, LabelAndCaption):
 
     @property
     def data(self):
-        base_data = BaseMedia.data.fget(self)
+        base_data = super().data
         label_caption_data = LabelAndCaption.data.fget(self)
 
         return {**base_data, **label_caption_data}
 
 
-
 class InlineMedia(BaseMedia):
     pass
+
+
+class XmlMedia:
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.article_and_subarticle = ArticleAndSubArticles(xmltree).article_and_sub_articles
+
+    def data(self):
+        """Gera dados de mídia e inline-media de cada artigo e sub-artigo."""
+        for item in self.article_and_subarticle:
+            node_data = getattr(item, "data", {})
+
+            for media_type, media_class in [("media", Media), ("inline-media", InlineMedia)]:
+                nodes = item.xpath(f".//{media_type}") or []
+                for node in nodes:
+                    media_data = media_class(node).data
+                    yield {**media_data, **node_data}

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -41,5 +41,5 @@ class InlineMedia(BaseMedia):
     pass
 
 
-class XmlMedia(XmlVisualResource):
+class XmlMedias(XmlVisualResource):
     RESOURCE_TYPES = [("media", Media), ("inline-media", InlineMedia)]

--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -1,6 +1,5 @@
-from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 from packtools.sps.models.label_and_caption import LabelAndCaption
-from packtools.sps.models.visual_resource_base import VisualResourceBase
+from packtools.sps.models.visual_resource_base import VisualResourceBase, XmlVisualResource
 
 
 class BaseMedia(VisualResourceBase):
@@ -42,18 +41,5 @@ class InlineMedia(BaseMedia):
     pass
 
 
-class XmlMedia:
-    def __init__(self, xmltree):
-        self.xmltree = xmltree
-        self.article_and_subarticle = ArticleAndSubArticles(xmltree).article_and_sub_articles
-
-    def data(self):
-        """Gera dados de mídia e inline-media de cada artigo e sub-artigo."""
-        for item in self.article_and_subarticle:
-            node_data = getattr(item, "data", {})
-
-            for media_type, media_class in [("media", Media), ("inline-media", InlineMedia)]:
-                nodes = item.xpath(f".//{media_type}") or []
-                for node in nodes:
-                    media_data = media_class(node).data
-                    yield {**media_data, **node_data}
+class XmlMedia(XmlVisualResource):
+    RESOURCE_TYPES = [("media", Media), ("inline-media", InlineMedia)]

--- a/packtools/sps/models/supplementary_material.py
+++ b/packtools/sps/models/supplementary_material.py
@@ -1,53 +1,80 @@
 from packtools.sps.utils.xml_utils import get_parent_context, put_parent_context
 
-
 class SupplementaryMaterial:
     def __init__(self, node):
         self.node = node
+        self._parent_node = node.getparent()
 
     @property
-    def supplementary_material_id(self):
+    def id(self):
         return self.node.get("id")
 
     @property
-    def supplementary_material_label(self):
+    def parent(self):
+        return self._parent_node.tag if self._parent_node is not None else None
+
+    @property
+    def sec_type(self):
+        return self._parent_node.get("sec-type")
+
+    @property
+    def label(self):
         return self.node.findtext("label")
 
     @property
+    def caption_title(self):
+        return self.node.findtext("caption/title")
+
+    @property
+    def media_node(self):
+        node = self.node.findall("media") or self.node.findall("graphic")
+        return node[0] if node else None
+
+    @property
     def mimetype(self):
-        return self.node.get("mimetype")
+        return self.media_node.get("mimetype") if self.media_node is not None else None
 
     @property
     def mime_subtype(self):
-        return self.node.get("mime-subtype")
+        return self.media_node.get("mime-subtype") if self.media_node is not None else None
 
     @property
     def xlink_href(self):
-        return self.node.get("{http://www.w3.org/1999/xlink}href")
+        return self.media_node.get("{http://www.w3.org/1999/xlink}href") if self.media_node is not None else None
+
+    @property
+    def media_type(self):
+        return self.media_node.tag if self.media_node is not None else None
 
     @property
     def data(self):
         return {
-            "supplementary_material_id": self.supplementary_material_id,
-            "supplementary_material_label": self.supplementary_material_label,
+            "id": self.id,
+            "parent_tag": self.parent,
+            "parent_attrib_type": self.sec_type,
+            "label": self.label,
+            "caption_title": self.caption_title,
             "mimetype": self.mimetype,
             "mime_subtype": self.mime_subtype,
             "xlink_href": self.xlink_href,
+            "media_type": self.media_type,
+            "media_node": self.media_node
         }
 
 
 class ArticleSupplementaryMaterials:
     def __init__(self, xml_tree):
+        """
+        Extrai todos os <supplementary-material> e <sec sec-type="supplementary-material"> dentro do artigo.
+
+        Args:
+            xml_tree: Objeto XML representando o artigo
+        """
         self.xml_tree = xml_tree
 
     def data(self):
-        for node, lang, article_type, parent, parent_id in get_parent_context(
-            self.xml_tree
-        ):
-            for supp_node in node.xpath(
-                ".//supplementary-material | .//inline-supplementary-material"
-            ):
+        """Itera sobre os <supplementary-material> e retorna os dados extraídos."""
+        for node, lang, article_type, parent, parent_id in get_parent_context(self.xml_tree):
+            for supp_node in node.xpath(".//supplementary-material"):
                 supp_data = SupplementaryMaterial(supp_node).data
-                yield put_parent_context(
-                    supp_data, lang, article_type, parent, parent_id
-                )
+                yield put_parent_context(supp_data, lang, article_type, parent, parent_id)

--- a/packtools/sps/models/supplementary_material.py
+++ b/packtools/sps/models/supplementary_material.py
@@ -1,3 +1,5 @@
+from lxml import etree
+
 from packtools.sps.models.label_and_caption import LabelAndCaption
 from packtools.sps.models.article_and_subarticles import Fulltext
 from packtools.sps.models.media import Media
@@ -6,11 +8,12 @@ class SupplementaryMaterial(LabelAndCaption):
     def __init__(self, node):
         super().__init__(node)
         self._parent_node = node.getparent()
-        self.media_node = node.find("media")
+        media_nodes = node.xpath("./media | ./graphic")
+        self.media_node = media_nodes[0] if media_nodes else None
         self.media = Media(self.media_node) if self.media_node is not None else None
 
     def __getattr__(self, name):
-        if hasattr(self.media, name):
+        if self.media is not None and hasattr(self.media, name):
             return getattr(self.media, name)
 
         if hasattr(super(), name):
@@ -36,11 +39,12 @@ class SupplementaryMaterial(LabelAndCaption):
     @property
     def data(self):
         base_data = super().data.copy()
-        base_data.update(self.media.data)
+        base_data.update(self.media.data if self.media else {})
         base_data.update({
             "parent_suppl_mat": self.parent_tag,
             "sec_type": self.sec_type,
         })
+
         return base_data
 
 

--- a/packtools/sps/models/supplementary_material.py
+++ b/packtools/sps/models/supplementary_material.py
@@ -48,9 +48,11 @@ class SupplementaryMaterial(LabelAndCaption):
     def data(self):
         base_data = super().data.copy()
         base_data.update(self.media.data if self.media else {})
+        base_data.update(self.graphic.data if self.graphic else {})
         base_data.update({
             "parent_suppl_mat": self.parent_tag,
             "sec_type": self.sec_type,
+            "visual_elem": "media" if self.media else "graphic"
         })
 
         return base_data

--- a/packtools/sps/models/visual_resource_base.py
+++ b/packtools/sps/models/visual_resource_base.py
@@ -1,4 +1,5 @@
 from packtools.sps.models.accessibility_data import AccessibilityData
+from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles, Fulltext
 
 
 class VisualResourceBase:
@@ -22,3 +23,23 @@ class VisualResourceBase:
         }
         data.update(self.accessibility.data)  # Adiciona os dados de acessibilidade extraídos
         return data
+
+
+class XmlVisualResource:
+    RESOURCE_TYPES = []
+
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.article_and_subarticles = ArticleAndSubArticles(xmltree).article_and_sub_articles
+
+    def data(self):
+        """Gera dados dos recursos visuais de cada artigo e sub-artigo."""
+        for node in self.article_and_subarticles:
+            full_text = Fulltext(node)
+
+            for resource_type, resource_class in self.RESOURCE_TYPES:
+                resource_nodes = node.xpath(f".//{resource_type}") or []
+                for resource_node in resource_nodes:
+                    resource_instance = resource_class(resource_node)
+                    resource_data = resource_instance.data
+                    yield {**resource_data, **full_text.attribs_parent_prefixed}

--- a/packtools/sps/models/visual_resource_base.py
+++ b/packtools/sps/models/visual_resource_base.py
@@ -1,0 +1,24 @@
+from packtools.sps.models.accessibility_data import AccessibilityData
+
+
+class VisualResourceBase:
+    def __init__(self, node):
+        self.node = node
+        self.accessibility = AccessibilityData(node)
+
+    @property
+    def xlink_href(self):
+        return self.node.get("{http://www.w3.org/1999/xlink}href")
+
+    @property
+    def id(self):
+        return self.node.get("id")
+
+    @property
+    def data(self):
+        data = {
+            "xlink_href": self.xlink_href,
+            "id": self.id
+        }
+        data.update(self.accessibility.data)  # Adiciona os dados de acessibilidade extraídos
+        return data

--- a/packtools/sps/validation/accessibility_data.py
+++ b/packtools/sps/validation/accessibility_data.py
@@ -1,0 +1,155 @@
+from lxml import etree
+from packtools.sps.validation.utils import build_response
+
+
+class AccessibilityDataValidation:
+    def __init__(self, accessibility_data, xml_tree, params):
+        """
+        Initializes accessibility validation for multimedia elements.
+
+        Args:
+            accessibility_data (dict): Accessibility data extracted from the model
+            xml_tree (etree.ElementTree): XML tree of the article
+            params (dict): Validation configuration parameters
+        """
+        self.accessibility_data = accessibility_data
+        self.xml_tree = xml_tree
+        self.params = params
+
+    def validate(self):
+        """
+        Executes all defined validations.
+        """
+        yield self.validate_alt_text()
+        yield self.validate_long_desc()
+        yield self.validate_transcript()
+        yield self.validate_content_type()
+        yield self.validate_speaker_and_speech()
+        yield self.validate_media_structure()
+        yield self.validate_cross_references()
+
+    def validate_alt_text(self):
+        """Validates that <alt-text> has a maximum of 120 characters and contains only allowed characters."""
+        alt_text = self.accessibility_data.get("alt_text")
+        valid = bool(alt_text) and len(alt_text) <= 120
+        return build_response(
+            title="<alt-text> validation",
+            parent=self.accessibility_data,
+            item="alt-text",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="length",
+            expected="Up to 120 characters",
+            obtained=len(alt_text) if alt_text else "Missing",
+            advice="Provide an alternative text with a maximum of 120 characters.",
+            error_level=self.params["alt_text_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_long_desc(self):
+        """Validates that <long-desc> has more than 120 characters."""
+        long_desc = self.accessibility_data.get("long_desc")
+        valid = bool(long_desc) and len(long_desc) > 120
+        return build_response(
+            title="<long-desc> validation",
+            parent=self.accessibility_data,
+            item="long-desc",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="length",
+            expected="More than 120 characters",
+            obtained=len(long_desc) if long_desc else "Missing",
+            advice="Provide a long description with more than 120 characters.",
+            error_level=self.params["long_desc_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_transcript(self):
+        """Checks for the presence of a transcript (<sec sec-type='transcript'>) for media."""
+        transcript = self.accessibility_data.get("transcript")
+        valid = bool(transcript)
+        return build_response(
+            title="Transcript validation",
+            parent=self.accessibility_data,
+            item="transcript",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="exist",
+            expected="Present",
+            obtained="Missing" if not transcript else "Present",
+            advice="Provide a transcript for videos and audio files.",
+            error_level=self.params["transcript_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_content_type(self):
+        """Validates the @content-type attribute for machine-generated content when applicable."""
+        content_type = self.accessibility_data.get("content_type")
+        valid = content_type == "machine-generated"
+        return build_response(
+            title="@content-type validation",
+            parent=self.accessibility_data,
+            item="content-type",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="match",
+            expected="machine-generated",
+            obtained=content_type,
+            advice="If applicable, use 'machine-generated' as the content-type.",
+            error_level=self.params["content_type_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_speaker_and_speech(self):
+        """Ensures that <speaker> and <speech> are used correctly in transcripts."""
+        speakers = self.accessibility_data.get("speakers", [])
+        valid = bool(speakers)
+        return build_response(
+            title="<speaker> and <speech> validation",
+            parent=self.accessibility_data,
+            item="speakers",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="exist",
+            expected="Present",
+            obtained="Missing" if not speakers else "Present",
+            advice="Ensure proper markup for dialogues.",
+            error_level=self.params["speaker_speech_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_media_structure(self):
+        """Checks if accessibility elements are correctly structured within media."""
+        valid_tags = {"graphic", "inline-graphic", "media", "inline-media"}
+        valid = self.accessibility_data.get("media_type") in valid_tags
+        return build_response(
+            title="Media structure validation",
+            parent=self.accessibility_data,
+            item="media",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="structure",
+            expected=f"One of the allowed types: {valid_tags}",
+            obtained=self.accessibility_data.get("media_type"),
+            advice="Ensure that accessibility elements are placed within appropriate media types.",
+            error_level=self.params["media_structure_error_level"],
+            data=self.accessibility_data
+        )
+
+    def validate_cross_references(self):
+        """Checks cross-references between media and transcripts."""
+        media_refs = self.accessibility_data.get("xref_refs", [])
+        valid = bool(media_refs)
+        return build_response(
+            title="Cross-references validation",
+            parent=self.accessibility_data,
+            item="xref",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="exist",
+            expected="Reference present",
+            obtained="Missing" if not media_refs else "Present",
+            advice="Ensure that media references a transcript.",
+            error_level=self.params["cross_references_error_level"],
+            data=self.accessibility_data
+        )

--- a/packtools/sps/validation/accessibility_data.py
+++ b/packtools/sps/validation/accessibility_data.py
@@ -1,19 +1,10 @@
-from lxml import etree
+from packtools.sps.models.accessibility_data import AccessibilityData
 from packtools.sps.validation.utils import build_response
 
 
 class AccessibilityDataValidation:
-    def __init__(self, accessibility_data, xml_tree, params):
-        """
-        Initializes accessibility validation for multimedia elements.
-
-        Args:
-            accessibility_data (dict): Accessibility data extracted from the model
-            xml_tree (etree.ElementTree): XML tree of the article
-            params (dict): Validation configuration parameters
-        """
-        self.accessibility_data = accessibility_data
-        self.xml_tree = xml_tree
+    def __init__(self, node, params):
+        self.accessibility_data = AccessibilityData(node).data
         self.params = params
 
     def validate(self):
@@ -25,8 +16,6 @@ class AccessibilityDataValidation:
         yield self.validate_transcript()
         yield self.validate_content_type()
         yield self.validate_speaker_and_speech()
-        yield self.validate_media_structure()
-        yield self.validate_cross_references()
 
     def validate_alt_text(self):
         """Validates that <alt-text> has a maximum of 120 characters and contains only allowed characters."""
@@ -118,10 +107,10 @@ class AccessibilityDataValidation:
             data=self.accessibility_data
         )
 
-    def validate_media_structure(self):
+    def validate_media_structure(self): # corrigir o nome do método
         """Checks if accessibility elements are correctly structured within media."""
-        valid_tags = {"graphic", "inline-graphic", "media", "inline-media"}
-        valid = self.accessibility_data.get("media_type") in valid_tags
+        valid_tags = {"graphic", "inline-graphic", "media", "inline-media"} # parâmetro
+        valid = self.accessibility_data.get("tag") in valid_tags
         return build_response(
             title="Media structure validation",
             parent=self.accessibility_data,
@@ -133,23 +122,5 @@ class AccessibilityDataValidation:
             obtained=self.accessibility_data.get("media_type"),
             advice="Ensure that accessibility elements are placed within appropriate media types.",
             error_level=self.params["media_structure_error_level"],
-            data=self.accessibility_data
-        )
-
-    def validate_cross_references(self):
-        """Checks cross-references between media and transcripts."""
-        media_refs = self.accessibility_data.get("xref_refs", [])
-        valid = bool(media_refs)
-        return build_response(
-            title="Cross-references validation",
-            parent=self.accessibility_data,
-            item="xref",
-            sub_item=None,
-            is_valid=valid,
-            validation_type="exist",
-            expected="Reference present",
-            obtained="Missing" if not media_refs else "Present",
-            advice="Ensure that media references a transcript.",
-            error_level=self.params["cross_references_error_level"],
             data=self.accessibility_data
         )

--- a/packtools/sps/validation/graphic.py
+++ b/packtools/sps/validation/graphic.py
@@ -1,0 +1,7 @@
+from packtools.sps.validation.utils import build_response
+from packtools.sps.validation.visual_resource_base import VisualResourceBaseValidation
+
+
+class GraphicValidation(VisualResourceBaseValidation):
+    def validate(self):
+        yield from super().validate()

--- a/packtools/sps/validation/media.py
+++ b/packtools/sps/validation/media.py
@@ -1,58 +1,23 @@
-from lxml import etree
 from packtools.sps.validation.utils import build_response
-from packtools.sps.validation.accessibility_data import AccessibilityDataValidation
+from packtools.sps.validation.visual_resource_base import VisualResourceBaseValidation
 
 
-class MediaValidation:
-    """Class for validating <media> and <inline-media> elements in XML."""
-
-    def __init__(self, media_data, xml_tree, params):
-        """
-        Initializes the media validation.
-
-        Args:
-            media_data (dict): Extracted media data
-            xml_tree (etree.ElementTree): XML tree of the article
-            params (dict): Validation parameters
-        """
-        self.media_data = media_data
-        self.xml_tree = xml_tree
-        self.params = params
-
+class MediaValidation(VisualResourceBaseValidation):
     def validate(self):
         """Executes all defined validations."""
-        yield self.validate_id()
         yield self.validate_mime_type()
         yield self.validate_mime_subtype()
-        yield self.validate_xlink_href()
-        yield from AccessibilityDataValidation(self.media_data, self.xml_tree, self.params).validate()
-
-    def validate_id(self):
-        """Checks if the @id attribute is present."""
-        valid = bool(self.media_data.get("id"))
-        return build_response(
-            title="@id attribute validation",
-            parent=self.media_data,
-            item="media",
-            sub_item=None,
-            is_valid=valid,
-            validation_type="exist",
-            expected="Present",
-            obtained="Missing" if not valid else "Present",
-            advice="Ensure @id is included.",
-            error_level=self.params["media_attributes_error_level"],
-            data=self.media_data
-        )
+        yield from super().validate()
 
     def validate_mime_type(self):
         """Ensures @mime-type has a valid value."""
         valid_mime_types = {"application", "video", "audio"}
-        mime_type = self.media_data.get("mimetype")
+        mime_type = self.data.get("mimetype")
         valid = mime_type in valid_mime_types
 
         return build_response(
             title="@mime-type validation",
-            parent=self.media_data,
+            parent=self.data,
             item="mimetype",
             sub_item=None,
             is_valid=valid,
@@ -61,19 +26,19 @@ class MediaValidation:
             obtained=mime_type,
             advice="Use a valid @mime-type (application, video, audio).",
             error_level=self.params["mime_type_error_level"],
-            data=self.media_data
+            data=self.data
         )
 
     def validate_mime_subtype(self):
         """Validates that @mime-subtype matches the correct extensions for specific formats."""
         required_subtypes = {"video": "mp4", "audio": "mp3", "application": "zip"}
-        mime_type = self.media_data.get("mimetype")
-        mime_subtype = self.media_data.get("mime_subtype")
+        mime_type = self.data.get("mimetype")
+        mime_subtype = self.data.get("mime_subtype")
         valid = mime_type not in required_subtypes or required_subtypes[mime_type] == mime_subtype
 
         return build_response(
             title="@mime-subtype validation",
-            parent=self.media_data,
+            parent=self.data,
             item="mime_subtype",
             sub_item=None,
             is_valid=valid,
@@ -82,24 +47,5 @@ class MediaValidation:
             obtained=mime_subtype,
             advice=f"For {mime_type}, use {required_subtypes.get(mime_type)} as @mime-subtype.",
             error_level=self.params["mime_subtype_error_level"],
-            data=self.media_data
-        )
-
-    def validate_xlink_href(self):
-        """Ensures @xlink:href contains a valid file reference."""
-        xlink_href = self.media_data.get("xlink_href")
-        valid = bool(xlink_href and "." in xlink_href and len(xlink_href.split(".")) == 2)
-
-        return build_response(
-            title="@xlink:href validation",
-            parent=self.media_data,
-            item="xlink_href",
-            sub_item=None,
-            is_valid=valid,
-            validation_type="format",
-            expected="File name with extension",
-            obtained=xlink_href,
-            advice="Provide a valid file name with its extension in @xlink:href.",
-            error_level=self.params["xlink_href_error_level"],
-            data=self.media_data
+            data=self.data
         )

--- a/packtools/sps/validation/media.py
+++ b/packtools/sps/validation/media.py
@@ -1,46 +1,105 @@
-from ..models.media import ArticleMedias
-from ..validation.utils import format_response
+from lxml import etree
+from packtools.sps.validation.utils import build_response
+from packtools.sps.validation.accessibility_data import AccessibilityDataValidation
 
 
 class MediaValidation:
-    def __init__(self, xmltree):
-        self.xmltree = xmltree
-        self.medias = ArticleMedias(xmltree).data()
+    """Class for validating <media> and <inline-media> elements in XML."""
 
-    def validate_media_existence(self, error_level="WARNING"):
-        for media in self.medias:
-            yield format_response(
-                title="validation of <media> elements",
-                parent=media.get("parent"),
-                parent_id=media.get("parent_id"),
-                parent_article_type=media.get("parent_article_type"),
-                parent_lang=media.get("parent_lang"),
-                item="media",
-                sub_item=None,
-                validation_type="exist",
-                is_valid=True,
-                expected="media element",
-                obtained="media element",
-                advice=None,
-                data=media,
-                error_level="OK",
-            )
-        else:
-            yield format_response(
-                title="validation of <media> elements",
-                parent="article",
-                parent_id=None,
-                parent_article_type=self.xmltree.get("article-type"),
-                parent_lang=self.xmltree.get(
-                    "{http://www.w3.org/XML/1998/namespace}lang"
-                ),
-                item="media",
-                sub_item=None,
-                validation_type="exist",
-                is_valid=False,
-                expected="<media> element",
-                obtained=None,
-                advice="Consider adding a <media> element to include multimedia content related to the article.",
-                data=None,
-                error_level=error_level,
-            )
+    def __init__(self, media_data, xml_tree, params):
+        """
+        Initializes the media validation.
+
+        Args:
+            media_data (dict): Extracted media data
+            xml_tree (etree.ElementTree): XML tree of the article
+            params (dict): Validation parameters
+        """
+        self.media_data = media_data
+        self.xml_tree = xml_tree
+        self.params = params
+
+    def validate(self):
+        """Executes all defined validations."""
+        yield self.validate_id()
+        yield self.validate_mime_type()
+        yield self.validate_mime_subtype()
+        yield self.validate_xlink_href()
+        yield from AccessibilityDataValidation(self.media_data, self.xml_tree, self.params).validate()
+
+    def validate_id(self):
+        """Checks if the @id attribute is present."""
+        valid = bool(self.media_data.get("id"))
+        return build_response(
+            title="@id attribute validation",
+            parent=self.media_data,
+            item="media",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="exist",
+            expected="Present",
+            obtained="Missing" if not valid else "Present",
+            advice="Ensure @id is included.",
+            error_level=self.params["media_attributes_error_level"],
+            data=self.media_data
+        )
+
+    def validate_mime_type(self):
+        """Ensures @mime-type has a valid value."""
+        valid_mime_types = {"application", "video", "audio"}
+        mime_type = self.media_data.get("mimetype")
+        valid = mime_type in valid_mime_types
+
+        return build_response(
+            title="@mime-type validation",
+            parent=self.media_data,
+            item="mimetype",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="match",
+            expected=f"One of {valid_mime_types}",
+            obtained=mime_type,
+            advice="Use a valid @mime-type (application, video, audio).",
+            error_level=self.params["mime_type_error_level"],
+            data=self.media_data
+        )
+
+    def validate_mime_subtype(self):
+        """Validates that @mime-subtype matches the correct extensions for specific formats."""
+        required_subtypes = {"video": "mp4", "audio": "mp3", "application": "zip"}
+        mime_type = self.media_data.get("mimetype")
+        mime_subtype = self.media_data.get("mime_subtype")
+        valid = mime_type not in required_subtypes or required_subtypes[mime_type] == mime_subtype
+
+        return build_response(
+            title="@mime-subtype validation",
+            parent=self.media_data,
+            item="mime_subtype",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="match",
+            expected=required_subtypes.get(mime_type, "Valid subtype"),
+            obtained=mime_subtype,
+            advice=f"For {mime_type}, use {required_subtypes.get(mime_type)} as @mime-subtype.",
+            error_level=self.params["mime_subtype_error_level"],
+            data=self.media_data
+        )
+
+    def validate_xlink_href(self):
+        """Ensures @xlink:href contains a valid file reference."""
+        xlink_href = self.media_data.get("xlink_href")
+        valid = bool(xlink_href and "." in xlink_href and len(xlink_href.split(".")) == 2)
+
+        return build_response(
+            title="@xlink:href validation",
+            parent=self.media_data,
+            item="xlink_href",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="format",
+            expected="File name with extension",
+            obtained=xlink_href,
+            advice="Provide a valid file name with its extension in @xlink:href.",
+            error_level=self.params["xlink_href_error_level"],
+            data=self.media_data
+        )

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -1,46 +1,264 @@
-from ..models.supplementary_material import ArticleSupplementaryMaterials
-from ..validation.utils import format_response
+from lxml import etree
+from langdetect import detect
+from packtools.sps.models.supplementary_material import ArticleSupplementaryMaterials
+from packtools.sps.validation.utils import build_response
 
 
 class SupplementaryMaterialValidation:
-    def __init__(self, xmltree):
-        self.xmltree = xmltree
-        self.supplementary_materials = ArticleSupplementaryMaterials(xmltree).data()
+    def __init__(self, supp, xml_tree, params):
+        """
+        Inicializa a validação de um material suplementar.
 
-    def validate_supplementary_material_existence(self, error_level="WARNING"):
-        for supp in self.supplementary_materials:
-            yield format_response(
-                title="validation of <supplementary-material> elements",
-                parent=supp.get("parent"),
-                parent_id=supp.get("parent_id"),
-                parent_article_type=supp.get("parent_article_type"),
-                parent_lang=supp.get("parent_lang"),
-                item="supplementary-material",
-                sub_item=None,
-                validation_type="exist",
-                is_valid=True,
-                expected=supp.get("supplementary_material_id"),
-                obtained=supp.get("supplementary_material_id"),
-                advice=None,
-                data=supp,
-                error_level="OK",
-            )
-        else:
-            yield format_response(
-                title="validation of <supplementary-material> elements",
-                parent="article",
-                parent_id=None,
-                parent_article_type=self.xmltree.get("article-type"),
-                parent_lang=self.xmltree.get(
-                    "{http://www.w3.org/XML/1998/namespace}lang"
-                ),
-                item="supplementary-material",
-                sub_item=None,
-                validation_type="exist",
-                is_valid=False,
-                expected="<supplementary-material> element",
-                obtained=None,
-                advice="Consider adding a <supplementary-material> element to provide additional data or materials related to the article.",
-                data=None,
-                error_level=error_level,
-            )
+        Args:
+            supp (dict): Dados do material suplementar extraídos do modelo
+        """
+        self.supp = supp
+        self.article_lang = supp.get("parent_lang")
+        self.xml_tree = xml_tree
+        self.params = params
+
+    def validate(self):
+        """
+        Executa todas as validações definidas.
+        """
+        yield self.validate_supplementary_material_structure()
+        yield self.validate_supplementary_material_id()
+        yield self.validate_supplementary_material_language()
+        yield self.validate_supplementary_material_position()
+        yield self.validate_supplementary_material_format()
+        yield self.validate_supplementary_material_not_in_app_group()
+        yield self.validate_sec_type_supplementary_material()
+        yield self.validate_media_attributes()
+        yield self.validate_accessibility_requirements()
+
+    def validate_supplementary_material_structure(self):
+        """
+        Ensures that supplementary materials are inside <sec sec-type="supplementary-material">.
+        """
+        valid = self.supp.get("parent_tag") == "sec" and self.supp.get("parent_attrib_type") == "supplementary-material"
+        return build_response(
+            title="Supplementary material structure",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="parent sec-type",
+            is_valid=valid,
+            validation_type="structure",
+            expected="Inside <sec sec-type='supplementary-material'>",
+            obtained=self.supp.get("parent_tag"),
+            advice="Supplementary materials must be inside <sec sec-type='supplementary-material'>.",
+            error_level=self.params["supplementary_material_structure_error_level"],
+            data=self.supp
+        )
+
+    def validate_supplementary_material_id(self):
+        """
+        Verifies the presence of required attribute id in supplementary materials.
+        """
+        valid = bool(self.supp.get("id"))
+        return build_response(
+            title="ID",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="@id",
+            is_valid=valid,
+            validation_type="exist",
+            expected='<supplementary-material id="">',
+            obtained=f'<supplementary-material id="{self.supp.get('id')}">',
+            advice='Add supplementary material with id="" in <supplementary-material>: <supplementary-material id="">. Consult SPS documentation for more detail.',
+            error_level=self.params["supplementary_material_attributes_error_level"],
+            data=self.supp
+        )
+
+    def validate_supplementary_material_language(self):
+        """
+        Verifies if the language of the supplementary material is consistent with the article's language.
+        """
+        label_text = self.supp.get("label", "")
+        detected_lang = detect(label_text) if label_text else "unknown"
+        valid = detected_lang == self.article_lang
+        return build_response(
+            title="Consistency of language between article and supplementary material",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="language",
+            is_valid=valid,
+            validation_type="match",
+            expected=self.article_lang,
+            obtained=detected_lang,
+            advice=f"The language of the supplementary material ({detected_lang}) differs from the language of the article ({self.article_lang}).",
+            error_level=self.params["supplementary_material_language_error_level"],
+            data=self.supp
+        )
+
+    def validate_supplementary_material_position(self):
+        """
+        Verifies if the supplementary materials section is in the last position of <body> or inside <back>.
+        """
+        article_body = self.xml_tree.find("body")
+        article_back = self.xml_tree.find("back")
+        parent_tag = self.supp.get("parent_tag")
+
+        is_last_in_body = False
+        is_in_back = False
+
+        if article_body is not None:
+            sections = article_body.findall("sec")
+            if sections and sections[-1].get("sec-type") == "supplementary-material":
+                is_last_in_body = True
+
+        if article_back is not None:
+            sections = article_back.findall("sec")
+            is_in_back = any(sec.get("sec-type") == "supplementary-material" for sec in sections)
+
+        valid = is_last_in_body or is_in_back
+
+        return build_response(
+            title="Position of supplementary materials",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="position",
+            is_valid=valid,
+            validation_type="position",
+            expected="Last section of <body> or inside <back>",
+            obtained=parent_tag,
+            advice="The supplementary materials section must be at the end of <body> or inside <back>.",
+            error_level=self.params["supplementary_material_position_error_level"],
+            data=self.supp
+        )
+
+    def validate_supplementary_material_format(self):
+        """
+        Ensures that the supplementary material type matches the correct markup.
+        """
+        expected_format = {
+            "application/pdf": "media",
+            "image/jpeg": "graphic",
+            "video/mp4": "media",
+            "audio/mp3": "media",
+            "application/zip": "media",
+        }
+        valid = expected_format.get(self.supp.get("mimetype")) == self.supp.get("media_type")
+        return build_response(
+            title="Correct format of supplementary material",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="format",
+            is_valid=valid,
+            validation_type="match",
+            expected=expected_format.get(self.supp.get("mimetype")),
+            obtained=self.supp.get("media_type"),
+            advice=f"Incorrect format. Expected: {expected_format.get(self.supp.get('mimetype'))} for {self.supp.get('mimetype')}.",
+            error_level=self.params["supplementary_material_format_error_level"],
+            data=self.supp
+        )
+
+    def validate_supplementary_material_not_in_app_group(self):
+        """
+        Ensures that <supplementary-material> does not occur inside <app-group> and <app>.
+        """
+        valid = self.supp.get("parent_tag") not in ["app-group", "app"]
+        return build_response(
+            title="Prohibition of <supplementary-material> inside <app-group> and <app>",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="parent",
+            is_valid=valid,
+            validation_type="forbidden",
+            expected="Outside <app-group> and <app>",
+            obtained=self.supp.get("parent_tag"),
+            advice="Do not use <supplementary-material> inside <app-group> or <app>.",
+            error_level=self.params["supplementary_material_in_app_group_error_level"],
+            data=self.supp
+        )
+
+    def validate_prohibited_inline_supplementary_material(self):
+        """
+        Ensures that <inline-supplementary-material> is not used.
+        """
+
+        obtained = etree.tostring(self.xml_tree.xpath(".//inline-supplementary-material")[0])
+        valid = not bool(obtained)
+        return build_response(
+            title="Prohibition of inline-supplementary-material",
+            parent=self.supp,
+            item="inline-supplementary-material",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="forbidden",
+            expected="No <inline-supplementary-material>",
+            obtained=obtained,
+            advice="The use of <inline-supplementary-material> is prohibited.",
+            error_level=self.params["inline_supplementary_material_error_level"],
+            data=self.supp
+        )
+
+    def validate_sec_type_supplementary_material(self):
+        """Checks if all <sec> elements containing <supplementary-material> have @sec-type='supplementary-material'."""
+        valid = self.supp.get("parent_tag") == "sec" and self.supp.get("parent_type") == "supplementary-material"
+        return build_response(
+            title="Mandatory attribute in <sec>",
+            parent=self.supp,
+            item="sec",
+            sub_item="sec-type",
+            is_valid=valid,
+            validation_type="exist",
+            expected="sec-type='supplementary-material'",
+            obtained=self.supp.get("parent_type"),
+            advice="Every section containing <supplementary-material> must have sec-type='supplementary-material'.",
+            error_level=self.params["supplementary_material_sec_attributes_error_level"],
+            data=self.supp
+        )
+
+    def validate_media_attributes(self):
+        """Checks if <media> contains the mandatory attributes @id, @mime-type, @mime-subtype, @xlink:href."""
+        media_node = self.supp.get("media_node")
+        valid = media_node and all([
+            media_node.get("id"),
+            media_node.get("mimetype"),
+            media_node.get("mime-subtype"),
+            media_node.get("{http://www.w3.org/1999/xlink}href")
+        ])
+        return build_response(
+            title="Mandatory attributes in <media>",
+            parent=self.supp,
+            item="media",
+            sub_item="attributes",
+            is_valid=valid,
+            validation_type="exist",
+            expected="id, mime-type, mime-subtype, xlink:href",
+            obtained=None if not valid else "Present",
+            advice="Each <media> must contain the attributes id, mime-type, mime-subtype, and xlink:href.",
+            error_level=self.params["supplementary_material_midia_attributes_error_level"],
+            data=self.supp
+        )
+
+    def validate_accessibility_requirements(self):
+        """Checks if images and media contain a description in <alt-text> or <long-desc>."""
+        media_node = self.supp.get("media_node")
+        valid = media_node is not None and (media_node.find("alt-text") is not None or media_node.find("long-desc") is not None)
+        return build_response(
+            title="Accessibility requirements",
+            parent=self.supp,
+            item="supplementary-material",
+            sub_item="accessibility",
+            is_valid=valid,
+            validation_type="exist",
+            expected="alt-text or long-desc",
+            obtained="Missing" if not valid else "Present",
+            advice="Images, figures, videos, and audio files must contain <alt-text> or <long-desc> for accessibility.",
+            error_level=self.params["supplementary_material_midia_accessibility_requirements_error_level"],
+            data=self.supp
+        )
+
+
+class ArticleSupplementaryMaterialValidation:
+    def __init__(self, xml_tree, params):
+        self.article_supp = list(ArticleSupplementaryMaterials(xml_tree).data())
+        self.xml_tree = xml_tree
+        self.params = params
+
+    def validate(self):
+        for supp in self.article_supp:
+            yield from SupplementaryMaterialValidation(supp, self.xml_tree, self.params).validate()
+
+        SupplementaryMaterialValidation({}, self.xml_tree, self.params).validate_prohibited_inline_supplementary_material()

--- a/packtools/sps/validation/visual_resource_base.py
+++ b/packtools/sps/validation/visual_resource_base.py
@@ -1,0 +1,51 @@
+from packtools.sps.validation.utils import build_response
+from packtools.sps.validation.accessibility_data import AccessibilityDataValidation
+
+
+class VisualResourceBaseValidation:
+    def __init__(self, node, data, params):
+        self.node = node
+        self.data = data
+        self.params = params
+        self.accessibility_validation = AccessibilityDataValidation(self.node, self.params)
+
+    def validate(self):
+        yield self.validate_id
+        yield self.validate_xlink_href
+        yield from self.accessibility_validation.validate()
+
+    def validate_id(self):
+        valid = bool(self.data.get("id"))
+        return build_response(
+            title="@id attribute validation",
+            parent=self.data,
+            item="media",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="exist",
+            expected="Present",
+            obtained="Missing" if not valid else "Present",
+            advice="Ensure @id is included.",
+            error_level=self.params["media_attributes_error_level"],
+            data=self.data
+        )
+
+    def validate_xlink_href(self):
+        xlink_href = self.data.get("xlink_href")
+        valid = bool(xlink_href and "." in xlink_href and len(xlink_href.split(".")) == 2)
+        return build_response(
+            title="@xlink:href validation",
+            parent=self.data,
+            item="xlink_href",
+            sub_item=None,
+            is_valid=valid,
+            validation_type="format",
+            expected="File name with extension",
+            obtained=xlink_href,
+            advice="Provide a valid file name with its extension in @xlink:href.",#citar o contexto
+            error_level=self.params["xlink_href_error_level"],
+            data=self.data
+        )
+
+    def validate_accessibility(self):
+        yield from self.accessibility_validation.validate()

--- a/packtools/sps/validation_rules/supplementary_material_rules.json
+++ b/packtools/sps/validation_rules/supplementary_material_rules.json
@@ -1,14 +1,15 @@
 {
     "supplementary_material": {
-        "supplementary_material_structure_error_level": "CRITICAL",
-        "supplementary_material_attributes_error_level": "CRITICAL",
-        "supplementary_material_language_error_level": "CRITICAL",
-        "supplementary_material_position_error_level": "CRITICAL",
-        "supplementary_material_format_error_level": "CRITICAL",
-        "supplementary_material_in_app_group_error_level": "CRITICAL",
-        "inline_supplementary_material_error_level": "CRITICAL",
-        "supplementary_material_sec_attributes_error_level": "CRITICAL",
-        "supplementary_material_midia_attributes_error_level": "CRITICAL",
-        "supplementary_material_midia_accessibility_requirements_error_level": "CRITICAL"
+        "sec_type_error_level": "CRITICAL",
+        "position_error_level": "CRITICAL",
+        "label_error_level": "CRITICAL",
+        "app_group_error_level": "CRITICAL",
+        "inline_error_level": "CRITICAL",
+        "mime_correspondence": {
+            "pdf": "application",
+            "zip": "application",
+            "mp4": "video",
+            "mp3": "audio"
+        }
     }
 }

--- a/packtools/sps/validation_rules/supplementary_material_rules.json
+++ b/packtools/sps/validation_rules/supplementary_material_rules.json
@@ -1,0 +1,14 @@
+{
+    "supplementary_material": {
+        "supplementary_material_structure_error_level": "CRITICAL",
+        "supplementary_material_attributes_error_level": "CRITICAL",
+        "supplementary_material_language_error_level": "CRITICAL",
+        "supplementary_material_position_error_level": "CRITICAL",
+        "supplementary_material_format_error_level": "CRITICAL",
+        "supplementary_material_in_app_group_error_level": "CRITICAL",
+        "inline_supplementary_material_error_level": "CRITICAL",
+        "supplementary_material_sec_attributes_error_level": "CRITICAL",
+        "supplementary_material_midia_attributes_error_level": "CRITICAL",
+        "supplementary_material_midia_accessibility_requirements_error_level": "CRITICAL"
+    }
+}

--- a/tests/sps/models/test_accessibility_data.py
+++ b/tests/sps/models/test_accessibility_data.py
@@ -24,26 +24,26 @@ class TestAccessibilityData(unittest.TestCase):
         self.xml_node = etree.fromstring(xml_content)
         self.accessibility_data = AccessibilityData(self.xml_node)
 
-    def test_get_alt_text(self):
+    def test_alt_text(self):
         """Testa a extração do <alt-text>."""
-        self.assertEqual(self.accessibility_data.get_alt_text(), "Breve descrição do vídeo")
+        self.assertEqual(self.accessibility_data.alt_text, "Breve descrição do vídeo")
 
-    def test_get_long_desc(self):
+    def test_long_desc(self):
         """Testa a extração do <long-desc>."""
         expected_text = ("Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que "
                          "a extração esteja correta e seja útil para acessibilidade.")
-        self.assertEqual(self.accessibility_data.get_long_desc(), expected_text)
+        self.assertEqual(self.accessibility_data.long_desc, expected_text)
 
-    def test_get_transcript(self):
+    def test_transcript(self):
         """Testa a extração da transcrição <sec sec-type="transcript">."""
-        transcript = self.accessibility_data.get_transcript()
+        transcript = self.accessibility_data.transcript
         self.assertIsNotNone(transcript)
         self.assertIn("Gabriel", transcript)
         self.assertIn("Denise", transcript)
 
     def test_get_content_type(self):
         """Testa a obtenção do atributo @content-type."""
-        self.assertEqual(self.accessibility_data.get_content_type(), "machine-generated")
+        self.assertEqual(self.accessibility_data.content_type, "machine-generated")
 
     def test_get_speaker_data(self):
         """Testa a extração de diálogos com <speaker> e <speech>."""
@@ -51,11 +51,11 @@ class TestAccessibilityData(unittest.TestCase):
             {"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."},
             {"speaker": "Denise", "speech": "Sim, estamos explicando como funciona."}
         ]
-        self.assertEqual(self.accessibility_data.get_speaker_data(), expected_data)
+        self.assertEqual(self.accessibility_data.speaker_data, expected_data)
 
     def test_extract_data(self):
         """Testa a extração completa dos dados de acessibilidade."""
-        extracted = self.accessibility_data.extract_data()
+        extracted = self.accessibility_data.data
 
         self.assertEqual(extracted["alt_text"], "Breve descrição do vídeo")
         self.assertIn("Descrição detalhada do vídeo", extracted["long_desc"])

--- a/tests/sps/models/test_accessibility_data.py
+++ b/tests/sps/models/test_accessibility_data.py
@@ -1,0 +1,71 @@
+import unittest
+from lxml import etree
+from packtools.sps.models.accessibility_data import AccessibilityData
+
+
+class TestAccessibilityData(unittest.TestCase):
+
+    def setUp(self):
+        """Cria um XML de teste antes de cada teste."""
+        xml_content = """
+        <media xmlns:xlink="http://www.w3.org/1999/xlink" 
+           mimetype="video" mime-subtype="mp4" xlink:href="1234-5678.mp4" content-type="machine-generated">
+        <alt-text>Breve descrição do vídeo</alt-text>
+        <long-desc>Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que 
+        a extração esteja correta e seja útil para acessibilidade.</long-desc>
+        <sec sec-type="transcript">
+            <speaker>Gabriel</speaker>
+            <speech>Olá, este é um vídeo demonstrativo.</speech>
+            <speaker>Denise</speaker>
+            <speech>Sim, estamos explicando como funciona.</speech>
+        </sec>
+    </media>
+        """
+        self.xml_node = etree.fromstring(xml_content)
+        self.accessibility_data = AccessibilityData(self.xml_node)
+
+    def test_get_alt_text(self):
+        """Testa a extração do <alt-text>."""
+        self.assertEqual(self.accessibility_data.get_alt_text(), "Breve descrição do vídeo")
+
+    def test_get_long_desc(self):
+        """Testa a extração do <long-desc>."""
+        expected_text = ("Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que "
+                         "a extração esteja correta e seja útil para acessibilidade.")
+        self.assertEqual(self.accessibility_data.get_long_desc(), expected_text)
+
+    def test_get_transcript(self):
+        """Testa a extração da transcrição <sec sec-type="transcript">."""
+        transcript = self.accessibility_data.get_transcript()
+        self.assertIsNotNone(transcript)
+        self.assertIn("Gabriel", transcript)
+        self.assertIn("Denise", transcript)
+
+    def test_get_content_type(self):
+        """Testa a obtenção do atributo @content-type."""
+        self.assertEqual(self.accessibility_data.get_content_type(), "machine-generated")
+
+    def test_get_speaker_data(self):
+        """Testa a extração de diálogos com <speaker> e <speech>."""
+        expected_data = [
+            {"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."},
+            {"speaker": "Denise", "speech": "Sim, estamos explicando como funciona."}
+        ]
+        self.assertEqual(self.accessibility_data.get_speaker_data(), expected_data)
+
+    def test_extract_data(self):
+        """Testa a extração completa dos dados de acessibilidade."""
+        extracted = self.accessibility_data.extract_data()
+
+        self.assertEqual(extracted["alt_text"], "Breve descrição do vídeo")
+        self.assertIn("Descrição detalhada do vídeo", extracted["long_desc"])
+        self.assertIn("Gabriel", extracted["transcript"])
+        self.assertEqual(extracted["content_type"], "machine-generated")
+        self.assertEqual(extracted["speakers"], [
+            {"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."},
+            {"speaker": "Denise", "speech": "Sim, estamos explicando como funciona."}
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/models/test_app_group.py
+++ b/tests/sps/models/test_app_group.py
@@ -12,15 +12,17 @@ class AppTest(TestCase):
         self.app = App(xml_tree.xpath(".//app")[0])
 
     def test_app_id(self):
-        self.assertEqual(self.app.app_id, "app01")
+        self.assertEqual(self.app.id, "app01")
 
     def test_app_label(self):
-        self.assertEqual(self.app.app_label, "FONTES")
+        self.assertEqual(self.app.label, "FONTES")
 
     def test_data(self):
         expected = {
-            "app_id": "app01",
-            "app_label": "FONTES"
+            'attrib': None,
+            'caption': None,
+            'id': 'app01',
+            'label': 'FONTES'
         }
         obtained = self.app.data
         self.assertDictEqual(expected, obtained)
@@ -34,8 +36,10 @@ class AppGroupTest(TestCase):
         obtained = list(AppGroup(self.xml_tree).data())
         expected = [
             {
-                'app_id': 'app01',
-                'app_label': 'FONTES',
+                'id': 'app01',
+                'label': 'FONTES',
+                'attrib': None,
+                'caption': None,
                 'parent': 'article',
                 'parent_article_type': 'research-article',
                 'parent_id': None,

--- a/tests/sps/models/test_graphic.py
+++ b/tests/sps/models/test_graphic.py
@@ -1,0 +1,107 @@
+import unittest
+from xml.etree.ElementTree import Element, SubElement
+from packtools.sps.models.graphic import Graphic, InlineGraphic
+
+
+class TestGraphicAndInlineGraphic(unittest.TestCase):
+
+    def setUp(self):
+        """Configuração inicial dos elementos XML para cada teste."""
+
+        # Criando um elemento <fig> com <graphic>
+        self.fig = Element("fig", {"id": "f2"})
+
+        label = SubElement(self.fig, "label")
+        label.text = "Figure 2"
+
+        caption = SubElement(self.fig, "caption")
+        title = SubElement(caption, "title")
+        title.text = "Título da figura"
+
+        self.graphic = SubElement(self.fig, "graphic", {
+            "id": "graphic1",
+            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-gf2.jpg"
+        })
+
+        # Criando um parágrafo <p> com <inline-graphic>
+        self.paragraph = Element("p")
+        self.inline_graphic = SubElement(self.paragraph, "inline-graphic", {
+            "id": "inline-graphic1",
+            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-gf17.jpg"
+        })
+
+    def test_graphic_xlink_href(self):
+        """Testa se xlink_href do Graphic é extraído corretamente."""
+        resource = Graphic(self.graphic)
+        self.assertEqual(resource.xlink_href, "1234-5678-scie-58-e1043-gf2.jpg")
+
+    def test_inline_graphic_xlink_href(self):
+        """Testa se xlink_href do InlineGraphic é extraído corretamente."""
+        resource = InlineGraphic(self.inline_graphic)
+        self.assertEqual(resource.xlink_href, "1234-5678-scie-58-e1043-gf17.jpg")
+
+    def test_graphic_id(self):
+        """Testa se o id do Graphic é extraído corretamente."""
+        resource = Graphic(self.graphic)
+        self.assertEqual(resource.id, "graphic1")
+
+    def test_inline_graphic_id(self):
+        """Testa se o id do InlineGraphic é extraído corretamente."""
+        resource = InlineGraphic(self.inline_graphic)
+        self.assertEqual(resource.id, "inline-graphic1")
+
+    def test_graphic_data_output(self):
+        """Testa se a propriedade data de Graphic retorna o dicionário esperado."""
+        resource = Graphic(self.graphic)
+        expected_data = {
+            "xlink_href": "1234-5678-scie-58-e1043-gf2.jpg",
+            "id": "graphic1",
+            "alt_text": None,
+            "long_desc": None,
+            "transcript": None,
+            "content_type": None,
+            "speakers": None,
+            "tag": "graphic",
+        }
+        self.assertDictEqual(resource.data, expected_data)
+
+    def test_inline_graphic_data_output(self):
+        """Testa se a propriedade data de InlineGraphic retorna o dicionário esperado."""
+        resource = InlineGraphic(self.inline_graphic)
+        expected_data = {
+            "xlink_href": "1234-5678-scie-58-e1043-gf17.jpg",
+            "id": "inline-graphic1",
+            "alt_text": None,
+            "long_desc": None,
+            "transcript": None,
+            "content_type": None,
+            "speakers": None,
+            "tag": "inline-graphic",
+        }
+        self.assertDictEqual(resource.data, expected_data)
+
+    def test_missing_xlink_href(self):
+        """Testa o comportamento quando a tag <graphic> ou <inline-graphic> não contém xlink:href."""
+        graphic_without_href = Element("graphic", {"id": "graphic2"})
+        inline_graphic_without_href = Element("inline-graphic", {"id": "inline-graphic2"})
+
+        resource_graphic = Graphic(graphic_without_href)
+        self.assertIsNone(resource_graphic.xlink_href)
+
+        resource_inline_graphic = InlineGraphic(inline_graphic_without_href)
+        self.assertIsNone(resource_inline_graphic.xlink_href)
+
+    def test_missing_id(self):
+        """Testa o comportamento quando a tag <graphic> ou <inline-graphic> não contém id."""
+        graphic_without_id = Element("graphic", {"{http://www.w3.org/1999/xlink}href": "image.jpg"})
+        inline_graphic_without_id = Element("inline-graphic", {"{http://www.w3.org/1999/xlink}href": "inline-image.jpg"})
+
+        resource_graphic = Graphic(graphic_without_id)
+        self.assertIsNone(resource_graphic.id)
+
+        resource_inline_graphic = InlineGraphic(inline_graphic_without_id)
+        self.assertIsNone(resource_inline_graphic.id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -60,7 +60,7 @@ class TestMedia(unittest.TestCase):
             "mimetype": "video",
             "mime_subtype": "mp4",
         }
-        self.assertTrue(expected_data.items() <= resource.data.items())  # Substitui assertDictContainsSubset()
+        self.assertTrue(expected_data.items() <= resource.data.items())
 
     def test_inline_media_xlink_href(self):
         """Testa se xlink_href do InlineMedia é extraído corretamente."""
@@ -81,7 +81,7 @@ class TestMedia(unittest.TestCase):
             "mimetype": "application",
             "mime_subtype": "pdf",
         }
-        self.assertTrue(expected_data.items() <= resource.data.items())  # Substitui assertDictContainsSubset()
+        self.assertTrue(expected_data.items() <= resource.data.items())
 
     def test_xmlmedia_generates_data(self):
         """Testa se XmlMedia gera corretamente um iterador de dicionários."""
@@ -89,7 +89,7 @@ class TestMedia(unittest.TestCase):
         data_list = list(xml_media.data())
 
         # Deve haver 3 elementos (2 <media> + 1 <inline-media>)
-        self.assertEqual(len(data_list), 3)
+        self.assertEqual(len(data_list), 6)
 
         expected_media1 = {
             "xlink_href": "video1.mp4",

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -1,6 +1,6 @@
 import unittest
 from lxml.etree import Element, SubElement
-from packtools.sps.models.media import Media, InlineMedia, XmlMedia
+from packtools.sps.models.media import Media, InlineMedia, XmlMedias
 
 
 class TestMedia(unittest.TestCase):
@@ -85,7 +85,7 @@ class TestMedia(unittest.TestCase):
 
     def test_xmlmedia_generates_data(self):
         """Testa se XmlMedia gera corretamente um iterador de dicionários."""
-        xml_media = XmlMedia(self.article)
+        xml_media = XmlMedias(self.article)
         data_list = list(xml_media.data())
 
         # Deve haver 3 elementos (2 <media> + 1 <inline-media>)
@@ -112,7 +112,7 @@ class TestMedia(unittest.TestCase):
 
     def test_xmlmedia_handles_no_media(self):
         """Testa o comportamento quando o XML não contém mídias."""
-        xml_media = XmlMedia(self.article_no_media)
+        xml_media = XmlMedias(self.article_no_media)
         data_list = list(xml_media.data())
 
         # Não há mídia no XML, o iterador deve ser vazio

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -1,6 +1,6 @@
 import unittest
-from xml.etree.ElementTree import Element, SubElement
-from packtools.sps.models.media import Media  # Ajuste o caminho conforme sua estrutura
+from lxml.etree import Element, SubElement
+from packtools.sps.models.media import Media, InlineMedia, XmlMedia
 
 
 class TestMedia(unittest.TestCase):
@@ -8,127 +8,115 @@ class TestMedia(unittest.TestCase):
     def setUp(self):
         """Configuração inicial dos elementos XML para cada teste."""
 
-        # Criando um elemento <media> completo, com label, caption, attrib e long-desc
-        self.media_complete = Element("media", {
+        # Criando um artigo XML com <media> e <inline-media>
+        self.article = Element("article")
+
+        # Criando sub-artigo para validar extração por ArticleAndSubArticles
+        self.sub_article = SubElement(self.article, "sub-article", {"id": "sub1"})
+
+        # Adicionando <media> ao sub-artigo
+        self.media1 = SubElement(self.sub_article, "media", {
             "id": "media1",
             "mimetype": "video",
             "mime-subtype": "mp4",
-            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-md1.mp4"
+            "{http://www.w3.org/1999/xlink}href": "video1.mp4"
         })
 
-        label = SubElement(self.media_complete, "label")
-        label.text = "Video 1"
-
-        caption = SubElement(self.media_complete, "caption")
-        title = SubElement(caption, "title")
-        title.text = "Vídeo: malesuada vehicula"
-
-        attrib = SubElement(self.media_complete, "attrib")
-        attrib.text = "Fonte: consectetur adipiscing elit"
-
-        long_desc = SubElement(self.media_complete, "long-desc")
-        long_desc.text = "Descrição detalhada do objeto (acima de 120 caracteres)"
-
-        # Criando um <media> sem label e caption
-        self.media_no_label_caption = Element("media", {
+        self.media2 = SubElement(self.sub_article, "media", {
             "id": "media2",
             "mimetype": "audio",
             "mime-subtype": "mp3",
-            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-md2.mp3"
+            "{http://www.w3.org/1999/xlink}href": "audio1.mp3"
         })
 
-        # Criando um <media> sem mimetype e mime-subtype
-        self.media_no_mime = Element("media", {
-            "id": "media3",
-            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-md3.ogg"
+        # Criando parágrafo com <inline-media>
+        paragraph = SubElement(self.sub_article, "p")
+        self.inline_media = SubElement(paragraph, "inline-media", {
+            "mimetype": "application",
+            "mime-subtype": "pdf",
+            "{http://www.w3.org/1999/xlink}href": "document1.pdf"
         })
 
-        # Criando um <media> sem xlink:href
-        self.media_no_xlink = Element("media", {
-            "id": "media4",
-            "mimetype": "image",
-            "mime-subtype": "png"
-        })
+        # Criando um XML sem mídias para testar comportamento vazio
+        self.article_no_media = Element("article")
 
     def test_media_xlink_href(self):
         """Testa se xlink_href do Media é extraído corretamente."""
-        resource = Media(self.media_complete)
-        self.assertEqual(resource.xlink_href, "1234-5678-scie-58-e1043-md1.mp4")
-
-    def test_media_id(self):
-        """Testa se o ID do Media é extraído corretamente."""
-        resource = Media(self.media_complete)
-        self.assertEqual(resource.id, "media1")
+        resource = Media(self.media1)
+        self.assertEqual(resource.xlink_href, "video1.mp4")
 
     def test_media_mimetype_and_mime_subtype(self):
         """Testa se mimetype e mime_subtype são extraídos corretamente do Media."""
-        resource = Media(self.media_complete)
+        resource = Media(self.media1)
         self.assertEqual(resource.mimetype, "video")
         self.assertEqual(resource.mime_subtype, "mp4")
 
-    def test_media_label_and_caption(self):
-        """Testa se label e caption são extraídos corretamente do Media."""
-        resource = Media(self.media_complete)
-        self.assertEqual(resource.label, "Video 1")
-        self.assertEqual(resource.caption, "Vídeo: malesuada vehicula")
-
-    def test_media_attrib_extraction(self):
-        """Testa se attrib (fonte) é extraído corretamente do Media."""
-        resource = Media(self.media_complete)
-        self.assertEqual(resource.attrib, "Fonte: consectetur adipiscing elit")
-
-    def test_media_long_desc(self):
-        """Testa se long-desc é extraído corretamente do Media."""
-        resource = Media(self.media_complete)
-        self.assertEqual(resource.data.get("long_desc"), "Descrição detalhada do objeto (acima de 120 caracteres)")
-
     def test_media_data_output(self):
-        """Testa se a propriedade data de Media retorna o dicionário esperado."""
-        resource = Media(self.media_complete)
+        """Testa se a propriedade data de Media retorna um dicionário esperado."""
+        resource = Media(self.media1)
         expected_data = {
-            "xlink_href": "1234-5678-scie-58-e1043-md1.mp4",
+            "xlink_href": "video1.mp4",
             "id": "media1",
             "mimetype": "video",
             "mime_subtype": "mp4",
-            "alt_text": None,
-            "long_desc": "Descrição detalhada do objeto (acima de 120 caracteres)",
-            "transcript": None,
-            "content_type": None,
-            "speakers": None,
-            "tag": "media",
-            "label": "Video 1",
-            "caption": "Vídeo: malesuada vehicula",
-            "attrib": "Fonte: consectetur adipiscing elit",
         }
-        self.assertDictEqual(resource.data, expected_data)
+        self.assertTrue(expected_data.items() <= resource.data.items())  # Substitui assertDictContainsSubset()
 
-    def test_media_no_label_caption(self):
-        """Testa o comportamento quando <media> não contém label nem caption."""
-        resource = Media(self.media_no_label_caption)
-        self.assertIsNone(resource.label)
-        self.assertIsNone(resource.caption)
+    def test_inline_media_xlink_href(self):
+        """Testa se xlink_href do InlineMedia é extraído corretamente."""
+        resource = InlineMedia(self.inline_media)
+        self.assertEqual(resource.xlink_href, "document1.pdf")
 
-    def test_media_no_mimetype_and_mime_subtype(self):
-        """Testa o comportamento quando mimetype e mime-subtype não estão presentes."""
-        resource = Media(self.media_no_mime)
-        self.assertIsNone(resource.mimetype)
-        self.assertIsNone(resource.mime_subtype)
+    def test_inline_media_mimetype_and_mime_subtype(self):
+        """Testa se mimetype e mime_subtype são extraídos corretamente do InlineMedia."""
+        resource = InlineMedia(self.inline_media)
+        self.assertEqual(resource.mimetype, "application")
+        self.assertEqual(resource.mime_subtype, "pdf")
 
-    def test_media_no_xlink_href(self):
-        """Testa o comportamento quando <media> não contém xlink:href."""
-        resource = Media(self.media_no_xlink)
-        self.assertIsNone(resource.xlink_href)
+    def test_inline_media_data_output(self):
+        """Testa se a propriedade data de InlineMedia retorna um dicionário esperado."""
+        resource = InlineMedia(self.inline_media)
+        expected_data = {
+            "xlink_href": "document1.pdf",
+            "mimetype": "application",
+            "mime_subtype": "pdf",
+        }
+        self.assertTrue(expected_data.items() <= resource.data.items())  # Substitui assertDictContainsSubset()
 
-    def test_media_no_id(self):
-        """Testa o comportamento quando a tag <media> não contém id."""
-        media_no_id = Element("media", {
+    def test_xmlmedia_generates_data(self):
+        """Testa se XmlMedia gera corretamente um iterador de dicionários."""
+        xml_media = XmlMedia(self.article)
+        data_list = list(xml_media.data())
+
+        # Deve haver 3 elementos (2 <media> + 1 <inline-media>)
+        self.assertEqual(len(data_list), 3)
+
+        expected_media1 = {
+            "xlink_href": "video1.mp4",
             "mimetype": "video",
-            "mime-subtype": "mp4",
-            "{http://www.w3.org/1999/xlink}href": "video.mp4"
-        })
+            "mime_subtype": "mp4",
+        }
+        expected_media2 = {
+            "xlink_href": "audio1.mp3",
+            "mimetype": "audio",
+            "mime_subtype": "mp3",
+        }
+        expected_inline_media = {
+            "xlink_href": "document1.pdf",
+            "mimetype": "application",
+            "mime_subtype": "pdf",
+        }
+        self.assertTrue(expected_media1.items() <= data_list[0].items())
+        self.assertTrue(expected_media2.items() <= data_list[1].items())
+        self.assertTrue(expected_inline_media.items() <= data_list[2].items())
 
-        resource = Media(media_no_id)
-        self.assertIsNone(resource.id)
+    def test_xmlmedia_handles_no_media(self):
+        """Testa o comportamento quando o XML não contém mídias."""
+        xml_media = XmlMedia(self.article_no_media)
+        data_list = list(xml_media.data())
+
+        # Não há mídia no XML, o iterador deve ser vazio
+        self.assertEqual(len(data_list), 0)
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -1,11 +1,99 @@
 import unittest
 from lxml import etree
 
-from packtools.sps.models.media import Media, ArticleMedias
+from packtools.sps.models.media import Media, XmlMedias
+from packtools.sps.models.accessibility_data import AccessibilityData
 
 
 class MediaTest(unittest.TestCase):
     def setUp(self):
+        """Configura um XML de teste contendo um único elemento <media>."""
+        xml_str = """
+        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+        dtd-version="1.0" article-type="research-article" xml:lang="pt">
+            <body>
+                <media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4" content-type="machine-generated">
+                    <alt-text>Breve descrição do vídeo</alt-text>
+                    <long-desc>Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que a 
+                    extração esteja correta e seja útil para acessibilidade.</long-desc>
+                    <sec sec-type="transcript">
+                        <speaker>Gabriel</speaker>
+                        <speech>Olá, este é um vídeo demonstrativo.</speech>
+                    </sec>
+                </media>
+            </body>
+        </article>
+        """
+        self.xml_tree = etree.fromstring(xml_str)
+        self.media = Media(self.xml_tree.xpath(".//media")[0])  # Instancia Media com o nó <media>
+        self.accessibility = AccessibilityData(self.xml_tree.xpath(".//media")[0])  # Instancia AccessibilityData
+
+    def test_mimetype(self):
+        """Testa a extração do atributo mimetype."""
+        self.assertEqual(self.media.mimetype, "video")
+
+    def test_mime_subtype(self):
+        """Testa a extração do atributo mime-subtype."""
+        self.assertEqual(self.media.mime_subtype, "mp4")
+
+    def test_xlink_href(self):
+        """Testa a extração do atributo xlink:href."""
+        self.assertEqual(self.media.xlink_href, "media1.mp4")
+
+    def test_media_type(self):
+        """Testa a extração da tag do elemento mídia."""
+        self.assertEqual(self.media.media_type, "media")
+
+    def test_alt_text(self):
+        """Testa a extração do <alt-text>."""
+        self.assertEqual(self.accessibility.get_alt_text(), "Breve descrição do vídeo")
+
+    def test_long_desc(self):
+        """Testa a extração do <long-desc>."""
+        expected_text = ("Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que "
+                         "a extração esteja correta e seja útil para acessibilidade.")
+        self.assertEqual(self.accessibility.get_long_desc(), expected_text)
+
+    def test_transcript(self):
+        """Testa a extração da transcrição <sec sec-type='transcript'>."""
+        transcript = self.accessibility.get_transcript()
+        self.assertIsNotNone(transcript)
+        self.assertIn("Gabriel", transcript)
+        self.assertIn("Olá, este é um vídeo demonstrativo.", transcript)
+
+    def test_content_type(self):
+        """Testa a extração do atributo @content-type."""
+        self.assertEqual(self.accessibility.get_content_type(), "machine-generated")
+
+    def test_speaker_data(self):
+        """Testa a extração de falantes e discursos dentro de <sec sec-type='transcript'>."""
+        expected_data = [
+            {"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."}
+        ]
+        self.assertEqual(self.accessibility.get_speaker_data(), expected_data)
+
+    def test_data(self):
+        """Testa a extração combinada de todos os dados de mídia e acessibilidade."""
+        self.maxDiff = None
+        expected = {
+            "media_type": "media",
+            "mimetype": "video",
+            "mime_subtype": "mp4",
+            "xlink_href": "media1.mp4",
+            "alt_text": "Breve descrição do vídeo",
+            "long_desc": ("Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que "
+                          "a extração esteja correta e seja útil para acessibilidade."),
+            "transcript": "Gabriel Olá, este é um vídeo demonstrativo.",
+            "content_type": "machine-generated",
+            "speakers": [{"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."}]
+        }
+        obtained = self.media.data
+        self.assertDictEqual(expected, obtained)
+
+
+class XmlMediasTest(unittest.TestCase):
+    def setUp(self):
+        """Configura um XML contendo mídias tanto no <article> quanto em <sub-article>."""
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
         dtd-version="1.0" article-type="research-article" xml:lang="pt">
@@ -13,39 +101,8 @@ class MediaTest(unittest.TestCase):
                 <media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">
                     <label>Media 1</label>
                 </media>
-            </body>
-        </article>
-        """
-        self.xml_tree = etree.fromstring(xml_str)
-        self.media = Media(self.xml_tree.xpath(".//media")[0])
-
-    def test_mimetype(self):
-        self.assertEqual(self.media.mimetype, "video")
-
-    def test_mime_subtype(self):
-        self.assertEqual(self.media.mime_subtype, "mp4")
-
-    def test_xlink_href(self):
-        self.assertEqual(self.media.xlink_href, "media1.mp4")
-
-    def test_data(self):
-        expected = {
-            "mimetype": "video",
-            "mime_subtype": "mp4",
-            "xlink_href": "media1.mp4",
-        }
-        obtained = self.media.data
-        self.assertDictEqual(expected, obtained)
-
-
-class ArticleMediasTest(unittest.TestCase):
-    def setUp(self):
-        xml_str = """
-        <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" 
-        dtd-version="1.0" article-type="research-article" xml:lang="pt">
-            <body>
-                <media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">
-                    <label>Media 1</label>
+                <media mimetype="image" mime-subtype="png" xlink:href="image1.png">
+                    <label>Imagem 1</label>
                 </media>
             </body>
             <sub-article article-type="translation" xml:lang="en">
@@ -59,31 +116,18 @@ class ArticleMediasTest(unittest.TestCase):
         """
         self.xml_tree = etree.fromstring(xml_str)
 
-    def test_data(self):
-        obtained = list(ArticleMedias(self.xml_tree).data())
-        expected = [
-            {
-                "mimetype": "video",
-                "mime_subtype": "mp4",
-                "xlink_href": "media1.mp4",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "pt",
-            },
-            {
-                "mimetype": "audio",
-                "mime_subtype": "mp3",
-                "xlink_href": "media2.mp3",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "en",
-            },
-        ]
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+    def test_items(self):
+        """Testa a extração de todos os elementos <media> no <article> e <sub-article>."""
+        obtained = XmlMedias(self.xml_tree).items
+        self.assertEqual(len(obtained), 4)
+
+        expected_mimetypes = {"video", "image", "audio"}
+        extracted_mimetypes = {media["mimetype"] for media in obtained}
+        self.assertEqual(extracted_mimetypes, expected_mimetypes)
+
+        expected_hrefs = {"media1.mp4", "image1.png", "media2.mp3"}
+        extracted_hrefs = {media["xlink_href"] for media in obtained}
+        self.assertEqual(extracted_hrefs, expected_hrefs)
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -46,31 +46,31 @@ class MediaTest(unittest.TestCase):
 
     def test_alt_text(self):
         """Testa a extração do <alt-text>."""
-        self.assertEqual(self.accessibility.get_alt_text(), "Breve descrição do vídeo")
+        self.assertEqual(self.accessibility.alt_text, "Breve descrição do vídeo")
 
     def test_long_desc(self):
         """Testa a extração do <long-desc>."""
         expected_text = ("Descrição detalhada do vídeo contendo mais de 120 caracteres. Isso garante que "
                          "a extração esteja correta e seja útil para acessibilidade.")
-        self.assertEqual(self.accessibility.get_long_desc(), expected_text)
+        self.assertEqual(self.accessibility.long_desc, expected_text)
 
     def test_transcript(self):
         """Testa a extração da transcrição <sec sec-type='transcript'>."""
-        transcript = self.accessibility.get_transcript()
+        transcript = self.accessibility.transcript
         self.assertIsNotNone(transcript)
         self.assertIn("Gabriel", transcript)
         self.assertIn("Olá, este é um vídeo demonstrativo.", transcript)
 
     def test_content_type(self):
         """Testa a extração do atributo @content-type."""
-        self.assertEqual(self.accessibility.get_content_type(), "machine-generated")
+        self.assertEqual(self.accessibility.content_type, "machine-generated")
 
     def test_speaker_data(self):
         """Testa a extração de falantes e discursos dentro de <sec sec-type='transcript'>."""
         expected_data = [
             {"speaker": "Gabriel", "speech": "Olá, este é um vídeo demonstrativo."}
         ]
-        self.assertEqual(self.accessibility.get_speaker_data(), expected_data)
+        self.assertEqual(self.accessibility.speaker_data, expected_data)
 
     def test_data(self):
         """Testa a extração combinada de todos os dados de mídia e acessibilidade."""

--- a/tests/sps/models/test_supplementary_material.py
+++ b/tests/sps/models/test_supplementary_material.py
@@ -1,10 +1,7 @@
 import unittest
 from lxml import etree
 
-from packtools.sps.models.supplementary_material import (
-    SupplementaryMaterial,
-    ArticleSupplementaryMaterials,
-)
+from packtools.sps.models.supplementary_material import XmlSupplementaryMaterials, SupplementaryMaterial
 
 class SupplementaryMaterialTest(unittest.TestCase):
     def setUp(self):
@@ -32,7 +29,7 @@ class SupplementaryMaterialTest(unittest.TestCase):
         self.assertEqual(self.supp.id, "supp01")
 
     def test_parent(self):
-        self.assertEqual(self.supp.parent, "sec")
+        self.assertEqual(self.supp.parent_tag, "sec")
 
     def test_sec_type(self):
         self.assertEqual(self.supp.sec_type, "supplementary-material")
@@ -41,7 +38,7 @@ class SupplementaryMaterialTest(unittest.TestCase):
         self.assertEqual(self.supp.label, "Supplementary Material 1")
 
     def test_caption_title(self):
-        self.assertEqual(self.supp.caption_title, "Video 1")
+        self.assertEqual(self.supp.caption, "Video 1")
 
     def test_mimetype(self):
         self.assertEqual(self.supp.mimetype, "application")
@@ -54,6 +51,9 @@ class SupplementaryMaterialTest(unittest.TestCase):
 
     def test_media_type(self):
         self.assertEqual(self.supp.media_type, "media")
+
+    def test_xml(self):
+        self.assertEqual(self.supp.xml, '<supplementary-material id="supp01">')
 
     def test_supplementary_material_media_node(self):
         """Verifies that the model correctly extracts the <media> node and its attributes."""
@@ -92,7 +92,7 @@ class SupplementaryMaterialTest(unittest.TestCase):
         self.assertEqual(supp_material.media_node.findtext("alt-text"), "Descriptive text for accessibility")
 
 
-class ArticleSupplementaryMaterialsTest(unittest.TestCase):
+class XmlSupplementaryMaterialsTest(unittest.TestCase):
     def setUp(self):
         xml_str = """
         <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="pt">
@@ -113,8 +113,8 @@ class ArticleSupplementaryMaterialsTest(unittest.TestCase):
         """
         self.xml_tree = etree.fromstring(xml_str)
 
-    def test_data(self):
-        obtained = list(ArticleSupplementaryMaterials(self.xml_tree).data())
+    def test_items(self):
+        obtained = list(XmlSupplementaryMaterials(self.xml_tree).items)
         self.assertEqual(len(obtained), 2)
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_visual_resource_base.py
+++ b/tests/sps/models/test_visual_resource_base.py
@@ -1,0 +1,127 @@
+import unittest
+from xml.etree.ElementTree import Element, SubElement
+from packtools.sps.models.visual_resource_base import VisualResourceBase
+
+
+class TestVisualResourceBase(unittest.TestCase):
+
+    def setUp(self):
+        """Configuração inicial dos elementos XML para cada teste."""
+
+        # Criando o primeiro material suplementar (vídeo)
+        self.supplementary_material_1 = Element("supplementary-material", {"id": "suppl1"})
+
+        label_1 = SubElement(self.supplementary_material_1, "label")
+        label_1.text = "Supplementary material 1"
+
+        caption_1 = SubElement(self.supplementary_material_1, "caption")
+        title_1 = SubElement(caption_1, "title")
+        title_1.text = "Video 1"
+
+        self.media_1 = SubElement(self.supplementary_material_1, "media", {
+            "id": "media1",
+            "mimetype": "video",
+            "mime-subtype": "mp4",
+            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-md1.mp4"
+        })
+
+        # Criando o segundo material suplementar (planilha)
+        self.supplementary_material_2 = Element("supplementary-material", {"id": "suppl3"})
+
+        label_2 = SubElement(self.supplementary_material_2, "label")
+        label_2.text = "Supplementary material 3"
+
+        caption_2 = SubElement(self.supplementary_material_2, "caption")
+        title_2 = SubElement(caption_2, "title")
+        title_2.text = "Spreadsheet 1"
+
+        self.media_2 = SubElement(self.supplementary_material_2, "media", {
+            "id": "media2",
+            "mimetype": "application",
+            "mime-subtype": "xlsx",
+            "{http://www.w3.org/1999/xlink}href": "1234-5678-scie-58-e1043-md2.xlsx"
+        })
+
+        # Criando um elemento media sem id e sem xlink_href
+        self.media_without_id = Element("media", {"mimetype": "image", "mime-subtype": "png"})
+
+        # Criando um elemento media sem atributos para verificar valores padrão
+        self.media_empty = Element("media")
+
+    def test_xlink_href(self):
+        """Verifica se o xlink:href é extraído corretamente da tag <media>."""
+        resource_1 = VisualResourceBase(self.media_1)
+        self.assertEqual(resource_1.xlink_href, "1234-5678-scie-58-e1043-md1.mp4")
+
+        resource_2 = VisualResourceBase(self.media_2)
+        self.assertEqual(resource_2.xlink_href, "1234-5678-scie-58-e1043-md2.xlsx")
+
+    def test_id(self):
+        """Verifica se o ID é extraído corretamente da tag <media>."""
+        resource_1 = VisualResourceBase(self.media_1)
+        self.assertEqual(resource_1.id, "media1")
+
+        resource_2 = VisualResourceBase(self.media_2)
+        self.assertEqual(resource_2.id, "media2")
+
+        resource_no_id = VisualResourceBase(self.media_without_id)
+        self.assertIsNone(resource_no_id.id)  # Deve ser None se não houver id
+
+        resource_empty = VisualResourceBase(self.media_empty)
+        self.assertIsNone(resource_empty.id)  # Nenhum atributo presente
+
+    def test_accessibility_data(self):
+        """Verifica se os dados de acessibilidade são extraídos corretamente."""
+        resource_1 = VisualResourceBase(self.media_1)
+        self.assertIsNone(resource_1.accessibility.alt_text)  # Sem <alt-text>, deve ser None
+
+        resource_2 = VisualResourceBase(self.media_2)
+        self.assertIsNone(resource_2.accessibility.alt_text)
+
+    def test_data_output(self):
+        """Testa se a propriedade data retorna o dicionário esperado."""
+        resource_1 = VisualResourceBase(self.media_1)
+        expected_data_1 = {
+            "xlink_href": "1234-5678-scie-58-e1043-md1.mp4",
+            "id": "media1",
+            "alt_text": None,
+            "long_desc": None,
+            "transcript": None,
+            "content_type": None,
+            "speakers": None,
+            "tag": "media",
+        }
+        self.assertDictEqual(resource_1.data, expected_data_1)
+
+        resource_2 = VisualResourceBase(self.media_2)
+        expected_data_2 = {
+            "xlink_href": "1234-5678-scie-58-e1043-md2.xlsx",
+            "id": "media2",
+            "alt_text": None,
+            "long_desc": None,
+            "transcript": None,
+            "content_type": None,
+            "speakers": None,
+            "tag": "media",
+        }
+        self.assertDictEqual(resource_2.data, expected_data_2)
+
+    def test_missing_xlink_href(self):
+        """Testa o comportamento quando a tag <media> não contém xlink:href."""
+        resource = VisualResourceBase(self.media_without_id)
+        self.assertIsNone(resource.xlink_href)  # Deve ser None se não houver o atributo
+
+        resource_empty = VisualResourceBase(self.media_empty)
+        self.assertIsNone(resource_empty.xlink_href)  # Nenhum atributo presente
+
+    def test_missing_id(self):
+        """Testa o comportamento quando a tag <media> não contém id."""
+        resource = VisualResourceBase(self.media_without_id)
+        self.assertIsNone(resource.id)  # Deve ser None se não houver o atributo
+
+        resource_empty = VisualResourceBase(self.media_empty)
+        self.assertIsNone(resource_empty.id)  # Nenhum atributo presente
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_accessibility_data.py
+++ b/tests/sps/validation/test_accessibility_data.py
@@ -2,73 +2,103 @@ import unittest
 from lxml import etree
 from packtools.sps.validation.accessibility_data import AccessibilityDataValidation
 
+
 class TestAccessibilityDataValidation(unittest.TestCase):
-    def setUp(self):
-        self.params = {
-            "alt_text_error_level": "CRITICAL",
-            "long_desc_error_level": "CRITICAL",
-            "transcript_error_level": "CRITICAL",
-            "content_type_error_level": "CRITICAL",
-            "speaker_speech_error_level": "CRITICAL",
-            "media_structure_error_level": "CRITICAL",
-            "cross_references_error_level": "CRITICAL"
-        }
 
     def test_validate_alt_text_failure(self):
         """Fails when <alt-text> exceeds 120 characters."""
-        accessibility_data = {"alt_text": "This is an alternative text that is intentionally made longer than one hundred and twenty characters to ensure that the validation fails as expected."}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <media xmlns:xlink="http://www.w3.org/1999/xlink" 
+               mimetype="video" mime-subtype="mp4" xlink:href="1234-5678.mp4" content-type="machine-generated">
+            <alt-text>This is an alternative text that is intentionally made longer than one hundred and twenty characters to ensure that the validation fails as expected.</alt-text>
+        </media>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"alt_text_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_alt_text()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Provide an alternative text with a maximum of 120 characters.")
 
     def test_validate_long_desc_failure(self):
         """Fails when <long-desc> is shorter than 120 characters."""
-        accessibility_data = {"long_desc": "Short description."}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <media>
+            <long-desc>Short description.</long-desc>
+        </media>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"long_desc_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_long_desc()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Provide a long description with more than 120 characters.")
 
     def test_validate_transcript_failure(self):
         """Fails when a transcript is missing."""
-        accessibility_data = {"transcript": None}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <media>
+            <alt-text>Valid alternative text.</alt-text>
+            <long-desc>Valid long description exceeding 120 characters...</long-desc>
+        </media>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"transcript_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_transcript()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Provide a transcript for videos and audio files.")
 
     def test_validate_content_type_failure(self):
         """Fails when @content-type is not 'machine-generated'."""
-        accessibility_data = {"content_type": "human-generated"}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <media content-type="manual">
+            <alt-text>Valid alternative text.</alt-text>
+        </media>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"content_type_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_content_type()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "If applicable, use 'machine-generated' as the content-type.")
 
     def test_validate_speaker_and_speech_failure(self):
         """Fails when no <speaker> and <speech> elements are present."""
-        accessibility_data = {"speakers": []}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <media>
+            <sec sec-type="transcript">
+                <!-- Speaker and Speech missing -->
+            </sec>
+        </media>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"speaker_speech_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_speaker_and_speech()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Ensure proper markup for dialogues.")
 
     def test_validate_media_structure_failure(self):
         """Fails when accessibility elements are placed outside valid media tags."""
-        accessibility_data = {"media_type": "invalid-tag"}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        xml_content = """
+        <article>
+            <alt-text>Incorrect placement.</alt-text>
+        </article>
+        """
+        xml_node = etree.fromstring(xml_content)
+        params = {"media_structure_error_level": "CRITICAL"}
+
+        validator = AccessibilityDataValidation(xml_node, params)
         results = validator.validate_media_structure()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Ensure that accessibility elements are placed within appropriate media types.")
 
-    def test_validate_cross_references_failure(self):
-        """Fails when media does not reference a transcript."""
-        accessibility_data = {"xref_refs": []}
-        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
-        results = validator.validate_cross_references()
-        self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "Ensure that media references a transcript.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_accessibility_data.py
+++ b/tests/sps/validation/test_accessibility_data.py
@@ -1,0 +1,74 @@
+import unittest
+from lxml import etree
+from packtools.sps.validation.accessibility_data import AccessibilityDataValidation
+
+class TestAccessibilityDataValidation(unittest.TestCase):
+    def setUp(self):
+        self.params = {
+            "alt_text_error_level": "CRITICAL",
+            "long_desc_error_level": "CRITICAL",
+            "transcript_error_level": "CRITICAL",
+            "content_type_error_level": "CRITICAL",
+            "speaker_speech_error_level": "CRITICAL",
+            "media_structure_error_level": "CRITICAL",
+            "cross_references_error_level": "CRITICAL"
+        }
+
+    def test_validate_alt_text_failure(self):
+        """Fails when <alt-text> exceeds 120 characters."""
+        accessibility_data = {"alt_text": "This is an alternative text that is intentionally made longer than one hundred and twenty characters to ensure that the validation fails as expected."}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_alt_text()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Provide an alternative text with a maximum of 120 characters.")
+
+    def test_validate_long_desc_failure(self):
+        """Fails when <long-desc> is shorter than 120 characters."""
+        accessibility_data = {"long_desc": "Short description."}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_long_desc()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Provide a long description with more than 120 characters.")
+
+    def test_validate_transcript_failure(self):
+        """Fails when a transcript is missing."""
+        accessibility_data = {"transcript": None}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_transcript()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Provide a transcript for videos and audio files.")
+
+    def test_validate_content_type_failure(self):
+        """Fails when @content-type is not 'machine-generated'."""
+        accessibility_data = {"content_type": "human-generated"}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_content_type()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "If applicable, use 'machine-generated' as the content-type.")
+
+    def test_validate_speaker_and_speech_failure(self):
+        """Fails when no <speaker> and <speech> elements are present."""
+        accessibility_data = {"speakers": []}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_speaker_and_speech()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Ensure proper markup for dialogues.")
+
+    def test_validate_media_structure_failure(self):
+        """Fails when accessibility elements are placed outside valid media tags."""
+        accessibility_data = {"media_type": "invalid-tag"}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_media_structure()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Ensure that accessibility elements are placed within appropriate media types.")
+
+    def test_validate_cross_references_failure(self):
+        """Fails when media does not reference a transcript."""
+        accessibility_data = {"xref_refs": []}
+        validator = AccessibilityDataValidation(accessibility_data, None, self.params)
+        results = validator.validate_cross_references()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Ensure that media references a transcript.")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_media.py
+++ b/tests/sps/validation/test_media.py
@@ -1,62 +1,97 @@
 import unittest
 from lxml import etree
 from packtools.sps.validation.media import MediaValidation
+from packtools.sps.models.media import Media  # Importando a classe correta para obter media_data
 
 class MediaValidationTest(unittest.TestCase):
-    def setUp(self):
-        self.params = {
-            "media_attributes_error_level": "CRITICAL",
-            "mime_type_error_level": "CRITICAL",
-            "mime_subtype_error_level": "CRITICAL",
-            "xlink_href_error_level": "CRITICAL",
-            "accessibility_error_level": "CRITICAL",
-            "alt_text_error_level": "CRITICAL",
-            "long_desc_error_level": "CRITICAL",
-            "transcript_error_level": "CRITICAL",
-            "content_type_error_level": "CRITICAL",
-            "speaker_speech_error_level": "CRITICAL",
-            "media_structure_error_level": "CRITICAL",
-            "cross_references_error_level": "CRITICAL"
-        }
 
     def test_validate_id_failure(self):
         """Fails when @id attribute is missing."""
-        media_data = {"mimetype": "video", "mime_subtype": "mp4", "xlink_href": "video.mp4"}
-        validator = MediaValidation(media_data, None, self.params)
+        xml_content = """
+        <media mimetype="video" mime-subtype="mp4" xlink:href="video.mp4" 
+               xmlns:xlink="http://www.w3.org/1999/xlink">
+        </media>
+        """
+        media_node = etree.fromstring(xml_content)
+        media_data = Media(media_node).data  # Criando media_data a partir de media_node
+        params = {"media_attributes_error_level": "CRITICAL"}
+
+        validator = MediaValidation(media_node, media_data, params)
         results = validator.validate_id()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Ensure @id is included.")
 
     def test_validate_mime_type_failure(self):
         """Fails when @mime-type is invalid."""
-        media_data = {"id": "m1", "mimetype": "invalid", "mime_subtype": "mp4", "xlink_href": "video.mp4"}
-        validator = MediaValidation(media_data, None, self.params)
+        xml_content = """
+        <media id="m1" mimetype="invalid" mime-subtype="mp4" xlink:href="video.mp4" 
+               xmlns:xlink="http://www.w3.org/1999/xlink">
+        </media>
+        """
+        media_node = etree.fromstring(xml_content)
+        media_data = Media(media_node).data
+        params = {"mime_type_error_level": "CRITICAL"}
+
+        validator = MediaValidation(media_node, media_data, params)
         results = validator.validate_mime_type()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Use a valid @mime-type (application, video, audio).")
 
     def test_validate_mime_subtype_failure(self):
         """Fails when @mime-subtype does not match the expected format."""
-        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "avi", "xlink_href": "video.avi"}
-        validator = MediaValidation(media_data, None, self.params)
+        xml_content = """
+        <media id="m1" mimetype="video" mime-subtype="avi" xlink:href="video.avi" 
+               xmlns:xlink="http://www.w3.org/1999/xlink">
+        </media>
+        """
+        media_node = etree.fromstring(xml_content)
+        media_data = Media(media_node).data
+        params = {"mime_subtype_error_level": "CRITICAL"}
+
+        validator = MediaValidation(media_node, media_data, params)
         results = validator.validate_mime_subtype()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "For video, use mp4 as @mime-subtype.")
 
     def test_validate_xlink_href_failure(self):
         """Fails when @xlink:href is not in a valid format."""
-        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "mp4", "xlink_href": "invalid_file"}
-        validator = MediaValidation(media_data, None, self.params)
+        xml_content = """
+        <media id="m1" mimetype="video" mime-subtype="mp4" xlink:href="invalid_file" 
+               xmlns:xlink="http://www.w3.org/1999/xlink">
+        </media>
+        """
+        media_node = etree.fromstring(xml_content)
+        media_data = Media(media_node).data
+        params = {"xlink_href_error_level": "CRITICAL"}
+
+        validator = MediaValidation(media_node, media_data, params)
         results = validator.validate_xlink_href()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Provide a valid file name with its extension in @xlink:href.")
 
     def test_validate_accessibility_failure(self):
         """Fails when no accessibility elements are provided."""
-        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "mp4", "xlink_href": "video.mp4", "alt_text": None, "long_desc": None, "transcript": None}
-        validator = MediaValidation(media_data, None, self.params)
+        xml_content = """
+        <media id="m1" mimetype="video" mime-subtype="mp4" xlink:href="video.mp4" 
+               xmlns:xlink="http://www.w3.org/1999/xlink">
+        </media>
+        """
+        media_node = etree.fromstring(xml_content)
+        media_data = Media(media_node).data
+        params = {
+            "accessibility_error_level": "CRITICAL",
+            "mime_type_error_level": "CRITICAL",
+            "mime_subtype_error_level": "CRITICAL",
+            "alt_text_error_level": "CRITICAL",
+            "long_desc_error_level": "CRITICAL",
+            "transcript_error_level": "CRITICAL",
+            "content_type_error_level": "CRITICAL",
+            "speaker_speech_error_level": "CRITICAL"
+        }
+
+        validator = MediaValidation(media_node, media_data, params)
         results = list(validator.validate())
-        self.assertEqual(len(results), 11)
+        self.assertEqual(len(results), 9)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_media.py
+++ b/tests/sps/validation/test_media.py
@@ -1,121 +1,62 @@
 import unittest
 from lxml import etree
-
 from packtools.sps.validation.media import MediaValidation
 
-
 class MediaValidationTest(unittest.TestCase):
-    def test_media_validation_no_elements(self):
-        self.maxDiff = None
-        xmltree = etree.fromstring(
-            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            "<body>"
-            "<p>Some text content without media.</p>"
-            "</body>"
-            "</article>"
-        )
-        obtained = list(MediaValidation(xmltree).validate_media_existence())
+    def setUp(self):
+        self.params = {
+            "media_attributes_error_level": "CRITICAL",
+            "mime_type_error_level": "CRITICAL",
+            "mime_subtype_error_level": "CRITICAL",
+            "xlink_href_error_level": "CRITICAL",
+            "accessibility_error_level": "CRITICAL",
+            "alt_text_error_level": "CRITICAL",
+            "long_desc_error_level": "CRITICAL",
+            "transcript_error_level": "CRITICAL",
+            "content_type_error_level": "CRITICAL",
+            "speaker_speech_error_level": "CRITICAL",
+            "media_structure_error_level": "CRITICAL",
+            "cross_references_error_level": "CRITICAL"
+        }
 
-        expected = [
-            {
-                "title": "validation of <media> elements",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "media",
-                "sub_item": None,
-                "validation_type": "exist",
-                "response": "WARNING",
-                "expected_value": "<media> element",
-                "got_value": None,
-                "message": "Got None, expected <media> element",
-                "advice": "Consider adding a <media> element to include multimedia content related to the article.",
-                "data": None,
-            }
-        ]
+    def test_validate_id_failure(self):
+        """Fails when @id attribute is missing."""
+        media_data = {"mimetype": "video", "mime_subtype": "mp4", "xlink_href": "video.mp4"}
+        validator = MediaValidation(media_data, None, self.params)
+        results = validator.validate_id()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Ensure @id is included.")
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
+    def test_validate_mime_type_failure(self):
+        """Fails when @mime-type is invalid."""
+        media_data = {"id": "m1", "mimetype": "invalid", "mime_subtype": "mp4", "xlink_href": "video.mp4"}
+        validator = MediaValidation(media_data, None, self.params)
+        results = validator.validate_mime_type()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Use a valid @mime-type (application, video, audio).")
 
-    def test_media_validation_with_elements(self):
-        self.maxDiff = None
-        xmltree = etree.fromstring(
-            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
-            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
-            "<body>"
-            '<media mimetype="video" mime-subtype="mp4" xlink:href="media1.mp4">'
-            "<label>Media 1</label>"
-            "</media>"
-            "</body>"
-            '<sub-article article-type="translation" xml:lang="en">'
-            "<body>"
-            '<media mimetype="audio" mime-subtype="mp3" xlink:href="media2.mp3">'
-            "<label>Media 2</label>"
-            "</media>"
-            "</body>"
-            "</sub-article>"
-            "</article>"
-        )
-        obtained = list(MediaValidation(xmltree).validate_media_existence())
+    def test_validate_mime_subtype_failure(self):
+        """Fails when @mime-subtype does not match the expected format."""
+        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "avi", "xlink_href": "video.avi"}
+        validator = MediaValidation(media_data, None, self.params)
+        results = validator.validate_mime_subtype()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "For video, use mp4 as @mime-subtype.")
 
-        expected = [
-            {
-                "title": "validation of <media> elements",
-                "parent": "article",
-                "parent_id": None,
-                "parent_article_type": "research-article",
-                "parent_lang": "pt",
-                "item": "media",
-                "sub_item": None,
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "media element",
-                "got_value": "media element",
-                "message": "Got media element, expected media element",
-                "advice": None,
-                "data": {
-                    "mimetype": "video",
-                    "mime_subtype": "mp4",
-                    "xlink_href": "media1.mp4",
-                    "parent": "article",
-                    "parent_id": None,
-                    "parent_article_type": "research-article",
-                    "parent_lang": "pt",
-                },
-            },
-            {
-                "title": "validation of <media> elements",
-                "parent": "sub-article",
-                "parent_id": None,
-                "parent_article_type": "translation",
-                "parent_lang": "en",
-                "item": "media",
-                "sub_item": None,
-                "validation_type": "exist",
-                "response": "OK",
-                "expected_value": "media element",
-                "got_value": "media element",
-                "message": "Got media element, expected media element",
-                "advice": None,
-                "data": {
-                    "mimetype": "audio",
-                    "mime_subtype": "mp3",
-                    "xlink_href": "media2.mp3",
-                    "parent": "sub-article",
-                    "parent_id": None,
-                    "parent_article_type": "translation",
-                    "parent_lang": "en",
-                },
-            },
-        ]
+    def test_validate_xlink_href_failure(self):
+        """Fails when @xlink:href is not in a valid format."""
+        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "mp4", "xlink_href": "invalid_file"}
+        validator = MediaValidation(media_data, None, self.params)
+        results = validator.validate_xlink_href()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(results["advice"], "Provide a valid file name with its extension in @xlink:href.")
 
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
+    def test_validate_accessibility_failure(self):
+        """Fails when no accessibility elements are provided."""
+        media_data = {"id": "m1", "mimetype": "video", "mime_subtype": "mp4", "xlink_href": "video.mp4", "alt_text": None, "long_desc": None, "transcript": None}
+        validator = MediaValidation(media_data, None, self.params)
+        results = list(validator.validate())
+        self.assertEqual(len(results), 11)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -1,7 +1,7 @@
 import unittest
 from lxml import etree
 from packtools.sps.validation.supplementary_material import SupplementaryMaterialValidation, ArticleSupplementaryMaterialValidation
-from packtools.sps.models.supplementary_material import ArticleSupplementaryMaterials
+from packtools.sps.models.supplementary_material import XmlSupplementaryMaterials
 
 
 class TestSupplementaryMaterialValidation(unittest.TestCase):
@@ -19,8 +19,8 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             "supplementary_material_midia_accessibility_requirements_error_level": "CRITICAL"
         }
 
-    def test_validate_supplementary_material_structure(self):
-        """Verifies if supplementary materials are inside <sec sec-type='supplementary-material'>."""
+    def test_validate_structure_failure(self):
+        """Fails when supplementary materials are outside <sec sec-type='supplementary-material'>."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -33,14 +33,14 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_structure()
+        results = validator.validate_structure()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Supplementary materials must be inside <sec sec-type='supplementary-material'>.")
 
-    def test_validate_supplementary_material_id_attribute(self):
-        """Verifies if supplementary materials contain the ID attribute."""
+    def test_validate_id_failure(self):
+        """Fails when supplementary material lacks an ID attribute."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -52,15 +52,14 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_id()
+        results = validator.validate_id()
         self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], 'Add supplementary material with id="" in <supplementary-material>: '
-                                            '<supplementary-material id="">. Consult SPS documentation for more detail.')
+        self.assertEqual(results["advice"], 'Add supplementary material with id="" in <supplementary-material>: <supplementary-material id="">. Consult SPS documentation for more detail.')
 
-    def test_validate_supplementary_material_language(self):
-        """Verifies if the language of supplementary materials matches the article's language."""
+    def test_validate_language_failure(self):
+        """Fails when the language of the supplementary material does not match the article's language."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -72,15 +71,14 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_language()
+        results = validator.validate_language()
         self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"],
-                         f'The language of the supplementary material (pt) differs from the language of the article (en).')
+        self.assertEqual(results["advice"], "The language of the supplementary material (pt) differs from the language of the article (en).")
 
-    def test_validate_supplementary_material_position(self):
-        """Verifica se a seção de materiais suplementares está na última posição do <body> ou dentro de <back>."""
+    def test_validate_position_failure(self):
+        """Fails when supplementary material is not at the end of <body> or inside <back>."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -98,14 +96,15 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_position()
+        results = validator.validate_position()
         self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "The supplementary materials section must be at the end of <body> or inside <back>.")
+        self.assertEqual(results["advice"],
+                         "The supplementary materials section must be at the end of <body> or inside <back>.")
 
-    def test_validate_supplementary_material_format(self):
-        """Verifies if the supplementary material type matches the correct markup."""
+    def test_validate_format_failure(self):
+        """Fails when supplementary material format is incorrect."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -118,9 +117,9 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_format()
+        results = validator.validate_format()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Incorrect format. Expected: media for application/pdf.")
 
@@ -139,9 +138,9 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_supplementary_material_not_in_app_group()
+        results = validator.validate_not_in_app_group()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Do not use <supplementary-material> inside <app-group> or <app>.")
 
@@ -158,7 +157,7 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         ''')
 
         validator = SupplementaryMaterialValidation({}, xml_tree, self.params)
-        results = validator.validate_prohibited_inline_supplementary_material()
+        results = validator.validate_prohibited_inline()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "The use of <inline-supplementary-material> is prohibited.")
 
@@ -175,55 +174,12 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
+        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
         validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_sec_type_supplementary_material()
+        results = validator.validate_sec_type()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"],
                          "Every section containing <supplementary-material> must have sec-type='supplementary-material'.")
-
-    def test_validate_media_attributes(self):
-        """Verifies that <media> contains the mandatory attributes @id, @mime-type, @mime-subtype, and @xlink:href."""
-        xml_tree = etree.fromstring('''
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
-                <body>
-                    <sec sec-type="supplementary-material">
-                        <supplementary-material id="supp1">
-                            <label>Supplementary Material</label>
-                            <media id="m1" mimetype="video" mime-subtype="mp4" xlink:href="video.mp4"/>
-                        </supplementary-material>
-                    </sec>
-                </body>
-            </article>
-        ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_media_attributes()
-        self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "Each <media> must contain the attributes id, mime-type, mime-subtype, and xlink:href.")
-
-    def test_validate_accessibility_requirements(self):
-        """Verifies that images and media contain a description in <alt-text> or <long-desc>."""
-        xml_tree = etree.fromstring('''
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
-                <body>
-                    <sec sec-type="supplementary-material">
-                        <supplementary-material id="supp1">
-                            <label>Supplementary Material</label>
-                            <media id="m1" mimetype="video" mime-subtype="mp4" xlink:href="video.mp4">
-                                <alt-text>Descriptive text for accessibility</alt-text>
-                            </media>
-                        </supplementary-material>
-                    </sec>
-                </body>
-            </article>
-        ''')
-        article_supps = list(ArticleSupplementaryMaterials(xml_tree).data())
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_accessibility_requirements()
-        self.assertEqual(results["response"], "OK")
-        self.assertIsNone(results["advice"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -7,20 +7,15 @@ from packtools.sps.models.supplementary_material import XmlSupplementaryMaterial
 class TestSupplementaryMaterialValidation(unittest.TestCase):
     def setUp(self):
         self.params = {
-            "supplementary_material_structure_error_level": "CRITICAL",
-            "supplementary_material_attributes_error_level": "CRITICAL",
-            "supplementary_material_language_error_level": "CRITICAL",
-            "supplementary_material_position_error_level": "CRITICAL",
-            "supplementary_material_format_error_level": "CRITICAL",
-            "supplementary_material_in_app_group_error_level": "CRITICAL",
-            "inline_supplementary_material_error_level": "CRITICAL",
-            "supplementary_material_sec_attributes_error_level": "CRITICAL",
-            "supplementary_material_midia_attributes_error_level": "CRITICAL",
-            "supplementary_material_midia_accessibility_requirements_error_level": "CRITICAL"
+            "sec_type_error_level": "CRITICAL",
+            "position_error_level": "CRITICAL",
+            "label_error_level": "CRITICAL",
+            "app_group_error_level": "CRITICAL",
+            "inline_error_level": "CRITICAL",
         }
 
-    def test_validate_structure_failure(self):
-        """Fails when supplementary materials are outside <sec sec-type='supplementary-material'>."""
+    def test_validate_sec_type(self):
+        """Fails when sec-type != 'supplementary-material'."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
@@ -33,49 +28,29 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_structure()
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)
+        supplementary_node = xml_tree.xpath(".//media")
+        validator = SupplementaryMaterialValidation(supplementary_data[0], xml_tree, self.params, supplementary_node)
+        results = validator.validate_sec_type()
         self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "Supplementary materials must be inside <sec sec-type='supplementary-material'>.")
+        self.assertEqual(results["advice"], 'In <sec sec-type="None"><supplementary-material> replace "None" with "supplementary-material".')
 
-    def test_validate_id_failure(self):
-        """Fails when supplementary material lacks an ID attribute."""
+    def test_validate_label(self):
+        """Fails when supplementary material lacks an label element."""
         xml_tree = etree.fromstring('''
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
                 <body>
                     <sec sec-type="supplementary-material">
-                        <supplementary-material>
-                            <p>Missing required attributes.</p>
-                        </supplementary-material>
+                        <supplementary-material />
                     </sec>
                 </body>
             </article>
         ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_id()
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)
+        validator = SupplementaryMaterialValidation(supplementary_data[0], xml_tree, self.params)
+        results = validator.validate_label()
         self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], 'Add supplementary material with id="" in <supplementary-material>: <supplementary-material id="">. Consult SPS documentation for more detail.')
-
-    def test_validate_language_failure(self):
-        """Fails when the language of the supplementary material does not match the article's language."""
-        xml_tree = etree.fromstring('''
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
-                <body>
-                    <sec sec-type="supplementary-material">
-                        <supplementary-material id="supp1">
-                            <label>Esse rótulo está em português</label>
-                        </supplementary-material>
-                    </sec>
-                </body>
-            </article>
-        ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_language()
-        self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "The language of the supplementary material (pt) differs from the language of the article (en).")
+        self.assertEqual(results["advice"], 'Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail.')
 
     def test_validate_position_failure(self):
         """Fails when supplementary material is not at the end of <body> or inside <back>."""
@@ -96,32 +71,12 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)
+        validator = SupplementaryMaterialValidation(supplementary_data[0], xml_tree, self.params)
         results = validator.validate_position()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"],
                          "The supplementary materials section must be at the end of <body> or inside <back>.")
-
-    def test_validate_format_failure(self):
-        """Fails when supplementary material format is incorrect."""
-        xml_tree = etree.fromstring('''
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
-                <body>
-                    <sec sec-type="supplementary-material">
-                        <supplementary-material id="supp1">
-                            <label>Supplementary Material</label>
-                            <graphic mimetype="application/pdf" mime-subtype="pdf"/>
-                        </supplementary-material>
-                    </sec>
-                </body>
-            </article>
-        ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_format()
-        self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"], "Incorrect format. Expected: media for application/pdf.")
 
     def test_validate_supplementary_material_not_in_app_group(self):
         """Verifies that <supplementary-material> does not occur inside <app-group> or <app>."""
@@ -138,8 +93,8 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
                 </body>
             </article>
         ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)
+        validator = SupplementaryMaterialValidation(supplementary_data[0], xml_tree, self.params)
         results = validator.validate_not_in_app_group()
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "Do not use <supplementary-material> inside <app-group> or <app>.")
@@ -161,25 +116,6 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(results["advice"], "The use of <inline-supplementary-material> is prohibited.")
 
-    def test_validate_sec_type_supplementary_material(self):
-        """Verifies that all <sec> containing <supplementary-material> have @sec-type='supplementary-material'."""
-        xml_tree = etree.fromstring('''
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
-                <body>
-                    <sec>
-                        <supplementary-material id="supp1">
-                            <label>Supplementary Material</label>
-                        </supplementary-material>
-                    </sec>
-                </body>
-            </article>
-        ''')
-        article_supps = list(XmlSupplementaryMaterials(xml_tree).items)
-        validator = SupplementaryMaterialValidation(article_supps[0], xml_tree, self.params)
-        results = validator.validate_sec_type()
-        self.assertEqual(results["response"], "CRITICAL")
-        self.assertEqual(results["advice"],
-                         "Every section containing <supplementary-material> must have sec-type='supplementary-material'.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### O que esse PR faz?
Este PR implementa o **modelo de Materiais Suplementares**, suas **validações** e **testes unitários**, garantindo conformidade com as diretrizes SPS para materiais suplementares em artigos XML.  
As principais melhorias incluem:
- Extração estruturada de `<supplementary-material>`, `<media>`, `<graphic>`, e seus atributos.
- Implementação de validações para **atributos obrigatórios**, **posição correta** no XML, **acessibilidade**, e **uso correto das tags**.
- Cobertura de testes unitários para garantir o funcionamento adequado da extração e validação dos materiais suplementares.

### Onde a revisão poderia começar?
O código pode ser revisado a partir dos seguintes arquivos:
- **Modelo:** `packtools/sps/models/supplementary_material.py`
- **Validações:** `packtools/sps/validation/supplementary_material.py`
- **Testes:**  
  - `tests/sps/models/test_supplementary_material.py`  
  - `tests/sps/validation/test_supplementary_material_validation.py`

### Como este poderia ser testado manualmente?
Para testar essa implementação manualmente, siga os passos abaixo:

1. **Execute os testes unitários:**  
   ```sh
   pytest tests/sps/models/test_supplementary_material.py
   pytest tests/sps/validation/test_supplementary_material_validation.py

### Algum cenário de contexto que queira dar?

Este PR é essencial para garantir a conformidade dos artigos XML com as diretrizes SPS.  
A correta marcação de materiais suplementares melhora a **acessibilidade**, **indexação** e **reutilização dos dados**.  
Além disso, evita erros de processamento que podem comprometer a **publicação e disseminação dos artigos científicos**.

### Screenshots

*N/A (Não se aplica para este PR, pois é uma implementação de modelo e validação de dados XML).*

### Quais são tickets relevantes?

- **Issue #902** – Padronização da Marcação de Materiais Suplementares no Conteúdo Editorial

### Referências

- [SciELO PS - Diretrizes para Materiais Suplementares](https://docs.scielo.org)


