### PR TITLE
fix(models): Corrige o idioma das versões de tradução dos resumos

### DIFF
--- a/packtools/sps/models/v2/abstract.py
+++ b/packtools/sps/models/v2/abstract.py
@@ -239,7 +239,7 @@ class XMLAbstracts:
         for node in self.xmltree.xpath(xpath):
             abstract = Abstract(
                 node,
-                self.lang,
+                node.get("{http://www.w3.org/XML/1998/namespace}lang") or self.lang,
                 tags_to_keep=self.tags_to_keep,
                 tags_to_keep_with_content=self.tags_to_keep_with_content,
                 tags_to_remove_with_content=self.tags_to_remove_with_content,


### PR DESCRIPTION
### Descrição

Esta alteração aprimora a extração de resumos no módulo `XMLAbstracts`. Anteriormente, o idioma era definido de forma estática através de `self.lang`. Agora, o código tenta primeiro obter o idioma diretamente do atributo `xml:lang` do nó XML específico e utiliza o `self.lang` apenas como valor padrão (fallback).

### Motivação

Em documentos XML JATS, é comum haver múltiplos resumos (ex: original e traduções). Cada nó `<abstract>` pode carregar seu próprio atributo de idioma. Esta mudança garante que a classe `Abstract` seja instanciada com o idioma correto de cada nó, evitando que traduções sejam marcadas incorretamente com o idioma principal do artigo.

### Mudanças Principais

* **Local:** `packtools/sps/models/v2/abstract.py`
* **Lógica:** Implementação de busca do atributo `{http://www.w3.org/XML/1998/namespace}lang` via XPath/LXML antes de recorrer ao atributo de classe.

### Tipo de Alteração

* [x] **Bug fix** (correção de uma funcionalidade que não estava operando corretamente)
* [ ] **New feature** (nova funcionalidade)
* [ ] **Breaking change** (correção ou funcionalidade que pode quebrar compatibilidade)
* [ ] **Documentation** (mudança em documentação)

### Como testar?

1. Utilize um XML que contenha resumos em múltiplos idiomas (ex: `pt` e `en`).
2. Instancie `XMLAbstracts`.
3. Verifique se a lista de objetos retornada por `self.xmltree.xpath(xpath)` reflete os idiomas individuais de cada nó e não apenas o idioma global definido no construtor.
