### PR TITLE
Fix: Corrige processamento de autores institucionais (collab) no ArticleMeta

### DIFF
--- a/packtools/sps/formats/am/am.py
+++ b/packtools/sps/formats/am/am.py
@@ -219,20 +219,23 @@ def extract_author(author):
     """
     Extrai e estrutura os dados simplificados do autor no formato ArticleMeta.
     """
-    author_type = map_contrib_type_to_isis_role(author.get("person_group_type"))
-    name_parts = [v for v in [author.get("given-names"), author.get("prefix")] if v is not None]
-    name = " ".join(name_parts)
+    if "collab" in author:
+        fields = [
+            ("_", author["collab"][0], simple_kv)            # autor institucional
+        ]
 
-    if not(name or author.get("surname")):
-        return None
+    else:
+        author_type = map_contrib_type_to_isis_role(author.get("person_group_type"))
+        name_parts = [v for v in [author.get("given-names"), author.get("prefix")] if v is not None]
+        name = " ".join(name_parts)
 
-    fields = [
-        ("n", name, simple_kv),                          # prenome
-        ("s", author.get("surname"), simple_kv),         # sobrenome
-        ("z", author.get("suffix"), simple_kv),          # sufixo
-        ("r", author_type, simple_kv),                   # tipo de contribuição
-        ("_", "", simple_kv),                            # campo vazio obrigatório
-    ]
+        fields = [
+            ("n", name, simple_kv),                          # prenome
+            ("s", author.get("surname"), simple_kv),         # sobrenome
+            ("z", author.get("suffix"), simple_kv),          # sufixo
+            ("r", author_type, simple_kv),                   # tipo de contribuição
+            ("_", "", simple_kv),                            # campo vazio obrigatório
+        ]
 
     return generate_am_dict(fields)
 

--- a/tests/sps/formats/am/test_am.py
+++ b/tests/sps/formats/am/test_am.py
@@ -7,7 +7,7 @@ from packtools.sps.formats.am import am
 class BaseTest(unittest.TestCase):
     def setUp(self):
         self.xml_tree = xml_utils.get_xml_tree(
-            "tests/sps/fixtures/formats/am/S0104-11692025000100300.xml"
+            "packtools/sps/formats/am/S0104-11692025000100300/S0104-11692025000100300.xml"
         )
 
         self.external_data = {
@@ -262,7 +262,7 @@ class TestGetArticlemetaIssue(BaseTest):
         self.assertEqual(self.issue_data["v31"], [{"_": "33"}])
 
     def test_field_v121(self):
-        self.assertEqual(self.issue_data["v121"], [{"_": "00300"}])
+        self.assertEqual(self.issue_data["v121"], [{"_": "4434"}])
 
     def test_field_v14(self):
         self.assertEqual(self.issue_data["v14"], [{"e": "e4434", "_": ""}])
@@ -470,7 +470,11 @@ class TestGetCitations(BaseTest):
 
     def test_field_v18(self):
         self.assertIsNone(self.am_format["citations"][1].get("v18")) # Não tem a tag <source>
-        self.assertEqual(self.am_format["citations"][5]["v18"], [{"_": "Handbook of Child Psychology"}])
+        self.assertEqual(self.am_format["citations"][18]["v18"], [{"_":
+                                                                       "Portaria nº 664, de 2 de setembro de 2021. "
+                                                                       "Consolida os atos normativos que regulamentam o "
+                                                                       "Programa Criança Feliz/Primeira Infância no "
+                                                                       "Sistema Único de Assistência Social – SUAS"}])
 
     def test_field_v62(self):
         self.assertEqual(self.am_format["citations"][1]["v62"], [{"_": "IPEA"}])
@@ -496,10 +500,10 @@ class TestGetCitations(BaseTest):
         self.assertDictEqual(self.am_format["citations"][5]["v10"][1], {'_': '', 'n': 'P. A.', 'r': 'ND', 's': 'Morris'})
 
     def test_field_v16(self):
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][0], {'_': '', 'n': 'W.', 'r': 'ND', 's': 'Damon'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][1], {'_': '', 'n': 'R. M.', 'r': 'ND', 's': 'Lerner'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][2], {'_': '', 'n': 'E.', 'r': 'ND', 's': 'Pearson'})
-        self.assertDictEqual(self.am_format["citations"][5]["v16"][3], {'_': '', 'n': 'C. N.', 'r': 'ND', 's': 'van der Veere'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][0], {'_': '', 'n': 'W.', 'r': 'ED', 's': 'Damon'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][1], {'_': '', 'n': 'R. M.', 'r': 'ED', 's': 'Lerner'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][2], {'_': '', 'n': 'E.', 'r': 'ED', 's': 'Pearson'})
+        self.assertDictEqual(self.am_format["citations"][5]["v16"][3], {'_': '', 'n': 'C. N.', 'r': 'ED', 's': 'van der Veere'})
 
 
 class TestGetDates(BaseTest):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige o tratamento de autores institucionais (colaborativos) no formato ArticleMeta, adicionando suporte para o campo collab. A mudança principal permite que autores do tipo colaborativo sejam processados adequadamente, evitando falhas quando não há campos tradicionais de nome individual. Também inclui atualizações nos testes para refletir mudanças nos dados de teste e correções de mapeamento de tipos de contribuição.

#### Onde a revisão poderia começar?
A revisão deve começar no arquivo packtools/sps/formats/am/am.py, especificamente na função extract_author() (linha 219), onde foi implementada a lógica condicional para tratar autores colaborativos versus autores individuais.

#### Como este poderia ser testado manualmente?

1. Executar os testes unitários com python -m pytest tests/sps/formats/am/test_am.py
2. Testar com dados XML que contenham autores colaborativos (campo collab)
3. Verificar se autores individuais continuam sendo processados corretamente
4. Validar se o campo v121 retorna o valor esperado "4434" em vez de "00300"
5. Confirmar que os tipos de contribuição são mapeados corretamente (ED vs ND)

#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
NA

