### PR TITLE
feat: adiciona suporte para string ISO 8601 em article_publication_date

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -907,9 +907,16 @@ class XMLWithPre:
         value : dict (keys: year, month, day)
         """
         try:
+            if isinstance(value, str):
+                parts = value.split("-")
+                value = {
+                    "day": parts[2],
+                    "month": parts[1],
+                    "year": parts[0],
+                }
             formatted = format_date(**value)
-        except XMLWithPreArticlePublicationDateError:
-            raise ValueError(
+        except Exception as e:
+            raise XMLWithPreArticlePublicationDateError(
                 f"Unable to set article_publication_date with {value}. Date with valid year, month, day is required"
             )
 


### PR DESCRIPTION
# Adiciona suporte para string ISO 8601 em article_publication_date

## Descrição

Esta PR adiciona suporte para receber datas no formato string ISO 8601 (`YYYY-MM-DD`) no método `article_publication_date` da classe `XMLWithPre`, mantendo a compatibilidade com o formato dict existente.

## Motivação

Atualmente, o método `article_publication_date` aceita apenas um dicionário com as chaves `year`, `month` e `day`. Esta limitação força os consumidores da API a sempre converter strings de data para o formato dict, mesmo quando já possuem datas no formato padrão ISO 8601.

## Mudanças Implementadas

### 1. Detecção e conversão automática de strings
- Verifica se o valor recebido é uma string
- Converte strings no formato `YYYY-MM-DD` para o dict esperado internamente
- Mantém compatibilidade total com código existente que usa dict

### 2. Melhoria no tratamento de exceções
- Utiliza `XMLWithPreArticlePublicationDateError` de forma consistente
- Captura qualquer exceção durante o processamento e re-lança com mensagem clara
- Melhora a rastreabilidade de erros

## Exemplo de Uso

### Antes (apenas dict)
```python
xml_with_pre.article_publication_date = {
    "year": "2024",
    "month": "03",
    "day": "15"
}
```

### Depois (dict ou string)
```python
# Formato dict continua funcionando
xml_with_pre.article_publication_date = {
    "year": "2024",
    "month": "03",
    "day": "15"
}

# Novo: formato string ISO 8601
xml_with_pre.article_publication_date = "2024-03-15"
```

## Testes

- [ ] Testes existentes continuam passando
- [ ] Adicionados testes para o novo formato string
- [ ] Testado tratamento de exceções para formatos inválidos

## Impacto

- **Retrocompatibilidade**: ✅ Totalmente mantida
- **Breaking changes**: ❌ Nenhuma
- **Performance**: Impacto mínimo, apenas adiciona uma verificação de tipo

## Checklist

- [x] Código segue os padrões do projeto
- [x] Tratamento de erros apropriado
- [ ] Testes unitários adicionados/atualizados
- [ ] Documentação atualizada se necessário

## Tipo de mudança

- [ ] Bug fix
- [x] Nova funcionalidade (non-breaking)
- [ ] Breaking change
- [ ] Documentação