### PR TITLE
refactor: mover lógica de âncora e título para abstracts sem título

### DIFF
--- a/packtools/catalogs/htmlgenerator/v3.0/article-meta-abstract.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-meta-abstract.xsl
@@ -38,8 +38,6 @@
     </xsl:template>
 
     <xsl:template match="*[abstract]" mode="text-abstracts">
-        <xsl:apply-templates select="." mode="create-anchor-and-title-for-abstracts-without-title"/>
-
         <xsl:apply-templates select="abstract[not(@abstract-type)]" mode="layout"/>
         <xsl:apply-templates select="abstract[@abstract-type='key-points']" mode="layout"/>
         <xsl:apply-templates select="abstract[@abstract-type='graphical']" mode="layout"/>
@@ -54,13 +52,20 @@
     </xsl:template>
 
     <xsl:template match="*[abstract]" mode="create-anchor-and-title-for-abstracts-without-title">
+        
+    </xsl:template>
+
+    <xsl:template match="abstract[not(title)] | trans-abstract[not(title)]" mode="anchor-and-title">
         <xsl:if test="not($has_abstract_title)">
             <xsl:variable name="title">
-                <xsl:apply-templates select="." mode="text-labels">
-                    <xsl:with-param name="text">
+                <xsl:apply-templates select="." mode="translate">
+                    <xsl:with-param name="term">Abstract</xsl:with-param>
+                    <xsl:with-param name="lang">
                         <xsl:choose>
-                            <xsl:when test="$total_abstracts=1">Abstract</xsl:when>
-                            <xsl:otherwise>Abstracts</xsl:otherwise>
+                            <xsl:when test="@xml:lang"><xsl:value-of select="@xml:lang"/></xsl:when>
+                            <xsl:when test="../../@xml:lang"><xsl:value-of select="../../@xml:lang"/></xsl:when>
+                            <xsl:when test="../../../@xml:lang"><xsl:value-of select="../../../@xml:lang"/></xsl:when>
+                            <xsl:otherwise>en</xsl:otherwise>
                         </xsl:choose>
                     </xsl:with-param>
                 </xsl:apply-templates>
@@ -69,9 +74,6 @@
                 <xsl:with-param name="title" select="$title"/>
             </xsl:call-template>
         </xsl:if>
-    </xsl:template>
-
-    <xsl:template match="abstract[not(title)] | trans-abstract[not(title)]" mode="anchor-and-title">
     </xsl:template>
 
     <xsl:template match="abstract[title] | trans-abstract[title]" mode="anchor-and-title">


### PR DESCRIPTION
## PR: Mover lógica de âncora e título para abstracts/trans-abstracts sem título

#### O que esse PR faz?

Refatora a geração de âncora e título para abstracts e trans-abstracts que não possuem elemento `<title>`. Anteriormente, a lógica era aplicada uma única vez no nível do elemento pai (via template `create-anchor-and-title-for-abstracts-without-title`), o que gerava um título genérico ("Abstract" ou "Abstracts") sem considerar o idioma de cada abstract individualmente. Com esta mudança, a lógica passa a ser aplicada diretamente no template `anchor-and-title` de cada `abstract[not(title)]` e `trans-abstract[not(title)]`, permitindo que o título seja traduzido corretamente de acordo com o idioma (`@xml:lang`) de cada elemento.

Principais mudanças:

- Remove a chamada ao template `create-anchor-and-title-for-abstracts-without-title` do fluxo principal (`text-abstracts`)
- Move a lógica de geração de âncora e título para o template `anchor-and-title` que trata `abstract[not(title)]` e `trans-abstract[not(title)]`
- Substitui a chamada ao mode `text-labels` pelo mode `translate`, passando o termo "Abstract" e o idioma determinado dinamicamente
- Determina o idioma a partir de `@xml:lang` do próprio elemento, do avô (`../../@xml:lang`) ou do bisavô (`../../../@xml:lang`), com fallback para `en`
- Remove a lógica condicional de singular/plural ("Abstract" vs "Abstracts") em favor da tradução individualizada do termo "Abstract"

#### Onde a revisão poderia começar?

`packtools/catalogs/htmlgenerator/v3.0/article-meta-abstract.xsl` — iniciar pelo template `match="abstract[not(title)] | trans-abstract[not(title)]" mode="anchor-and-title"` (linha ~55), que agora contém a lógica principal.

#### Como este poderia ser testado manualmente?

1. Preparar um XML JATS com múltiplos abstracts sem `<title>`, em idiomas diferentes (por exemplo, `abstract` em `pt` e `trans-abstract` em `en` e `es`)
2. Gerar o HTML via htmlgenerator v3.0
3. Verificar que cada abstract/trans-abstract sem título recebe a âncora e o título traduzido no idioma correto (ex.: "Resumo" para `pt`, "Abstract" para `en`, "Resumen" para `es`)
4. Testar também com abstracts que já possuem `<title>` — estes não devem ser afetados pela mudança
5. Testar com um único abstract sem título para garantir que o comportamento permanece correto sem a lógica de singular/plural

#### Algum cenário de contexto que queira dar?

O comportamento anterior apresentava duas limitações: (1) o título era gerado uma única vez para todos os abstracts, sem considerar o idioma individual de cada um; (2) a lógica de singular/plural ("Abstract" vs "Abstracts") era baseada na contagem total de abstracts, mas não refletia a necessidade real de traduzir o termo para o idioma correto de cada abstract. Com a refatoração, cada abstract/trans-abstract sem título é responsável por gerar seu próprio título traduzido, o que é mais consistente com o modelo de templates XSLT e com o suporte multilíngue do SciELO.

### Screenshots

N/A

#### Quais são tickets relevantes?
#1208 

### Referências

<!-- Indicar referências utilizadas -->