### PR TITLE
Melhora o utilitário de validação

### DIFF
--- a/packtools/sps/validation/xml_validator.py
+++ b/packtools/sps/validation/xml_validator.py
@@ -2,6 +2,37 @@ from packtools.sps.validation import xml_validations
 from packtools.sps.validation.xml_validator_rules import get_default_rules
 
 
+def get_validation_results(xmltree, params):
+    for result in validate_xml_content(xmltree, params):
+        try:
+            group = None
+            group = result["group"]
+            for index, item in enumerate(result["items"]):
+                if not item:
+                    continue
+                try:
+                    data = {}
+                    data.update(item)
+                    data["group"] = group
+                    yield data
+                except Exception as e:
+                    data = {
+                        "response": "exception",
+                        "group": group,
+                        "error": str(e),
+                        "type": str(type(e))
+                    }
+                    data.update(item)
+                    yield data
+        except Exception as e:
+            yield {
+                "response": "exception",
+                "group": group,
+                "error": str(e),
+                "type": str(type(e))
+            }
+
+
 def validate_xml_content(xmltree, rules):
     params = get_default_rules()
     params.update(rules or {})


### PR DESCRIPTION
#### O que esse PR faz?
Melhora o utilitário de validação:
- modifica os parâmetros
- permite criar um csv por xml  ou criar um csv para todos os xmls

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

1. Validando apenas 1 xml, criando csv junto ao xml
```console
python packtools/data_checker.py /path/2175-9146-jatm-16-e21243.xml diretorio_de_saida --csv_per_xml
```
No `diretorio_de_saida`, será gerado um arquivo de exceções, se acontecer.

2. Validando apenas 1 xml, criando csv no diretorio_de_saida
```console
python packtools/data_checker.py /path/2175-9146-jatm-16-e21243.xml diretorio_de_saida
```

3. Validando vários xmls, criando csv junto ao xml
```console
python packtools/data_checker.py /path/xmls diretorio_de_saida --csv_per_xml
```
Sendo:
- `/path/xmls` - pasta com os xmls, o sistema percorrerá daí para baixo, obterá todos os xmls
- `diretorio_de_saida` - onde será gerado as saídas (exceções e/ou csv)
- `--csv_per_xml` - gerará os csv junto a cada xml

4. Validando vários xmls, criando csv no diretorio_de_saida, pela ausência de `--csv_per_xml` no comando
```console
python packtools/data_checker.py /path/xmls diretorio_de_saida
```
Sendo:
- `/path/xmls` - pasta com os xmls, o sistema percorrerá daí para baixo, obterá todos os xmls
- `diretorio_de_saida` - onde será gerado as saídas (exceções e/ou csv)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
