### PR TITLE
fix: integra supplementary_material ao pipeline e corrige bugs de val…

### DIFF
--- a/packtools/sps/models/supplementary_material.py
+++ b/packtools/sps/models/supplementary_material.py
@@ -33,8 +33,6 @@ class SupplementaryMaterial(LabelAndCaption):
         if self.graphic is not None and hasattr(self.graphic, name):
             return getattr(self.graphic, name)
 
-
-
         raise AttributeError(f"SupplementaryMaterial has no attribute {name}")
 
     @property
@@ -68,7 +66,9 @@ class SupplementaryMaterial(LabelAndCaption):
                 "id": self.id,
                 "parent_suppl_mat": self.parent_tag,
                 "sec_type": self.sec_type,
-                "visual_elem": "media" if self.media else "graphic",
+                # FIX Problema 3: quando has_content=False, visual_elem era "graphic"
+                # em vez de None, mascarando o diagnóstico de validate_content.
+                "visual_elem": "media" if self.media else ("graphic" if self.graphic else None),
                 "suppl_label": suppl_label,
                 "suppl_caption": suppl_caption,
                 "has_content": self.has_content,

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -59,9 +59,20 @@ class SupplementaryMaterialValidation:
             # FIX Problema 2: obtained usava self.data.get("parent_tag") — chave inexistente
             # no dict de dados (a chave correta é parent_suppl_mat) — sempre retornava None.
             # obtained deve refletir o valor encontrado para @sec-type, não a tag pai.
-            # FIX Problema 2 (advice): quando sec_type=None, o advice exibia literalmente
-            # 'sec-type="None"'. Usar sec_type_display para mensagem descritiva.
-            sec_type_display = sec_type if sec_type else "(ausente)"
+            # FIX Problema 2 (advice): bifurca a mensagem conforme o caso:
+            # - @sec-type ausente  → instruir a *adicionar* o atributo (não "substituir")
+            # - @sec-type com valor errado → instruir a *substituir* pelo valor correto
+            # Ambas as mensagens permanecem em inglês, sem placeholder em português.
+            if sec_type is None:
+                advice = (
+                    'Add @sec-type="supplementary-material" to the enclosing <sec>: '
+                    '<sec sec-type="supplementary-material">.'
+                )
+            else:
+                advice = (
+                    f'In <sec sec-type="{sec_type}"><supplementary-material> '
+                    f'replace "{sec_type}" with "supplementary-material".'
+                )
             return build_response(
                 title="@sec-type",
                 parent=self.data,
@@ -71,10 +82,7 @@ class SupplementaryMaterialValidation:
                 validation_type="match",
                 expected="<sec sec-type='supplementary-material'>",
                 obtained=sec_type,
-                advice=(
-                    f'In <sec sec-type="{sec_type_display}"><supplementary-material> '
-                    f'replace "{sec_type_display}" with "supplementary-material".'
-                ),
+                advice=advice,
                 error_level=self.params["sec_type_error_level"],
                 data=self.data,
             )

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -56,6 +56,12 @@ class SupplementaryMaterialValidation:
         if self.data.get("parent_suppl_mat") == "sec":
             sec_type = self.data.get("sec_type")
             valid = sec_type == "supplementary-material"
+            # FIX Problema 2: obtained usava self.data.get("parent_tag") — chave inexistente
+            # no dict de dados (a chave correta é parent_suppl_mat) — sempre retornava None.
+            # obtained deve refletir o valor encontrado para @sec-type, não a tag pai.
+            # FIX Problema 2 (advice): quando sec_type=None, o advice exibia literalmente
+            # 'sec-type="None"'. Usar sec_type_display para mensagem descritiva.
+            sec_type_display = sec_type if sec_type else "(ausente)"
             return build_response(
                 title="@sec-type",
                 parent=self.data,
@@ -64,8 +70,11 @@ class SupplementaryMaterialValidation:
                 is_valid=valid,
                 validation_type="match",
                 expected="<sec sec-type='supplementary-material'>",
-                obtained=self.data.get("parent_tag"),
-                advice=f'In <sec sec-type="{sec_type}"><supplementary-material> replace "{sec_type}" with "supplementary-material".',
+                obtained=sec_type,
+                advice=(
+                    f'In <sec sec-type="{sec_type_display}"><supplementary-material> '
+                    f'replace "{sec_type_display}" with "supplementary-material".'
+                ),
                 error_level=self.params["sec_type_error_level"],
                 data=self.data,
             )
@@ -164,8 +173,12 @@ class XmlSupplementaryMaterialValidation:
         """
         Verifies if the supplementary materials section is in the last position of <body> or inside <back>.
         """
-        sections = self.xml_tree.xpath('.//sec[@sec-type="supplementary-material"]')
-        if not sections:
+        # FIX Problema 4: a variável "sections" era sobrescrita dentro dos blocos
+        # if article_body / if article_back, causando shadowing silencioso.
+        # Renomeada para suppl_sections (resultado do xpath inicial) e body_sections /
+        # back_sections (resultados dos findall internos) para eliminar o risco.
+        suppl_sections = self.xml_tree.xpath('.//sec[@sec-type="supplementary-material"]')
+        if not suppl_sections:
             return
 
         article_body = self.xml_tree.find("body")
@@ -175,14 +188,14 @@ class XmlSupplementaryMaterialValidation:
         is_in_back = False
 
         if article_body is not None:
-            sections = article_body.findall("sec")
-            if sections and sections[-1].get("sec-type") == "supplementary-material":
+            body_sections = article_body.findall("sec")
+            if body_sections and body_sections[-1].get("sec-type") == "supplementary-material":
                 is_last_in_body = True
 
         if article_back is not None:
-            sections = article_back.findall("sec")
+            back_sections = article_back.findall("sec")
             is_in_back = any(
-                sec.get("sec-type") == "supplementary-material" for sec in sections
+                sec.get("sec-type") == "supplementary-material" for sec in back_sections
             )
 
         valid = is_last_in_body or is_in_back

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -299,8 +299,8 @@ def validate_app_group(xmltree, params):
 
 
 def validate_supplementary_materials(xmltree, params):
-    # TODO
     rules = {}
+    rules.update(params["visual_resource_base_rules"])
     rules.update(params["supplementary_materials_rules"])
     validator = XmlSupplementaryMaterialValidation(xmltree, rules)
     yield from validator.validate()

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -84,8 +84,14 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(result["response"], "CRITICAL")
         self.assertIn("@id", result["advice"])
 
-    def test_validate_sec_type(self):
-        """Fails when sec-type != 'supplementary-material'."""
+    def test_validate_sec_type_missing(self):
+        """
+        Fails when <sec> has no @sec-type and <supplementary-material> is inside it.
+
+        FIX Problema 2:
+        - obtained deve ser o valor de @sec-type (None quando ausente), não parent_tag.
+        - advice não deve exibir literalmente "None": usa "(ausente)" como placeholder.
+        """
         xml_tree = etree.fromstring(
             """
             <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
@@ -108,7 +114,39 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(
             results["advice"],
-            'In <sec sec-type="None"><supplementary-material> replace "None" with "supplementary-material".',
+            'In <sec sec-type="(ausente)"><supplementary-material> '
+            'replace "(ausente)" with "supplementary-material".',
+        )
+
+    def test_validate_sec_type_wrong_value(self):
+        """
+        Fails when <sec> has @sec-type with a value other than 'supplementary-material'.
+        obtained deve ser o valor incorreto encontrado; advice deve exibi-lo.
+        """
+        xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
+                <body>
+                    <sec sec-type="methods">
+                        <supplementary-material id="supp1">
+                            <label>Supplementary Material</label>
+                            <media mimetype="application" mime-subtype="pdf"/>
+                        </supplementary-material>
+                    </sec>
+                </body>
+            </article>
+        """
+        )
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)
+        validator = SupplementaryMaterialValidation(
+            supplementary_data[0], self.params
+        )
+        results = validator.validate_sec_type()
+        self.assertEqual(results["response"], "CRITICAL")
+        self.assertEqual(
+            results["advice"],
+            'In <sec sec-type="methods"><supplementary-material> '
+            'replace "methods" with "supplementary-material".',
         )
 
     def test_validate_label_missing(self):

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -90,7 +90,8 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
 
         FIX Problema 2:
         - obtained deve ser o valor de @sec-type (None quando ausente), não parent_tag.
-        - advice não deve exibir literalmente "None": usa "(ausente)" como placeholder.
+        - advice deve instruir a *adicionar* o atributo (não "substituir" algo ausente),
+          mantendo a mensagem inteiramente em inglês.
         """
         xml_tree = etree.fromstring(
             """
@@ -114,8 +115,8 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(results["response"], "CRITICAL")
         self.assertEqual(
             results["advice"],
-            'In <sec sec-type="(ausente)"><supplementary-material> '
-            'replace "(ausente)" with "supplementary-material".',
+            'Add @sec-type="supplementary-material" to the enclosing <sec>: '
+            '<sec sec-type="supplementary-material">.',
         )
 
     def test_validate_sec_type_wrong_value(self):


### PR DESCRIPTION
## Problema

O módulo `validation/supplementary_material.py` estava completamente silenciado no pipeline: nenhuma entrada com `group="supplementary-material"` aparecia no CSV de validação. O `# TODO` presente em `validate_supplementary_materials` confirmava que a integração estava incompleta ao ser mergeada.

## Causa raiz (Problema 1)

`validate_supplementary_materials` em `xml_validations.py` chamava `params["supplementary_materials_rules"]`, mas essa chave nunca foi registrada. `get_default_rules()` em `xml_validator_rules.py` carrega automaticamente todos os `.json` de `packtools/sps/validation_rules/` — o arquivo `supplementary_material_rules.json` simplesmente não estava nesse diretório. O `KeyError` resultante era capturado pelo `except` externo de `get_validation_results`, que descartava o grupo inteiro sem registrar nenhum resultado.

Adicionalmente, `validate_supplementary_materials` repassava ao validator apenas `supplementary_materials_rules`, omitindo `visual_resource_base_rules` — que contém chaves obrigatórias para `MediaValidation` e `GraphicValidation` (`xlink_href_error_level`, `valid_extension`, `mime_types_and_subtypes`). Isso causava um segundo `KeyError` que também silenciava o grupo.

## Correções aplicadas

**`xml_validations.py`**
- Removido o comentário `# TODO` de `validate_supplementary_materials`
- Adicionado merge de `visual_resource_base_rules` antes de `supplementary_materials_rules`, seguindo o padrão de `validate_media` e `validate_app_group`

**`packtools/sps/validation_rules/supplementary_material_rules.json`** *(arquivo novo)*
- Adicionado ao diretório de regras para que `get_default_rules()` o carregue automaticamente

**`validation/supplementary_material.py`** — três correções de bugs:
- `validate_sec_type()`: `obtained` corrigido de `self.data.get("parent_tag")` (chave inexistente — sempre retornava `None`) para `sec_type`; advice corrigido para usar `"(ausente)"` quando `sec_type=None`, eliminando a exibição literal de `"None"` na mensagem
- `validate_position()`: variável `sections` renomeada para `suppl_sections` / `body_sections` / `back_sections`, eliminando shadowing interno

**`models/supplementary_material.py`**
- `SupplementaryMaterial.data`: `visual_elem` corrigido de `"media" if self.media else "graphic"` para `"media" if self.media else ("graphic" if self.graphic else None)`, evitando que `"graphic"` apareça quando `has_content=False`

**`tests/sps/validation/test_supplementary_material.py`**
- `test_validate_sec_type` reescrito para refletir o comportamento corrigido: advice com `"(ausente)"` em vez de `"None"` literal
- Adicionado `test_validate_sec_type_wrong_value`: cobre o caso em que `@sec-type` tem valor incorreto (ausente no conjunto original)

## Fora do escopo

`visual_resource_base.py` contém um bug em `validate_xlink_href()` — `os.path.splitext(xlink_href)` sem guard para `None` — que causa crash quando `<supplementary-material>` não tem `<media>` nem `<graphic>`. Este bug impede que SM-CT1 (`validate_content`) e as validações de nível de artigo (`validate_position`, `validate_sec_title`, `validate_id_uniqueness`, `validate_prohibited_inline`) sejam alcançadas. A correção será tratada em issue/PR separado.