### PR TITLE
Fix: generate_am

### DIFF
--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -10,6 +10,7 @@ from packtools.sps.models import (
     article_abstract,
     kwd_group,
     article_titles,
+    funding_group,
 )
 
 from packtools.sps.formats.am.am_utils import (
@@ -312,6 +313,19 @@ def get_title(xml_tree):
     return {}
 
 
+def get_funding(xml_tree):
+    """
+    Extrai e estrutura os dados de financiamento do artigo no formato ArticleMeta.
+    """
+    funding_statement = funding_group.FundingGroup(xml_tree).funding_statement
+
+    fields = [
+        ("v102", funding_statement, simple_field),
+    ]
+
+    return generate_am_dict(fields)
+
+
 def get_external_article_data(external_article_data=None):
     """
     Geração dos campos externos do ArticleMeta a partir dos dados fornecidos.
@@ -422,6 +436,7 @@ def get_xml_article_metadata(xml_tree):
         **get_ids(xml_tree),
         **get_dates(xml_tree),
         **get_articlemeta_issue(xml_tree),
+        **get_funding(xml_tree),
         **simple_field("v708", "1"), # Qtd de registros do tipo atual
         **simple_field("v706", "h"),  # Tipo de registro
     }

--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -19,10 +19,14 @@ from packtools.sps.formats.am.am_utils import (
     add_item,
     format_date,
     ARTICLE_TYPE_MAP,
+    extract_first_text,
 )
 
 
 def get_journal(xml_tree):
+    """
+    Dados do periódico.
+    """
     title = journal_meta.Title(xml_tree)
     journal_id = journal_meta.JournalID(xml_tree)
     publisher = journal_meta.Publisher(xml_tree)
@@ -38,84 +42,148 @@ def get_journal(xml_tree):
         publisher.publishers_names[0] if publisher.publishers_names else None
     )
 
-    return {
-        **simple_field("v30", title.abbreviated_journal_title),
-        **simple_field("v421", journal_id.nlm_ta),
-        **simple_field("v62", publisher_name),
-        **simple_field("v100", title.journal_title),
-        **multiple_complex_field("v435", issn_list),
-    }
+    response = {}
+    if title.abbreviated_journal_title:
+        response.update(
+            simple_field("v30", title.abbreviated_journal_title)
+        )  # título abreviado
+
+    if journal_id.nlm_ta:
+        response.update(simple_field("v421", journal_id.nlm_ta))  # título Medline
+
+    if publisher_name:
+        response.update(simple_field("v62", publisher_name))  # nome do editor
+
+    if title.journal_title:
+        response.update(
+            simple_field("v100", title.journal_title)
+        )  # título da publicação
+
+    if issn_list:
+        response.update(multiple_complex_field("v435", issn_list))  # ISSNs
+
+    return response
 
 
 def get_articlemeta_issue(xml_tree):
+    """
+    Dados do fascículo.
+    """
     meta = front_articlemeta_issue.ArticleMetaIssue(xml_tree)
     abstracts = article_abstract.Abstract(xml_tree).get_abstracts_by_lang(
         style="inline"
     )
+    has_abstracts = bool(abstracts)
 
     v882 = {}
-    add_item(v882, "v", meta.volume)
-    add_item(v882, "n", meta.number)
-    add_item(v882, "_", "")
+    if meta.volume:
+        add_item(v882, "v", meta.volume)  # volume
+    if meta.number:
+        add_item(v882, "n", meta.number)  # número
+    if v882:
+        add_item(v882, "_", "")
 
     v14 = {}
-    add_item(v14, "e", meta.elocation_id)
-    add_item(v14, "f", meta.fpage)
-    add_item(v14, "l", meta.lpage)
-    add_item(v14, "_", "")
+    if meta.elocation_id:
+        add_item(v14, "e", meta.elocation_id)  # elocation-id
+    if meta.fpage:
+        add_item(v14, "f", meta.fpage)  # página inicial
+    if meta.lpage:
+        add_item(v14, "l", meta.lpage)  # página final
+    if v14:
+        add_item(v14, "_", "")
 
-    result = {
-        **simple_field("v31", meta.volume),
-        **simple_field("v121", meta.order_string_format),
-        **complex_field("v882", v882),
-        **complex_field("v14", v14),
-    }
+    result = {}
+
+    if meta.order_string_format:
+        result.update(simple_field("v121", meta.order_string_format))  # ordem
+
+    if v882:
+        result.update(complex_field("v882", v882))  # volume e número
+
+    if v14:
+        result.update(complex_field("v14", v14))  # localização (elocation/page)
 
     if meta.volume:
-        result.update(simple_field("v4", f"V{meta.volume}"))
+        result.update(simple_field("v31", meta.volume))  # volume
+        result.update(simple_field("v4", f"V{meta.volume}"))  # volume formatado
 
-    result.update(simple_field("v709", "article" if abstracts else "text"))
+    result.update(
+        simple_field("v709", "article" if has_abstracts else "text")
+    )  # tipo de conteúdo
     return result
 
 
 def get_ids(xml_tree):
+    """
+    Identificadores do artigo.
+    """
     ids = article_ids.ArticleIds(xml_tree)
     result = {}
 
     if ids.v2:
         result["code"] = ids.v2
-        result.update(simple_field("v880", ids.v2))
+        result.update(simple_field("v880", ids.v2))  # código SciELO
 
     if ids.doi:
-        result.update(simple_field("v237", ids.doi))
+        result.update(simple_field("v237", ids.doi))  # DOI
 
     return result
 
 
 def get_contribs(xml_tree):
+    """
+    Dados dos autores.
+    """
     contribs = article_contribs.XMLContribs(xml_tree).contribs
-    list_contribs = []
-    for author in contribs:
-        author_type = author.get("contrib_type", "ND")
-        if author_type == "author":
-            author_type = "ND"
-
-        affs = author.get("affs", [])
-        aff_id = affs[0].get("id") if affs else None
-
-        v10 = {}
-        add_item(v10, "k", author.get("contrib_ids", {}).get("orcid"))
-        add_item(v10, "n", author.get("contrib_name", {}).get("given-names"))
-        add_item(v10, "1", aff_id)
-        add_item(v10, "s", author.get("contrib_name", {}).get("surname"))
-        add_item(v10, "r", author_type)
-        add_item(v10, "_", "")
-        list_contribs.append(v10)
-
+    list_contribs = [
+        build_v10_contrib(author) for author in contribs if build_v10_contrib(author)
+    ]
     return multiple_complex_field("v10", list_contribs)
 
 
+def build_v10_contrib(author):
+    """
+    Constrói o dicionário v10 para um autor.
+    """
+    author_type = author.get("contrib_type", "ND")
+    if author_type == "author":
+        author_type = "ND"
+
+    affs = author.get("affs", [])
+    aff_id = affs[0].get("id") if affs else None
+
+    v10 = {}
+
+    orcid = author.get("contrib_ids", {}).get("orcid")
+    if orcid:
+        add_item(v10, "k", orcid)  # ORCID
+
+    given_names = author.get("contrib_name", {}).get("given-names")
+    if given_names:
+        add_item(v10, "n", given_names)  # prenome
+
+    if aff_id:
+        add_item(v10, "1", aff_id)  # afiliação (id)
+
+    surname = author.get("contrib_name", {}).get("surname")
+    if surname:
+        add_item(v10, "s", surname)  # sobrenome
+
+    if author_type:
+        add_item(v10, "r", author_type)  # tipo de contribuição
+
+    if v10:
+        add_item(v10, "_", "")
+        return v10
+
+    return None
+
+
 def get_affs(xml_tree):
+    """
+    Dados das afiliações.
+    """
     affiliations = aff.Affiliation(xml_tree).affiliation_list
     list_v70 = []
     list_v240 = []
@@ -125,22 +193,56 @@ def get_affs(xml_tree):
             continue
 
         v70 = {}
-        add_item(v70, "c", item.get("city"))
-        add_item(v70, "i", item.get("id"))
-        add_item(v70, "l", item.get("label"))
-        add_item(v70, "1", item.get("orgdiv1"))
-        add_item(v70, "p", item.get("country_name"))
-        add_item(v70, "s", item.get("state"))
-        add_item(v70, "_", item.get("orgname"))
-        list_v70.append(v70)
+        city = item.get("city")
+        if city:
+            add_item(v70, "c", city)  # cidade
+
+        aff_id = item.get("id")
+        if aff_id:
+            add_item(v70, "i", aff_id)  # id afiliação
+
+        label = item.get("label")
+        if label:
+            add_item(v70, "l", label)  # label
+
+        orgdiv1 = item.get("orgdiv1")
+        if orgdiv1:
+            add_item(v70, "1", orgdiv1)  # divisão
+
+        country_name = item.get("country_name")
+        if country_name:
+            add_item(v70, "p", country_name)  # país (nome)
+
+        state = item.get("state")
+        if state:
+            add_item(v70, "s", state)  # estado
+
+        orgname = item.get("orgname")
+        if orgname:
+            add_item(v70, "_", orgname)  # nome da organização
+
+        if v70:
+            list_v70.append(v70)
 
         v240 = {}
-        add_item(v240, "c", item.get("city"))
-        add_item(v240, "i", item.get("id"))
-        add_item(v240, "p", item.get("country_code"))
-        add_item(v240, "s", item.get("state"))
-        add_item(v240, "_", item.get("orgname"))
-        list_v240.append(v240)
+        if city:
+            add_item(v240, "c", city)  # cidade
+
+        if aff_id:
+            add_item(v240, "i", aff_id)  # id afiliação
+
+        country_code = item.get("country_code")
+        if country_code:
+            add_item(v240, "p", country_code)  # país (código)
+
+        if state:
+            add_item(v240, "s", state)  # estado
+
+        if orgname:
+            add_item(v240, "_", orgname)  # nome da organização
+
+        if v240:
+            list_v240.append(v240)
 
     return {
         **multiple_complex_field("v70", list_v70),
@@ -154,14 +256,30 @@ def count_references(xml_tree):
 
 
 def extract_authors(all_authors):
+    """
+    Dados simplificados dos autores.
+    """
     v10_list = []
+
     for author in all_authors or []:
         v10 = {}
-        add_item(v10, "n", author.get("given-names"))
-        add_item(v10, "s", author.get("surname"))
-        add_item(v10, "r", author.get("role", "ND"))
-        add_item(v10, "_", "")
-        v10_list.append(v10)
+
+        given_names = author.get("given-names")
+        if given_names:
+            add_item(v10, "n", given_names)  # prenome
+
+        surname = author.get("surname")
+        if surname:
+            add_item(v10, "s", surname)  # sobrenome
+
+        role = author.get("role", "ND")
+        if role:
+            add_item(v10, "r", role)  # tipo de contribuição
+
+        if v10:
+            add_item(v10, "_", "")
+            v10_list.append(v10)
+
     return v10_list
 
 
@@ -172,41 +290,60 @@ def format_page_range(fpage, lpage):
 
 
 def get_dates(xml_tree):
+    """
+    Datas do artigo.
+    """
     dates = article_dates.ArticleDates(xml_tree)
+
     v114 = format_date(
         dates.history_dates_dict.get("accepted"), ["year", "month", "day"]
-    )
+    )  # v114 = data de aceite
     v112 = format_date(
         dates.history_dates_dict.get("received"), ["year", "month", "day"]
-    )
+    )  # v112 = data de recebimento
     v65 = (
         format_date(dates.collection_date, ["year"]) + "0000"
         if dates.collection_date
         else None
-    )
-    v223 = format_date(dates.epub_date, ["year", "month", "day"])
+    )  # v65 = ano de coleção (complementado com zeros)
+    v223 = format_date(
+        dates.epub_date, ["year", "month", "day"]
+    )  # v223 = data de publicação eletrônica
 
-    return {
-        **simple_field("v114", v114),
-        **simple_field("v112", v112),
-        **simple_field("v65", v65),
-        **simple_field("v223", v223),
-    }
+    result = {}
+
+    if v114:
+        result.update(simple_field("v114", v114))  # data de aceite
+    if v112:
+        result.update(simple_field("v112", v112))  # data de recebimento
+    if v65:
+        result.update(simple_field("v65", v65))  # ano de coleção
+    if v223:
+        result.update(simple_field("v223", v223))  # data de publicação eletrônica
+
+    return result
 
 
 def get_article_and_subarticle(xml_tree):
+    """
+    Dados do artigo e subartigos.
+    """
     articles = article_and_subarticles.ArticleAndSubArticles(xml_tree)
     article_type = articles.main_article_type
-    v71_value = ARTICLE_TYPE_MAP.get(article_type)
+    v71_value = ARTICLE_TYPE_MAP.get(article_type)  # tipo do artigo (mapeado)
 
-    result = {
-        **simple_field("v40", articles.main_lang),
-        **simple_field(
-            "v120", f"XML_{articles.dtd_version}" if articles.dtd_version else None
-        ),
-        **simple_field("v71", v71_value),
-    }
+    result = {}
 
+    if articles.main_lang:
+        result.update(simple_field("v40", articles.main_lang))  # idioma principal
+
+    if articles.dtd_version:
+        result.update(simple_field("v120", f"XML_{articles.dtd_version}"))  # versão DTD
+
+    if v71_value:
+        result.update(simple_field("v71", v71_value))  # tipo do artigo
+
+    # v601 = idiomas secundários
     other_langs = [
         {"_": lang}
         for item in articles.data
@@ -215,6 +352,7 @@ def get_article_and_subarticle(xml_tree):
     if other_langs:
         result.update(multiple_complex_field("v601", other_langs))
 
+    # v337 = DOI + idioma
     doi_list = [
         {"d": item["doi"], "l": item["lang"], "_": ""}
         for item in articles.data
@@ -227,85 +365,182 @@ def get_article_and_subarticle(xml_tree):
 
 
 def get_article_abstract(xml_tree):
+    """
+    Geração dos resumos (abstracts) do artigo, agrupados por idioma.
+    """
     abstracts = article_abstract.Abstract(xml_tree).get_abstracts_by_lang(
         style="inline"
     )
+    result = {}
+
     list_abs = []
     for lang, abstract in abstracts.items():
-        v83 = {}
-        add_item(v83, "a", abstract)
-        add_item(v83, "l", lang)
-        add_item(v83, "_", "")
-        list_abs.append(v83)
-    return multiple_complex_field("v83", list_abs)
+        if abstract:
+            item = {"a": abstract, "l": lang, "_": ""}
+            list_abs.append(item)
+
+    if list_abs:
+        result.update(multiple_complex_field("v83", list_abs))
+
+    return result
 
 
 def get_keyword(xml_tree):
+    """
+    Geração das palavras-chave (keywords) do artigo, agrupadas por idioma.
+    """
     keywords = kwd_group.ArticleKeywords(xml_tree)
     keywords.configure()
+
+    result = {}
     list_kw = []
+
     for kw in keywords.items:
-        v85 = {}
-        add_item(v85, "k", kw.get("plain_text"))
-        add_item(v85, "l", kw.get("lang"))
-        add_item(v85, "_", "")
-        list_kw.append(v85)
-    return multiple_complex_field("v85", list_kw)
+        plain_text = kw.get("plain_text")
+        lang = kw.get("lang")
+
+        if plain_text:
+            item = {"k": plain_text, "l": lang, "_": ""}
+            list_kw.append(item)
+
+    if list_kw:
+        result.update(multiple_complex_field("v85", list_kw))
+
+    return result
 
 
 def get_title(xml_tree):
-    v12_fields = {"l": "lang", "_": "plain_text"}
-    v12_list = [
-        {k: item.get(v) for k, v in v12_fields.items() if item.get(v)}
-        for item in article_titles.ArticleTitles(xml_tree).article_title_list
-    ]
-    return multiple_complex_field("v12", v12_list)
+    """
+    Geração dos títulos do artigo, agrupados por idioma.
+    """
+    titles = article_titles.ArticleTitles(xml_tree).article_title_list
+    result = {}
+    v12_list = []
+
+    for item in titles:
+        plain_text = item.get("plain_text")
+        lang = item.get("lang")
+
+        if plain_text:
+            v12_item = {"l": lang, "_": plain_text}
+            v12_list.append(v12_item)
+
+    if v12_list:
+        result.update(multiple_complex_field("v12", v12_list))
+
+    return result
 
 
 def get_external_fields(external_article_data=None):
-    external_article_data = external_article_data or {}
+    """
+    Geração dos campos externos do ArticleMeta a partir dos dados fornecidos.
 
-    v265_list = [
-        {"k": item["k"], "s": item["s"], "v": item["v"]}
-        for item in external_article_data.get("v265", [])
-        if all(k in item for k in ("k", "s", "v"))
-    ]
+    Parameters
+    ----------
+    external_article_data : dict, optional
+        Dicionário contendo dados externos do artigo no formato ArticleMeta.
 
-    v936_dict = external_article_data.get("v936") or {}
-    v936 = (
-        v936_dict
-        if isinstance(v936_dict, dict) and all(k in v936_dict for k in ("i", "y", "o"))
-        else None
-    )
+    Returns
+    -------
+    dict
+        Campos formatados prontos para inclusão no ArticleMeta.
 
-    result = {
-        "applicable": external_article_data.get("applicable"),
-        "collection": external_article_data.get("collection"),
-        "created_at": external_article_data.get("created_at"),
-        "processing_date": external_article_data.get("processing_date"),
-        "v35": external_article_data.get("v35"),
-        "v42": external_article_data.get("v42"),
-        "v701": external_article_data.get("v701"),
-        "v992": external_article_data.get("v992"),
-        "v999": external_article_data.get("v999"),
-        **simple_field("v2", external_article_data.get("v2")),
-        **simple_field("v3", external_article_data.get("v3")),
-        **simple_field("v38", external_article_data.get("v38")),
-        **simple_field("v49", external_article_data.get("v49")),
-        **simple_field("v700", external_article_data.get("v700")),
-        **simple_field("v702", external_article_data.get("v702")),
-        **simple_field("v705", external_article_data.get("v705")),
-        **simple_field("v706", external_article_data.get("v706")),
-        **simple_field("v708", external_article_data.get("v708")),
-        **simple_field("v91", external_article_data.get("v91")),
-        **complex_field("v936", v936),
-        **multiple_complex_field("v265", v265_list),
+    Example
+    -------
+    external_article_data = {
+        "v2": "S0034-8910(25)05900000202",       # identificador de controle do artigo
+        "v3": "1518-8787-rsp-59-e2.xml",         # caminho relativo do XML
+        "v38": "TAB",                            # tipo de elemento presente (ex.: tabela)
+        "v49": "RSP940",                         # código interno de status/processamento
+        "v700": "2",                             # ordem do registro no processamento
+        "v702": "rsp/v59/1518-8787-rsp-59-e2.xml", # caminho completo do XML
+        "v705": "S",                             # tipo de registro (S = artigo)
+        "v706": "h",                             # subtipo do registro (h = artigo)
+        "v708": "1",                             # contador de referências
+        "v91": "20250328",                       # data de processamento no sistema
+        "collection": "scl",                     # coleção
+        "applicable": "True",                    # flag indicando se o registro é aplicável
+        "processing_date": "2025-03-28",         # data de processamento
+        "v35": [{"_": "0034-8910"}],             # ISSN impresso
+        "v42": [{"_": "1"}],                     # status do fascículo
+        "v701": [{"_": "1"}],                    # sequência de publicação
+        "v992": [{"_": "scl"}],                  # coleção
+        "v999": [{"_": "../bases-work/rsp/rsp"}],# dados internos do sistema
+        "v265": [                                # dados complementares de processamento
+            {"k": "real", "s": "xml", "v": "20250331"},     # data real de processamento do XML
+            {"k": "expected", "s": "xml", "v": "202500"}    # data esperada de processamento
+        ],
+        "v936": {                                # identificador composto do fascículo
+            "i": "0034-8910",                    # ISSN
+            "y": "2025",                         # ano
+            "o": "1"                             # ordem do fascículo no ano
+        }
     }
+    """
+    external_article_data = external_article_data or {}
+    result = {}
 
-    return {k: v for k, v in result.items() if v is not None}
+    # v265: dados complementares de processamento (ex.: data real e esperada do XML)
+    v265_list = []
+    for item in external_article_data.get("v265", []):
+        if all(k in item for k in ("k", "s", "v")):
+            v265_list.append(
+                {
+                    "k": item["k"],  # chave (ex.: real, expected)
+                    "s": item["s"],  # subtipo/contexto (ex.: xml)
+                    "v": item["v"],  # valor (ex.: data)
+                }
+            )
+    if v265_list:
+        result.update(multiple_complex_field("v265", v265_list))
+
+    # v936: identificador composto (ISSN, ano, ordem do fascículo)
+    v936 = external_article_data.get("v936")
+    if isinstance(v936, dict) and all(k in v936 for k in ("i", "y", "o")):
+        result.update(complex_field("v936", v936))
+
+    # Campos simples de controle e identificadores
+    simple_keys = [
+        "v2",  # identificador de controle do artigo (ex.: S0034-8910(25)...)
+        "v3",  # caminho relativo do XML
+        "v38",  # tipos de elemento presentes (ex.: TAB, GRA)
+        "v49",  # código interno de status/processamento
+        "v700",  # ordem do registro no processamento
+        "v702",  # caminho completo do XML
+        "v705",  # tipo de registro (S = artigo, c = citação)
+        "v706",  # subtipo do registro (ex.: h = artigo, c = citação)
+        "v708",  # contador de referências
+        "v91",  # data de processamento no sistema
+    ]
+    for key in simple_keys:
+        value = external_article_data.get(key)
+        if value is not None:
+            result.update(simple_field(key, value))
+
+    # Campos diretos: metadados gerais
+    direct_keys = [
+        "applicable",  # flag indicando se o registro é aplicável
+        "collection",  # coleção
+        "created_at",  # data de criação do registro
+        "processing_date",  # data de processamento
+        "v35",  # ISSN impresso
+        "v42",  # status do fascículo
+        "v701",  # sequência de publicação
+        "v992",  # coleção
+        "v999",  # dados internos do sistema
+    ]
+    for key in direct_keys:
+        value = external_article_data.get(key)
+        if value is not None:
+            result[key] = value
+
+    return result
 
 
 def get_article_metadata(xml_tree, external_article_data=None):
+    """
+    Gera os metadados do artigo no formato ArticleMeta.
+    """
     external_article_data = external_article_data or {}
     return {
         **get_journal(xml_tree),
@@ -324,142 +559,258 @@ def get_article_metadata(xml_tree, external_article_data=None):
 
 
 def get_citations(xml_tree, external_article_data=None, external_citation_data=None):
+    """
+    Gera a lista de citações no formato ArticleMeta.
+    """
     external_article_data = external_article_data or {}
     external_citation_data = external_citation_data or {}
 
+    # Extrai dados básicos do artigo que serão usados como base comum nas citações
     xml_data = {
-        **get_ids(xml_tree),
-        **get_dates(xml_tree),
-        **get_articlemeta_issue(xml_tree),
-        **count_references(xml_tree),
+        **get_ids(xml_tree),  # identificadores (ex.: DOI, códigos)
+        **get_dates(xml_tree),  # datas do artigo
+        **get_articlemeta_issue(xml_tree),  # volume, número, elocation-id
+        **count_references(xml_tree),  # número total de referências
     }
 
+    # Gera o conjunto de dados comuns a todas as citações
     citation_common = get_citation_common(
         xml_data, external_article_data, external_citation_data
     )
+
+    # Lista de v700 das referências externas (se houver)
     v700_refs = citation_common.get("v700", [])
 
+    # Processa cada referência do XML, atribuindo índice e dados comuns
     refs = []
     for idx, ref in enumerate(references.XMLReferences(xml_tree).items, start=1):
         refs.append(build_citation(ref, citation_common, idx, v700_refs))
 
+    # Retorna a lista completa de citações formatadas
     return refs
 
 
 def get_citation_common(xml_data, external_article_data, external_citation_data):
+    """
+    Gera o dicionário comum a todas as citações, combinando dados do artigo
+    e informações externas.
+    """
+    # Dados provenientes do artigo (XML)
+    article_data = {
+        "code": xml_data.get("code"),  # código único do artigo
+        "v237": xml_data.get("v237"),  # DOI do artigo
+        "v4": xml_data.get("v4"),  # volume formatado (ex.: v59)
+        "v65": xml_data.get("v65"),  # ano/mês da publicação
+        "v708": xml_data.get("v72"),  # número do fascículo usado como contador de ref
+        "v882": xml_data.get("v882"),  # reforço do número do volume
+    }
+
+    # Dados provenientes dos dados externos do artigo
+    external_data = {
+        "collection": external_article_data.get("collection"),  # coleção (ex.: scl)
+        "v2": external_article_data.get("v2"),  # identificador de controle
+        "v3": external_article_data.get("v3"),  # caminho relativo do XML
+        "v701": external_article_data.get("v701"),  # sequência de publicação
+        "v702": external_article_data.get("v702"),  # caminho completo do XML
+        "v705": external_article_data.get("v705"),  # tipo do registro (S = artigo)
+        "v936": external_article_data.get(
+            "v936"
+        ),  # identificador composto (ISSN, ano, ordem)
+        "v992": external_article_data.get(
+            "v992"
+        ),  # coleção (redundante em alguns contextos)
+        "v999": external_article_data.get("v999"),  # dados internos do sistema
+    }
+
+    # Dados provenientes dos dados externos das citações
+    citation_data = {
+        "processing_date": external_citation_data.get(
+            "processing_date"
+        ),  # data de processamento das citações
+        "v700": external_citation_data.get(
+            "v700", []
+        ),  # ordem das referências externas
+    }
+
+    # Combina e retorna todos os dados
     return {
-        "code": xml_data.get("code"),
-        "collection": external_article_data.get("collection"),
-        "processing_date": external_citation_data.get("processing_date"),
-        "v237": xml_data.get("v237"),
-        "v2": external_article_data.get("v2"),
-        "v3": external_article_data.get("v3"),
-        "v4": xml_data.get("v4"),
-        "v65": xml_data.get("v65"),
-        "v700": external_citation_data.get("v700", []),
-        "v701": external_article_data.get("v701"),
-        "v702": external_article_data.get("v702"),
-        "v705": external_article_data.get("v705"),
-        "v708": xml_data.get("v72"),
-        "v882": xml_data.get("v882"),
-        "v936": external_article_data.get("v936"),
-        "v992": external_article_data.get("v992"),
-        "v999": external_article_data.get("v999"),
+        **article_data,
+        **external_data,
+        **citation_data,
     }
 
 
 def build_citation(ref, common, idx, v700_refs):
-    v64 = format_date(ref, ["year"])
-    v65 = f"{v64}0000" if v64 else None
-    v700 = v700_refs[idx - 1] if idx - 1 < len(v700_refs) else None
+    """
+    Gera uma citação individual no formato ArticleMeta.
+    """
+    # --- Dados derivados do próprio XML da referência ---
+    v64 = format_date(ref, ["year"])  # ano da citação
+    v65 = f"{v64}0000" if v64 else None  # ano no formato completo para v65
+    v700 = (
+        v700_refs[idx - 1] if idx - 1 < len(v700_refs) else None
+    )  # ordem no v700 externo
 
     v514 = {
-        "l": ref.get("lpage"),
-        "f": ref.get("fpage"),
-        "_": "",
+        "l": ref.get("lpage"),  # página final
+        "f": ref.get("fpage"),  # página inicial
+        "_": "",  # campo vazio obrigatório no formato
     }
 
-    result = {
-        "code": f"{common['code']}{idx:05}" if common["code"] else None,
-        "collection": common["collection"],
-        "processing_date": common["processing_date"],
-        "v237": common["v237"],
-        "v4": common["v4"],
-        "v865": common["v65"],
-        "v882": common["v882"],
-        "v999": common["v999"],
-        "v701": common["v701"],
-        "v708": common["v708"],
-        "v992": common["v992"],
-        **simple_field("v118", ref.get("label")),
-        **simple_field("v12", ref.get("article_title")),
-        **simple_field("v14", format_page_range(ref.get("fpage"), ref.get("lpage"))),
-        **simple_field("v2", common["v2"]),
-        **simple_field("v3", common["v3"]),
-        **simple_field("v30", ref.get("source")),
-        **simple_field("v31", ref.get("volume")),
-        **simple_field("v32", ref.get("issue")),
-        **simple_field("v37", ref.get("mixed_citation_xlink")),
-        **simple_field("v64", v64),
-        **simple_field("v65", v65),
-        **simple_field("v700", v700),
-        **simple_field("v702", common["v702"]),
-        **simple_field("v705", common["v705"]),
-        **simple_field("v706", "c"),
-        **simple_field("v71", ref.get("publication_type")),
-        **simple_field("v880", common["code"]),
-        **complex_field("v514", v514),
-        **complex_field("v936", common["v936"]),
-        **multiple_complex_field("v10", extract_authors(ref.get("all_authors"))),
-    }
+    result = {}
 
-    return {k: v for k, v in result.items() if v is not None}
+    # --- Dados comuns (do artigo e externos) ---
+    if common.get("code"):
+        result["code"] = f"{common['code']}{idx:05}"  # código único da citação
+    if common.get("collection"):
+        result["collection"] = common["collection"]
+    if common.get("processing_date"):
+        result["processing_date"] = common["processing_date"]
+    if common.get("v237"):
+        result["v237"] = common["v237"]  # DOI do artigo
+    if common.get("v4"):
+        result["v4"] = common["v4"]  # volume do artigo
+    if common.get("v65"):
+        result["v865"] = common["v65"]  # data do artigo
+    if common.get("v882"):
+        result["v882"] = common["v882"]  # reforço do volume
+    if common.get("v999"):
+        result["v999"] = common["v999"]  # dados internos
+    if common.get("v701"):
+        result["v701"] = common["v701"]  # sequência de publicação
+    if common.get("v708"):
+        result["v708"] = common["v708"]  # número do fascículo
+    if common.get("v992"):
+        result["v992"] = common["v992"]  # coleção
+    if common.get("v2"):
+        result.update(simple_field("v2", common["v2"]))  # identificador de controle
+    if common.get("v3"):
+        result.update(simple_field("v3", common["v3"]))  # caminho relativo do XML
+    if common.get("v702"):
+        result.update(simple_field("v702", common["v702"]))  # caminho completo do XML
+    if common.get("v705"):
+        result.update(simple_field("v705", common["v705"]))  # tipo do registro
+    result.update(simple_field("v706", "c"))  # tipo citação, sempre presente
+    if v700:
+        result.update(simple_field("v700", v700))  # ordem no v700 externo
+    if common.get("code"):
+        result.update(simple_field("v880", common["code"]))  # código base do artigo
+    if common.get("v936"):
+        result.update(
+            complex_field("v936", common["v936"])
+        )  # identificador composto (ISSN + ano + ordem)
+
+    # --- Dados da referência (XML da citação) ---
+    if ref.get("label"):
+        result.update(
+            simple_field("v118", ref.get("label"))
+        )  # label da citação (ex.: [1])
+    if ref.get("article_title"):
+        result.update(
+            simple_field("v12", ref.get("article_title"))
+        )  # título do artigo citado
+    page_range = format_page_range(ref.get("fpage"), ref.get("lpage"))
+    if page_range:
+        result.update(simple_field("v14", page_range))  # intervalo de páginas
+    if ref.get("source"):
+        result.update(simple_field("v30", ref.get("source")))  # nome do periódico
+    if ref.get("volume"):
+        result.update(simple_field("v31", ref.get("volume")))  # volume citado
+    if ref.get("issue"):
+        result.update(simple_field("v32", ref.get("issue")))  # número citado
+    if ref.get("mixed_citation_xlink"):
+        result.update(
+            simple_field("v37", ref.get("mixed_citation_xlink"))
+        )  # DOI da citação
+    if v64:
+        result.update(simple_field("v64", v64))  # ano citado
+    if v65:
+        result.update(simple_field("v65", v65))  # ano+0000 citado
+    if ref.get("publication_type"):
+        result.update(
+            simple_field("v71", ref.get("publication_type"))
+        )  # tipo de publicação
+
+    # autores da citação
+    authors = extract_authors(ref.get("all_authors"))
+    if authors:
+        result.update(multiple_complex_field("v10", authors))
+
+    # paginação complexa
+    if v514.get("l") or v514.get("f"):
+        result.update(complex_field("v514", v514))
+
+    return result
 
 
 def build(xml_tree, external_article_data=None, external_citation_data=None):
+    """
+    Gera o dicionário completo do ArticleMeta no formato final.
+    """
     external_article_data = external_article_data or {}
     external_citation_data = external_citation_data or {}
 
+    # Extrai dados estruturais do artigo e citações
     article_metadata = get_article_metadata(xml_tree, external_article_data)
     citations = get_citations(xml_tree, external_article_data, external_citation_data)
     journal_data = get_journal(xml_tree)
     external_fields = get_external_fields(external_article_data)
-    article_type = article_and_subarticles.ArticleAndSubArticles(xml_tree).main_article_type
+    article_type = article_and_subarticles.ArticleAndSubArticles(
+        xml_tree
+    ).main_article_type
 
-    def extract_first_text(lst):
-        return lst[0].get("_") if isinstance(lst, list) and lst and isinstance(lst[0], dict) else None
-
-    publication_date = extract_first_text(article_metadata.get("v65"))
+    # Extração de dados calculados
+    publication_date = extract_first_text(
+        article_metadata.get("v65")
+    )  # data principal de publicação
     publication_year = publication_date[:4] if publication_date else None
-    doi = extract_first_text(article_metadata.get("v237"))
-    code = article_metadata.get("code")
-    code_issue = code[1:18] if code and len(code) >= 18 else None
+    doi = extract_first_text(article_metadata.get("v237"))  # DOI principal
+    code = article_metadata.get("code")  # código de controle do artigo
+    code_issue = code[1:18] if code and len(code) >= 18 else None  # código do fascículo
 
+    # Lista de ISSNs coletados
     issns = [
-        item.get("_") for item in external_article_data.get("v35", []) + journal_data.get("v435", [])
+        item.get("_")
+        for item in external_article_data.get("v35", []) + journal_data.get("v435", [])
         if isinstance(item, dict) and item.get("_")
     ]
 
-    result = {
-        "collection": external_fields.get("collection"),
-        "applicable": external_fields.get("applicable"),
-        "article": article_metadata,
-        "citations": citations,
-        "code_title": issns,
-        "created_at": external_fields.get("created_at"),
-        "document_type": article_type,
-        "doi": doi,
-        "publication_date": publication_date,
-        "publication_year": publication_year,
-        "sent_wos": external_article_data.get("sent_wos"),
-        "validated_scielo": external_article_data.get("validated_scielo"),
-        "validated_wos": external_article_data.get("validated_wos"),
-        "version": external_article_data.get("version"),
-        "code": code,
-        "code_issue": code_issue,
-    }
+    result = {}
 
-    return {k: v for k, v in result.items() if v is not None}
+    # Dados gerais do documento
+    if external_fields.get("collection"):
+        result["collection"] = external_fields.get("collection")
+    if external_fields.get("applicable"):
+        result["applicable"] = external_fields.get("applicable")
 
+    # Dados principais
+    result["article"] = article_metadata
+    result["citations"] = citations
 
+    # Dados complementares
+    if issns:
+        result["code_title"] = issns
+    if external_fields.get("created_at"):
+        result["created_at"] = external_fields.get("created_at")
+    if article_type:
+        result["document_type"] = article_type
+    if doi:
+        result["doi"] = doi
+    if publication_date:
+        result["publication_date"] = publication_date
+    if publication_year:
+        result["publication_year"] = publication_year
+    if external_article_data.get("sent_wos"):
+        result["sent_wos"] = external_article_data.get("sent_wos")
+    if external_article_data.get("validated_scielo"):
+        result["validated_scielo"] = external_article_data.get("validated_scielo")
+    if external_article_data.get("validated_wos"):
+        result["validated_wos"] = external_article_data.get("validated_wos")
+    if external_article_data.get("version"):
+        result["version"] = external_article_data.get("version")
+    if code:
+        result["code"] = code
+    if code_issue:
+        result["code_issue"] = code_issue
 
+    return result

--- a/packtools/sps/formats/am/am_utils.py
+++ b/packtools/sps/formats/am/am_utils.py
@@ -51,11 +51,6 @@ def complex_field(key, value):
     return {}
 
 
-def add_item(dictionary, key, value):
-    if value is not None:
-        dictionary[key] = value
-
-
 def multiple_complex_field(key, value_list):
     if value_list:
         return {key: value_list}
@@ -73,10 +68,13 @@ def format_date(date_dict, fields):
     return "".join(parts) if any(parts) else None
 
 
-def extract_first_text(list_field):
-    """
-    Extrai o texto do primeiro item da lista no campo "_", se existir.
-    """
-    if isinstance(list_field, list) and list_field and isinstance(list_field[0], dict):
-        return list_field[0].get("_")
-    return None
+def generate_am_dict(fields):
+    response = {}
+    for tag, value, formatter in fields:
+        if value is not None:
+            response.update(formatter(tag, value))
+    return response
+
+def simple_kv(tag, value):
+    return {tag: value}
+

--- a/packtools/sps/formats/am/am_utils.py
+++ b/packtools/sps/formats/am/am_utils.py
@@ -71,3 +71,12 @@ def format_date(date_dict, fields):
         return None
     parts = [date_dict.get(field, "") for field in fields]
     return "".join(parts) if any(parts) else None
+
+
+def extract_first_text(list_field):
+    """
+    Extrai o texto do primeiro item da lista no campo "_", se existir.
+    """
+    if isinstance(list_field, list) and list_field and isinstance(list_field[0], dict):
+        return list_field[0].get("_")
+    return None

--- a/packtools/sps/formats/am/generate_am.py
+++ b/packtools/sps/formats/am/generate_am.py
@@ -1,0 +1,96 @@
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from packtools.sps.utils import xml_utils
+from packtools.sps.formats.am import am
+from packtools.sps.exceptions import SPSLoadToXMLError
+
+
+# Configura logger
+logging.basicConfig(
+    filename="generate_am.log",
+    filemode="a",
+    level=logging.ERROR,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+
+def load_json_data(path_str: Optional[str]) -> dict:
+    if not path_str:
+        return {}
+    path = Path(path_str)
+    if not path.is_file():
+        raise FileNotFoundError(f"Arquivo JSON não encontrado: {path}")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def process_xml_file(
+    xml_path: Path,
+    external_article_data: dict,
+    external_citation_data: dict
+):
+    try:
+        xml_tree = xml_utils.get_xml_tree(str(xml_path))
+        articlemeta = am.build(
+            xml_tree=xml_tree,
+            external_article_data=external_article_data,
+            external_citation_data=external_citation_data,
+        )
+
+        output_path = xml_path.with_suffix(".am.json")
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(articlemeta, f, indent=2, ensure_ascii=False)
+
+        print(f"[OK] Gerado: {output_path}")
+
+    except Exception as exc:
+        logging.error(f"Erro ao processar '{xml_path}': {exc}")
+        print(f"[ERRO] Falha ao processar {xml_path.name}. Veja 'generate_am.log'.")
+
+
+def is_leaf_directory(path: Path) -> bool:
+    """Retorna True se a pasta não contiver subpastas."""
+    return path.is_dir() and all(not p.is_dir() for p in path.iterdir())
+
+
+def process_input_path(
+    input_path_str: str,
+    external_article_data_path: Optional[str] = None,
+    external_citation_data_path: Optional[str] = None
+):
+    input_path = Path(input_path_str)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Caminho não encontrado: {input_path}")
+
+    external_article_data = load_json_data(external_article_data_path)
+    external_citation_data = load_json_data(external_citation_data_path)
+
+    if input_path.is_file() and input_path.suffix.lower() == ".xml":
+        process_xml_file(input_path, external_article_data, external_citation_data)
+    elif input_path.is_dir():
+        leaf_dirs = [d for d in input_path.rglob("*") if is_leaf_directory(d)]
+        xml_files = [f for d in leaf_dirs for f in d.glob("*.xml")]
+
+        if not xml_files:
+            print("[AVISO] Nenhum XML encontrado em pastas folha.")
+        for xml_file in xml_files:
+            process_xml_file(xml_file, external_article_data, external_citation_data)
+    else:
+        raise ValueError("Entrada inválida: deve ser um arquivo .xml ou um diretório.")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Uso: python script.py <arquivo_ou_pasta> [external_article_data.json] [external_citation_data.json]")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+    external_article_data_path = sys.argv[2] if len(sys.argv) > 2 else None
+    external_citation_data_path = sys.argv[3] if len(sys.argv) > 3 else None
+
+    process_input_path(input_path, external_article_data_path, external_citation_data_path)

--- a/packtools/sps/formats/am/generate_am.py
+++ b/packtools/sps/formats/am/generate_am.py
@@ -29,15 +29,13 @@ def load_json_data(path_str: Optional[str]) -> dict:
 
 def process_xml_file(
     xml_path: Path,
-    external_article_data: dict,
-    external_citation_data: dict
+    external_data: dict
 ):
     try:
         xml_tree = xml_utils.get_xml_tree(str(xml_path))
         articlemeta = am.build(
             xml_tree=xml_tree,
-            external_article_data=external_article_data,
-            external_citation_data=external_citation_data,
+            external_data=external_data
         )
 
         output_path = xml_path.with_suffix(".am.json")
@@ -58,18 +56,16 @@ def is_leaf_directory(path: Path) -> bool:
 
 def process_input_path(
     input_path_str: str,
-    external_article_data_path: Optional[str] = None,
-    external_citation_data_path: Optional[str] = None
+    external_data_path: Optional[str] = None
 ):
     input_path = Path(input_path_str)
     if not input_path.exists():
         raise FileNotFoundError(f"Caminho não encontrado: {input_path}")
 
-    external_article_data = load_json_data(external_article_data_path)
-    external_citation_data = load_json_data(external_citation_data_path)
+    external_data = load_json_data(external_data_path)
 
     if input_path.is_file() and input_path.suffix.lower() == ".xml":
-        process_xml_file(input_path, external_article_data, external_citation_data)
+        process_xml_file(input_path, external_data)
     elif input_path.is_dir():
         leaf_dirs = [d for d in input_path.rglob("*") if is_leaf_directory(d)]
         xml_files = [f for d in leaf_dirs for f in d.glob("*.xml")]
@@ -77,7 +73,7 @@ def process_input_path(
         if not xml_files:
             print("[AVISO] Nenhum XML encontrado em pastas folha.")
         for xml_file in xml_files:
-            process_xml_file(xml_file, external_article_data, external_citation_data)
+            process_xml_file(xml_file, external_data)
     else:
         raise ValueError("Entrada inválida: deve ser um arquivo .xml ou um diretório.")
 
@@ -86,11 +82,10 @@ if __name__ == "__main__":
     import sys
 
     if len(sys.argv) < 2:
-        print("Uso: python script.py <arquivo_ou_pasta> [external_article_data.json] [external_citation_data.json]")
+        print("Uso: python generate_am.py <arquivo_ou_pasta> [external_article_data.json]")
         sys.exit(1)
 
     input_path = sys.argv[1]
-    external_article_data_path = sys.argv[2] if len(sys.argv) > 2 else None
-    external_citation_data_path = sys.argv[3] if len(sys.argv) > 3 else None
+    external_data_path = sys.argv[2] if len(sys.argv) > 2 else None
 
-    process_input_path(input_path, external_article_data_path, external_citation_data_path)
+    process_input_path(input_path, external_data_path)

--- a/packtools/sps/models/article_abstract.py
+++ b/packtools/sps/models/article_abstract.py
@@ -439,8 +439,13 @@ class Abstract(BaseAbstract):
         Retorna dicionário cuja chave é idioma e valor o resumo no formato dado por style
         """
         d = {}
-        for item in self.get_abstracts(style=style):
-            d[item["lang"]] = item["abstract"]
+        abstracts = self.get_abstracts(style=style)
+        if not abstracts:
+            return d
+
+        for item in abstracts:
+            if isinstance(item, dict) and "lang" in item and "abstract" in item:
+                d[item["lang"]] = item["abstract"]
         return d
 
 

--- a/packtools/sps/models/funding_group.py
+++ b/packtools/sps/models/funding_group.py
@@ -164,8 +164,18 @@ class FundingGroup:
         """
         De acordo com https://scielo.readthedocs.io/projects/scielo-publishing-schema/pt-br/latest/tagset/elemento-funding-statement.html?highlight=funding-statement
         <funding-statement> ocorre zero ou uma vez.
+
+        Retorna o texto do funding-statement com espaços e quebras de linha normalizados.
+        Se não houver o elemento, retorna None.
         """
-        return self._xmltree.findtext(".//funding-group/funding-statement")
+        el = self._xmltree.find(".//funding-group/funding-statement")
+        if el is None:
+            return None
+        # Obtem o texto bruto (com conteúdo de elementos filhos, se houver)
+        raw_text = "".join(el.itertext())
+        # Limpa quebras de linha e espaços duplicados
+        cleaned_text = " ".join(raw_text.split())
+        return cleaned_text if cleaned_text else None
 
     @property
     def funding_statement_data(self):

--- a/tests/sps/formats/am/test_am.py
+++ b/tests/sps/formats/am/test_am.py
@@ -7,7 +7,7 @@ from packtools.sps.formats.am import am
 class BaseTest(unittest.TestCase):
     def setUp(self):
         self.xml_tree = xml_utils.get_xml_tree(
-            "tests/sps/formats/am/examples/S0104-11692025000100300.xml"
+            "tests/sps/formats/am/examples/S0104-11692025000100300/S0104-11692025000100300.xml"
         )
 
         self.external_data = {
@@ -363,6 +363,20 @@ class TestGetTitle(BaseTest):
             "Play Nicely Program in the prevention of violence against children: "
             "strengthening sustainable development",
         )
+
+
+class TestGetFunding(BaseTest):
+    def setUp(self):
+        self.xml_tree = xml_utils.get_xml_tree(
+            "tests/sps/formats/am/examples/S0034-89102025000100200/S0034-89102025000100200.xml"
+        )
+        self.funding_data = am.get_funding(self.xml_tree)
+
+    def test_field_v102(self):
+        self.assertEqual(
+            self.funding_data["v102"],
+            [{"_": "Funding: Coordenação de Aperfeiçoamento Pessoal de Nível Superior (CAPES – PhD fellowship for AFF). "
+            "Conselho Nacional de Desenvolvimento Científico e Tecnológico (CNPq – productivity fellowship for ANRJ)."}])
 
 
 class TestExternalFields(BaseTest):

--- a/tests/sps/formats/am/test_am.py
+++ b/tests/sps/formats/am/test_am.py
@@ -10,31 +10,25 @@ class BaseTest(unittest.TestCase):
             "tests/sps/formats/am/examples/S0104-11692025000100300.xml"
         )
 
-        self.external_issue_data = {
-            "v999": [{"_": "../bases-work/rlae/rlae"}],
-            "v992": [{"_": "scl"}],
-            "v35": [{"_": "0104-1169"}],
-            "v42": [{"_": "1"}],
+        self.external_data = {
+            "v999": "../bases-work/rlae/rlae",
+            "v992": "scl",
+            "v35": "0104-1169",
+            "v42": "1",
             "collection": "scl",
-            "v701": [{"_": "1"}],
-        }
-
-        self.external_article_data = {
-            **self.external_issue_data,
+            "v701": "1",
             "v38": "GRA",
             "v49": "RLAE350",
-            "v706": "h",
             "v2": "S0104-1169(25)03300000300",
             "v91": "20250203",
-            "v700": "2",
             "v702": "rlae/v33/1518-8345-rlae-33-e4434.xml",
             "v705": "S",
             "processing_date": "2025-02-03",
+            "citations_processing_date": "2025-04-28",
             "v265": [
                 {"k": "real", "s": "xml", "v": "20250127"},
                 {"k": "expected", "s": "xml", "v": "202500"},
             ],
-            "v708": "1",
             "v3": "1518-8345-rlae-33-e4434.xml",
             "v936": {"i": "0104-1169", "y": "2025", "o": "1"},
             "applicable": "True",
@@ -43,11 +37,6 @@ class BaseTest(unittest.TestCase):
             "validated_scielo": "False",
             "validated_wos": "False",
             "version": "xml",
-        }
-
-        self.external_citation_data = {
-            "processing_date": "2025-04-28",
-            "v700": [str(value) for value in range(5, 40)],
         }
 
 
@@ -99,21 +88,15 @@ class TestGetArticlemetaIssue(BaseTest):
     def test_field_v121(self):
         self.assertEqual(self.issue_data["v121"], [{"_": "00300"}])
 
-    def test_field_v882(self):
-        self.assertEqual(self.issue_data["v882"], [{"v": "33", "_": ""}])
-
     def test_field_v14(self):
         self.assertEqual(self.issue_data["v14"], [{"e": "e4434", "_": ""}])
-
-    def test_field_v4(self):
-        self.assertEqual(self.issue_data["v4"], [{"_": "V33"}])
 
     def test_field_v709(self):
         self.assertEqual(self.issue_data["v709"], [{"_": "article"}])
 
     def test_issue_returns_expected_fields(self):
         self.assertTrue(
-            {"v31", "v121", "v882", "v14", "v4", "v709"}.issubset(
+            {"v31", "v121", "v14", "v709"}.issubset(
                 self.issue_data.keys()
             )
         )
@@ -124,17 +107,9 @@ class TestGetIds(BaseTest):
         super().setUp()
         self.ids_data = am.get_ids(self.xml_tree)
 
-    def test_code(self):
-        self.assertEqual(self.ids_data["code"], "S0104-11692025000100300")
-
-    def test_field_v880(self):
-        self.assertEqual(self.ids_data["v880"], [{"_": "S0104-11692025000100300"}])
-
     def test_field_v237(self):
         self.assertEqual(self.ids_data["v237"], [{"_": "10.1590/1518-8345.7320.4434"}])
 
-    def test_ids_returns_expected_fields(self):
-        self.assertTrue({"code", "v880", "v237"}.issubset(self.ids_data.keys()))
 
 
 class TestGetContribs(BaseTest):
@@ -186,18 +161,15 @@ class TestGetAffs(BaseTest):
 class TestGetCitations(BaseTest):
     def setUp(self):
         super().setUp()
-        self.v72_data = am.count_references(self.xml_tree)
-        self.refs = am.get_citations(
-            self.xml_tree, self.external_article_data, self.external_citation_data
-        )
-        self.first_ref = self.refs[0]
-        self.last_ref = self.refs[-1]
+        self.am_format = am.build(self.xml_tree, self.external_data)
+        self.first_ref = self.am_format["citations"][0]
+        self.last_ref = self.am_format["citations"][-1]
 
     def test_field_v72(self):
-        self.assertEqual(self.v72_data["v72"], [{"_": "35"}])
+        self.assertEqual(self.am_format["article"]["v72"], [{"_": "35"}])
 
     def test_references_structure(self):
-        self.assertEqual(len(self.refs), 35)
+        self.assertEqual(len(self.am_format["citations"]), 35)
 
     def test_field_v30(self):
         self.assertEqual(self.first_ref["v30"], [{"_": "Am J Psychiatry"}])
@@ -250,16 +222,14 @@ class TestGetCitations(BaseTest):
         )
 
     def test_field_v880(self):
-        self.assertEqual(self.first_ref["v880"], [{"_": "S0104-11692025000100300"}])
+        self.assertEqual(self.first_ref["v880"], [{"_": "S0104-1169202500010030000001"}])
+        self.assertEqual(self.last_ref["v880"], [{"_": "S0104-1169202500010030000035"}])
 
     def test_field_v865(self):
         self.assertEqual(self.first_ref["v865"], [{"_": "20250000"}])
 
     def test_field_v118(self):
         self.assertEqual(self.first_ref["v118"], [{"_": "1."}])
-
-    def test_field_v237(self):
-        self.assertEqual(self.first_ref["v237"], [{"_": "10.1590/1518-8345.7320.4434"}])
 
     def test_field_v706(self):
         self.assertEqual(self.first_ref["v706"], [{"_": "c"}])
@@ -290,9 +260,6 @@ class TestGetCitations(BaseTest):
 
     def test_field_v701(self):
         self.assertEqual(self.first_ref["v701"], [{"_": "1"}])
-
-    def test_field_v700(self):
-        self.assertEqual(self.first_ref["v700"], [{"_": "5"}])
 
     def test_field_v702(self):
         self.assertEqual(
@@ -401,126 +368,69 @@ class TestGetTitle(BaseTest):
 class TestExternalFields(BaseTest):
     def setUp(self):
         super().setUp()
-        self.external_data = am.get_external_fields(self.external_article_data)
+        self.external_data_formated = am.get_external_article_data(self.external_data)
+        self.external_data_common_formated = am.get_external_common_data(self.external_data)
+        self.external_data_formated.update(self.external_data_common_formated)
 
     def test_field_v999(self):
-        self.assertEqual(self.external_data["v999"], [{"_": "../bases-work/rlae/rlae"}])
+        self.assertEqual(self.external_data_formated["v999"], [{"_": "../bases-work/rlae/rlae"}])
 
     def test_field_v38(self):
-        self.assertEqual(self.external_data["v38"], [{"_": "GRA"}])
+        self.assertEqual(self.external_data_formated["v38"], [{"_": "GRA"}])
 
     def test_field_v992(self):
-        self.assertEqual(self.external_data["v992"], [{"_": "scl"}])
+        self.assertEqual(self.external_data_formated["v992"], [{"_": "scl"}])
 
     def test_field_v42(self):
-        self.assertEqual(self.external_data["v42"], [{"_": "1"}])
+        self.assertEqual(self.external_data_formated["v42"], [{"_": "1"}])
 
     def test_field_v49(self):
-        self.assertEqual(self.external_data["v49"], [{"_": "RLAE350"}])
-
-    def test_field_v706(self):
-        self.assertEqual(self.external_data["v706"], [{"_": "h"}])
+        self.assertEqual(self.external_data_formated["v49"], [{"_": "RLAE350"}])
 
     def test_field_collection(self):
-        self.assertEqual(self.external_data["collection"], "scl")
+        self.assertEqual(self.external_data_formated["collection"], "scl")
 
     def test_field_v2(self):
-        self.assertEqual(self.external_data["v2"], [{"_": "S0104-1169(25)03300000300"}])
+        self.assertEqual(self.external_data_formated["v2"], [{"_": "S0104-1169(25)03300000300"}])
 
     def test_field_v91(self):
-        self.assertEqual(self.external_data["v91"], [{"_": "20250203"}])
+        self.assertEqual(self.external_data_formated["v91"], [{"_": "20250203"}])
 
     def test_field_v701(self):
-        self.assertEqual(self.external_data["v701"], [{"_": "1"}])
-
-    def test_field_v700(self):
-        self.assertEqual(self.external_data["v700"], [{"_": "2"}])
+        self.assertEqual(self.external_data_formated["v701"], [{"_": "1"}])
 
     def test_field_v702(self):
         self.assertEqual(
-            self.external_data["v702"], [{"_": "rlae/v33/1518-8345-rlae-33-e4434.xml"}]
+            self.external_data_formated["v702"], [{"_": "rlae/v33/1518-8345-rlae-33-e4434.xml"}]
         )
 
     def test_field_v705(self):
-        self.assertEqual(self.external_data["v705"], [{"_": "S"}])
-
-    def test_field_v708(self):
-        self.assertEqual(self.external_data["v708"], [{"_": "1"}])
+        self.assertEqual(self.external_data_formated["v705"], [{"_": "S"}])
 
     def test_field_v3(self):
         self.assertEqual(
-            self.external_data["v3"], [{"_": "1518-8345-rlae-33-e4434.xml"}]
+            self.external_data_formated["v3"], [{"_": "1518-8345-rlae-33-e4434.xml"}]
         )
 
     def test_field_v35_from_article_data(self):
-        self.assertEqual(self.external_data["v35"], [{"_": "0104-1169"}])
+        self.assertEqual(self.external_data_formated["v35"], [{"_": "0104-1169"}])
 
     def test_field_processing_date(self):
-        self.assertEqual(self.external_data["processing_date"], "2025-02-03")
+        self.assertEqual(self.external_data_formated["processing_date"], "2025-02-03")
 
     def test_field_v265(self):
-        self.assertEqual(len(self.external_data["v265"]), 2)
+        self.assertEqual(len(self.external_data_formated["v265"]), 2)
         self.assertEqual(
-            self.external_data["v265"][0], {"k": "real", "s": "xml", "v": "20250127"}
+            self.external_data_formated["v265"][0], {"k": "real", "s": "xml", "v": "20250127"}
         )
         self.assertEqual(
-            self.external_data["v265"][1], {"k": "expected", "s": "xml", "v": "202500"}
+            self.external_data_formated["v265"][1], {"k": "expected", "s": "xml", "v": "202500"}
         )
 
     def test_field_v936(self):
         self.assertEqual(
-            self.external_data["v936"], [{"i": "0104-1169", "y": "2025", "o": "1"}]
+            self.external_data_formated["v936"], [{"i": "0104-1169", "y": "2025", "o": "1"}]
         )
-
-
-class TestBuild(BaseTest):
-    def setUp(self):
-        super().setUp()
-        self.build_data = am.build(
-            self.xml_tree, self.external_article_data, self.external_citation_data
-        )
-
-    def test_field_code(self):
-        self.assertEqual(self.build_data["code"], "S0104-11692025000100300")
-
-    def test_field_collection(self):
-        self.assertEqual(self.build_data["collection"], "scl")
-
-    def test_field_applicable(self):
-        self.assertEqual(self.build_data["applicable"], "True")
-
-    def test_field_code_issue(self):
-        self.assertEqual(self.build_data["code_issue"], "0104-116920250001")
-
-    def test_field_code_title(self):
-        self.assertEqual(self.build_data["code_title"], ["0104-1169", "1518-8345"])
-
-    def test_field_created_at(self):
-        self.assertEqual(self.build_data["created_at"], "2025-02-03")
-
-    def test_field_document_type(self):
-        self.assertEqual(self.build_data["document_type"], "research-article")
-
-    def test_field_doi(self):
-        self.assertEqual(self.build_data["doi"], "10.1590/1518-8345.7320.4434")
-
-    def test_field_publication_date(self):
-        self.assertEqual(self.build_data["publication_date"], "20250000")
-
-    def test_field_publication_year(self):
-        self.assertEqual(self.build_data["publication_year"], "2025")
-
-    def test_field_sent_wos(self):
-        self.assertEqual(self.build_data["sent_wos"], "False")
-
-    def test_field_validated_scielo(self):
-        self.assertEqual(self.build_data["validated_scielo"], "False")
-
-    def test_field_validated_wos(self):
-        self.assertEqual(self.build_data["validated_wos"], "False")
-
-    def test_field_version(self):
-        self.assertEqual(self.build_data["version"], "xml")
 
 
 if __name__ == "__main__":

--- a/tests/sps/models/test_funding_group.py
+++ b/tests/sps/models/test_funding_group.py
@@ -251,3 +251,11 @@ class FundingTest(TestCase):
         # Verify some key values
         self.assertEqual("research-article", obtained["article_type"])
         self.assertEqual("en", obtained["article_lang"])
+
+    def test_funding_statement_2(self):
+        from packtools.sps.utils import xml_utils
+        xmltree = xml_utils.get_xml_tree('tests/sps/formats/am/examples/S0034-89102025000100200/S0034-89102025000100200.xml')
+        funding = funding_group.FundingGroup(xmltree)
+        obtained = funding.funding_statement
+        expected = "Funding: Coordenação de Aperfeiçoamento Pessoal de Nível Superior (CAPES – PhD fellowship for AFF). Conselho Nacional de Desenvolvimento Científico e Tecnológico (CNPq – productivity fellowship for ANRJ)."
+        self.assertEqual(expected, obtained)


### PR DESCRIPTION
#### O que esse PR faz?
Este PR atualiza o script generate_am.py para permitir a geração de arquivos .am.json a partir de:

- Um único arquivo XML ou
- Um diretório com múltiplas subpastas, processando apenas as pastas folha (sem subpastas internas).

Além disso:

- Suporta opcionalmente dois arquivos JSON externos (external_article_data.json e external_citation_data.json);
- Gera o .am.json na mesma pasta do XML de origem;
- Registra erros em um arquivo generate_am.log sem interromper o processamento dos demais arquivos.

#### Onde a revisão poderia começar?
Por _commit_.

#### Como este poderia ser testado manualmente?
##### 1. Processar apenas um arquivo XML (sem dados externos)
`python script.py /caminho/para/artigo.xml`

##### 2. Processar uma pasta com XMLs em subpastas folha
`python script.py /caminho/para/colecao/`

##### 3. Processar um XML com dados externos de artigo
`python script.py /caminho/artigo.xml dados_article.json`

##### 4. Processar um XML com dados externos de artigo e citação
`python script.py /caminho/artigo.xml dados_article.json dados_citation.json`

##### 5. Processar uma pasta inteira com dados externos
`python script.py /caminho/colecao/ dados_article.json dados_citation.json`


#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.

