### PR TITLE
Suporte a novos campos e normalização em citações ArticleMeta

### DIFF
--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -21,6 +21,7 @@ from packtools.sps.formats.am.am_utils import (
     ARTICLE_TYPE_MAP,
     generate_am_dict,
     simple_kv,
+    abbreviate_page_range, format_page_range,
 )
 
 
@@ -64,10 +65,13 @@ def get_articlemeta_issue(xml_tree):
     abstracts = article_abstract.Abstract(xml_tree).get_abstracts_by_lang(style="inline")
     has_abstracts = bool(abstracts)
 
+    # Evitar repetição de dígitos quando last_page começa com os mesmos dígitos que first_page
+    first_page, last_page = abbreviate_page_range(meta.fpage, meta.lpage)
+
     fields = [
         ("e", meta.elocation_id, simple_kv),
-        ("f", meta.fpage, simple_kv),
-        ("l", meta.lpage, simple_kv),
+        ("f", first_page, simple_kv),
+        ("l", last_page, simple_kv),
         ("_", "", simple_kv),
     ]
     paginations_or_elocation = generate_am_dict(fields)
@@ -90,7 +94,6 @@ def get_articlemeta_issue(xml_tree):
         ("v42", pages, simple_field),  # tipo de conteúdo
         ("v701", "1", simple_field),  # Número sequencial por tipo de registro
         # fixme: definir a obtenção do valor de v701
-
     ]
 
     return generate_am_dict(fields)
@@ -172,10 +175,12 @@ def get_affs(xml_tree):
             ("1", item.get("orgdiv1"), simple_kv),             # orgdiv1
             ("2", item.get("orgdiv2"), simple_kv),             # orgdiv2
             ("3", item.get("orgdiv3"), simple_kv),             # orgdiv3
+            ("4", item.get("normalized"), simple_kv),          # instituição normalizada
             ("p", item.get("country_name"), simple_kv),        # país (nome)
             ("s", item.get("state"), simple_kv),               # estado
             ("e", item.get("email"), simple_kv),               # e-mail
             ("_", item.get("orgname"), simple_kv),             # nome da organização
+            ("9", item.get("original_affiliation_text"), simple_kv),            # original
         ]
         full_affs = generate_am_dict(fields_full_affs)
         if full_affs:
@@ -214,33 +219,64 @@ def extract_authors(all_authors):
 
     for author in all_authors or []:
         name_parts = [v for v in [author.get("given-names"), author.get("prefix")] if v is not None]
-        surname_parts = [v for v in [author.get("surname"), author.get("suffix")] if v is not None]
-
         name = " ".join(name_parts)
-        surname = " ".join(surname_parts)
 
         fields = [
-            ("n", name, simple_kv),     # prenome
-            ("s", surname, simple_kv),         # sobrenome
+            ("n", name, simple_kv),                          # prenome
+            ("s", author.get("surname"), simple_kv),         # sobrenome
+            ("z", author.get("suffix"), simple_kv),          # sufixo
             ("r", author.get("role", "ND"), simple_kv),      # tipo de contribuição
             ("_", "", simple_kv),                            # campo vazio obrigatório
         ]
 
         authors = generate_am_dict(fields)
-        if name or surname:
+        if name or author.get("surname"):
             authors_list.append(authors)
 
     return authors_list
 
 
-def format_page_range(fpage, lpage):
-    if fpage and not lpage:
-        return fpage
-    if lpage and not fpage:
-        return lpage
-    if fpage == lpage:
-        return fpage
-    return f"{fpage}-{lpage}"
+def normalize_date_from_parts(date_parts):
+    """
+    Converte um dicionário com partes de data (como o retornado por `Date.data`)
+    para o formato AAAAMMDD, tratando season, year, month e day.
+
+    Prioridade:
+    - year + season → usa último mês do trimestre
+    - year + month + day
+    - year + month
+    - year
+
+    Retorna:
+        str ou None: Data normalizada no formato AAAAMMDD ou None
+    """
+    if not date_parts or "year" not in date_parts:
+        return None
+
+    year = date_parts["year"]
+    season = date_parts.get("season")
+    month = date_parts.get("month")
+    day = date_parts.get("day")
+
+    if season:
+        season_to_month = {
+            "Jan-Mar": "03",
+            "Apr-Jun": "06",
+            "Jul-Sep": "09",
+            "Oct-Dec": "12",
+        }
+        mm = season_to_month.get(season)
+        if mm:
+            return f"{year}{mm}00"
+        # fallback: só o ano
+        return f"{year}0000"
+
+    if month and day:
+        return f"{year}{month.zfill(2)}{day.zfill(2)}"
+    elif month:
+        return f"{year}{month.zfill(2)}00"
+    else:
+        return f"{year}0000"
 
 
 def get_dates(xml_tree):
@@ -251,7 +287,8 @@ def get_dates(xml_tree):
 
     accepted_date = format_date(dt.history_dates_dict.get("accepted"), ["year", "month", "day"])
     received_date = format_date(dt.history_dates_dict.get("received"), ["year", "month", "day"])
-    collection_year = f"{format_date(dt.collection_date, ['year'])}0000" if dt.collection_date else None
+    #collection_year = f"{format_date(dt.collection_date, ['year'])}0000" if dt.collection_date else None
+    collection_year = normalize_date_from_parts(dt.collection_date)
     epub_date = format_date(dt.epub_date, ["year", "month", "day"])
 
     fields = [
@@ -358,7 +395,7 @@ def get_funding(xml_tree):
     statement = funding.funding_statement
 
     # v58: órgãos financiadores do artigo.
-    sponsors = [{"_": sponsor} for sponsor in funding.funding_sources]
+    sponsors = [{"_": sponsor} for sponsor in funding.funding_sources] or None
 
     fields = [
         ("v102", statement, simple_field),
@@ -366,6 +403,36 @@ def get_funding(xml_tree):
     ]
 
     return generate_am_dict(fields)
+
+
+def fill_languages_in_citation_fields(citation_data, external_data, idx, fields):
+    """
+    Preenche o idioma ("l") em campos específicos de uma citação (como "v12"),
+    utilizando os dados externos de citação, se disponíveis.
+
+    Parâmetros:
+    - citation_data: dict com os dados da citação (ex: uma entrada da lista de citações)
+    - external_data: dict com a chave "external_citation_data"
+    - idx: índice da citação (1-based, como em v865)
+    - fields: tupla com os nomes dos campos a serem atualizados (ex: ("v12", "v17"))
+
+    A função modifica citation_data in-place.
+    """
+    external_citations = external_data.get("external_citation_data", [])
+    if not (0 <= idx - 1 < len(external_citations)):
+        return  # índice fora do intervalo
+
+    lang = external_citations[idx - 1].get("lang")
+    if not lang:
+        return
+
+    for field in fields:
+        values = citation_data.get(field)
+        if isinstance(values, list) and values:
+            first = values[0]
+            if isinstance(first, dict) and "l" not in first:
+                first["l"] = lang
+
 
 
 def get_external_article_data(external_article_data=None):
@@ -381,14 +448,6 @@ def get_external_article_data(external_article_data=None):
         if all(k in item for k in ("k", "s", "v"))
     ]
 
-    # v936: Identificador composto do fascículo: inclui ISSN (i), ano (y), ordem no ano (o).
-    composite_issue_id = external_article_data.get("v936")
-    composite_issue_id_valid = (
-        composite_issue_id
-        if isinstance(composite_issue_id, dict) and all(k in composite_issue_id for k in ("i", "y", "o"))
-        else None
-    )
-
     # v38: tipo de ilustrações ou recursos visuais existentes no artigo.
     elements_type = [{"_": item} for item in external_article_data.get("v38") or []]
 
@@ -402,7 +461,6 @@ def get_external_article_data(external_article_data=None):
         ("created_at", external_article_data.get("created_at"), simple_kv),  # Data de criação
         ("processing_date", external_article_data.get("processing_date"), simple_kv),  # Data de processamento
         ("v35", external_article_data.get("v35"), simple_field),  # ISSN impresso
-        ("v42", external_article_data.get("v42"), simple_field),  # Status do fascículo
     ]
 
     return generate_am_dict(fields)
@@ -416,6 +474,7 @@ def get_external_common_data(external_article_data=None):
 
     fields = [
         ("collection", external_article_data.get("collection"), simple_kv),  # Nome da coleção
+        ("v1", external_article_data.get("v1"), simple_field),  # Código do centro processador
         ("v2", external_article_data.get("v2"), simple_field),               # Identificador de controle
         ("v3", external_article_data.get("v3"), simple_field),               # Caminho relativo do XML
         ("v705", external_article_data.get("v705"), simple_field),           # Tipo do registro (S = artigo)
@@ -453,12 +512,22 @@ def get_xml_common_data(xml_tree):
     ]
     volume_and_number = generate_am_dict(fields)
 
+    # valor para a tag v4 - volume e número - ex.: v4n1
+    vol = meta.volume
+    num = meta.number
+    if vol and num:
+        vol_and_num = f"v{vol}n{num}"
+    elif vol:
+        vol_and_num = f"v{vol}"
+    else:
+        vol_and_num = None
+
     # (campo comum, valor, função geradora)
     fields = [
         ("code", ids.v2, simple_kv),  # código SciELO no dicionário direto
         ("v882", volume_and_number if volume_and_number else None, complex_field),  # volume e número do fascículo
         ("v880", ids.v2, simple_field),  # código SciELO no campo v880
-        ("v4", f"v{meta.volume}" if meta.volume else None, simple_field),  # volume formatado
+        ("v4", vol_and_num, simple_field),  # volume formatado
     ]
 
     return generate_am_dict(fields)
@@ -488,67 +557,102 @@ def get_xml_article_metadata(xml_tree):
 
 
 def get_xml_citation_data(ref):
+    # Campos auxiliares para composição de valores
     comment = ref.get("comment")
     availability_note = " ".join(comment.split()) if comment else None
-    citation_title = ref.get("article_title") or ref.get("chapter_title") or ref.get("part_title")
 
+    mixed = ref.get("mixed_citation")
+    v704 = f"<mixed-citation>{mixed}</mixed-citation>" if mixed else None
+
+    size_info = ref.get("size_info")
+    v20 = {"u": size_info.get("units"), "_": size_info.get("text")} if size_info else None
+
+    url = ref.get("mixed_citation_xlink") or ref.get("comment_xlink")
+
+    citation_title = ref.get("article_title") or ref.get("chapter_title") or ref.get("part_title")
+    citation_lang = ref.get("lang")
+
+    fpage = ref.get("fpage")
+    lpage = ref.get("lpage")
+    elocation = ref.get("elocation_id")
+    first_page, last_page = abbreviate_page_range(fpage, lpage)
+
+    citation_ids = ref.get("citation_ids", {})
+    source = ref.get("source")
+    pub_type = ref.get("publication_type")
+    collab = ref.get("collab")
+    all_authors = ref.get("all_authors", [])
+
+    # Campos bibliográficos básicos (formato AM)
     fields = [
-        ("v118", ref.get("label"), simple_field),  # rótulo da citação
-        ("v12", citation_title, simple_field),  # título do artigo citado
-        ("v31", ref.get("volume"), simple_field),  # volume citado
-        ("v32", ref.get("issue"), simple_field),  # número citado
-        ("v37", ref.get("mixed_citation_xlink"), simple_field),  # link do DOI da citação
-        ("v71", ref.get("publication_type"), simple_field),  # tipo de publicação
-        ("v14", format_page_range(ref.get("fpage"), ref.get("lpage")), simple_field), # intervalo de páginas
-        ("v64", format_date(ref, ["year"]), simple_field),  # ano da publicação da referência
-        ("v65", f"{format_date(ref, ["year"])}0000", simple_field),  # ano + '0000'
-        ("v237", ref.get("citation_ids", {}).get("doi"), simple_field),  # DOI
-        ("v62", ref.get("publisher_name"), simple_field),  # Nome do editor
-        ("v66", ref.get("publisher_loc"), simple_field),  # Localização do editor
-        ("v61", availability_note, simple_field), # Nota de disponibilidade da obra citada
+        ("v118", ref.get("label"), simple_field),
+        ("v20", v20, complex_field),
+        ("v31", ref.get("volume"), simple_field),
+        ("v32", ref.get("issue"), simple_field),
+        ("v37", url, simple_field),
+        ("v71", pub_type, simple_field),
+        ("v14", format_page_range(first_page, last_page), simple_field),
+        ("v64", format_date(ref, ["year"]), simple_field),
+        ("v65", f"{format_date(ref, ['year'])}0000", simple_field),
+        ("v237", citation_ids.get("doi"), simple_field),
+        ("v62", ref.get("publisher_name"), simple_field),
+        ("v66", ref.get("publisher_loc"), simple_field),
+        ("v61", availability_note, simple_field),
         ("v810", "et al" if ref.get("has_etal") else None, simple_field),
         ("v63", ref.get("edition"), simple_field),
+        ("v704", v704, simple_field),
+        ("v60", comment, simple_field),
     ]
 
-    pagination_fields = [
-        ("l", lpage := ref.get("lpage"), simple_kv),
-        ("f", fpage := ref.get("fpage"), simple_kv),
-        ("e", elocation := ref.get("elocation_id"), simple_kv),
-    ]
-    if lpage or fpage or elocation:
-        pagination_fields.append(
-            ("_", "", simple_kv),
+    # Título da parte citada
+    if citation_title:
+        title_field = (
+            {"_": citation_title, "l": citation_lang}
+            if citation_lang else citation_title
         )
-    if ref.get("publication_type") in ["book", "confproc", "journal", "legal-doc", "newspaper", "report", "thesis"]:
-        fields.append(("v514", generate_am_dict(pagination_fields), complex_field))  # paginação
+        fields.append(("v12", title_field, complex_field if citation_lang else simple_field))
 
-    # Determina se a referência é analítica (possui título de parte)
+    # Paginação completa (v514)
+    pagination_fields = [
+        ("l", lpage, simple_kv),
+        ("f", fpage, simple_kv),
+        ("e", elocation, simple_kv),
+    ]
+    if any([lpage, fpage, elocation]):
+        pagination_fields.append(("_", "", simple_kv))
+    if pub_type in ["book", "confproc", "journal", "legal-doc", "newspaper", "report", "thesis"]:
+        fields.append(("v514", generate_am_dict(pagination_fields), complex_field))
+
+    # Autores e tipo de obra
     is_analytic = any(ref.get(tag) for tag in ("article_title", "part_title", "chapter_title"))
-
-    all_authors = ref.get("all_authors", [])
-    collab = ref.get("collab")
-    source = ref.get("source")
 
     if is_analytic:
         analytic_authors = [a for a in all_authors if a.get("person_group_type") == "author"]
         monographic_authors = [a for a in all_authors if a.get("person_group_type") == "editor"]
 
-        fields.append(("v10", extract_authors(analytic_authors), multiple_complex_field))  # autores analíticos
-        fields.append(("v16", extract_authors(monographic_authors),
-                       multiple_complex_field))  # editores como autores monográficos (ex: capítulo de livro)
-        fields.append(("v11", collab[0] if collab else None, simple_field))  # colaborador institucional (analítico)
+        fields.append(("v10", extract_authors(analytic_authors), multiple_complex_field))
+        fields.append(("v16", extract_authors(monographic_authors), multiple_complex_field))
+        fields.append(("v11", collab[0] if collab else None, simple_field))
 
-        # Decide se é obra monográfica (editor) ou periódica (ex: journal)
-        fields.append(("v18" if monographic_authors else "v30", source, simple_field))
-
+        if monographic_authors and source:
+            title_value = {"_": source, "l": citation_lang} if citation_lang else source
+            title_func = complex_field if citation_lang else simple_field
+            fields.append(("v18", title_value, title_func))
+        else:
+            fields.append(("v30", source, simple_field))
     else:
-        fields.append(("v16", extract_authors(all_authors), multiple_complex_field))  # autores monográficos
-        fields.append(("v17", collab[0] if collab else None, simple_field))  # colaborador institucional (monográfico)
-        fields.append(("v18", source, simple_field))  # título da obra monográfica
+        fields.append(("v16", extract_authors(all_authors), multiple_complex_field))
+        fields.append(("v17", collab[0] if collab else None, simple_field))
 
-    fields.append(("v109", ref.get("date_in_citation"), simple_field))  # Data de publicação de obra não seriada
+        title_value = {"_": source, "l": citation_lang} if citation_lang else source
+        title_func = complex_field if citation_lang else simple_field
+        fields.append(("v18", title_value, title_func))
+
+    # Data de publicação não seriada
+    fields.append(("v109", ref.get("date_in_citation"), simple_field))
 
     return generate_am_dict(fields)
+
 
 
 def build(xml_tree, external_data=None):
@@ -602,6 +706,9 @@ def build(xml_tree, external_data=None):
         citation_data.update(simple_field("v701", str(idx))) # Número sequencial por tipo de registro
         citation_data.update(simple_field("v708", citations_number)) # Número de citações do artigo
         citation_data.update(simple_field("v706", "c"))  # Tipo de registro
+
+        # Caso não haja idioma para o título da citação, tenta preencher com dado externo (e houver)
+        fill_languages_in_citation_fields(citation_data, external_data, idx, ("v12", "v18"))
 
         citations_data.append(citation_data)
 

--- a/packtools/sps/formats/am/am_utils.py
+++ b/packtools/sps/formats/am/am_utils.py
@@ -1,3 +1,5 @@
+import re
+
 ARTICLE_TYPE_MAP = {
     "research-article": "oa",
     "editorial": "ed",
@@ -78,3 +80,34 @@ def generate_am_dict(fields):
 def simple_kv(tag, value):
     return {tag: value}
 
+def format_page_range(fpage, lpage):
+    if fpage and not lpage:
+        return fpage
+    if lpage and not fpage:
+        return lpage
+    if fpage == lpage:
+        return fpage
+    return f"{fpage}-{lpage}"
+
+
+def abbreviate_page_range(first, last):
+    """
+    Abrevia a última página removendo o primeiro dígito comum com a primeira página,
+    apenas se ambos tiverem o mesmo número de dígitos.
+    """
+    if not first or not last:
+        return first, last
+
+    if not first.isdigit() or not last.isdigit():
+        return first, last
+
+    if first == last:
+        return first, last
+
+    if len(first) != len(last):
+        return first, last
+
+    if first[0] == last[0]:
+        return first, last[1:]
+
+    return first, last

--- a/packtools/sps/models/references.py
+++ b/packtools/sps/models/references.py
@@ -119,6 +119,12 @@ class Reference:
             return ext_link.get("{http://www.w3.org/1999/xlink}href")
         return None
 
+    def get_comment_xlink(self):
+        ext_link = self.ref.find(".//comment//ext-link[@ext-link-type='uri']")
+        if ext_link is not None:
+            return ext_link.get("{http://www.w3.org/1999/xlink}href")
+        return None
+
     def get_mixed_citation_sub_tags(self):
         element = self.ref.find("./mixed-citation")
         if element is not None:
@@ -192,6 +198,20 @@ class Reference:
     def get_edition(self):
         return node_plain_text(self.ref.find("./element-citation/edition"))
 
+    def get_citation_lang(self):
+        citation = self.ref.find("./element-citation")
+        if citation is not None:
+            return citation.get("{http://www.w3.org/XML/1998/namespace}lang")
+        return None
+
+    def get_size_info(self):
+        size_el = self.ref.find(".//size")
+        if size_el is not None and size_el.text:
+            units = size_el.get("units")
+            text = size_el.text.strip()
+            return {"units": units, "text": text}
+        return None
+
     @property
     def data(self):
         tags = [
@@ -214,12 +234,15 @@ class Reference:
             ("chapter_title", self.get_chapter_title()),
             ("part_title", self.get_part_title()),
             ("mixed_citation_xlink", self.get_mixed_citation_xlink()),
+            ("comment_xlink", self.get_comment_xlink()),
             ("collab", self.get_collab()),
             ("publisher_name", self.get_publisher_name()),
             ("publisher_loc", self.get_publisher_loc()),
             ("date_in_citation", self.get_date_in_citation()),
             ("comment", self.get_comment()),
             ("edition", self.get_edition()),
+            ("lang", self.get_citation_lang()),
+            ("size_info", self.get_size_info()),
         ]
         d = dict()
         for name, value in tags:

--- a/tests/sps/formats/am/test_am.py
+++ b/tests/sps/formats/am/test_am.py
@@ -431,7 +431,7 @@ class TestGetCitations(BaseTest):
         self.assertEqual(self.first_ref["v3"], [{"_": "1518-8345-rlae-33-e4434.xml"}])
 
     def test_field_v4(self):
-        self.assertEqual(self.first_ref["v4"], [{"_": "V33"}])
+        self.assertEqual(self.first_ref["v4"], [{"_": "v33"}])
 
     def test_field_v992(self):
         self.assertEqual(self.first_ref["v992"], [{"_": "scl"}])
@@ -465,9 +465,6 @@ class TestGetCitations(BaseTest):
         self.assertEqual(self.first_ref["v237"], [{"_": "10.1176/appi.ajp.2019.19010020"}])
         self.assertEqual(self.last_ref["v237"], [{"_": "10.4013/ctc.2019.121.10"}])
 
-    def test_field_v17(self):
-        self.assertEqual(self.am_format["citations"][1]["v17"], [{"_": "Instituto de Pesquisa Econômica Aplicada"}])
-
     def test_field_v18(self):
         self.assertIsNone(self.am_format["citations"][1].get("v18")) # Não tem a tag <source>
         self.assertEqual(self.am_format["citations"][5]["v18"], [{"_": "Handbook of Child Psychology"}])
@@ -492,10 +489,10 @@ class TestGetCitations(BaseTest):
         self.assertEqual(self.am_format["citations"][1]["v11"], [{"_": "Instituto de Pesquisa Econômica Aplicada"}])
 
     def test_field_v16(self):
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][0], {'_': '', 'n': 'U.', 'r': 'ND', 's': 'Bronfenbrenner'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][1], {'_': '', 'n': 'P. A.', 'r': 'ND', 's': 'Morris'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][2], {'_': '', 'n': 'W.', 'r': 'ND', 's': 'Damon'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][3], {'_': '', 'n': 'R. M.', 'r': 'ND', 's': 'Lerner'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][0], {'_': '', 'n': 'W.', 'r': 'ND', 's': 'Damon'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][1], {'_': '', 'n': 'R. M.', 'r': 'ND', 's': 'Lerner'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][2], {'_': '', 'n': 'E.', 'r': 'ND', 's': 'Pearson'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][3], {'_': '', 'n': 'C. N.', 'r': 'ND', 's': 'van der Veere'})
 
 
 
@@ -587,7 +584,7 @@ class TestGetTitle(BaseTest):
 class TestGetFunding(BaseTest):
     def setUp(self):
         self.xml_tree = xml_utils.get_xml_tree(
-            "tests/sps/formats/am/examples/S0034-89102025000100200/S0034-89102025000100200.xml"
+            "packtools/sps/formats/am/S0034-89102025000100200/S0034-89102025000100200.xml"
         )
         self.funding_data = am.get_funding(self.xml_tree)
 
@@ -619,9 +616,6 @@ class TestExternalFields(BaseTest):
 
     def test_field_v992(self):
         self.assertEqual(self.external_data_formated["v992"], [{"_": "scl"}])
-
-    def test_field_v42(self):
-        self.assertEqual(self.external_data_formated["v42"], [{"_": "1"}])
 
     def test_field_v49(self):
         self.assertEqual(self.external_data_formated["v49"], [{"_": "RLAE350"}])

--- a/tests/sps/models/test_aff.py
+++ b/tests/sps/models/test_aff.py
@@ -727,6 +727,7 @@ class AffiliationTest(TestCase):
             {
                 "id": "aff1",
                 "label": "I",
+                "normalized": None,
                 "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
                 "orgdiv1": None,
                 "orgdiv2": None,
@@ -748,6 +749,7 @@ class AffiliationTest(TestCase):
                 "state": "MG",
                 "country_code": None,
                 "country_name": "Brasil",
+                "normalized": None,
                 "orgname": "Universidade Federal de Minas Gerais",
                 "orgdiv1": "Faculdade de Medicina",
                 "orgdiv2": None,
@@ -761,6 +763,7 @@ class AffiliationTest(TestCase):
             {
                 "id": "aff3",
                 "label": "III",
+                "normalized": None,
                 "orgname": "Fundação Oswaldo Cruz",
                 "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
                 "orgdiv2": "Departamento de Ciências Sociais",
@@ -778,6 +781,7 @@ class AffiliationTest(TestCase):
             {
                 "id": "aff4",
                 "label": "IV",
+                "normalized": None,
                 "orgname": "Universidade Federal de Minas Gerais",
                 "orgdiv1": "Faculdade de Farmácia",
                 "orgdiv2": "Departamento de Farmácia Social",
@@ -795,6 +799,7 @@ class AffiliationTest(TestCase):
             {
                 "id": "aff5",
                 "label": "V",
+                "normalized": None,
                 "orgname": "Universidade Federal do Ceará",
                 "orgdiv1": "Faculdade de Medicina",
                 "orgdiv2": "Departamento de Saúde Comunitária",
@@ -835,6 +840,7 @@ class AffiliationTest(TestCase):
                         <label>II</label>
                         <institution content-type="orgdiv1">Faculdade de Medicina</institution>
                         <institution content-type="orgname">Universidade Federal de Minas Gerais</institution>
+                        <institution content-type="normalized">Universidade Estadual do Oeste do Paraná</institution>
                         <addr-line>
                             <named-content content-type="city">Belo Horizonte</named-content>
                             <named-content content-type="state">MG</named-content>
@@ -894,6 +900,7 @@ class AffiliationTest(TestCase):
             "aff1": {
                 "id": "aff1",
                 "label": "I",
+                "normalized": None,
                 "orgname": "Secretaria Municipal de Saúde de Belo Horizonte",
                 "orgdiv1": None,
                 "orgdiv2": None,
@@ -915,6 +922,7 @@ class AffiliationTest(TestCase):
                 "state": "MG",
                 "country_code": None,
                 "country_name": "Brasil",
+                "normalized": "Universidade Estadual do Oeste do Paraná",
                 "orgname": "Universidade Federal de Minas Gerais",
                 "orgdiv1": "Faculdade de Medicina",
                 "orgdiv2": None,
@@ -928,6 +936,7 @@ class AffiliationTest(TestCase):
             "aff3": {
                 "id": "aff3",
                 "label": "III",
+                "normalized": None,
                 "orgname": "Fundação Oswaldo Cruz",
                 "orgdiv1": "Escola Nacional de Saúde Pública Sergio Arouca",
                 "orgdiv2": "Departamento de Ciências Sociais",
@@ -945,6 +954,7 @@ class AffiliationTest(TestCase):
             "aff4": {
                 "id": "aff4",
                 "label": "IV",
+                "normalized": None,
                 "orgname": "Universidade Federal de Minas Gerais",
                 "orgdiv1": "Faculdade de Farmácia",
                 "orgdiv2": "Departamento de Farmácia Social",
@@ -962,6 +972,7 @@ class AffiliationTest(TestCase):
             "aff5": {
                 "id": "aff5",
                 "label": "V",
+                "normalized": None,
                 "orgname": "Universidade Federal do Ceará",
                 "orgdiv1": "Faculdade de Medicina",
                 "orgdiv2": "Departamento de Saúde Comunitária",

--- a/tests/sps/models/test_references.py
+++ b/tests/sps/models/test_references.py
@@ -478,6 +478,7 @@ class XMLReferencesTest(TestCase):
         self.assertEqual(None, ref["text_between"])
         self.assertEqual(False, ref["has_comment"])    
     # Teste para subarticle_references
+
     def test_subarticle_references(self):
         xml = """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
@@ -536,3 +537,22 @@ class XMLReferencesTest(TestCase):
         sources = [ref.get("source") for ref in all_items]
         self.assertIn("Main Source", sources)
         self.assertIn("Abstract Source", sources)
+
+    def test_get_citation_lang(self):
+        xml = """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article">
+                <back>
+                    <ref-list>
+                        <ref id="B1">
+                            <element-citation publication-type="journal" xml:lang="es">
+                                <source>Main Source</source>
+                            </element-citation>
+                        </ref>
+                    </ref-list>
+                </back>
+            </article>
+        """
+        xml_tree = etree.fromstring(xml)
+        references = list(XMLReferences(xml_tree).main_references)
+        lang = references[0].get("lang")
+        self.assertEqual(lang, "es")


### PR DESCRIPTION
#### O que esse PR faz?
Este PR aprimora a geração dos metadados ArticleMeta com foco na qualidade e completude das citações bibliográficas, afiliações institucionais e dados de paginação. As principais melhorias incluem:

- Abreviação inteligente de intervalos de páginas (ex: 123–129 → 123–29)
- Inclusão dos campos `normalized` e `original_affiliation_text` nas afiliações
- Normalização de datas a partir de partes (como `year`, `season`, `month`, `day`)
- Inclusão dos campos `v20`, `v704` e aprimoramento no preenchimento de `v12` e `v18` com suporte a idiomas
- Novo método `fill_languages_in_citation_fields` que complementa idioma de campos a partir de dados externos
- Refatoração da função `get_xml_citation_data` para tornar a estrutura de citação mais clara e precisa
- Ajustes nos testes unitários para refletir as mudanças

#### Onde a revisão poderia começar?
O ponto ideal para início da revisão é em:
`packtools/sps/formats/am/am.py`
Dessa forma é possível acompanhar a lógica central das mudanças na geração dos campos do ArticleMeta. Em seguida, revisar:

- `am_utils.py `para as novas funções auxiliares (`abbreviate_page_range`, `format_page_range`, etc.)
- `models/aff.py` e `models/references.py` para as novas extrações de dados
- Testes em `tests/sps/...` para ver a cobertura e adequação

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.
