### PR TITLE
fix(tablewrap): corrige validação de caption — usa presença de `<title>` em vez de conteúdo textual

### DIFF
--- a/packtools/sps/models/tablewrap.py
+++ b/packtools/sps/models/tablewrap.py
@@ -31,7 +31,7 @@ class TableWrap:
 
     @property
     def caption(self):
-        caption_element = self.element.find(".//caption")
+        caption_element = self.element.find("caption")
         if caption_element is not None:
             return ET.tostring(
                 caption_element, encoding="unicode", method="text"
@@ -50,7 +50,7 @@ class TableWrap:
         Returns:
             bool: True if <caption><title> exists (even if empty), False otherwise.
         """
-        caption_element = self.element.find(".//caption")
+        caption_element = self.element.find("caption")
         if caption_element is not None:
             return caption_element.find("title") is not None
         return False

--- a/packtools/sps/models/tablewrap.py
+++ b/packtools/sps/models/tablewrap.py
@@ -39,6 +39,23 @@ class TableWrap:
         return ""
 
     @property
+    def caption_has_title(self):
+        """
+        Checks whether <caption> contains a <title> child element.
+
+        A <title/> (empty) is structurally valid per SPS documentation and counts
+        as present. Returns False only when <caption> is absent entirely or when
+        <caption> has no <title> child at all.
+
+        Returns:
+            bool: True if <caption><title> exists (even if empty), False otherwise.
+        """
+        caption_element = self.element.find(".//caption")
+        if caption_element is not None:
+            return caption_element.find("title") is not None
+        return False
+
+    @property
     def table_wrap_foot(self):
         table_wrap_foot_elem = self.element.find(".//table-wrap-foot")
         if table_wrap_foot_elem is None:
@@ -149,6 +166,7 @@ class TableWrap:
             "table_wrap_id": self.table_wrap_id,
             "label": self.label,
             "caption": self.caption,
+            "caption_has_title": self.caption_has_title,
             "footnotes": self.table_wrap_foot,
             "alternative_elements": self.alternative_elements,
             "table": self.table,

--- a/packtools/sps/validation/tablewrap.py
+++ b/packtools/sps/validation/tablewrap.py
@@ -76,6 +76,10 @@ class TableWrapValidation:
         self.xml = f'<table-wrap id="{self.table_id}">' if self.table_id else '<table-wrap>'
 
     def get_default_params(self):
+        # Note: the former separate keys `label_error_level` and `caption_error_level`
+        # were consolidated into `label_or_caption_error_level` when the two individual
+        # validations were merged. Callers still passing the old keys will have them
+        # silently ignored; update any external rule dictionaries accordingly.
         return {
             "absent_error_level": "WARNING",
             "id_error_level": "CRITICAL",
@@ -136,21 +140,32 @@ class TableWrapValidation:
 
     def validate_label_or_caption(self):
         """
-        Validates the presence of <label> or <caption> in the <table-wrap>.
-        At least one of <label> or <caption> with <title> must be present.
+        Validates the presence of <label> or <caption> with <title> in the <table-wrap>.
+
+        At least one of the following must be present:
+          - <label> with non-empty text, OR
+          - <caption> containing a <title> child element (even if <title/> is empty,
+            its structural presence satisfies the SPS requirement).
+
+        Note: checking ``bool(caption_text)`` is insufficient because it treats a
+        structurally valid ``<caption><title/></caption>`` as missing (empty string),
+        and accepts a bare ``<caption>text</caption>`` without ``<title>`` as valid.
+        The model field ``caption_has_title`` performs the correct structural check.
 
         Returns:
             The validation result in the expected format.
         """
         label = self.data.get("label")
-        caption = self.data.get("caption")
-        is_valid = bool(label) or bool(caption)
+        caption_has_title = self.data.get("caption_has_title")
+        is_valid = bool(label) or bool(caption_has_title)
+
         obtained = []
         if label:
             obtained.append(f"label={label}")
-        if caption:
-            obtained.append(f"caption={caption}")
+        if caption_has_title:
+            obtained.append("caption with title")
         obtained_str = ", ".join(obtained) if obtained else None
+
         advice = f'Add <label> or <caption> with <title> inside {self.xml}. Consult SPS documentation for more detail.'
 
         return build_response(

--- a/tests/sps/models/test_tablewrap.py
+++ b/tests/sps/models/test_tablewrap.py
@@ -118,6 +118,7 @@ class TableWrapTest(unittest.TestCase):
             "table_wrap_id": "t2",
             "caption": "Produção de tecidos de algodão da Fábrica Votorantim, do estado de São Paulo e do "
             "restante do Brasil, 1918-1930 - em milhões de metros",
+            "caption_has_title": True,
             "label": "Tabela 2:",
             "footnotes": [{
                 "text": "*Fonte: Cano (1981, p. 293); SÃO PAULO. Diário Oficial do Estado de São Paulo, "
@@ -241,6 +242,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "table_wrap_id": "t2",
                 "caption": "Produção de tecidos de algodão da Fábrica Votorantim, do estado de São Paulo e do "
                 "restante do Brasil, 1918-1930 - em milhões de metros",
+                "caption_has_title": True,
                 "label": "Tabela 2:",
                 "footnotes": [{
                    "text":  "*Fonte: Cano (1981, p. 293); SÃO PAULO. Diário Oficial do Estado de São Paulo, "
@@ -270,6 +272,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Produção de tecidos de algodão da Fábrica XYZ, do estado de Minas "
                 "Gerais e do restante do Brasil, 1931-1940 - em milhões de metros",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Fonte: Autor (2023, p. 123); MINAS GERAIS. Diário Oficial do "
                            "Estado de Minas Gerais, 10/01/1932, p. 1932; 20/03/1933, p. "
@@ -317,6 +320,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Production of cotton fabrics by XYZ Factory, state of Minas "
                 "Gerais and the rest of Brazil, 1941-1950 - in millions of meters",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Source: Author (2023, p. 123); MINAS GERAIS. Official Journal "
                             "of the State of Minas Gerais, 10/01/1942, p. 1942; 20/03/1943, "
@@ -348,6 +352,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Production of cotton fabrics by ABC Factory, state of Rio de "
                 "Janeiro and the rest of Brazil, 1951-1960 - in millions of meters",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Source: Author (2023, p. 123); RIO DE JANEIRO. Official "
                             "Journal of the State of Rio de Janeiro, 10/01/1952, p. 1952; "
@@ -401,6 +406,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "table_wrap_id": "t2",
                 "caption": "Produção de tecidos de algodão da Fábrica Votorantim, do estado de São Paulo e do "
                 "restante do Brasil, 1918-1930 - em milhões de metros",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Fonte: Cano (1981, p. 293); SÃO PAULO. Diário Oficial do Estado de São Paulo, "
                             "30/06/1922, p. 1922; 15/02/1923, p. 1923; 14/02/1925, p. 1233; 12/02/1926, p. 1243; 22/03/1931 p. 2327.",
@@ -430,6 +436,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Produção de tecidos de algodão da Fábrica XYZ, do estado de Minas "
                 "Gerais e do restante do Brasil, 1931-1940 - em milhões de metros",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Fonte: Autor (2023, p. 123); MINAS GERAIS. Diário Oficial do "
                             "Estado de Minas Gerais, 10/01/1932, p. 1932; 20/03/1933, p. "
@@ -461,6 +468,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Production of cotton fabrics by XYZ Factory, state of Minas "
                 "Gerais and the rest of Brazil, 1941-1950 - in millions of meters",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Source: Author (2023, p. 123); MINAS GERAIS. Official Journal "
                             "of the State of Minas Gerais, 10/01/1942, p. 1942; 20/03/1943, "
@@ -492,6 +500,7 @@ class ArticleTableWrappersTest(unittest.TestCase):
                 "alternative_parent": "table-wrap",
                 "caption": "Production of cotton fabrics by ABC Factory, state of Rio de "
                 "Janeiro and the rest of Brazil, 1951-1960 - in millions of meters",
+                "caption_has_title": True,
                 "footnotes": [{
                     "text": "*Source: Author (2023, p. 123); RIO DE JANEIRO. Official "
                             "Journal of the State of Rio de Janeiro, 10/01/1952, p. 1952; "

--- a/tests/sps/validation/test_tablewrap.py
+++ b/tests/sps/validation/test_tablewrap.py
@@ -666,8 +666,8 @@ class TableWrapCompleteValidationTest(unittest.TestCase):
 
         A bare <caption>text</caption> does not satisfy the SPS requirement of
         <caption><title>. The former bool(caption_text) check would have accepted
-        this as valid (false negative). The corrected caption_has_title check
-        correctly rejects it.
+        this as valid (failed to flag the invalid structure). The corrected
+        caption_has_title check correctly rejects it.
         """
         self.maxDiff = None
         xml_tree = etree.fromstring(

--- a/tests/sps/validation/test_tablewrap.py
+++ b/tests/sps/validation/test_tablewrap.py
@@ -587,7 +587,13 @@ class TableWrapCompleteValidationTest(unittest.TestCase):
             self.assertEqual("OK", result["response"], f"Validation '{result['title']}' should pass but got {result['response']}")
 
     def test_valid_table_wrap_with_empty_title(self):
-        """Table-wrap with empty <title/> inside <caption> should pass label_or_caption validation."""
+        """
+        Table-wrap with <label> AND <caption><title/> passes label_or_caption validation.
+
+        This test confirms that <label> alone is sufficient even when <title/> is empty.
+        It does NOT isolate the case where <caption><title/> alone satisfies the rule —
+        that scenario is covered by test_label_or_caption_only_caption_with_empty_title.
+        """
         self.maxDiff = None
         xml_tree = etree.fromstring(
             '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
@@ -612,8 +618,82 @@ class TableWrapCompleteValidationTest(unittest.TestCase):
 
         results = [r for r in obtained if r["title"] == "label or caption"]
         self.assertEqual(1, len(results))
-        # label is present, so this should pass
+        # label is present, so this must pass regardless of caption content
         self.assertEqual("OK", results[0]["response"])
+
+    def test_label_or_caption_only_caption_with_empty_title(self):
+        """
+        Table-wrap with NO <label> but <caption><title/> must pass label_or_caption.
+
+        Per SPS documentation, <caption><title/> (structurally present, even if empty)
+        satisfies the requirement. This isolates the scenario that
+        test_valid_table_wrap_with_empty_title does not cover: without a <label>,
+        only caption_has_title determines validity.
+
+        The former bool(caption_text) check would have failed here because
+        ET.tostring() returns "" for <title/>, while the corrected caption_has_title
+        property detects the element's presence regardless of text content.
+        """
+        self.maxDiff = None
+        xml_tree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<table-wrap id="t01">'
+            "<caption><title/></caption>"
+            "<table>"
+            "<tbody><tr><td>Data 1</td></tr></tbody>"
+            "</table>"
+            "</table-wrap>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(
+            ArticleTableWrapValidation(
+                xml_tree=xml_tree,
+                rules={},
+            ).validate()
+        )
+
+        results = [r for r in obtained if r["title"] == "label or caption"]
+        self.assertEqual(1, len(results))
+        # <caption><title/> is structurally valid per SPS — must pass
+        self.assertEqual("OK", results[0]["response"])
+
+    def test_label_or_caption_only_caption_without_title_fails(self):
+        """
+        Table-wrap with NO <label> and <caption> without <title> must fail label_or_caption.
+
+        A bare <caption>text</caption> does not satisfy the SPS requirement of
+        <caption><title>. The former bool(caption_text) check would have accepted
+        this as valid (false negative). The corrected caption_has_title check
+        correctly rejects it.
+        """
+        self.maxDiff = None
+        xml_tree = etree.fromstring(
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.0" article-type="research-article" xml:lang="pt">'
+            "<body>"
+            '<table-wrap id="t01">'
+            "<caption>Some caption text without title element</caption>"
+            "<table>"
+            "<tbody><tr><td>Data 1</td></tr></tbody>"
+            "</table>"
+            "</table-wrap>"
+            "</body>"
+            "</article>"
+        )
+        obtained = list(
+            ArticleTableWrapValidation(
+                xml_tree=xml_tree,
+                rules={},
+            ).validate()
+        )
+
+        results = [r for r in obtained if r["title"] == "label or caption"]
+        self.assertEqual(1, len(results))
+        # <caption> without <title> must fail — neither label nor caption_has_title is True
+        self.assertEqual("CRITICAL", results[0]["response"])
 
     def test_table_wrap_with_table_wrap_foot(self):
         """Table with table-wrap-foot should pass all validations."""


### PR DESCRIPTION
### Descrição

#### Problema

`validate_label_or_caption` avaliava `bool(caption)`, onde `caption` é o texto extraído por `ET.tostring(..., method="text")`. Isso produzia dois comportamentos incorretos:

- **Falso negativo estrutural:** `<caption><title/></caption>` (título vazio, mas estruturalmente   válido per SPS) retornava `""` e era tratado como ausente — a validação falhava indevidamente.
- **Falso positivo estrutural:** `<caption>texto livre</caption>` (sem `<title>`) retornava o texto   e era aceito como válido — a validação passava indevidamente.

O problema foi identificado na revisão do Copilot do PR #1130.

#### Solução

**`models/tablewrap.py`**
- Adicionada a propriedade `caption_has_title`: verifica a *presença do elemento* `<title>` dentro   de `<caption>` via `caption_element.find("title") is not None`, independente do seu conteúdo.
- Chave `caption_has_title` exposta em `TableWrap.data`.

**`validation/tablewrap.py`**
- `validate_label_or_caption` substitui `bool(caption)` por `bool(caption_has_title)`.
- Adicionado comentário em `get_default_params` registrando que as chaves `label_error_level` e   `caption_error_level` foram descontinuadas em favor de `label_or_caption_error_level`.

**`tests/sps/validation/test_tablewrap.py`**
- Corrigido o docstring de `test_valid_table_wrap_with_empty_title`: o teste passava por causa do   `<label>`, não do `<caption><title/>` — o docstring anterior era enganoso.
- Adicionado `test_label_or_caption_only_caption_with_empty_title`: isola o cenário em que apenas   `<caption><title/>` está presente (sem `<label>`) — deve retornar `OK`.
- Adicionado `test_label_or_caption_only_caption_without_title_fails`: `<caption>` sem `<title>`   e sem `<label>` — deve retornar `CRITICAL`.

**`tests/sps/models/test_tablewrap.py`**
- Adicionada a chave `caption_has_title: True` nos 9 dicts `expected` dos testes do modelo,   sincronizando-os com o contrato atual de `TableWrap.data`.

#### Testes

```
pytest tests/sps/models/test_tablewrap.py tests/sps/validation/test_tablewrap.py
```