### PR TITLE
feat: Implementa sistema de navegação por âncoras internas em artigos HTML para material suplementar

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-back.xsl
@@ -122,6 +122,7 @@
     </xsl:template>
         
     <xsl:template match="*" mode="back-section">
+        <xsl:apply-templates select="@id" mode="add_span_id"/>
         <div>
             <xsl:apply-templates select="." mode="back-section-menu"/>
             <xsl:apply-templates select="." mode="back-section-h"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-supplementary-material.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-supplementary-material.xsl
@@ -41,9 +41,11 @@
         <xsl:variable name="media_text"><xsl:apply-templates select="media" mode="texts"/></xsl:variable>
         <xsl:choose>
             <xsl:when test="normalize-space($media_text)=''">
-                <a href="{media/@xlink:href}" download="1">
-                    <xsl:value-of select="label"/>
-                </a>
+                <p name="{@id}">
+                    <a href="{media/@xlink:href}" download="1">
+                        <xsl:value-of select="label"/>
+                    </a>
+                </p>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:apply-templates select="*|text()"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-xref.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-xref.xsl
@@ -46,6 +46,10 @@
         <xsl:apply-templates select="*|text()"/>
     </xsl:template>
 
+    <xsl:template match="xref">
+        <a href="#{@rid}"><xsl:apply-templates select="*|text()"/></a>
+    </xsl:template>
+
     <xsl:template match="xref[@ref-type='equation' or @ref-type='disp-formula']">
         <!-- <a href="#{@rid}" class="goto"><span class="sci-ico-fileFormula"></span> <xsl:apply-templates select="*|text()"></xsl:apply-templates></a> -->
         <a href="" class="open-asset-modal" data-toggle="modal" data-target="#ModalScheme{translate(@rid,'.','_')}">

--- a/packtools/catalogs/htmlgenerator/v3.0/generic.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/generic.xsl
@@ -5,4 +5,8 @@
 
     <xsl:include href="../v2.0/generic.xsl"/>
 
+    <xsl:template match="@id" mode="add_span_id">
+        <span id="{.}"/>
+    </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
#### O que esse PR faz?
Implementa navegação por âncoras internas para melhorar a experiência de leitura de artigos científicos:
- Adiciona IDs em elementos estruturais (seções back, material suplementar)
- Transforma referências cruzadas (xref) em links clicáveis que navegam até o elemento referenciado
- Corrige estrutura de material suplementar envolvendo links em parágrafos identificados

#### Onde a revisão poderia começar?
`packtools/catalogs/htmlgenerator/v3.0/generic.xsl` - contém o template base que gera spans com ID, fundamental para entender o sistema.

#### Como este poderia ser testado manualmente?
1. Gere HTML de artigo com: seções back matter, referências cruzadas (xref) e material suplementar
2. Verifique no HTML gerado:
   - Elementos com `@id` possuem `<span id="..."/>`
   - Cliques em xref navegam para elemento referenciado
   - Links de material suplementar estão em `<p name="id">`
3. Teste navegação direta via URL com `#id-do-elemento`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac_5/issues/314

### Referências
n/a