### PR TITLE
Fix pkg name2

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -540,27 +540,41 @@ class XMLWithPre:
     @cached_property
     def alternative_sps_pkg_name_suffix(self):
         return self.order or self.filename
+    
+    @property
+    def additional_sps_pkg_name_suffix(self):
+        return self._additional_sps_pkg_name_suffix
+
+    @additional_sps_pkg_name_suffix.setter
+    def additional_sps_pkg_name_suffix(self, value):
+        self._additional_sps_pkg_name_suffix = value
 
     @cached_property
     def sps_pkg_name(self):
         """Cache do nome do pacote SPS que é usado frequentemente"""
-        try:
-            suppl = self.suppl
-            if suppl and int(suppl) == 0:
-                suppl = "suppl"
-        except (TypeError, ValueError):
-            pass
-
         xml_acron = Acronym(self.xmltree)
         parts = [
             self.journal_issn_electronic or self.journal_issn_print,
             xml_acron.text,
             self.volume,
             self.number and self.number.zfill(2),
-            suppl,
+            self.sps_pkg_name_suppl,
             self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
+            self.additional_sps_pkg_name_suffix,
         ]
         return "-".join([part for part in parts if part])
+    
+    @property
+    def sps_pkg_name_suppl(self):
+        suppl = self.suppl
+        if not suppl:
+            return None
+        try:
+            if int(suppl) == 0:
+                return "suppl"
+        except (TypeError, ValueError):
+            pass
+        return f"s{self.suppl}"
 
     @cached_property
     def article_id_parent(self):

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -526,12 +526,8 @@ class XMLWithPre:
     def sps_pkg_name_suffix(self):
         if self.elocation_id:
             return self.elocation_id
-        if self.fpage:
-            try:
-                if int(self.fpage) != 0:
-                    return self.fpage + (self.fpage_seq or "")
-            except (TypeError, ValueError):
-                return self.fpage + (self.fpage_seq or "")
+        if self.sps_pkg_name_fpage:
+            return self.sps_pkg_name_fpage
         if self.main_doi:
             doi = self.main_doi
             if "/" in doi:
@@ -539,17 +535,27 @@ class XMLWithPre:
             return doi.replace(".", "-")
 
     @cached_property
+    def sps_pkg_name_fpage(self):
+        fpage = self.fpage
+        if not fpage:
+            return None
+        try:
+            if int(fpage) == 0:
+                return None
+        except (TypeError, ValueError):
+            pass
+        seq = self.fpage_seq
+        if not seq:
+            if self.lpage == fpage:
+                seq = self.v2 and self.v2[-5:]
+        if seq:
+            return f"{fpage}_{seq}"
+        return fpage
+
+    @cached_property
     def alternative_sps_pkg_name_suffix(self):
         return self.order or self.filename
     
-    @property
-    def additional_sps_pkg_name_suffix(self):
-        return self._additional_sps_pkg_name_suffix
-
-    @additional_sps_pkg_name_suffix.setter
-    def additional_sps_pkg_name_suffix(self, value):
-        self._additional_sps_pkg_name_suffix = value
-
     @cached_property
     def sps_pkg_name(self):
         """Cache do nome do pacote SPS que é usado frequentemente"""
@@ -561,7 +567,6 @@ class XMLWithPre:
             self.number and self.number.zfill(2),
             self.sps_pkg_name_suppl,
             self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
-            self.additional_sps_pkg_name_suffix,
         ]
         return "-".join([part for part in parts if part])
     

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -424,6 +424,7 @@ class XMLWithPre:
         self.relative_system_id = None
         self._sps_version = None
         self.errors = None
+        self._additional_sps_pkg_name_suffix = None
 
     @property
     def data(self):
@@ -574,7 +575,7 @@ class XMLWithPre:
                 return "suppl"
         except (TypeError, ValueError):
             pass
-        return f"s{self.suppl}"
+        return f"s{suppl}"
 
     @cached_property
     def article_id_parent(self):


### PR DESCRIPTION
# PR: Refatoração do sistema de nomenclatura de pacotes SPS

## Descrição
Evita que pacotes diferentes que apesar de ter a mesma fpage tenha o mesmo nome de pacote.
Quando houver fpage == lpage, o pacote ganha um sufixo `_NNNNN` (último 5 dígitos de pid v2)

Esta PR refatora o sistema de geração de nomes de pacotes SPS em `XMLWithPre`, melhorando a organização do código e adicionando nova funcionalidade para tratamento de sequências de páginas.

## Motivação

- Código de processamento de `fpage` estava duplicado e difícil de manter
- Necessidade de suportar geração automática de sequência para artigos com página única
- Propriedade `additional_sps_pkg_name_suffix` não estava sendo utilizada no sistema

## Mudanças Implementadas

### 1. Novo método `sps_pkg_name_fpage`
- ✨ Extrai lógica de processamento de `fpage` para método dedicado com `@cached_property`
- ✨ Adiciona geração automática de sequência usando últimos 5 caracteres de `v2` quando `lpage == fpage`
- 🔧 Altera formato de concatenação de sequência para usar underscore: `fpage_seq` ao invés de `fpageseq`
- ✅ Mantém validação existente de `fpage != 0`

### 2. Simplificação de `sps_pkg_name_suffix`
- ♻️ Delega processamento de fpage para o novo método `sps_pkg_name_fpage`
- ✅ Mantém lógica de fallback para `elocation_id` e `main_doi`

### 3. Remoção de código não utilizado
- 🔥 Remove propriedade `additional_sps_pkg_name_suffix` e seus métodos getter/setter
- 🔥 Remove `additional_sps_pkg_name_suffix` da construção de `sps_pkg_name`

## Exemplo de Impacto

### Antes:
```python
# Artigo com fpage=100, lpage=100, sem fpage_seq
nome_pacote = "...-100"  # Sem diferenciação
```

### Depois:
```python
# Artigo com fpage=100, lpage=100, v2="...abc123"
nome_pacote = "...-100_c123"  # Com sequência automática dos últimos 5 chars de v2
```

## Testes

- [ ] Verificado comportamento com artigos que possuem `elocation_id`
- [ ] Verificado comportamento com artigos que possuem apenas `fpage`
- [ ] Verificado novo comportamento quando `fpage == lpage`
- [ ] Verificado fallback para DOI quando não há fpage válido
- [ ] Confirmado que remoção de `additional_sps_pkg_name_suffix` não impacta sistema

## Breaking Changes

⚠️ **Potencial breaking change**: O formato de concatenação mudou de `fpageseq` para `fpage_seq` quando há sequência. Verificar se há dependências externas que fazem parsing do nome do pacote.

## Checklist

- [x] Código segue padrões do projeto
- [x] Mantém retrocompatibilidade para casos sem sequência
- [x] Usa `@cached_property` para otimização de performance
- [ ] Testes unitários atualizados
- [ ] Documentação atualizada se necessário

## Observações

Esta refatoração faz parte do esforço contínuo de modernização e otimização do sistema de processamento de artigos SciELO, melhorando a manutenibilidade e adicionando suporte para casos específicos de paginação em publicações acadêmicas.