### PR TITLE
Feat: add prepare_request_data for ORCID API integration

### DIFF
--- a/packtools/sps/utils/prepare_request_data.py
+++ b/packtools/sps/utils/prepare_request_data.py
@@ -1,0 +1,129 @@
+from packtools.sps.models.article_contribs import Contrib
+from packtools.sps.models.article_titles import ArticleTitles
+from packtools.sps.models.journal_meta import Title
+from packtools.sps.models.dates import XMLDates
+from packtools.sps.models.article_doi_with_lang import DoiWithLang
+from packtools.sps.models.aff import Affiliation
+from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
+
+
+class Author:
+    def __init__(self, author_node, affs):
+        self.author_obj = Contrib(author_node)
+        self.name = self.author_obj.contrib_full_name
+        self.orcid = self.author_obj.contrib_ids.get("orcid")
+        self.affs = affs
+
+    @property
+    def email(self):
+        for item in list(self.author_obj.contrib_xref):
+            if rid := item.get("rid"):
+                if email := self.affs.get(rid, {}).get("email"):
+                    return email
+
+    @property
+    def data(self):
+        if not (self.orcid and self.name):  # Obrigatórios
+            return None
+        return {
+            "orcid_id": self.orcid,
+            "author_email": self.email,
+            "author_name": self.name,
+        }
+
+
+class Authors:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+
+    @property
+    def affs(self):
+        return Affiliation(self.xml_tree).affiliation_by_id
+
+    @property
+    def data(self):
+        for author in self.xml_tree.xpath(".//contrib"):
+            yield Author(author, self.affs).data
+
+
+class Work:
+    def __init__(self, xml_tree):
+        self.xml_tree = xml_tree
+        self.article_title = (ArticleTitles(xml_tree).article_title or {}).get(
+            "plain_text"
+        )
+        self.journal_title = Title(xml_tree).journal_title
+        self.article_type = ArticleAndSubArticles(xml_tree).main_article_type
+
+    @property
+    def pub_date(self):
+        dates = XMLDates(self.xml_tree)
+        pub_date_data = dates.epub_date or dates.collection_date
+
+        if not pub_date_data or not pub_date_data.get("year"):
+            return None
+
+        pub_date = {"year": {"value": str(pub_date_data["year"])}}
+
+        if month := pub_date_data.get("month"):
+            pub_date["month"] = {"value": str(month).zfill(2)}
+
+        if day := pub_date_data.get("day"):
+            pub_date["day"] = {"value": str(day).zfill(2)}
+
+        return pub_date
+
+    @property
+    def external_ids(self):
+        """Extrai IDs externos usando DoiWithLang (obrigatório)"""
+        doi_extractor = DoiWithLang(self.xml_tree)
+        doi = doi_extractor.main_doi
+
+        if not doi or not doi.strip():
+            return None  # DOI é obrigatório
+
+        external_ids = {
+            "external-id": [
+                {
+                    "external-id-type": "doi",
+                    "external-id-value": doi.strip(),
+                    "external-id-url": {"value": f"https://doi.org/{doi.strip()}"},
+                }
+            ]
+        }
+
+        return external_ids
+
+    @property
+    def data(self):
+        if not (
+            self.article_title and self.journal_title and self.article_type
+        ):  # Obrigatórios
+            return None
+        data = {
+            "work_data": {
+                "title": {
+                    "title": {"value": self.article_title},
+                },
+                "journal-title": {"value": self.journal_title},
+                "type": self.article_type,
+            }
+        }
+        if not self.pub_date:
+            return None
+        data.update(self.pub_date)  # Obrigatório ano
+
+        if self.external_ids:
+            data.update(self.external_ids)  # Opcional
+
+        return data
+
+
+def prepare_request_data(xml_tree):
+    work_data = Work(xml_tree).data
+    if not work_data:
+        return
+
+    for author_data in Authors(xml_tree).data:
+        if author_data:
+            yield {**author_data, **work_data}

--- a/tests/sps/utils/test_prepare_request_data.py
+++ b/tests/sps/utils/test_prepare_request_data.py
@@ -1,0 +1,662 @@
+# coding: utf-8
+import unittest
+from lxml import etree
+from packtools.sps.utils.prepare_request_data import prepare_request_data
+
+
+class PrepareTest(unittest.TestCase):
+    def setUp(self):
+        xml = """
+            <article xmlns:mml="http://www.w3.org/1998/Math/MathML" 
+                     xmlns:xlink="http://www.w3.org/1999/xlink" 
+                     article-type="rapid-communication" 
+                     dtd-version="1.1" 
+                     specific-use="sps-1.8" 
+                     xml:lang="en">
+                <front>
+                    <journal-meta>
+                        <journal-id journal-id-type="nlm-ta">Braz J Med Biol Res</journal-id>
+                        <journal-id journal-id-type="publisher-id">bjmbr</journal-id>
+                        <journal-title-group>
+                            <journal-title>Brazilian Journal of Medical and Biological Research</journal-title>
+                            <abbrev-journal-title abbrev-type="publisher">Braz. J. Med. Biol. Res.</abbrev-journal-title>
+                        </journal-title-group>
+                        <issn pub-type="epub">1414-431X</issn>
+                        <publisher>
+                            <publisher-name>Associação Brasileira de Divulgação Científica</publisher-name>
+                        </publisher>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id specific-use="scielo-v3" pub-id-type="publisher-id">ywDM7t6mxHzCRWp7kGF9rXQ</article-id>
+                        <article-id specific-use="scielo-v2" pub-id-type="publisher-id">S0100-879X2021001000551</article-id>
+                        <article-id pub-id-type="other">00551</article-id>
+                        <article-id pub-id-type="doi">10.1590/1414-431X2021e11439</article-id>
+                        <article-categories>
+                            <subj-group subj-group-type="heading">
+                                <subject>Short Communication</subject>
+                            </subj-group>
+                        </article-categories>
+                        <title-group>
+                            <article-title>Decreased levels of cathepsin Z mRNA expressed by immune blood cells: diagnostic and prognostic implications in prostate cancer</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <contrib-id contrib-id-type="scopus">24771926600</contrib-id>
+                                <collab>The MARS Group</collab>
+                                <name>
+                                    <surname>Einstein</surname>
+                                    <given-names>Albert</given-names>
+                                    <prefix>Prof</prefix>
+                                    <suffix>Nieto</suffix>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <label>1</label>
+                                <institution content-type="orgname">Fundação Oswaldo Cruz</institution>
+                                <institution content-type="orgdiv1">Escola Nacional de Saúde Pública Sérgio Arouca</institution>
+                                <institution content-type="orgdiv2">Centro de Estudos da Saúde do Trabalhador e Ecologia Humana</institution>
+                                <addr-line>
+                                    <named-content content-type="city">Manguinhos</named-content>
+                                    <named-content content-type="state">RJ</named-content>
+                                </addr-line>
+                                <country country="BR">Brasil</country>
+                                <email>denise.peres@email.com</email>
+                                <institution content-type="original">Fundação Oswaldo Cruz; da Escola Nacional de Saúde Pública Sérgio Arouca, do Centro de Estudos da Saúde do Trabalhador e Ecologia Humana. RJ - Manguinhos, Brasil. denise.peres@email.com</institution>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2021</year>
+                            <month>10</month>
+                            <day>15</day>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        self.xmltree = etree.fromstring(xml)
+
+    def test_orcid_extraction(self):
+        """Testa se o ORCID ID é extraído corretamente"""
+        expected = "0000-0001-8528-2091"
+        obtained = list(prepare_request_data(self.xmltree))
+        self.assertEqual(len(obtained), 1)
+        self.assertIn("orcid_id", obtained[0])
+        self.assertEqual(expected, obtained[0]["orcid_id"])
+
+    def test_author_name_extraction(self):
+        """Testa se o nome completo do autor é extraído corretamente"""
+        expected = "Prof Albert Einstein Nieto"
+        obtained = list(prepare_request_data(self.xmltree))
+        self.assertEqual(len(obtained), 1)
+        self.assertIn("author_name", obtained[0])
+        self.assertEqual(expected, obtained[0]["author_name"])
+
+    def test_author_email_extraction(self):
+        """Testa se o email é extraído das afiliações"""
+        expected = "denise.peres@email.com"
+        obtained = list(prepare_request_data(self.xmltree))
+        self.assertEqual(len(obtained), 1)
+        self.assertIn("author_email", obtained[0])
+        self.assertEqual(expected, obtained[0]["author_email"])
+
+    def test_work_data_structure(self):
+        """Testa se work_data tem a estrutura correta"""
+        obtained = list(prepare_request_data(self.xmltree))
+        self.assertEqual(len(obtained), 1)
+
+        work_data = obtained[0]["work_data"]
+
+        # Testa estrutura básica
+        self.assertIn("title", work_data)
+        self.assertIn("journal-title", work_data)
+        self.assertIn("type", work_data)
+
+        # Testa título
+        self.assertIn("title", work_data["title"])
+        self.assertEqual(work_data["title"]["title"]["value"],
+                         "Decreased levels of cathepsin Z mRNA expressed by immune blood cells: diagnostic and prognostic implications in prostate cancer")
+
+        # Testa journal
+        self.assertEqual(work_data["journal-title"]["value"], "Brazilian Journal of Medical and Biological Research")
+
+        # Testa tipo
+        self.assertEqual(work_data["type"], "rapid-communication")
+
+    def test_work_data_external_ids(self):
+        """Testa se external-ids (DOI) são extraídos corretamente"""
+        obtained = list(prepare_request_data(self.xmltree))
+        work_data = obtained[0]
+
+        self.assertIn("external-id", work_data)
+        external_ids = work_data["external-id"]
+        self.assertEqual(len(external_ids), 1)
+
+        doi_entry = external_ids[0]
+        self.assertEqual(doi_entry["external-id-type"], "doi")
+        self.assertEqual(doi_entry["external-id-value"], "10.1590/1414-431X2021e11439")
+        self.assertEqual(doi_entry["external-id-url"]["value"], "https://doi.org/10.1590/1414-431X2021e11439")
+
+    def test_work_data_publication_date(self):
+        """Testa se a data de publicação é extraída corretamente"""
+        obtained = list(prepare_request_data(self.xmltree))
+
+        self.assertIn("year", obtained[0])
+        self.assertEqual(obtained[0]["year"]["value"], "2021")
+
+        self.assertIn("month", obtained[0])
+        self.assertEqual(obtained[0]["month"]["value"], "10")
+
+        self.assertIn("day", obtained[0])
+        self.assertEqual(obtained[0]["day"]["value"], "15")
+
+    def test_complete_payload_structure(self):
+        """Testa se o payload completo tem todos os campos obrigatórios"""
+        obtained = list(prepare_request_data(self.xmltree))
+        self.assertEqual(len(obtained), 1)
+
+        payload = obtained[0]
+        required_fields = ["orcid_id", "author_email", "author_name", "work_data"]
+
+        for field in required_fields:
+            self.assertIn(field, payload, f"Campo obrigatório '{field}' ausente no payload")
+
+    def test_missing_orcid_and_name(self):
+        """Testa se contribuidor sem ORCID E nome é rejeitado"""
+        xml_no_orcid_and_name = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_orcid_and_name)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+    def test_missing_orcid_only(self):
+        """Testa se contribuidor sem ORCID (mas com nome) é rejeitado"""
+        xml_no_orcid = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_orcid)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+    def test_missing_name_only(self):
+        """Testa se contribuidor sem nome (mas com ORCID) é rejeitado"""
+        xml_no_name = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_name)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+    def test_missing_required_work_fields(self):
+        """Testa se trabalhos com campos obrigatórios ausentes são rejeitados"""
+
+        # XML sem DOI
+        xml_no_doi = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_doi)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+        # XML sem título do artigo
+        xml_no_title = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_title)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+        # XML sem journal title
+        xml_no_journal = """
+            <article>
+                <front>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_journal)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+        # XML sem article-type
+        xml_no_type = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_type)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+        # XML sem ano de publicação
+        xml_no_year = """
+            <article>
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_year)
+        obtained = list(prepare_request_data(xmltree))
+        self.assertEqual(len(obtained), 0)
+
+    def test_multiple_contributors(self):
+        """Testa processamento de múltiplos contribuidores"""
+        xml_multiple = """
+            <article article-type="research-article">
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.multiple.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>First</surname>
+                                    <given-names>Author</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0002-1825-0097</contrib-id>
+                                <name>
+                                    <surname>Second</surname>
+                                    <given-names>Author</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff2">2</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>first@email.com</email>
+                            </aff>
+                            <aff id="aff2">
+                                <email>second@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                            <month>03</month>
+                            <day>15</day>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_multiple)
+        obtained = list(prepare_request_data(xmltree))
+
+        self.assertEqual(len(obtained), 2)
+
+        # Verifica primeiro autor
+        first_author = obtained[0]
+        self.assertEqual(first_author["orcid_id"], "0000-0001-8528-2091")
+        self.assertEqual(first_author["author_name"], "Author First")
+        self.assertEqual(first_author["author_email"], "first@email.com")
+
+        # Verifica segundo autor
+        second_author = obtained[1]
+        self.assertEqual(second_author["orcid_id"], "0000-0002-1825-0097")
+        self.assertEqual(second_author["author_name"], "Author Second")
+        self.assertEqual(second_author["author_email"], "second@email.com")
+
+    def test_work_data_shared_between_authors(self):
+        """Testa se work_data é compartilhado corretamente entre múltiplos autores"""
+        xml_multiple = """
+            <article article-type="research-article">
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Shared Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/shared.123</article-id>
+                        <title-group>
+                            <article-title>Shared Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-1111-1111</contrib-id>
+                                <name>
+                                    <surname>Author</surname>
+                                    <given-names>First</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0002-2222-2222</contrib-id>
+                                <name>
+                                    <surname>Author</surname>
+                                    <given-names>Second</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff2">2</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>first@email.com</email>
+                            </aff>
+                            <aff id="aff2">
+                                <email>second@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_multiple)
+        obtained = list(prepare_request_data(xmltree))
+
+        self.assertEqual(len(obtained), 2)
+
+        # Verifica se work_data é idêntico entre os autores
+        work_data_1 = obtained[0]["work_data"]
+        work_data_2 = obtained[1]["work_data"]
+
+        self.assertEqual(work_data_1, work_data_2)
+        self.assertEqual(work_data_1["title"]["title"]["value"], "Shared Article")
+        self.assertEqual(work_data_1["journal-title"]["value"], "Shared Journal")
+
+    def test_email_optional_field(self):
+        """Testa que email pode ser None quando não encontrado"""
+        xml_no_email = """
+            <article article-type="research-article">
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <label>1</label>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_no_email)
+        obtained = list(prepare_request_data(xmltree))
+
+        self.assertEqual(len(obtained), 1)
+        self.assertIn("author_email", obtained[0])
+        self.assertIsNone(obtained[0]["author_email"])
+
+    def test_date_formatting(self):
+        """Testa formatação correta de datas (zfill para month/day)"""
+        xml_single_digit = """
+            <article article-type="research-article">
+                <front>
+                    <journal-meta>
+                        <journal-title-group>
+                            <journal-title>Test Journal</journal-title>
+                        </journal-title-group>
+                    </journal-meta>
+                    <article-meta>
+                        <article-id pub-id-type="doi">10.1000/test.123</article-id>
+                        <title-group>
+                            <article-title>Test Article</article-title>
+                        </title-group>
+                        <contrib-group>
+                            <contrib contrib-type="author">
+                                <contrib-id contrib-id-type="orcid">0000-0001-8528-2091</contrib-id>
+                                <name>
+                                    <surname>Test</surname>
+                                    <given-names>User</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1">1</xref>
+                            </contrib>
+                            <aff id="aff1">
+                                <email>test@email.com</email>
+                            </aff>
+                        </contrib-group>
+                        <pub-date pub-type="epub">
+                            <year>2024</year>
+                            <month>3</month>
+                            <day>5</day>
+                        </pub-date>
+                    </article-meta>
+                </front>
+            </article>
+            """
+        xmltree = etree.fromstring(xml_single_digit)
+        obtained = list(prepare_request_data(xmltree))
+
+        self.assertEqual(len(obtained), 1)
+        self.assertEqual(obtained[0]["year"]["value"], "2024")
+        self.assertEqual(obtained[0]["month"]["value"], "03")
+        self.assertEqual(obtained[0]["day"]["value"], "05")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona funcionalidade para extrair e transformar dados de artigos XML (formato SciELO SPS) em payloads compatíveis com APIs externas, especificamente para integração com ORCID. A função `prepare_request_data` processa metadados de autores (ORCID, nome, email) e trabalhos acadêmicos (título, journal, DOI, datas de publicação) com validações rigorosas para garantir qualidade dos dados.

#### Onde a revisão poderia começar?
Inicie pela leitura do arquivo `packtools/sps/utils/prepare_request_data.py` que contém a implementação principal com as classes `Author`, `Authors` e `Work`. Em seguida, examine `test_prepare_request_data.py` para entender os casos de uso e validações implementadas.

#### Como este poderia ser testado manualmente?

1. Prepare um arquivo XML no formato SciELO SPS com contribuidores que possuam ORCID e nome completo
2. Execute o código:

```
from lxml import etree
from packtools.sps.utils.prepare_request_data import prepare_request_data

xml_tree = etree.parse('seu_arquivo.xml')
results = list(prepare_request_data(xml_tree))
print(results)
```

3. Verifique se o payload retornado contém todos os campos obrigatórios: `orcid_id`, `author_name`, `work_data`, `year`, `external-id`
4. Teste com XMLs que tenham campos ausentes para validar as rejeições automáticas


#### Algum cenário de contexto que queira dar?
NA

### Screenshots
NA

#### Quais são tickets relevantes?
NA

### Referências
[orcid-profile-publication-service](https://github.com/lepidus/orcid-profile-publication-service)

