### PR TITLE
fix: trata valores nulos ao extrair texto via XPath em XMLWithPre

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -791,7 +791,7 @@ class XMLWithPre:
                     [
                         text.strip()
                         for text in item.xpath(".//text()")
-                        if text.strip()
+                        if (text or "").strip()
                     ]
                 )
                 names.append({"surname": content})
@@ -801,7 +801,7 @@ class XMLWithPre:
                     [
                         text.strip()
                         for text in item.xpath(".//text()")
-                        if text.strip()
+                        if (text or "").strip()
                     ]
                 )
                 collab = content
@@ -825,7 +825,7 @@ class XMLWithPre:
         titles = []
         for item in self.xmltree.xpath(xpath):
             title = " ".join(
-                [text.strip() for text in item.xpath(".//text()") if text.strip()]
+                [text.strip() for text in item.xpath(".//text()") if text and text.strip()]
             )
             titles.append(title)
         return sorted(titles)


### PR DESCRIPTION
## PR: Corrige AttributeError ao processar elementos XML vazios

#### O que esse PR faz?
Corrige bug onde `text.strip()` causava `AttributeError` quando XPath retornava `None` para elementos XML vazios. Adiciona verificações defensivas nos métodos `person_group_from_aff_xpath` e `get_partial_titles`.

#### Onde a revisão poderia começar?
`packtools/sps/pid_provider/xml_sps_lib.py`, linha 791

#### Como este poderia ser testado manualmente?
```python
# XML com elemento vazio que causava erro
xml = XMLWithPre('<article><name><surname></surname></name></article>')
xml.person_group_from_aff_xpath()  # Antes: AttributeError, Agora: OK
```

#### Algum cenário de contexto que queira dar?
Bug identificado ao processar XMLs legados com elementos vazios. O `xpath(".//text()")` pode retornar `None` em elementos sem conteúdo textual, causando falha no `.strip()`.

#### Quais são tickets relevantes?
N/A

### Referências
- [[lxml XPath text() behavior](https://lxml.de/xpathxslt.html#xpath-return-values)](https://lxml.de/xpathxslt.html#xpath-return-values)