### PR TITLE
Refactor/validate funding and authors

### DIFF
--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -402,7 +402,10 @@ def get_funding(xml_tree):
     funding = funding_group.FundingGroup(xml_tree)
 
     # v102: declaração de financiamento
-    statement = funding.funding_statement or funding.funding_ack[0].get("text")
+    statement = (
+            funding.funding_statement
+            or (funding.funding_ack[0].get("text") if funding.funding_ack else None)
+    )
 
     # v58: órgãos financiadores do artigo.
     sponsors = [{"_": sponsor} for sponsor in funding.funding_sources] or None

--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -631,16 +631,15 @@ def is_analytic_author(ref, person_group_type=None):
     - Em publicações do tipo "book", autores de capítulo são analíticos.
     - Editores em livros são monográficos.
     """
+    if person_group_type == "editor":
+        return False
+
+    if ref.get("part_title") or ref.get("chapter_title") or ref.get("article_title"):
+        return True
+
     pub_type = ref.get("publication_type")
-    is_book = pub_type == "book"
-    has_chapter = bool(ref.get("part_title") or ref.get("chapter_title"))
 
-    if is_book:
-        if person_group_type == "editor":
-            return False
-        return has_chapter
-
-    return pub_type in {"journal", "confproc", "newspaper", "preprint"}
+    return pub_type in {"confproc", "newspaper", "preprint"}
 
 
 def determine_author_tag(ref, person_group_type):

--- a/packtools/sps/models/references.py
+++ b/packtools/sps/models/references.py
@@ -254,11 +254,16 @@ class Reference:
         ]
         d = dict()
         for name, value in tags:
-            if value is not None and len(value) > 0:
-                try:
-                    d[name] = value.text
-                except AttributeError:
-                    d[name] = value
+            if value is not None:
+                if isinstance(value, str):
+                    if value.strip():
+                        d[name] = value
+                else:
+                    try:
+                        d[name] = value.text
+                    except AttributeError:
+                        d[name] = value
+
         d["author_type"] = "institutional" if self.get_collab() else "person"
         d["count_persons"] = len(self.ref.findall(".//person-group"))
         d["has_etal"] = self.ref.find(".//person-group/etal") is not None


### PR DESCRIPTION
###### O que esse PR faz?
Este PR melhora a robustez e a consistência na extração de metadados para o formato ArticleMeta. As principais alterações incluem:

- Correção na extração do campo `funding_statement`, garantindo que o sistema não quebre quando a lista de `funding_ack` estiver vazia.
- Refatoração da função `is_analytic_author`, com lógica mais precisa para distinguir entre autores analíticos e monográficos, desconsiderando editores como analíticos.
- Validação mais segura ao acessar o conteúdo de elementos XML em `Reference.get_reference_data()`, prevenindo erros quando o elemento está presente mas vazio.

Essas mudanças aumentam a resiliência do sistema e evitam exceções silenciosas em cenários reais.

#### Onde a revisão poderia começar?
A revisão pode começar pelos seguintes arquivos:

`packtools/sps/formats/am/am.py: funções get_funding e is_analytic_author.`
`packtools/sps/models/references.py: método get_reference_data() da classe Reference.`

#### Como este poderia ser testado manualmente?
NA.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
NA.

### Referências
NA.