### PR TITLE
test: corrige mocks obsoletos e assertions incompletas após refatoraç…

### DIFF
--- a/packtools/sps/validation/visual_resource_base.py
+++ b/packtools/sps/validation/visual_resource_base.py
@@ -1,7 +1,5 @@
 import os
 
-from packtools.sps.validation.accessibility_data import \
-    AccessibilityDataValidation
 from packtools.sps.validation.utils import build_response
 
 
@@ -9,9 +7,6 @@ class VisualResourceBaseValidation:
     def __init__(self, data, params):
         self.data = data
         self.params = params
-        self.accessibility_validation = AccessibilityDataValidation(
-            data, self.params
-        )
 
     def validate(self):
         yield self.validate_id()
@@ -71,5 +66,3 @@ class VisualResourceBaseValidation:
             data=self.data,
         )
 
-    def validate_accessibility(self):
-        yield from self.accessibility_validation.validate()

--- a/tests/sps/models/test_visual_resource_base.py
+++ b/tests/sps/models/test_visual_resource_base.py
@@ -104,7 +104,13 @@ class TestVisualResourceBase(unittest.TestCase):
             "tag": "media",
             "xml": '<media xmlns:ns0="http://www.w3.org/1999/xlink" id="media1" mimetype="video" mime-subtype="mp4" '
                    'ns0:href="1234-5678-scie-58-e1043-md1.mp4"/>',
-            "xref_sec_rid": None
+            "xref_sec_rid": None,
+            "mimetype": "video",
+            "mime_subtype": "mp4",
+            "parent_tag": "supplementary-material",
+            "parent_label": "Supplementary material 1",
+            "parent_caption_title": "Video 1",
+            "long_desc_count": 0,
         }
         self.assertDictEqual(resource_1.data, expected_data_1)
 
@@ -116,6 +122,12 @@ class TestVisualResourceBase(unittest.TestCase):
             "xml": '<media xmlns:ns0="http://www.w3.org/1999/xlink" id="media2" mimetype="application" mime-subtype="xlsx" '
                    'ns0:href="1234-5678-scie-58-e1043-md2.xlsx"/>',
             "xref_sec_rid": None,
+            "mimetype": "application",
+            "mime_subtype": "xlsx",
+            "parent_tag": "supplementary-material",
+            "parent_label": "Supplementary material 3",
+            "parent_caption_title": "Spreadsheet 1",
+            "long_desc_count": 0,
         }
         self.assertDictEqual(resource_2.data, expected_data_2)
 

--- a/tests/sps/validation/test_media.py
+++ b/tests/sps/validation/test_media.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import MagicMock
 
 from packtools.sps.validation.media import MediaValidation
 
@@ -124,13 +123,14 @@ class MediaValidationTest(unittest.TestCase):
         result = validator.validate_xlink_href()
         self.assertEqual(result["response"], "OK")
 
-    def test_validate_integration_with_mocked_accessibility(self):
+    def test_validate_integration_yields_only_mime_id_and_xlink_href(self):
         """Tests full validate() flow ensures accessibility is NOT duplicated.
 
         Accessibility validation is performed separately by the orchestrator
         through ``XMLAccessibilityDataValidation``, so ``MediaValidation``
         must not yield accessibility entries to avoid duplicated rows in the
-        validation report.
+        validation report. VisualResourceBaseValidation no longer holds an
+        AccessibilityDataValidation instance, so no patching is required.
         """
         data = {
             "tag": "media",
@@ -141,21 +141,11 @@ class MediaValidationTest(unittest.TestCase):
             "mime_subtype": "mp4",
         }
 
-        from packtools.sps.validation import visual_resource_base
-        original = visual_resource_base.AccessibilityDataValidation
-        visual_resource_base.AccessibilityDataValidation = lambda data, params: MagicMock(
-            validate=lambda: iter([{"mocked": True}])
-        )
-
-        try:
-            validator = MediaValidation(data, self.params)
-            results = list(validator.validate())
-            # 1 (mime_type_and_subtype) + 1 (id) + 1 (xlink_href);
-            # accessibility entries must NOT be present here.
-            self.assertEqual(len(results), 3)
-            self.assertFalse(any(r.get("mocked") for r in results))
-        finally:
-            visual_resource_base.AccessibilityDataValidation = original
+        validator = MediaValidation(data, self.params)
+        results = list(validator.validate())
+        # 1 (mime_type_and_subtype) + 1 (id) + 1 (xlink_href);
+        # accessibility entries must NOT be present here.
+        self.assertEqual(len(results), 3)
 
     def test_validate_xlink_href_missing_attribute(self):
         """Missing @xlink:href must produce an error entry, not be swallowed.

--- a/tests/sps/validation/test_visual_resource_base.py
+++ b/tests/sps/validation/test_visual_resource_base.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import MagicMock
 from packtools.sps.validation.visual_resource_base import VisualResourceBaseValidation
 
 
@@ -47,7 +46,7 @@ class TestVisualResourceBaseValidation(unittest.TestCase):
         self.assertEqual(result["response"], "WARNING")
         self.assertEqual(result["expected_value"], "File name with extension")
 
-    def test_validate_integration_with_mocked_accessibility(self):
+    def test_validate_integration_yields_only_id_and_xlink_href(self):
         data = {
             "tag": "media",
             "xml": "<media></media>",
@@ -55,20 +54,13 @@ class TestVisualResourceBaseValidation(unittest.TestCase):
             "xlink_href": "video.mp4"
         }
 
-        # Monkey patch AccessibilityDataValidation to ensure it is NOT
-        # invoked from VisualResourceBaseValidation.validate(): accessibility
-        # checks are run separately by XMLAccessibilityDataValidation in the
-        # orchestrator, so calling them again here would duplicate entries.
-        from packtools.sps.validation import visual_resource_base
-        visual_resource_base.AccessibilityDataValidation = lambda data, params: MagicMock(validate=lambda: iter([{"mocked": True}]))
-
         validator = VisualResourceBaseValidation(data, self.params)
         results = list(validator.validate())
 
         # Only validate_id and validate_xlink_href are yielded; accessibility
         # is intentionally excluded to avoid duplicated validation entries.
+        # XMLAccessibilityDataValidation handles it separately in the orchestrator.
         self.assertEqual(len(results), 2)
-        self.assertFalse(any(r.get("mocked") for r in results))
 
     def test_validate_xlink_href_missing(self):
         data = {"tag": "media", "xlink_href": None, "xml": "<media></media>", "id": "m1"}


### PR DESCRIPTION
## Contexto

Este PR depende do #1131, que remove `AccessibilityDataValidation` de `VisualResourceBaseValidation.__init__` e exclui o método morto `validate_accessibility()`.

Três arquivos de teste precisaram de correção como consequência dessa refatoração, mais uma lacuna de assertion pré-existente sem relação com ela.

## Alterações

### `tests/sps/validation/test_visual_resource_base.py`
- Removido monkey-patch de `visual_resource_base.AccessibilityDataValidation`   (símbolo não existe mais no módulo; patcheá-lo levanta `AttributeError`)
- Removido import órfão `from unittest.mock import MagicMock` 
- Teste renomeado para `test_validate_integration_yields_only_id_and_xlink_href`;   verifica `len(results) == 2` diretamente, sem necessidade de mock

### `tests/sps/validation/test_media.py`
- Mesma correção: removidos monkey-patch, bloco `try/finally` e import de `MagicMock`
- Teste renomeado para `test_validate_integration_yields_only_mime_id_and_xlink_href`;
  verifica `len(results) == 3` diretamente

### `tests/sps/models/test_visual_resource_base.py`
- Falha pré-existente: `test_data_output` com dicionário esperado incompleto
- Adicionadas as seis chaves que o modelo realmente retorna: `mimetype`,
  `mime_subtype`, `parent_tag`, `parent_label`, `parent_caption_title`,
  `long_desc_count`

## Testes
pytest tests/sps/validation/test_visual_resource_base.py  # todos passaram
pytest tests/sps/validation/test_media.py                 # todos passaram
pytest tests/sps/models/test_visual_resource_base.py      # todos passaram
