### PR TITLE
Corrige apresentação de material suplementar

### DIFF
--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-supplementary-material.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-supplementary-material.xsl
@@ -97,21 +97,55 @@
         </div>
     </xsl:template>
     -->
-
     <xsl:template match="supplementary-material">
+        <xsl:apply-templates select="." mode="supplementary-material-label-and-caption"/>
         <div class="row fig" id="{@id}">
             <div class="col-md-12 col-sm-12">
                 <a target="_blank" download="1">
                     <xsl:apply-templates select="." mode="supplementary-material-link"/>
-                    <xsl:apply-templates select="." mode="supplementary-material-label-caption"/>
+                    <xsl:apply-templates select="." mode="supplementary-material-lnktxt"/>
                 </a>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template match="*" mode="supplementary-material-label-caption">
-        <xsl:value-of select="label"/>&#160;<xsl:apply-templates select="caption"/>
+    <xsl:template match="supplementary-material" mode="supplementary-material-label-and-caption">
+        <xsl:if test="label">
+            <h2 class="h5">
+                <xsl:apply-templates select="label"/>
+            </h2>
+        </xsl:if>
     </xsl:template>
+
+    <xsl:template match="supplementary-material" mode="supplementary-material-lnktxt">
+        <xsl:variable name="text"><xsl:apply-templates select="." mode="supplementary-material-variable-text"/></xsl:variable>
+        <xsl:apply-templates select="*|text()" mode="sm-link-text"/>
+        <xsl:if test="normalize-space($text)=''">
+            <xsl:apply-templates select="label" mode="sm-alt-link-text"/>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="*" mode="supplementary-material-variable-text">
+        <xsl:apply-templates select="*|text()" mode="supplementary-material-variable-text"/>
+    </xsl:template>
+    <xsl:template match="text()" mode="supplementary-material-variable-text">
+        <xsl:value-of select="."/>
+    </xsl:template>
+    <xsl:template match="supplementary-material/label" mode="supplementary-material-variable-text">
+    </xsl:template>
+
+    <xsl:template match="supplementary-material/*[text()]" mode="sm-link-text">
+        <xsl:apply-templates select="."/>
+    </xsl:template>
+    <xsl:template match="supplementary-material/label" mode="sm-link-text">
+    </xsl:template>
+    <xsl:template match="supplementary-material/label" mode="sm-alt-link-text">
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+    <!--xsl:template match="supplementary-material//p" mode="supplementary-material-lnktxt">
+        <p><xsl:apply-templates select="@*|*|text()"/></p>
+    </xsl:template-->
 
     <xsl:template match="supplementary-material[@xlink:href]" mode="supplementary-material-link">
         <xsl:attribute name="href"><xsl:value-of select="@xlink:href"/></xsl:attribute>


### PR DESCRIPTION
#### O que esse PR faz?
Corrige apresentação de material suplementar

```xml
<back>
<sec>
--
<supplementary-material id="suppl02" mime-subtype="pdf" mimetype="application" orientation="portrait" position="float" xlink:href="https://minio.scielo.br/documentstore/2318-0331/4nz5gmtGxgDrPFMFyLYYdMn/b4ced55f07aba9a7ee82f9f7b77107476ec45dae.pdf">
--
<label>Figure A. 1 –</label>
<caption>
<title>Accumulated daily rainfall anomalies for the climatological year of 2004, highlighting the beginning and end of the rainy season.</title>
</caption>
</supplementary-material>
<supplementary-material id="suppl2">
<label>Supplementary Material II</label>
<media mimetype="application" mime-subtype="pdf"
xlink:href="1980-5764-dn-19-s1-e20240251-suppl02.pdf"/>
</supplementary-material>
</sec>

<app-group>
<app id="app01">
<label>SUPPLEMENTARY MATERIAL</label>
<supplementary-material id="suppl01" mime-subtype="pdf" mimetype="application" xlink:href="0001-3765-aabc-96-01-e20230092-suppl01.pdf">
<p>Tables SI - SIV.</p>
<p> Figure S1.</p>
</supplementary-material>
</app>
</app-group>
</back>

```
#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
tendo um xml contendo o elemento

```console
python packtools/htmlgenerator.py arqyuvi.xml --nonetwork --nochecks --css ./packtools/catalogs/htmlgenerator/v3.0/static/css
```

#### Algum cenário de contexto que queira dar?
A estrutura deste elemento é bem variada.

### Screenshots
<img width="461" height="426" alt="Captura de Tela 2025-10-01 às 10 09 09" src="https://github.com/user-attachments/assets/7aecf0dd-849e-4043-b43c-267d28b79540" />

#### Quais são tickets relevantes?
Resolve https://github.com/scieloorg/opac_5/issues/345

Relacionados com:
https://github.com/scieloorg/opac_5/issues/332
https://github.com/scieloorg/opac_5/issues/313

### Referências
n/a
