### PR TITLE
Adapta os testes às correções implementadas para o modelo de article-xref

### DIFF
--- a/tests/sps/models/v2/test_article_xref.py
+++ b/tests/sps/models/v2/test_article_xref.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, skip
 from lxml import etree
 
-from packtools.sps.models.v2.article_xref import Xref, Id, Ids, ArticleXref
+from packtools.sps.models.v2.article_xref import Xref, Element, XMLCrossReference
 
 
 class XrefTest(TestCase):
@@ -30,13 +30,20 @@ class XrefTest(TestCase):
     def test_text(self):
         self.assertEqual(self.xref.xref_text, "1")
 
-    @skip("Teste pendente de correção e/ou ajuste")
     def test_data(self):
-        obtained = {"ref-type": "aff", "rid": "aff1", "text": "1"}
+        obtained = {
+            'content': '1',
+            'elem_name': 'aff',
+            'elem_xml': '<aff id="aff1">',
+            'ref-type': 'aff',
+            'rid': 'aff1',
+            'tag_and_attribs': '<xref ref-type="aff" rid="aff1">',
+            'text': '1'
+        }
         self.assertDictEqual(self.xref.data, obtained)
 
 
-class IdTest(TestCase):
+class ElementTest(TestCase):
     def setUp(self):
         self.xml_tree = etree.fromstring(
             """
@@ -51,125 +58,42 @@ class IdTest(TestCase):
             """
         )
         self.node = self.xml_tree.xpath(".//aff")[0]
-        self.node_id = Id(self.node)
+        self.elem = Element(self.node)
 
     def test_node_id(self):
-        self.assertEqual(self.node_id.node_id, "aff1")
+        self.assertEqual(self.elem.node_id, "aff1")
 
     def test_node_tag(self):
-        self.assertEqual(self.node_id.node_tag, "aff")
+        self.assertEqual(self.elem.node_tag, "aff")
 
     def test_data(self):
-        obtained = {"tag": "aff", "id": "aff1"}
-        self.assertDictEqual(self.node_id.data, obtained)
+        obtained = {
+            'id': 'aff1',
+            'tag': 'aff',
+            'tag_and_attribs': '<aff id="aff1">',
+            'tag_id': '<aff id="aff1">',
+            'xref_xml': '<xref ref-type="aff" rid="aff1">'
+        }
+        self.assertDictEqual(self.elem.data, obtained)
 
-    def test_str_main_tag(self):
-        self.assertEqual(
-            self.node_id.str_main_tag,
-            '<aff id="aff1">'
-        )
+    def test_str_tag_and_attribs(self):
+        self.assertEqual(self.elem.tag_and_attribs, '<aff id="aff1">')
 
     def test_str(self):
-        self.assertEqual(
-            str(self.node_id),
-            """<?xml version='1.0' encoding='utf-8'?>
-<aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>
-                """
-        )
+        result = str(self.elem)
+        self.assertIn('<aff id="aff1">', result)
+        self.assertIn('<p>affiliation</p>', result)
 
-    def test_xml_1(self):
-        self.maxDiff = None
-        result = self.node_id.xml(doctype=None, pretty_print=True, xml_declaration=True)
-        expected = """<?xml version='1.0' encoding='utf-8'?>
-<aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>
-                
-"""
-        self.assertEqual(result, expected)
+    def test_xml_with_declaration(self):
+        result = self.elem.xml(doctype=None, pretty_print=True, xml_declaration=True)
+        self.assertIn('<?xml version=', result)
 
-    def test_xml_2(self):
-        self.maxDiff = None
-        result = self.node_id.xml(doctype=None, pretty_print=True, xml_declaration=None)
-        expected = """<aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>
-                
-"""
-        self.assertEqual(result, expected)
-
-    def test_xml_3(self):
-        self.maxDiff = None
-        result = self.node_id.xml(doctype=None, pretty_print=None, xml_declaration=None)
-        expected = """<aff id="aff1">
-                        <p>affiliation</p>
-                    </aff>"""
-        self.assertEqual(result.strip(), expected)
+    def test_xml_no_declaration(self):
+        result = self.elem.xml(doctype=None, pretty_print=True, xml_declaration=False)
+        self.assertIn('<aff id="aff1">', result)
 
 
-class IdsTest(TestCase):
-    def setUp(self):
-        self.xml_tree = etree.fromstring(
-            """
-            <article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
-            dtd-version="1.1" specific-use="sps-1.9" article-type="research-article" xml:lang="en">
-                <front>
-                    <article-meta>
-                    
-                        <p><xref ref-type="aff" rid="aff1">1</xref></p>
-                        <aff id="aff1">
-                            <p>affiliation</p>
-                        </aff>
-                        
-                        <aff id="aff2">
-                            <p>affiliation</p>
-                        </aff>    
-        
-                        <p><xref ref-type="fig" rid="fig1">1</xref></p>
-                        <fig id="fig1">
-                            <p>figure</p>
-                        </fig>
-                        <p><xref ref-type="table" rid="table1">1</xref></p>
-                        <table id="table1">
-                            <p>table</p>
-                        </table>
-                    
-                    </article-meta>
-                </front>
-            </article>
-            """
-        )
-        self.ids = Ids(self.xml_tree)
-
-    def test_ids(self):
-        obtained = list(self.ids.ids(element_name="aff"))
-        expected = [
-            {
-                "id": "aff1",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "aff",
-            },
-            {
-                "id": "aff2",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "aff",
-            }
-        ]
-        self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
-
-class ArticleXrefTest(TestCase):
+class XMLCrossReferenceTest(TestCase):
     def setUp(self):
         self.xml_tree = etree.fromstring(
             """
@@ -178,15 +102,14 @@ class ArticleXrefTest(TestCase):
                 <front>
                     <article-meta>
                         <p><xref ref-type="aff" rid="aff1">1</xref></p>
-                        <aff id="aff1">
-                            <p>affiliation</p>
-                        </aff>
-                        <aff id="aff2">
-                            <p>affiliation</p>
-                        </aff>
+                        <aff id="aff1"><p>affiliation</p></aff>
+                        <aff id="aff2"><p>affiliation</p></aff>
+                        <p><xref ref-type="fig" rid="fig1">2</xref></p>
+                        <fig id="fig1"><p>figure</p></fig>
+                        <p><xref ref-type="table" rid="table1">3</xref></p>
+                        <table id="table1"><p>table</p></table>
                     </article-meta>
                 </front>
-
                 <sub-article article-type="translation" xml:lang="es">
                     <front-stub>
                         <contrib-group>
@@ -198,145 +121,29 @@ class ArticleXrefTest(TestCase):
                                 <xref ref-type="aff" rid="aff2">2</xref>
                             </contrib>
                         </contrib-group>
-                        <aff id="aff3">
-                            <institution>Universidad Ejemplo</institution>
-                        </aff>
-                        <aff id="aff4">
-                            <institution>Universidad Ejemplo</institution>
-                        </aff>
+                        <aff id="aff3"><institution>Universidad Ejemplo</institution></aff>
+                        <aff id="aff4"><institution>Universidad Ejemplo</institution></aff>
                     </front-stub>
                 </sub-article>
             </article>
-
             """
         )
-        self.article_xref = ArticleXref(self.xml_tree)
+        self.xref = XMLCrossReference(self.xml_tree)
 
-    def test_all_ids(self):
-        obtained = self.article_xref.all_ids(element_name="aff")
-        expected = {
-            "aff1": [
-                {
-                    "id": "aff1",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "en",
-                    "tag": "aff",
-                }
-            ],
-            "aff2": [
-                {
-                    "id": "aff2",
-                    "parent": "article",
-                    "parent_article_type": "research-article",
-                    "parent_id": None,
-                    "parent_lang": "en",
-                    "tag": "aff",
-                }
-            ],
-            "aff3": [
-                {
-                    "id": "aff3",
-                    "parent": "sub-article",
-                    "parent_article_type": "translation",
-                    "parent_id": None,
-                    "parent_lang": "es",
-                    "tag": "aff",
-                }
-            ],
-            "aff4": [
-                {
-                    "id": "aff4",
-                    "parent": "sub-article",
-                    "parent_article_type": "translation",
-                    "parent_id": None,
-                    "parent_lang": "es",
-                    "tag": "aff",
-                }
-            ]
-        }
-        self.assertEqual(len(obtained), 4)
-        for id, item in expected.items():
-            for i, subitem in enumerate(item):
-                with self.subTest(id):
-                    self.assertDictEqual(subitem, obtained[id][i])
+    def test_elems_by_id(self):
+        results = self.xref.elems_by_id(element_name="aff")
+        self.assertEqual(len(results), 4)
+        self.assertIn("aff1", results)
+        self.assertIn("aff2", results)
+        self.assertIn("aff3", results)
+        self.assertIn("aff4", results)
 
-    @skip("Teste pendente de correção e/ou ajuste")
-    def test_all_xref_rids(self):
-        obtained = self.article_xref.all_xref_rids()
-        expected = {
-            "aff1": [
-                {
-                    "ref-type": "aff",
-                    "rid": "aff1",
-                    "text": "1",
-                }
-            ],
-            "aff2": [
-                {
-                    "ref-type": "aff",
-                    "rid": "aff2",
-                    "text": "2",
-                }
-            ]
-        }
-        self.assertEqual(len(obtained), 2)
-        for rid, item in expected.items():
-            for i, subitem in enumerate(item):
-                with self.subTest(rid):
-                    self.assertDictEqual(subitem, obtained[rid][i])
-
-    def test_article_ids(self):
-        obtained = list(self.article_xref.article_ids(element_name="aff"))
-        expected = [
-            {
-                "id": "aff1",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "aff",
-            },
-            {
-                "id": "aff2",
-                "parent": "article",
-                "parent_article_type": "research-article",
-                "parent_id": None,
-                "parent_lang": "en",
-                "tag": "aff",
-            }
-        ]
-        self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
-    def test_sub_article_translation_ids(self):
-        obtained = list(self.article_xref.sub_article_translation_ids(element_name="aff"))
-        expected = [
-            {
-                "id": "aff3",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "es",
-                "tag": "aff",
-            },
-            {
-                "id": "aff4",
-                "parent": "sub-article",
-                "parent_article_type": "translation",
-                "parent_id": None,
-                "parent_lang": "es",
-                "tag": "aff",
-            }
-        ]
-        self.assertEqual(len(obtained), 2)
-        for i, item in enumerate(expected):
-            with self.subTest(i):
-                self.assertDictEqual(item, obtained[i])
-
-    def test_sub_article_non_translation_ids(self):
-        obtained = list(self.article_xref.sub_article_non_translation_ids(element_name="aff"))
-        self.assertEqual(len(obtained), 0)
+    def test_xrefs_by_rid(self):
+        results = self.xref.xrefs_by_rid()
+        self.assertEqual(len(results), 4)
+        self.assertIn("aff1", results)
+        self.assertIn("aff2", results)
+        self.assertIn("fig1", results)
+        self.assertIn("table1", results)
+        self.assertEqual(results["aff1"][0]["ref-type"], "aff")
+        self.assertEqual(results["fig1"][0]["ref-type"], "fig")


### PR DESCRIPTION
#### O que esse PR faz?
Corrige e atualiza os testes do módulo `article_xref` para refletir corretamente a lógica atual de extração de elementos com `id` e referências cruzadas (`xref`) em XML JATS. Ajusta testes quebrados, métodos inexistentes e validações incorretas.

#### Onde a revisão poderia começar?
`tests/sps/models/v2/test_article_xref.py`

#### Como este poderia ser testado manualmente?
`python3 -m unittest -v tests/sps/models/v2/test_article_xref.py`

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

