### PR TITLE
Corrige os testes para media

### DIFF
--- a/packtools/sps/models/media.py
+++ b/packtools/sps/models/media.py
@@ -34,8 +34,8 @@ class Media(BaseMedia, LabelAndCaption):
 
     @property
     def data(self):
-        base_data = super(BaseMedia, self).data
-        label_caption_data = super(LabelAndCaption, self).data
+        base_data = BaseMedia.data.fget(self)
+        label_caption_data = LabelAndCaption.data.fget(self)
 
         return {**base_data, **label_caption_data}
 

--- a/tests/sps/models/test_media.py
+++ b/tests/sps/models/test_media.py
@@ -101,7 +101,7 @@ class TestMedia(unittest.TestCase):
         data_list = list(xml_media.data())
 
         # Deve haver 3 elementos (2 <media> + 1 <inline-media>)
-        self.assertEqual(len(data_list), 6)
+        self.assertEqual(len(data_list), 3)
 
         expected_media1 = {
             "xlink_href": "video1.mp4",


### PR DESCRIPTION
#### O que esse PR faz?
Corrige os testes e a obtenção de `data` a partir das super classes.

#### Onde a revisão poderia começar?
NA

#### Como este poderia ser testado manualmente?
NA

#### Algum cenário de contexto que queira dar?

```
base_data = super(BaseMedia, self).data
label_caption_data = super(LabelAndCaption, self).data
```
Isso não está chamando `BaseMedia.data` nem `LabelAndCaption.data` diretamente — está chamando `super()` do ponto de vista da classe atual (`Media`), o que pode causar resultados inesperados se o MRO estiver envolvido (especialmente se alguma dessas classes também usar `super()`)*.

_*Avaliação produzida por IA, devido a quebra nos testes._


### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

