### PR TITLE
Deprecate article_authors in favor of article_contribs

### DIFF
--- a/packtools/sps/models/article_authors.py
+++ b/packtools/sps/models/article_authors.py
@@ -1,3 +1,7 @@
+# WARNING: The `article_authors` module is deprecated.
+# Please use `article_contribs` instead.
+# `article_authors` will be removed in future versions.
+
 from packtools.sps.models.aff import Affiliation
 from packtools.sps.utils.xml_utils import node_plain_text
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR marca o módulo `article_authors` como obsoleto e o substitui por `article_contribs`.

#### Onde a revisão poderia começar?
NA

#### Como este poderia ser testado manualmente?
NA

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA
