### PR TITLE
Fix/pdf generator minor fixes

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -278,7 +278,6 @@ def docx_cite_as_pipe(
         cite_as_part_one,
         journal_title,
         footer_data,
-
 ):
     """
     Adds the citation information to the first page footer of the DOCX document.

--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -100,7 +100,6 @@ def docx_journal_title_pipe(docx, journal_title_text, style_name='SCL Journal Ti
         python-docx.Paragraph: The paragraph object containing the journal title text.
     """
     first_page_header = docx_utils.get_first_page_header(docx)
-    first_page_header
     para = docx_utils.get_first_paragraph(first_page_header)
 
     left_run = para.add_run(journal_title_text.replace(' ', '\n'))

--- a/packtools/sps/formats/pdf/utils/docx_utils.py
+++ b/packtools/sps/formats/pdf/utils/docx_utils.py
@@ -256,7 +256,10 @@ def add_table(docx, table_data, header_style_name='SCL Table Heading'):
         header_row = table.rows[0]
         for i, header in enumerate(headers[0]):
             cell = header_row.cells[i]
-            cell.text = header
+            try:
+                cell.text = header
+            except TypeError:
+                cell.text = ''
             style_cell(cell, bold=True, font_size=7, align='center')
 
     for i, row_data in enumerate(rows):

--- a/packtools/sps/formats/pdf/utils/file_utils.py
+++ b/packtools/sps/formats/pdf/utils/file_utils.py
@@ -10,6 +10,18 @@ class DirectoryRemovalError(Exception):
 
 
 def convert_docx_to_pdf(docx_path, libreoffice_binary="libreoffice"):
+    """
+    Converts a DOCX file to PDF format using LibreOffice in headless mode.
+    The function runs a subprocess to call LibreOffice, specifying the input DOCX file
+    and the output directory for the generated PDF file.
+    Args:
+        docx_path (str): The path to the DOCX file to be converted.
+        libreoffice_binary (str): The path to the LibreOffice binary. Defaults to "libreoffice".
+    Raises:
+        RuntimeError: If the PDF file was not created successfully.
+    Returns:
+        str: The path to the generated PDF file.
+    """
 
     output_dir = os.path.dirname(docx_path)
     os.makedirs(output_dir, exist_ok=True)

--- a/packtools/sps/formats/pdf/utils/file_utils.py
+++ b/packtools/sps/formats/pdf/utils/file_utils.py
@@ -39,8 +39,10 @@ def convert_docx_to_pdf(docx_path, libreoffice_binary="libreoffice"):
     base_name = os.path.basename(docx_path)
     f_name, f_ext = os.path.splitext(base_name)
     pdf_path = os.path.join(output_dir, f"{f_name}.pdf")
+
     if not os.path.exists(pdf_path):
-        raise RuntimeError(f"PDF não gerado: {pdf_path}")
+        raise RuntimeError(f"PDF file was not created: {pdf_path}")
+
     return pdf_path
 
 def unzip_docx(path, prefix="scl_xml2pdf"):

--- a/packtools/sps/formats/pdf/utils/file_utils.py
+++ b/packtools/sps/formats/pdf/utils/file_utils.py
@@ -9,28 +9,26 @@ class DirectoryRemovalError(Exception):
     ...
 
 
-def convert_docx_to_pdf(docx_path, pdf_path, libreoffice_binary="libreoffice24.2"):
-    """
-    Convert a DOCX file to PDF using LibreOffice.
+def convert_docx_to_pdf(docx_path, libreoffice_binary="libreoffice"):
 
-    Args:
-        docx_path (str): The path to the DOCX file to convert.
-        pdf_path (str): The path to the PDF file to create.
-        libreoffice_binary (str): The path to the LibreOffice binary to use for conversion.
-
-    Returns:
-        str: The path to the created PDF file.
-    """
-    output_dir = os.path.dirname(pdf_path)
+    output_dir = os.path.dirname(docx_path)
     os.makedirs(output_dir, exist_ok=True)
 
-    subprocess.run([libreoffice_binary, '--headless', '--convert-to', 'pdf', docx_path, '--outdir', output_dir], check=True)
-    
-    base_name = os.path.basename(docx_path)
-    base_name_no_ext = os.path.splitext(base_name)[0]
-    temp_pdf_path = os.path.join(output_dir, f"{base_name_no_ext}.pdf")
-    os.rename(temp_pdf_path, pdf_path)
+    subprocess.run([
+        libreoffice_binary,
+        '--headless',
+        '--convert-to',
+        'pdf',
+        docx_path,
+        '--outdir',
+        output_dir
+    ], check=True)
 
+    base_name = os.path.basename(docx_path)
+    f_name, f_ext = os.path.splitext(base_name)
+    pdf_path = os.path.join(output_dir, f"{f_name}.pdf")
+    if not os.path.exists(pdf_path):
+        raise RuntimeError(f"PDF não gerado: {pdf_path}")
     return pdf_path
 
 def unzip_docx(path, prefix="scl_xml2pdf"):

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -49,8 +49,16 @@ def main():
     else:
         pdf_path = arguments.path_to_read.replace('.xml', '.pdf')
 
-    file_utils.convert_docx_to_pdf(path_intermediate_docx, arguments.path_to_write)
+    dir_name = os.path.dirname(pdf_path)
+    base_name = os.path.basename(pdf_path)
+    f_name, f_ext = os.path.splitext(base_name)
+    docx_path = os.path.join(dir_name, f"{f_name}.docx")
 
+    document.save(docx_path)
+    print(f'DOCX generated at {docx_path}')
+    
+    file_utils.convert_docx_to_pdf(docx_path, arguments.libreoffice_binary)
+    print(f'PDF generated at {pdf_path}')
 
 if __name__ == "__main__":
     main()

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -39,9 +39,7 @@ def main():
     )
     arguments = parser.parse_args()
 
-    data = {
-        'base_layout': arguments.layout,
-    }
+    data = {'base_layout': arguments.layout,}
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
     document = docx.pipeline_docx(xml_tree, data)

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -32,6 +32,10 @@ def main():
         required=False,
         help="Path for writing the PDF file. If omitted, a default name will be used.",
     )
+    parser.add_argument(
+        "--libreoffice-binary",
+        action="store",
+        dest="libreoffice_binary",
     )
     arguments = parser.parse_args()
 

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -44,9 +44,10 @@ def main():
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
     document = docx.pipeline_docx(xml_tree, data)
 
-    path_intermediate_docx = arguments.path_to_write.replace(".pdf", ".docx")
-    document.save(path_intermediate_docx)
-    print(f"Documento intermediário salvo em {path_intermediate_docx}")
+    if arguments.path_to_write:
+        pdf_path = arguments.path_to_write
+    else:
+        pdf_path = arguments.path_to_read.replace('.xml', '.pdf')
 
     file_utils.convert_docx_to_pdf(path_intermediate_docx, arguments.path_to_write)
 

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -29,8 +29,9 @@ def main():
         "--pdf",
         action="store",
         dest="path_to_write",
-        required=True,
-        help="Path for writing the PDF file.",
+        required=False,
+        help="Path for writing the PDF file. If omitted, a default name will be used.",
+    )
     )
     arguments = parser.parse_args()
 

--- a/packtools/sps/formats/pdf_generator.py
+++ b/packtools/sps/formats/pdf_generator.py
@@ -1,8 +1,7 @@
 import argparse
+import os
 
-from packtools.sps.formats.pdf.pipeline import (
-    docx,
-)   
+from packtools.sps.formats.pdf.pipeline import docx  
 from packtools.sps.formats.pdf.utils import file_utils
 from packtools.sps.utils import xml_utils
 

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '4.11.13'
+__version__ = '4.11.22'


### PR DESCRIPTION
#### O que esse PR faz?

* Corrige métodos de geração de DOCX e PDF.
* Adiciona argumento para definir o binário do LibreOffice.
* Retira obrigatoriedade de informar o path do PDF: se não for passado, o sistema gera um nome padrão.
* Atualiza versão para **4.11.22**.

#### Onde a revisão poderia começar?

Sugiro iniciar por:

* `packtools/sps/formats/pdf_generator.py` (mudanças principais no fluxo de geração de arquivos).
* Em seguida: `utils/file_utils.py` (ajuste na conversão para PDF).

#### Como este poderia ser testado manualmente?

1. Rodar o comando principal informando um arquivo XML de entrada.
2. Testar com e sem `--pdf` para validar a geração automática do nome do arquivo.
3. Testar com e sem `--libreoffice-binary` para validar o binário padrão.
4. Verificar se os arquivos `.docx` e `.pdf` são gerados corretamente.

#### Algum cenário de contexto que queira dar?
O PR visa tornar a geração de PDF mais robusta, com menos dependência de parâmetros obrigatórios e maior flexibilidade na escolha do binário do LibreOffice. Esses ajustes são necessários para correta utilização no markapi.

### Screenshots

N/A

#### Quais são tickets relevantes?

N/A

### Referências

N/A