### PR TITLE
Refactor/am fields v121 v32 v170

### DIFF
--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -21,7 +21,9 @@ from packtools.sps.formats.am.am_utils import (
     ARTICLE_TYPE_MAP,
     generate_am_dict,
     simple_kv,
-    abbreviate_page_range, format_page_range,
+    abbreviate_page_range,
+    format_page_range,
+    map_contrib_type_to_isis_role,
 )
 
 
@@ -213,29 +215,26 @@ def count_references(xml_tree):
     return str(len(refs))
 
 
-def extract_authors(all_authors):
+def extract_author(author):
     """
-    Extrai e estrutura os dados simplificados dos autores no formato ArticleMeta (v10).
+    Extrai e estrutura os dados simplificados do autor no formato ArticleMeta.
     """
-    authors_list = []
+    author_type = map_contrib_type_to_isis_role(author.get("person_group_type"))
+    name_parts = [v for v in [author.get("given-names"), author.get("prefix")] if v is not None]
+    name = " ".join(name_parts)
 
-    for author in all_authors or []:
-        name_parts = [v for v in [author.get("given-names"), author.get("prefix")] if v is not None]
-        name = " ".join(name_parts)
+    if not(name or author.get("surname")):
+        return None
 
-        fields = [
-            ("n", name, simple_kv),                          # prenome
-            ("s", author.get("surname"), simple_kv),         # sobrenome
-            ("z", author.get("suffix"), simple_kv),          # sufixo
-            ("r", author.get("role", "ND"), simple_kv),      # tipo de contribuição
-            ("_", "", simple_kv),                            # campo vazio obrigatório
-        ]
+    fields = [
+        ("n", name, simple_kv),                          # prenome
+        ("s", author.get("surname"), simple_kv),         # sobrenome
+        ("z", author.get("suffix"), simple_kv),          # sufixo
+        ("r", author_type, simple_kv),                   # tipo de contribuição
+        ("_", "", simple_kv),                            # campo vazio obrigatório
+    ]
 
-        authors = generate_am_dict(fields)
-        if name or author.get("surname"):
-            authors_list.append(authors)
-
-    return authors_list
+    return generate_am_dict(fields)
 
 
 def normalize_date_from_parts(date_parts):
@@ -571,6 +570,93 @@ def get_xml_article_metadata(xml_tree):
     }
 
 
+def get_citation_title(ref):
+    """
+    Extrai o título da parte citada, retornando os dados para o campo v12 do formato ArticleMeta.
+    """
+    citation_title = (
+        ref.get("article_title")
+        or ref.get("chapter_title")
+        or ref.get("part_title")
+    )
+    if not citation_title:
+        return None
+
+    citation_lang = ref.get("lang")
+    title_field = (
+        {"_": citation_title, "l": citation_lang}
+        if citation_lang else citation_title
+    )
+    title_func = complex_field if citation_lang else simple_field
+
+    return "v12", title_field, title_func
+
+
+def get_citation_pagination(ref):
+    """
+    Retorna a informação de paginação (v514) de uma citação.
+    """
+    fpage = ref.get("fpage")
+    lpage = ref.get("lpage")
+    elocation = ref.get("elocation_id")
+    pub_type = ref.get("publication_type")
+
+    if not any([fpage, lpage, elocation]):
+        return None
+
+    pagination_fields = [
+        ("l", lpage, simple_kv),
+        ("f", fpage, simple_kv),
+        ("e", elocation, simple_kv),
+        ("_", "", simple_kv),  # campo obrigatório quando existe qualquer valor
+    ]
+
+    if pub_type in {
+        "book", "confproc", "journal", "legal-doc",
+        "newspaper", "report", "thesis"
+    }:
+        return "v514", generate_am_dict(pagination_fields), complex_field
+
+    return None
+
+
+def is_analytic_author(ref, person_group_type=None):
+    """
+    Retorna True se o autor deve ser considerado analítico (parte de uma obra),
+    ou False se for monográfico (obra completa).
+
+    - Em publicações do tipo "book", autores de capítulo são analíticos.
+    - Editores em livros são monográficos.
+    """
+    pub_type = ref.get("publication_type")
+    is_book = pub_type == "book"
+    has_chapter = bool(ref.get("part_title") or ref.get("chapter_title"))
+
+    if is_book:
+        if person_group_type == "editor":
+            return False
+        return has_chapter
+
+    return pub_type in {"journal", "confproc", "newspaper", "preprint"}
+
+
+def determine_author_tag(ref, person_group_type):
+    """
+    Decide qual tag de autor aplicar (v10, v11, v16 ou v17) com base nos metadados de uma referência.
+    """
+    is_person = ref.get("author_type") == "person"
+    is_analytic = is_analytic_author(ref, person_group_type)
+
+    if is_person and is_analytic:
+        return "v10"  # Pessoa, analítica
+    elif not is_person and is_analytic:
+        return "v11"  # Instituição, analítica
+    elif is_person and not is_analytic:
+        return "v16"  # Pessoa, monográfica
+    else:
+        return "v17"  # Instituição, monográfica
+
+
 def get_xml_citation_data(ref):
     # Campos auxiliares para composição de valores
     comment = ref.get("comment")
@@ -582,87 +668,61 @@ def get_xml_citation_data(ref):
     size_info = ref.get("size_info")
     v20 = {"u": size_info.get("units"), "_": size_info.get("text")} if size_info else None
 
-    citation_title = ref.get("article_title") or ref.get("chapter_title") or ref.get("part_title")
-    citation_lang = ref.get("lang")
-
-    fpage = ref.get("fpage")
-    lpage = ref.get("lpage")
-    elocation = ref.get("elocation_id")
-    first_page, last_page = abbreviate_page_range(fpage, lpage)
+    first_page, last_page = abbreviate_page_range(ref.get("fpage"), ref.get("lpage"))
 
     citation_ids = ref.get("citation_ids", {})
-    source = ref.get("source")
-    pub_type = ref.get("publication_type")
-    collab = ref.get("collab")
-    all_authors = ref.get("all_authors", [])
 
     # Campos bibliográficos básicos (formato AM)
     fields = [
-        ("v118", ref.get("label"), simple_field),
+        ("v14", format_page_range(first_page, last_page), simple_field),
         ("v20", v20, complex_field),
         ("v31", ref.get("volume"), simple_field),
         ("v32", ref.get("issue"), simple_field),
         ("v37", ref.get("xlink"), simple_field),
-        ("v71", pub_type, simple_field),
-        ("v14", format_page_range(first_page, last_page), simple_field),
+        ("v51", ref.get("degree"), simple_field),
+        ("v53", ref.get("conf_name"), simple_field),
+        ("v56", ref.get("conf_loc"), simple_field),
+        ("v60", comment, simple_field),
+        ("v61", availability_note, simple_field),
+        ("v62", ref.get("publisher_name"), simple_field),
+        ("v63", ref.get("edition"), simple_field),
         ("v64", format_date(ref, ["year"]), simple_field),
         ("v65", f"{format_date(ref, ['year'])}0000", simple_field),
-        ("v237", citation_ids.get("doi"), simple_field),
-        ("v62", ref.get("publisher_name"), simple_field),
         ("v66", ref.get("publisher_loc"), simple_field),
-        ("v61", availability_note, simple_field),
-        ("v810", "et al" if ref.get("has_etal") else None, simple_field),
-        ("v63", ref.get("edition"), simple_field),
+        ("v71", ref.get("publication_type"), simple_field),
+        ("v109", ref.get("date_in_citation"), simple_field),
+        ("v118", ref.get("label"), simple_field),
+        ("v237", citation_ids.get("doi"), simple_field),
         ("v704", v704, simple_field),
-        ("v60", comment, simple_field),
-        ("v53", ref.get("conf_name"), simple_field),
+        ("v810", "et al" if ref.get("has_etal") else None, simple_field),
     ]
 
-    # Título da parte citada
-    if citation_title:
-        title_field = (
-            {"_": citation_title, "l": citation_lang}
-            if citation_lang else citation_title
-        )
-        fields.append(("v12", title_field, complex_field if citation_lang else simple_field))
+    citation_title_field = get_citation_title(ref) # v12
+    if citation_title_field:
+        fields.append(citation_title_field)
 
-    # Paginação completa (v514)
-    pagination_fields = [
-        ("l", lpage, simple_kv),
-        ("f", fpage, simple_kv),
-        ("e", elocation, simple_kv),
-    ]
-    if any([lpage, fpage, elocation]):
-        pagination_fields.append(("_", "", simple_kv))
-    if pub_type in ["book", "confproc", "journal", "legal-doc", "newspaper", "report", "thesis"]:
-        fields.append(("v514", generate_am_dict(pagination_fields), complex_field))
+    pagination_field = get_citation_pagination(ref) # v514
+    if pagination_field:
+        fields.append(pagination_field)
 
-    # Autores e tipo de obra
-    is_analytic = any(ref.get(tag) for tag in ("article_title", "part_title", "chapter_title"))
-    analytic_authors = [a for a in all_authors if a.get("person_group_type") == "author"]
-    monographic_authors = [a for a in all_authors if a.get("person_group_type") == "editor"]
+    # Autores (v10, v11, v16 ou v17)
+    authors = {}
+    for author in ref.get("all_authors", []):
+        tag = determine_author_tag(ref, author.get("person_group_type"))
+        authors.setdefault(tag, [])
+        authors[tag].append(extract_author(author))
 
-    fields.append(("v10", extract_authors(analytic_authors), multiple_complex_field))
-    fields.append(("v16", extract_authors(monographic_authors), multiple_complex_field))
+    for tag, author_list in authors.items():
+        fields.append((tag, author_list, multiple_complex_field))
 
-    if is_analytic:
-        fields.append(("v11", collab[0] if collab else None, simple_field))
-
-        if monographic_authors and source:
-            title_value = {"_": source, "l": citation_lang} if citation_lang else source
-            title_func = complex_field if citation_lang else simple_field
-            fields.append(("v18", title_value, title_func))
-        else:
-            fields.append(("v30", source, simple_field))
+    citation_lang = ref.get("lang")
+    source = ref.get("source")
+    if is_analytic_author(ref):
+        fields.append(("v30", source, simple_field))
     else:
-        fields.append(("v17", collab[0] if collab else None, simple_field))
-
         title_value = {"_": source, "l": citation_lang} if citation_lang else source
         title_func = complex_field if citation_lang else simple_field
         fields.append(("v18", title_value, title_func))
-
-    # Data de publicação não seriada
-    fields.append(("v109", ref.get("date_in_citation"), simple_field))
 
     return generate_am_dict(fields)
 

--- a/packtools/sps/formats/am/am_utils.py
+++ b/packtools/sps/formats/am/am_utils.py
@@ -59,7 +59,7 @@ def multiple_complex_field(key, value_list):
     return {}
 
 
-def format_date(date_dict, fields):
+def format_date(date_dict, fields, sep=""):
     """
     Concatena campos de uma data (como 'year', 'month', 'day') em uma string compacta.
     Retorna None se o dicionário for None ou se todos os campos estiverem ausentes.
@@ -67,7 +67,7 @@ def format_date(date_dict, fields):
     if not date_dict:
         return None
     parts = [date_dict.get(field, "") for field in fields]
-    return "".join(parts) if any(parts) else None
+    return sep.join(parts) if any(parts) else None
 
 
 def generate_am_dict(fields):
@@ -107,7 +107,8 @@ def abbreviate_page_range(first, last):
     if len(first) != len(last):
         return first, last
 
-    if first[0] == last[0]:
-        return first, last[1:]
+    for i in range(len(first)):
+        if first[i] != last[i]:
+            return first, last[i:]
 
     return first, last

--- a/packtools/sps/formats/am/am_utils.py
+++ b/packtools/sps/formats/am/am_utils.py
@@ -112,3 +112,35 @@ def abbreviate_page_range(first, last):
             return first, last[i:]
 
     return first, last
+
+
+def map_contrib_type_to_isis_role(person_group_type):
+    """
+    Mapeia valores de @person-group-type (JATS) para os códigos 'r' usados em ArticleMeta (ISIS).
+
+    Parâmetros:
+    -----------
+    person_group_type : str
+        Valor do atributo @person-group-type (ex: 'author', 'editor', 'translator', etc.)
+
+    Retorna:
+    --------
+    str
+        Código do atributo 'r' correspondente (ex: 'ND', 'ED', 'TR', etc.)
+    """
+    person_type = (person_group_type or "").strip().lower()
+
+    mapping = {
+        "author": "ND",
+        "allauthors": "ND",
+        "editor": "ED",
+        "guest-editor": "ED",
+        "transed": "ED",
+        "translator": "TR",
+        "compiler": "CO",
+        "research-assistant": "CO",
+        "director": "ED",
+    }
+
+    # Retorna o valor mapeado ou None se não houver mapeamento válido
+    return mapping.get(person_type, None)

--- a/packtools/sps/models/references.py
+++ b/packtools/sps/models/references.py
@@ -113,14 +113,8 @@ class Reference:
     def get_mixed_citation(self):
         return node_plain_text(self.ref.find("./mixed-citation"))
 
-    def get_mixed_citation_xlink(self):
-        ext_link = self.ref.find(".//mixed-citation//ext-link[@ext-link-type='uri']")
-        if ext_link is not None:
-            return ext_link.get("{http://www.w3.org/1999/xlink}href")
-        return None
-
-    def get_comment_xlink(self):
-        ext_link = self.ref.find(".//comment//ext-link[@ext-link-type='uri']")
+    def get_xlink(self):
+        ext_link = self.ref.find(".//ext-link[@ext-link-type='uri']")
         if ext_link is not None:
             return ext_link.get("{http://www.w3.org/1999/xlink}href")
         return None
@@ -212,6 +206,9 @@ class Reference:
             return {"units": units, "text": text}
         return None
 
+    def get_conf_name(self):
+        return node_plain_text(self.ref.find("./element-citation/conf-name"))
+
     @property
     def data(self):
         tags = [
@@ -233,8 +230,7 @@ class Reference:
             ("mixed_citation_sub_tags", self.get_mixed_citation_sub_tags()),
             ("chapter_title", self.get_chapter_title()),
             ("part_title", self.get_part_title()),
-            ("mixed_citation_xlink", self.get_mixed_citation_xlink()),
-            ("comment_xlink", self.get_comment_xlink()),
+            ("xlink", self.get_xlink()),
             ("collab", self.get_collab()),
             ("publisher_name", self.get_publisher_name()),
             ("publisher_loc", self.get_publisher_loc()),
@@ -243,6 +239,7 @@ class Reference:
             ("edition", self.get_edition()),
             ("lang", self.get_citation_lang()),
             ("size_info", self.get_size_info()),
+            ("conf_name", self.get_conf_name()),
         ]
         d = dict()
         for name, value in tags:

--- a/packtools/sps/models/references.py
+++ b/packtools/sps/models/references.py
@@ -189,6 +189,12 @@ class Reference:
             return None
         return "".join(el.itertext()).strip()
 
+    def get_degree(self):
+        el = self.ref.xpath('./element-citation/comment[@content-type="degree"]')
+        if len(el) == 0:
+            return None
+        return "".join(el[0].itertext()).strip()
+
     def get_edition(self):
         return node_plain_text(self.ref.find("./element-citation/edition"))
 
@@ -208,6 +214,9 @@ class Reference:
 
     def get_conf_name(self):
         return node_plain_text(self.ref.find("./element-citation/conf-name"))
+
+    def get_conf_loc(self):
+        return node_plain_text(self.ref.find("./element-citation/conf-loc"))
 
     @property
     def data(self):
@@ -240,6 +249,8 @@ class Reference:
             ("lang", self.get_citation_lang()),
             ("size_info", self.get_size_info()),
             ("conf_name", self.get_conf_name()),
+            ("conf_loc", self.get_conf_loc()),
+            ("degree", self.get_degree()),
         ]
         d = dict()
         for name, value in tags:

--- a/tests/sps/models/test_aff.py
+++ b/tests/sps/models/test_aff.py
@@ -822,6 +822,7 @@ class AffiliationTest(TestCase):
                 self.assertDictEqual(item, expected_output[i])
 
     def test_extract_affiliation_by_id_only_from_article_meta(self):
+        self.maxDiff = None
         xml = """
         <article>
             <front>


### PR DESCRIPTION
#### O que esse PR faz?

Este Pull Request refatora e melhora a lógica de extração de metadados no formato **ArticleMeta**. As principais mudanças incluem:

- **Extração explícita do campo `v121`** a partir de `elocation-id` ou `fpage`, substituindo o uso de `meta.order_string_format`.
- **Inclusão dos campos `v32` (número do fascículo)** e **`v170` (texto original de afiliação)**.
- **Remoção da lógica de cálculo do total de páginas (`v42`)**.
- **Eliminação do uso da função `abbreviate_page_range`**, utilizando os valores brutos de `fpage` e `lpage`.
- Ajustes em utilitários auxiliares e melhorias na extração de dados de referências.
- Adição de testes para garantir a extração correta de `v170`.

#### Onde a revisão poderia começar?

Sugere-se iniciar a revisão pelo arquivo:

```
packtools/sps/formats/am/am.py
```

Particularmente na função `get_articlemeta_issue`, onde se concentram as mudanças na lógica de geração dos campos `v121`, `v32`, `v14`, `v70`, `v170`.

Outros arquivos que merecem atenção:

- `packtools/sps/formats/am/am_utils.py` (funções auxiliares)
- `packtools/sps/models/references.py` (extração de dados de citação)
- `tests/sps/models/test_aff.py` (teste para v170)

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.