### PR TITLE
Melhora desempenho de XMLWithPre

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -276,7 +276,6 @@ def get_xml_with_pre_from_uri(uri, timeout=30):
 
 def get_xml_with_pre(xml_content):
     try:
-        xml_content = xml_content.strip()
         # return etree.fromstring(xml_content)
         pref, xml = split_processing_instruction_doctype_declaration_and_xml(
             xml_content
@@ -293,36 +292,14 @@ def get_xml_with_pre(xml_content):
 
 
 def split_processing_instruction_doctype_declaration_and_xml(xml_content):
-    xml_content = xml_content.strip()
+    if not xml_content:
+        return "", ""
 
-    if not xml_content.startswith("<?") and not xml_content.startswith("<!"):
-        return "", xml_content
-    if xml_content.endswith("/>"):
-        # <article/>
-        p = xml_content.rfind("<")
-        if p >= 0:
-            pre = xml_content[:p].strip()
-            if pre.endswith(">"):
-                return xml_content[:p], xml_content[p:]
-            else:
-                return "", xml_content
+    p = xml_content.find("<article")
+    if p >= 0:
+        return xml_content[:p], xml_content[p:].strip()
 
-    p = xml_content.rfind("</")
-    if p:
-        # </article>
-        endtag = xml_content[p:]
-        starttag1 = endtag.replace("/", "").replace(">", " ")
-        starttag2 = endtag.replace("/", "")
-        for starttag in (starttag1, starttag2):
-            p = xml_content.find(starttag)
-            if p >= 0:
-                pre = xml_content[:p].strip()
-                if pre.endswith(">"):
-                    return xml_content[:p], xml_content[p:]
-                else:
-                    return "", xml_content
-
-    return "", xml_content
+    return xml_content, ""
 
 
 class XMLWithPre:

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -688,7 +688,6 @@ class XMLWithPre:
         return True
 
     @property
-    @lru_cache(maxsize=1)
     def xml_dates(self):
         # ("year", "month", "season", "day")
         return ArticleDates(self.xmltree)
@@ -838,7 +837,6 @@ class XMLWithPre:
         return self.issns.get("epub")
 
     @property
-    @lru_cache(maxsize=1)
     def article_publication_date(self):
         # ("year", "month", "season", "day")
         _date = self.xml_dates.article_date
@@ -912,7 +910,6 @@ class XMLWithPre:
                 elem.text = str(numbers[name]).zfill(max_length)
 
     @property
-    @lru_cache(maxsize=1)
     def article_pub_year(self):
         # ("year", "month", "season", "day")
         try:


### PR DESCRIPTION
#### O que esse PR faz?
Melhora desempenho de XMLWithPre através da implementação de cache com `@lru_cache`, refatoração do parsing de DOCTYPE e XML, e simplificação geral do código removendo duplicações e padrões manuais de cache.

#### Onde a revisão poderia começar?
`packtools/sps/pid_provider/xml_sps_lib.py` - começar pela linha 5 onde foi adicionado o import de `lru_cache`, seguindo para as mudanças em:
- `get_xml_items_from_zip_file()` (linha ~105)
- `split_processing_instruction_doctype_declaration_and_xml()` (linha ~290)
- Classe `XMLWithPre.__init__()` (linha ~326)
- Propriedades com `@lru_cache` (linha ~459 em diante)

#### Como este poderia ser testado manualmente?
```bash
# 1. Testar processamento de arquivo XML individual
python -c "from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre; 
xml = XMLWithPre.create(path='arquivo.xml'); 
print(list(xml)[0].sps_pkg_name)"

# 2. Testar processamento de arquivo ZIP
python -c "from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre; 
xmls = XMLWithPre.create(path='pacote.zip'); 
for xml in xmls: print(xml.sps_pkg_name)"

# 3. Verificar performance com múltiplos acessos
python -c "from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre;
import time;
xml = list(XMLWithPre.create(path='arquivo.xml'))[0];
start = time.time();
for _ in range(1000): _ = xml.article_titles;
print(f'Tempo: {time.time() - start:.4f}s')"
```

#### Algum cenário de contexto que queira dar?
O código anterior utilizava um padrão manual de cache com `hasattr()` e atributos privados (`_attribute`), causando:
- Código verboso e repetitivo
- Manutenção difícil
- Possíveis inconsistências

As melhorias incluem:
- **Performance**: `@lru_cache` fornece cache automático e otimizado
- **Robustez**: Melhor tratamento de erros com `capture_errors`
- **Clareza**: Remoção de ~200 linhas de código redundante
- **Manutenibilidade**: Código mais pythônico e fácil de entender

Antes e depois
```diff
-  Tempo: 46.765s | Memória: 0.18MB
-         12760031 function calls (12750031 primitive calls) in 46.765 seconds
+  Tempo: 38.274s | Memória: 0.19MB
+         7900030 function calls (7890030 primitive calls) in 38.274 seconds

```

```diff
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
-        1    0.370    0.370   46.765   46.765 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/x.py:538(processar_xml)
-    10000    1.146    0.000   41.588    0.004 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/x.py:5(exec_properties)
-   160000    0.223    0.000   13.664    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/xml_sps_lib.py:1049(assets)
-   160000    0.148    0.000   12.777    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/models/article_assets.py:47(items)
-   200000   12.575    0.000   12.630    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/models/article_assets.py:59(get_assets)
+        1    0.074    0.074   38.274   38.274 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/x.py:538(processar_xml)
+    10000    1.621    0.000   33.640    0.003 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/x.py:5(exec_properties)
+   160000    0.222    0.000   13.499    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/xml_sps_lib.py:947(assets)
+   160000    0.155    0.000   12.609    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/models/article_assets.py:47(items)
+   200000   12.398    0.000   12.454    0.000 /Users/roberta.takenaka/github.com/scieloorg/packtools/packtools/packtools/sps/pid_provider/models/article_assets.py:59(get_assets)
```

### Screenshots
N/A - Mudanças são internas sem impacto visual.

#### Quais são tickets relevantes?
- Otimização de performance no processamento de XML
- Refatoração de código legado

### Referências
- [[Python functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache)](https://docs.python.org/3/library/functools.html#functools.lru_cache)
- [[PEP 8 - Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)](https://www.python.org/dev/peps/pep-0008/)
- [[Effective Python: 90 Specific Ways to Write Better Python](https://effectivepython.com/)](https://effectivepython.com/)