### PR TITLE
fix(pdf): avoid UnboundLocalError in extract_table_data when table-wrap has no table

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -585,6 +585,8 @@ def extract_table_data(table_wrap):
 
     headers = []
     rows = []
+    header_spans = []
+    row_spans = []
     table = table_wrap.find('.//table')
     layout = determine_table_layout(table_wrap)
 

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1104,6 +1104,19 @@ class TestExtractTableData(unittest.TestCase):
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
 
+    def test_extract_table_data_no_table_returns_empty_spans(self):
+        xml_str = """
+            <table-wrap>
+                <label>Table 4</label>
+                <title>Graphic Only</title>
+                <graphic xlink:href="t04.tif" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+            </table-wrap>
+        """
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap)
+        self.assertEqual([], result['header_spans'])
+        self.assertEqual([], result['row_spans'])
+
 
 class TestExtractTransAbstractData(unittest.TestCase):
 


### PR DESCRIPTION
Corrige o #1213. Quando um `table-wrap` não possui `<table>` (por exemplo, traz apenas `<graphic>`), `header_spans` e `row_spans` ficavam sem atribuição e o `return` final lançava UnboundLocalError. Inicializei ambas como listas vazias antes do bloco `if table is not None`, junto com `headers`/`rows`. Incluí um teste cobrindo o caso de table-wrap sem table.