### PR TITLE
feat(htmlgenerator/v3.0): refatora apresentação de autores na página do artigo

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
+++ b/packtools/catalogs/htmlgenerator/v2.0/config-labels.xml
@@ -618,4 +618,89 @@
         <name lang="pt">Navegação do artigo</name>
         <name lang="es">Navegación del artículo</name>
     </term>
+    
+    <term>
+        <name>author-notes-fn-edited-by</name>
+        <name lang="en">Edited by</name>
+        <name lang="pt">Editado por</name>
+        <name lang="es">Editado por</name>
+    </term>
+    <term>
+        <name>author-notes-fn-corresp</name>
+        <name lang="en">Correspondence</name>
+        <name lang="pt">Correspondência</name>
+        <name lang="es">Correspondencia</name>
+    </term>
+    <term>
+        <name>author-notes-fn-abbr</name>
+        <name lang="en">Abbreviations</name>
+        <name lang="pt">Abreviações</name>
+        <name lang="es">Abreviaciones</name>
+    </term>
+    <term>
+        <name>author-notes-fn-con</name>
+        <name lang="en">Contributions</name>
+        <name lang="pt">Contribuições</name>
+        <name lang="es">Contribuciones</name>
+    </term>
+    <term>
+        <name>author-notes-fn-coi-statement</name>
+        <name lang="en">Conflict of Interest</name>
+        <name lang="pt">Conflito de Interesse</name>
+        <name lang="es">Conflicto de Interés</name>
+    </term>
+    <term>
+        <name>author-notes-fn-current-aff</name>
+        <name lang="en">Current Affiliation</name>
+        <name lang="pt">Afiliação Atual</name>
+        <name lang="es">Afiliación Actual</name>
+    </term>
+    <term>
+        <name>author-notes-fn-deceased</name>
+        <name lang="en">Deceased</name>
+        <name lang="pt">Falecido</name>
+        <name lang="es">Fallecido</name>
+    </term>
+    <term>
+        <name>author-notes-fn-equal</name>
+        <name lang="en">Equal Contribution</name>
+        <name lang="pt">Contribuição Igualitária</name>
+        <name lang="es">Contribución Igualitaria</name>
+    </term>
+    <term>
+        <name>author-notes-fn-on-leave</name>
+        <name lang="en">On Leave</name>
+        <name lang="pt">Em Licença</name>
+        <name lang="es">Con Licencia</name>
+    </term>
+    <term>
+        <name>author-notes-fn-participating-researchers</name>
+        <name lang="en">Researchers</name>
+        <name lang="pt">Pesquisadores</name>
+        <name lang="es">Investigadores</name>
+    </term>
+    <term>
+        <name>author-notes-fn-previously-at</name>
+        <name lang="en">Previous Affiliation</name>
+        <name lang="pt">Afiliação Anterior</name>
+        <name lang="es">Afiliación Anterior</name>
+    </term>
+    <term>
+        <name>author-notes-fn-study-group-members</name>
+        <name lang="en">Study Group</name>
+        <name lang="pt">Grupo de Estudo</name>
+        <name lang="es">Grupo de Estudio</name>
+    </term>
+    <term>
+        <name>author-notes-fn-present-address</name>
+        <name lang="en">Present Address</name>
+        <name lang="pt">Endereço Atual</name>
+        <name lang="es">Dirección Actual</name>
+    </term>
+    <term>
+        <name>author-notes-fn-presented-by</name>
+        <name lang="en">Presented by</name>
+        <name lang="pt">Apresentado por</name>
+        <name lang="es">Presentado por</name>
+    </term>
 </labels>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
@@ -12,6 +12,16 @@
         </div>
     </xsl:template>
 
+    <xsl:template match="article | sub-article" mode="contrib-group">
+        <xsl:variable name="AUTHOR_LIST_LABEL"><xsl:apply-templates select="." mode="interface">
+            <xsl:with-param name="text">Author list</xsl:with-param>
+        </xsl:apply-templates></xsl:variable>
+        <div>
+            <xsl:attribute name="class">scielo__contribGroup</xsl:attribute>
+            <ul aria-label="{$AUTHOR_LIST_LABEL}" class="author-list" id="authorList"></ul>
+        </div>
+    </xsl:template>
+
     <xsl:template match="contrib-group" mode="about-the-contrib-group-button">
         <xsl:param name="id"/>
         <!--

--- a/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
@@ -13,9 +13,6 @@
             <xsl:apply-templates select="front | front-stub" mode="scimago-button">
                 <xsl:with-param name="id"><xsl:value-of select="$id"/></xsl:with-param>
             </xsl:apply-templates>
-            <xsl:apply-templates select="front | front-stub" mode="button-author-notes">
-                <xsl:with-param name="id"><xsl:value-of select="$id"/></xsl:with-param>
-            </xsl:apply-templates>
         </div>
     </xsl:template>
 
@@ -118,53 +115,6 @@
         <div class="corresp">
             <xsl:apply-templates select="*|text()"/>
         </div>
-    </xsl:template>
-
-    <xsl:template match=" front | front-stub" mode="button-author-notes">
-        <xsl:if test=".//author-notes">
-            <xsl:apply-templates select=".//author-notes" mode="button-author-notes"/>
-        </xsl:if>
-    </xsl:template>
-
-    <xsl:template match="author-notes" mode="button-author-notes">
-        <button class="btn btn-secondary btn-sm outlineFadeLink mt-2" type="button" data-bs-toggle="collapse" data-bs-target="#authornotesInline" aria-expanded="false" aria-controls="authornotesInline">
-            <xsl:apply-templates select="." mode="interface">
-                <xsl:with-param name="text">Author notes</xsl:with-param>
-            </xsl:apply-templates>
-        </button>
-    </xsl:template>
-
-    <xsl:template match="*" mode="button-author-notes-content">
-        <xsl:choose>
-            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//author-notes">
-                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//author-notes" mode="button-author-notes-content"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select=".//article-meta//author-notes" mode="button-author-notes-content"/>                    
-            </xsl:otherwise>
-        </xsl:choose>
-    </xsl:template>
-
-    <xsl:template match="author-notes" mode="button-author-notes-content">
-        <div class="collapse mt-3" id="authornotesInline">
-            <div>
-                <xsl:apply-templates select="*" mode="author-notes-inline"/>
-            </div>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="author-notes/*" mode="author-notes-inline">
-        <div class="row">
-            <xsl:apply-templates select="*|text()" mode="author-notes-inline"/>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="label|title" mode="author-notes-inline">
-        <p><strong><xsl:apply-templates select="*|text()"/></strong></p>
-    </xsl:template>
-
-    <xsl:template match="p" mode="author-notes-inline">
-        <p><xsl:apply-templates select="*|text()"/></p>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-meta-contrib.xsl
@@ -6,20 +6,24 @@
     <xsl:include href="../v2.0/article-meta-contrib.xsl"/>
 
     <xsl:template match="article | sub-article" mode="contrib-group">
+        <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
         <div>
             <xsl:attribute name="class">scielo__contribGroup</xsl:attribute>
             <xsl:apply-templates select="front | front-stub" mode="contrib-group"/>
+            <xsl:apply-templates select="front | front-stub" mode="scimago-button">
+                <xsl:with-param name="id"><xsl:value-of select="$id"/></xsl:with-param>
+            </xsl:apply-templates>
+            <xsl:apply-templates select="front | front-stub" mode="button-author-notes">
+                <xsl:with-param name="id"><xsl:value-of select="$id"/></xsl:with-param>
+            </xsl:apply-templates>
         </div>
     </xsl:template>
 
-    <xsl:template match="article | sub-article" mode="contrib-group">
+    <xsl:template match="front | front-stub" mode="contrib-group">
         <xsl:variable name="AUTHOR_LIST_LABEL"><xsl:apply-templates select="." mode="interface">
             <xsl:with-param name="text">Author list</xsl:with-param>
         </xsl:apply-templates></xsl:variable>
-        <div>
-            <xsl:attribute name="class">scielo__contribGroup</xsl:attribute>
-            <ul aria-label="{$AUTHOR_LIST_LABEL}" class="author-list" id="authorList"></ul>
-        </div>
+        <ul aria-label="{$AUTHOR_LIST_LABEL}" class="author-list" id="authorList"></ul>
     </xsl:template>
 
     <xsl:template match="contrib-group" mode="about-the-contrib-group-button">
@@ -37,7 +41,7 @@
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="front | front-stub" mode="scimago-button">
+    <xsl:template match="article-meta | front | front-stub" mode="scimago-button">
         <xsl:param name="id"/>
         <!--
             Adiciona o botão 'SCIMAGO INSTITUTIONS RANKINGS'
@@ -45,7 +49,7 @@
         <xsl:if test=".//aff">
             <a href="" class="btn btn-secondary btn-sm outlineFadeLink"
                 data-bs-toggle="modal"
-                data-bs-target="#ModalScimago{$id}">SCIMAGO INSTITUTIONS RANKINGS</a>
+                data-bs-target="#ModalScimago{$id}">SCImago Institutions Rankings</a>
         </xsl:if>
     </xsl:template>
 
@@ -114,6 +118,53 @@
         <div class="corresp">
             <xsl:apply-templates select="*|text()"/>
         </div>
+    </xsl:template>
+
+    <xsl:template match=" front | front-stub" mode="button-author-notes">
+        <xsl:if test=".//author-notes">
+            <xsl:apply-templates select=".//author-notes" mode="button-author-notes"/>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="author-notes" mode="button-author-notes">
+        <button class="btn btn-secondary btn-sm outlineFadeLink mt-2" type="button" data-bs-toggle="collapse" data-bs-target="#authornotesInline" aria-expanded="false" aria-controls="authornotesInline">
+            <xsl:apply-templates select="." mode="interface">
+                <xsl:with-param name="text">Author notes</xsl:with-param>
+            </xsl:apply-templates>
+        </button>
+    </xsl:template>
+
+    <xsl:template match="*" mode="button-author-notes-content">
+        <xsl:choose>
+            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//author-notes">
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//author-notes" mode="button-author-notes-content"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select=".//article-meta//author-notes" mode="button-author-notes-content"/>                    
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="author-notes" mode="button-author-notes-content">
+        <div class="collapse mt-3" id="authornotesInline">
+            <div>
+                <xsl:apply-templates select="*" mode="author-notes-inline"/>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="author-notes/*" mode="author-notes-inline">
+        <div class="row">
+            <xsl:apply-templates select="*|text()" mode="author-notes-inline"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="label|title" mode="author-notes-inline">
+        <p><strong><xsl:apply-templates select="*|text()"/></strong></p>
+    </xsl:template>
+
+    <xsl:template match="p" mode="author-notes-inline">
+        <p><xsl:apply-templates select="*|text()"/></p>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-fn.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-fn.xsl
@@ -32,7 +32,7 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="fn[@fn-type='edited-by'] | fn[ @fn-type='data-availability']" mode="back-section-h">
+    <xsl:template match="fn| fn[@fn-type='edited-by'] | fn[@fn-type='data-availability']" mode="back-section-h">
         <!--
             Apresenta o título da seção no texto completo
         -->
@@ -40,10 +40,35 @@
         <xsl:if test="not(preceding-sibling::node()) or preceding-sibling::*[1][not(@fn-type)] or preceding-sibling::*[1][@fn-type!=$name]">
             <h2 class="h5">
                 <xsl:apply-templates select="." mode="text-labels">
-                    <xsl:with-param name="text"><xsl:value-of select="@fn-type"/></xsl:with-param>
+                    <xsl:with-param name="text">author-notes-fn-<xsl:value-of select="@fn-type"/></xsl:with-param>
                 </xsl:apply-templates>
             </h2>
         </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="author-notes" mode="author-notes-as-sections">
+        <!-- apresenta todas as notas de autores -->
+        <xsl:apply-templates select="fn" mode="back-section"/>
+    </xsl:template>
+
+    <xsl:template match="fn" mode="back-section-menu">
+        <xsl:variable name="name" select="@fn-type"/>
+        <!--
+        Evita que no menu apareça o mesmo título mais de uma vez 
+        -->
+        <xsl:if test="not(preceding-sibling::node()) or preceding-sibling::*[1][not(@fn-type)] or preceding-sibling::*[1][@fn-type!=$name]">
+            <!-- manter pareado class="articleSection" e data-anchor="nome da seção no menu esquerdo" -->
+            <xsl:attribute name="class">articleSection</xsl:attribute>
+            <xsl:attribute name="data-anchor">
+                <xsl:apply-templates select="." mode="text-labels">
+                    <xsl:with-param name="text">author-notes-fn-<xsl:value-of select="@fn-type"/></xsl:with-param>
+                </xsl:apply-templates>
+            </xsl:attribute>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="fn" mode="back-section-content">
+        <xsl:apply-templates select="label|p" mode="div-fn-list-item"/>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article.xsl
@@ -63,6 +63,7 @@
     <xsl:include href="html-head.xsl"/>
 
     <xsl:include href="bottom-floating-menu.xsl"/>
+    <xsl:include href="article-css.xsl"/>
 
     <xsl:variable name="ref" select="//ref"/>
     <xsl:variable name="fn" select="//*[name()!='table-wrap-foot']//fn"/>
@@ -140,6 +141,7 @@
             scrollbar-gutter:stable;
         }
         </style>
+        <xsl:apply-templates select="." mode="modal-contrib-group-css"/>
     </xsl:template>
 
     <xsl:template match="/" mode="js">
@@ -221,7 +223,6 @@
 
     <xsl:template match="article" mode="div-article">
         <article id="articleText">
-            <xsl:apply-templates select="." mode="button-author-notes-content"/>
             <xsl:apply-templates select="." mode="article-meta-product"/>
             <xsl:apply-templates select="." mode="article-meta-abstract"/>
             <xsl:apply-templates select="." mode="article-meta-no-abstract-keywords"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article.xsl
@@ -55,6 +55,7 @@
     <xsl:include href="html-modals-graphics.xsl"/>
     <xsl:include href="html-modals.xsl"/>
     <xsl:include href="html-modals-contribs.xsl"/>
+    <xsl:include href="html-modals-contrib-group.xsl"/>
     <xsl:include href="html-modals-tables.xsl"/>
     <xsl:include href="html-modals-figs.xsl"/>
     <xsl:include href="html-modals-scheme.xsl"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article.xsl
@@ -134,7 +134,7 @@
         <link rel="stylesheet" href="https://ds.scielo.org/css/article.css"/-->
         <link rel="stylesheet" href="{$CSS_PATH}/bootstrap.css"/>
         <link rel="stylesheet" href="{$CSS_PATH}/article.css"/>
-        <style>
+        <style type="text/css">
         .modal-dialog-scrollable .modal-body {
             overflow-y:auto;
             scrollbar-gutter:stable;
@@ -164,7 +164,9 @@
         </xsl:if>
         <xsl:if test="$CROSSMARK_POLICY_PAGE!=''">
             <script src="https://crossmark-cdn.crossref.org/widget/v2.0/widget.js"/>
-        </xsl:if>
+        </xsl:if>        
+        
+        <xsl:apply-templates select="." mode="modal-contrib-js"/>
     </xsl:template>
 
     <xsl:template match="article" mode="article">
@@ -219,6 +221,7 @@
 
     <xsl:template match="article" mode="div-article">
         <article id="articleText">
+            <xsl:apply-templates select="." mode="button-author-notes-content"/>
             <xsl:apply-templates select="." mode="article-meta-product"/>
             <xsl:apply-templates select="." mode="article-meta-abstract"/>
             <xsl:apply-templates select="." mode="article-meta-no-abstract-keywords"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/html-modals-contrib-group.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/html-modals-contrib-group.xsl
@@ -3,81 +3,33 @@
     xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
     exclude-result-prefixes="xlink mml">
 
-    <xsl:include href="../v2.0/html-modals-contribs.xsl"/>
+    <xsl:template match="front" mode="modal-contrib">
+        <!-- sobrescreve article-meta mode="modal-contrib" -->
+        <xsl:apply-templates select="article-meta" mode="modal-contrib-div"/>
+    </xsl:template>
 
     <xsl:template match="article-meta | front-stub" mode="modal-contrib">
-        <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
-        <div class="modal fade ModalDefault ModalTutors" id="ModalTutors{$id}" tabindex="-1" role="dialog" aria-hidden="true">
-                
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title">
-                             <xsl:apply-templates select="contrib-group" mode="about-the-contrib-group-button-text"/>
-                        </h5>
-                        <button class="btn-close" data-bs-dismiss="modal">
-                            <xsl:attribute name="aria-label">
-                                <xsl:apply-templates select="." mode="interface">
-                                    <xsl:with-param name="text">Close</xsl:with-param>
-                                </xsl:apply-templates>
-                            </xsl:attribute>
-                        </button>
-                    </div>
-                    <xsl:call-template name="modal-author-css"/>
-                    <div class="modal-body">
-                        <xsl:apply-templates select="contrib-group/contrib" mode="modal-contrib"></xsl:apply-templates>
-                        <xsl:apply-templates select=".//author-notes" mode="modal-contrib"></xsl:apply-templates>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <!-- sobrescreve article-meta mode="modal-contrib" -->
+        <xsl:apply-templates select="." mode="modal-contrib-div"/>
     </xsl:template>
 
-    <xsl:template name="modal-author-css">
-        <style>
-            .author-card {
-                border-bottom: 1px solid #ccc;
-                padding: 1rem 0;
-            }
-            .author-card:last-child {
-                border-bottom: 0px;
-            }
-            .author-name {
-                font-weight: 600;
-            }
-            
-            .orcid-button {
-                padding-left: 2.5rem;
-            }
-            .modal-body {
-                padding-bottom: 3rem;
-            }
-            .orcid-button::before {
-                content: "";
-                position: absolute;
-                background-image: url(https://ds.scielo.org/img/logo-orcid.svg);
-                background-repeat: no-repeat;
-                background-size: 1.5em auto;
-                background-position: .5em center;
-                display: block;
-                width: 60px;
-                height: 60px;
-                top: -10px;
-                left: 0;
-            }
-        </style>
-    </xsl:template>
+    <xsl:template match="article-meta | front-stub" mode="modal-contrib-div">
+        <div class="modal fade ModalDefault ModalTutors"
+            id="ModalTutors"
+            tabindex="-1"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="ModalTutorsLabel"
+            aria-hidden="true">
 
-    <xsl:template match="article-meta | front-stub" mode="modal-scimago">
-        <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
-        <div class="modal fade ModalDefault ModalTutors" id="ModalScimago{$id}" tabindex="-1" role="dialog" aria-hidden="true">
-                
-            <div class="modal-dialog">
+            <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title">
-                            SCIMAGO INSTITUTIONS RANKINGS
-                        </h5>
+                        <h2 class="h4 modal-title" id="ModalTutorsLabel">
+                            <xsl:apply-templates select="." mode="interface">
+                                <xsl:with-param name="text">About the authors</xsl:with-param>
+                            </xsl:apply-templates>
+                        </h2>
                         <button class="btn-close" data-bs-dismiss="modal">
                             <xsl:attribute name="aria-label">
                                 <xsl:apply-templates select="." mode="interface">
@@ -87,184 +39,410 @@
                         </button>
                     </div>
                     <div class="modal-body">
-                        <div class="info">
-                            <xsl:apply-templates select=".//aff" mode="modal-scimago"/>
-                        </div>
-                    </div>
+                        <div id="authorCardsContainer"></div>
+                    </div>                    
                 </div>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template match="contrib" mode="modal-contrib">
-        <!--
-            ((contrib-id)*, (anonymous | collab | collab-alternatives | name | name-alternatives | string-name)*, (degrees)*, (address | aff | aff-alternatives | author-comment | bio | email | ext-link | on-behalf-of | role | uri | xref)*)
-        -->
-        
-        <div class="author-card">
-            <div class="author-name">
-                <span class="material-icons-outlined">person</span>
-                <xsl:apply-templates select="anonymous|name|collab|on-behalf-of"/>
-                <xsl:apply-templates select="xref[@ref-type='corresp']"/>
-            </div>
-            <div class="author-roles ms-4 mb-2 scielo__text-color__subtle--light">
-                <xsl:apply-templates select="role | bio" mode="modal-contrib"/>
-            </div>
-            <div class="author-institution ms-4 mb-2 scielo__text-color__subtle--light">
-                <xsl:apply-templates select="xref" mode="modal-contrib"/>
-            </div>
-            <div class="ms-4">
-                <xsl:apply-templates select="contrib-id" mode="modal-contrib"/>
+    <xsl:template match="author-notes" mode="modal-contrib-div">
+        <xsl:apply-templates select="*" mode="modal-contrib-div"/>
+    </xsl:template>
+
+    <xsl:template match="corresp" mode="modal-contrib-div">
+        <div class="correspondence mt-3 mb-4 d-none" id="correspondenceSection">
+            <div class="section-grid">
+                <span class="material-icons-outlined" aria-hidden="true">
+                person
+                </span>
+                <div>
+                    <xsl:apply-templates select="*" mode="modal-contrib-div"/>
+                </div>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template match="contrib/xref" mode="modal-contrib">
-        <xsl:variable name="rid" select="@rid"/>
-            <xsl:apply-templates select="$article//aff[@id=$rid]" mode="modal-contrib"/>
-        <xsl:apply-templates select="$article//fn[@id=$rid]" mode="xref"/>
+    <xsl:template match="corresp/*" mode="modal-contrib-div">
+        <div class="section-content">
+            <span id="correspondenceText"></span>
+            <br/>
+            <a href="" id="correspondenceEmail">
+            </a>
+        </div>
     </xsl:template>
-    
-    <xsl:template match="role" mode="modal-contrib">
+
+    <xsl:template match="corresp/label| corresp/title" mode="modal-contrib-div">
+        <p class="section-title mb-1"><xsl:apply-templates/></p>
+    </xsl:template>
+
+    <xsl:template match="/" mode="modal-contrib-js">
+        <script type="text/javascript">
+            <!-- base js -->
+            <xsl:apply-templates select="." mode="modal-contrib-js-base"/>
+
+            <!-- affiliation data -->
+            <xsl:apply-templates select="." mode="modal-contrib-js-affs"/>
+            <!-- authors data -->
+            <xsl:apply-templates select="." mode="modal-contrib-js-authors"/>
+
+            <!-- js functions -->
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-create-author-button"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-append-author-item"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-append-summary-item"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-render-authors"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-build-institution-text"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-build-author-card"/>
+            <xsl:apply-templates select="." mode="modal-contrib-js-function-open-author-modal"/>
+        </script>
+    </xsl:template>
+
+    <xsl:template match="/" mode="modal-contrib-js-affs">
         <xsl:choose>
-            <xsl:when test="position()=1"></xsl:when>
-            <xsl:otherwise> · </xsl:otherwise>
-        </xsl:choose><xsl:value-of select="."/>
-    </xsl:template>
-
-    <xsl:template match="aff" mode="modal-contrib">
-        <span class="material-icons-outlined">school</span>
-        <span data-aff-display="{@id}">
-            <xsl:apply-templates select="." mode="display"/>
-        </span>
-        <xsl:apply-templates select="." mode="hidden-for-scimago"/>
-    </xsl:template>
-    
-    <xsl:template match="contrib-id" mode="modal-contrib">
-        <xsl:variable name="access_text">
-            <xsl:apply-templates select="." mode="interface">
-                <xsl:with-param name="text">access_contributor</xsl:with-param>
-            </xsl:apply-templates>
-        </xsl:variable>
-        <xsl:variable name="new_tab_text">
-            <xsl:apply-templates select="." mode="interface">
-                <xsl:with-param name="text">opens_new_tab</xsl:with-param>
-            </xsl:apply-templates>
-        </xsl:variable>
-        <xsl:variable name="external_resource_text">
-            <xsl:apply-templates select="." mode="interface">
-                <xsl:with-param name="text">external_resource</xsl:with-param>
-            </xsl:apply-templates>
-        </xsl:variable>
-        <xsl:variable name="contributor_url">
-            <xsl:apply-templates select="." mode="url"/><xsl:value-of select="."/>
-        </xsl:variable>
-        <xsl:variable name="aria_label">
-            <xsl:value-of select="$access_text"/>
-            <xsl:text> </xsl:text>
-            <xsl:value-of select="."/>
-            <xsl:text>. </xsl:text>
-            <xsl:value-of select="$new_tab_text"/>
-            <xsl:text>. </xsl:text>
-            <xsl:value-of select="$external_resource_text"/>
-            <xsl:text>.</xsl:text>
-        </xsl:variable>
-        <a target="_blank" class="btn btn-secondary  {@contrib-id-type}-button" href="{$contributor_url}" aria-label="{normalize-space($aria_label)}">
-            <xsl:value-of select="."/>
-        </a>
-    </xsl:template>
-
-    <xsl:template match="author-notes/*" mode="modal-contrib">
-        <xsl:apply-templates select="*|text()"/>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn/label" mode="modal-contrib">
-        <xsl:variable name="text"><xsl:apply-templates select=".//text()"/></xsl:variable>
-        <xsl:choose>
-            <xsl:when test="contains('123456789',substring(normalize-space($text),1,1))">
-                <sup><strong><xsl:apply-templates select="*|text()"/></strong></sup>
+            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//contrib">
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub" mode="modal-contrib-js-affiliation-data"/>
             </xsl:when>
             <xsl:otherwise>
-                <strong><xsl:apply-templates select="*|text()"/></strong>
+                <xsl:apply-templates select=".//article-meta" mode="modal-contrib-js-affiliation-data"/>                    
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="author-notes/fn/label[sup]" mode="modal-contrib">
-        <strong><xsl:apply-templates select="*|text()"/></strong>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn" mode="modal-contrib">
-        <div>
-            <xsl:apply-templates select="." mode="author-notes-fn-class"/>
-            <xsl:apply-templates select="*|text()" mode="modal-contrib"/>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn" mode="author-notes-fn-class">
-        <xsl:attribute name="class">mb-3</xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn[@fn-type='con']" mode="author-notes-fn-class">
-        <xsl:attribute name="class">author-contributions mb-3</xsl:attribute>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn[@fn-type='con']/label" mode="modal-contrib">
-        <strong><span class="material-icons-outlined">groups</span> <xsl:apply-templates select="."/></strong>
-    </xsl:template>
-
-    <xsl:template match="author-notes/fn/p | author-notes/fn/text()" mode="modal-contrib">
-        <p class="scielo__text-color__subtle--light mb-0">
-            <xsl:apply-templates select="."/>
-        </p>
-    </xsl:template>
-
-    <xsl:template match="author-notes/corresp" mode="modal-contrib">
-        <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
-        <a class="" name="{@id}_ref"/>
-        <div class="correspondence mt-3 mb-4">
-            <xsl:apply-templates select="*|text()" mode="modal-contrib"/>
-        </div>
-    </xsl:template>
-
-    <xsl:template match="author-notes/corresp/label" mode="modal-contrib">
-        <strong>
-            <span class="material-icons-outlined">
-                <xsl:choose>
-                    <xsl:when test="contains(., 'mail')">email</xsl:when>
-                    <xsl:otherwise>person</xsl:otherwise>
-                </xsl:choose>
-            </span><xsl:value-of select="."/>
-        </strong>
-    </xsl:template>
-
-    <xsl:template match="author-notes/corresp/text()" mode="modal-contrib">
+    <xsl:template match="/" mode="modal-contrib-js-authors">
         <xsl:choose>
-            <xsl:when test="normalize-space(.)!=''">
-                <span class="scielo__text-color__subtle--light">
-                    <xsl:value-of select="."/>
-                </span><br/>
+            <xsl:when test=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub//aff">
+                <xsl:apply-templates select=".//sub-article[@xml:lang=$TEXT_LANG and @article-type='translation']//front-stub" mode="modal-contrib-js-author-data"/>
             </xsl:when>
-            <xsl:when test="contains(., 'mail')">1
-                <strong><span class="material-icons-outlined">email</span> </strong>
-            </xsl:when>
-            <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+            <xsl:otherwise>
+                <xsl:apply-templates select=".//article-meta" mode="modal-contrib-js-author-data"/>                    
+            </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="text()" mode="corresp-texts">
+    <xsl:template match="*" mode="modal-contrib-js-base">
+        const MAX_VISIBLE_AUTHORS = 25;
+        const ALWAYS_VISIBLE_FIRST = 2;
+        const ALWAYS_VISIBLE_LAST = 1;
+
+        const authorList = document.getElementById("authorList");
+
+        const authorModalElement = document.getElementById("ModalTutors");
+        const authorCardsContainer = document.getElementById("authorCardsContainer");
+        const correspondenceSection = document.getElementById("correspondenceSection");
+        const correspondenceText = document.getElementById("correspondenceText");
+        const correspondenceEmail = document.getElementById("correspondenceEmail");
+
+        const authorModal = authorModalElement
+        ? new bootstrap.Modal(authorModalElement)
+        : null;
+
+        let expanded = false;
+
+    </xsl:template>
+
+    <xsl:template match="*" mode="modal-contrib-js-affiliation-data">
+        const affiliationMap = {<xsl:apply-templates select=".//aff" mode="modal-contrib-js-affiliation-map-affiliation-text"/>
+        };
+    </xsl:template>
+
+    <xsl:template match="aff" mode="modal-contrib-js-affiliation-map-affiliation-text"><xsl:text>
+            </xsl:text>&quot;<xsl:value-of select="@id"/>&quot;: &quot;<xsl:apply-templates select="institution[@content-type='original']" /><xsl:if test="not(institution[@content-type='original'])"><xsl:apply-templates select=".//*" mode="modal-contrib-js-affiliation-map-affiliation-text-base"/></xsl:if>&quot;<xsl:if test="position() != last()">,</xsl:if>
+    </xsl:template>
+
+    <xsl:template match="aff//*[@content-type!='original']" mode="modal-contrib-js-affiliation-map-affiliation-text-base"><xsl:value-of select="."/><xsl:if test="position() != last()">, </xsl:if></xsl:template>
+
+    <xsl:template match="contrib" mode="modal-contrib-js-corresponding">
+        <xsl:choose>
+            <xsl:when test="xref[@ref-type='corresp']">true</xsl:when>
+            <xsl:otherwise>false</xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="contrib" mode="modal-contrib-js-affiliation">[<xsl:for-each select="xref[@ref-type='aff']">&quot;<xsl:value-of select="@rid"/>&quot;<xsl:if test="position() != last()">, </xsl:if></xsl:for-each>]</xsl:template>
+
+    <xsl:template match="xref[@ref-type='corresp']" mode="modal-contrib-js-email">
+        <xsl:variable name="rid"><xsl:value-of select="@rid"/></xsl:variable>
+        <xsl:apply-templates select="../../..//corresp[@id=$rid]/email"/>
+    </xsl:template>
+
+    <xsl:template match="contrib" mode="modal-contrib-js-roles">
+        <xsl:for-each select="role">
+            <xsl:value-of select="."/>
+            <xsl:if test="position() != last()"> · </xsl:if>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="article-meta|front-stub" mode="modal-contrib-js-author-data">
+        const authors = [
+            <xsl:for-each select=".//contrib[@contrib-type='author']">
+                {
+                    name: &quot;<xsl:apply-templates select="name|collab" mode="modal-contrib-js-author"/>&quot;,
+                    affiliations: <xsl:apply-templates select="." mode="modal-contrib-js-affiliation"/>,
+                    orcid: &quot;<xsl:value-of select="contrib-id[@contrib-id-type='orcid']"/>&quot;,
+                    email: &quot;<xsl:apply-templates select="xref[@ref-type='corresp']" mode="modal-contrib-js-email"/>&quot;,
+                    corresponding: <xsl:apply-templates select="." mode="modal-contrib-js-corresponding"/>,
+                    roles: &quot;<xsl:apply-templates select="." mode="modal-contrib-js-roles"/>&quot;
+                }<xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+        ];
+    </xsl:template>
+
+    <xsl:template match="name" mode="modal-contrib-js-author">
+        <xsl:value-of select="given-names"/><xsl:text> </xsl:text><xsl:value-of select="surname"/><xsl:if test="string-length(@suffix) > 0"><xsl:text>, </xsl:text><xsl:value-of select="@suffix"/></xsl:if>
+    </xsl:template>
+
+    <xsl:template match="collab" mode="modal-contrib-js-author">
         <xsl:value-of select="."/>
     </xsl:template>
 
-    <xsl:template match="author-notes/corresp/email" mode="modal-contrib">
-        <xsl:variable name="text"><xsl:apply-templates select="..//text()" mode="corresp-texts"/></xsl:variable>
-        <xsl:choose>
-            <xsl:when test="contains($text, 'mail')">
-                <xsl:apply-templates select="."/>
-            </xsl:when>
-            <xsl:otherwise>
-                <strong><span class="material-icons-outlined">email</span> </strong><xsl:apply-templates select="."/>
-            </xsl:otherwise>
-        </xsl:choose>
+    <xsl:template match="*" mode="modal-contrib-js-function-create-author-button">
+        function createAuthorButton(author, index) {
+            const button = document.createElement("button");
+
+            button.type = "button";
+            button.className = "btn-link px-0";
+            button.setAttribute("data-author-index", index);
+            button.setAttribute("aria-label", `Abrir detalhes de ${author.name}`);
+
+            if (author.corresponding || author.email) {
+                const icon = document.createElement("span");
+
+                icon.className = "material-icons-outlined me-1 fs-6";
+                icon.setAttribute("aria-hidden", "true");
+                icon.textContent = "mail";
+
+                button.appendChild(icon);
+            }
+
+            const name = document.createElement("span");
+            name.textContent = author.name;
+
+            button.appendChild(name);
+
+            button.addEventListener("click", () => {
+                openAuthorModal(index);
+            });
+
+            return button;
+        }
     </xsl:template>
+    
+    <xsl:template match="*" mode="modal-contrib-js-function-append-author-item">
+        function appendAuthorItem(author, index, isLastVisibleItem) {
+            const li = document.createElement("li");
+
+            li.appendChild(createAuthorButton(author, index));
+
+            if (!isLastVisibleItem) {
+                const separator = document.createElement("span");
+                separator.className = "author-separator";
+                separator.setAttribute("aria-hidden", "true");
+                separator.textContent = ",";
+
+                li.appendChild(separator);
+            }
+
+            authorList.appendChild(li);
+        }
+    </xsl:template>
+
+
+    <xsl:template match="*" mode="modal-contrib-js-function-append-summary-item">
+        function appendSummaryItem(hiddenCount, isLastItem = false) {
+            const li = document.createElement("li");
+
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className = "btn btn-secondary btn-sm outlineFadeLink ms-0";
+
+            if (expanded) {
+                button.textContent = "Ocultar autores";
+                button.setAttribute("aria-label", "Ocultar autores intermediários");
+                button.setAttribute("aria-expanded", "true");
+            } else {
+                button.textContent = `+ ${hiddenCount} autores`;
+                button.setAttribute("aria-label", `Mostrar os ${hiddenCount} autores ocultos`);
+                button.setAttribute("aria-expanded", "false");
+            }
+
+            button.addEventListener("click", () => {
+                expanded = !expanded;
+                renderAuthors();
+            });
+
+            li.appendChild(button);
+
+            if (!isLastItem) {
+                const separator = document.createElement("span");
+                separator.className = "author-separator";
+                separator.setAttribute("aria-hidden", "true");
+                separator.textContent = ",";
+
+                li.appendChild(separator);
+            }
+
+            authorList.appendChild(li);
+        }
+    </xsl:template>
+    
+    <xsl:template match="*" mode="modal-contrib-js-function-render-authors">
+        <xsl:text>
+        function renderAuthors() {
+            if (!authorList) return;
+
+            authorList.innerHTML = "";
+
+            const total = authors.length;
+            const hiddenCount = total - (ALWAYS_VISIBLE_FIRST + ALWAYS_VISIBLE_LAST);
+            const canCollapse = total > MAX_VISIBLE_AUTHORS &amp;&amp; hiddenCount > 0;
+
+            if (!canCollapse) {
+                authors.forEach((author, index) => {
+                appendAuthorItem(author, index, index === total - 1);
+                });
+
+                return;
+            }
+
+            if (expanded) {
+                authors.forEach((author, index) => {
+                appendAuthorItem(author, index, index === total - 1);
+                });
+
+                appendSummaryItem(hiddenCount, true);
+                return;
+            }
+
+            const firstAuthors = authors.slice(0, ALWAYS_VISIBLE_FIRST);
+            const lastAuthors = authors.slice(total - ALWAYS_VISIBLE_LAST);
+
+            firstAuthors.forEach((author, index) => {
+                appendAuthorItem(author, index, false);
+            });
+
+            appendSummaryItem(hiddenCount, false);
+
+            lastAuthors.forEach((author, idx) => {
+                const realIndex = total - ALWAYS_VISIBLE_LAST + idx;
+                appendAuthorItem(author, realIndex, true);
+            });
+        }
+        </xsl:text>
+    </xsl:template>
+    
+    <xsl:template match="*" mode="modal-contrib-js-function-build-institution-text">
+        function buildInstitutionText(author) {
+            return author.affiliations
+                .map(code => affiliationMap[code] || `Afiliação ${code}`)
+                .join(" ");
+        }
+    </xsl:template>
+
+    <xsl:template match="*" mode="modal-contrib-js-function-build-author-card">
+        function buildAuthorCard(author) {
+            const card = document.createElement("div");
+            card.className = "author-card";
+
+            const nameRow = document.createElement("div");
+            nameRow.className = "author-grid-row";
+
+            const personIcon = document.createElement("span");
+            personIcon.className = "material-icons-outlined";
+            personIcon.setAttribute("aria-hidden", "true");
+            personIcon.textContent = "person";
+
+            const nameWrapper = document.createElement("div");
+            nameWrapper.className = "author-name";
+
+            const nameText = document.createElement("span");
+            nameText.className = "author-name-text";
+            nameText.textContent = author.name;
+
+            nameWrapper.appendChild(nameText);
+            nameRow.appendChild(personIcon);
+            nameRow.appendChild(nameWrapper);
+
+            card.appendChild(nameRow);
+
+            const roles = document.createElement("div");
+            roles.className = "author-roles author-subrow mb-2";
+            roles.textContent = author.roles || "Sem funções informadas.";
+
+            card.appendChild(roles);
+
+            const institutionRow = document.createElement("div");
+            institutionRow.className = "author-grid-row author-subrow mb-2";
+
+            const schoolIcon = document.createElement("span");
+            schoolIcon.className = "material-icons-outlined";
+            schoolIcon.setAttribute("aria-hidden", "true");
+            schoolIcon.textContent = "school";
+
+            const institution = document.createElement("div");
+            institution.className = "author-institution";
+
+            const institutionText = document.createElement("span");
+            institutionText.className = "author-inst-text";
+            institutionText.textContent = buildInstitutionText(author);
+
+            institution.appendChild(institutionText);
+            institutionRow.appendChild(schoolIcon);
+            institutionRow.appendChild(institution);
+
+            card.appendChild(institutionRow);
+
+            if (author.orcid) {
+                const orcidWrap = document.createElement("div");
+                orcidWrap.className = "orcid-button-wrap ms-4";
+
+                const orcidLink = document.createElement("a");
+                orcidLink.target = "_blank";
+                orcidLink.rel = "noopener noreferrer";
+                orcidLink.className = "btn btn-secondary orcid-button";
+                orcidLink.href = `https://orcid.org/${author.orcid}`;
+                orcidLink.textContent = author.orcid;
+                orcidLink.setAttribute(
+                "aria-label",
+                `Acessar perfil ORCID ${author.orcid}. Abre em nova aba.`
+                );
+
+                orcidWrap.appendChild(orcidLink);
+                card.appendChild(orcidWrap);
+            }
+
+            return card;
+        }
+    </xsl:template>
+
+    <xsl:template match="*" mode="modal-contrib-js-function-open-author-modal">
+        function openAuthorModal(index) {
+            if (!authorModal || !authorCardsContainer) return;
+
+            const author = authors[index];
+
+            if (!author) return;
+
+            authorCardsContainer.innerHTML = "";
+            authorCardsContainer.appendChild(buildAuthorCard(author));
+
+            if (correspondenceSection){
+                if (author.email) {
+                    correspondenceSection.classList.remove("d-none");
+                    correspondenceText.textContent = `${author.name}. E-mail: `;
+                    correspondenceEmail.href = `mailto:${author.email}`;
+                    correspondenceEmail.textContent = author.email;
+                } else {
+                    correspondenceSection.classList.add("d-none");
+                    correspondenceText.textContent = "";
+                    correspondenceEmail.removeAttribute("href");
+                    correspondenceEmail.textContent = "";
+                }
+            }
+            
+            authorModal.show();
+        }
+
+        renderAuthors();
+    </xsl:template>
+    
 </xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/html-modals-contrib-group.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/html-modals-contrib-group.xsl
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML"
+    exclude-result-prefixes="xlink mml">
+
+    <xsl:include href="../v2.0/html-modals-contribs.xsl"/>
+
+    <xsl:template match="article-meta | front-stub" mode="modal-contrib">
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
+        <div class="modal fade ModalDefault ModalTutors" id="ModalTutors{$id}" tabindex="-1" role="dialog" aria-hidden="true">
+                
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">
+                             <xsl:apply-templates select="contrib-group" mode="about-the-contrib-group-button-text"/>
+                        </h5>
+                        <button class="btn-close" data-bs-dismiss="modal">
+                            <xsl:attribute name="aria-label">
+                                <xsl:apply-templates select="." mode="interface">
+                                    <xsl:with-param name="text">Close</xsl:with-param>
+                                </xsl:apply-templates>
+                            </xsl:attribute>
+                        </button>
+                    </div>
+                    <xsl:call-template name="modal-author-css"/>
+                    <div class="modal-body">
+                        <xsl:apply-templates select="contrib-group/contrib" mode="modal-contrib"></xsl:apply-templates>
+                        <xsl:apply-templates select=".//author-notes" mode="modal-contrib"></xsl:apply-templates>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="modal-author-css">
+        <style>
+            .author-card {
+                border-bottom: 1px solid #ccc;
+                padding: 1rem 0;
+            }
+            .author-card:last-child {
+                border-bottom: 0px;
+            }
+            .author-name {
+                font-weight: 600;
+            }
+            
+            .orcid-button {
+                padding-left: 2.5rem;
+            }
+            .modal-body {
+                padding-bottom: 3rem;
+            }
+            .orcid-button::before {
+                content: "";
+                position: absolute;
+                background-image: url(https://ds.scielo.org/img/logo-orcid.svg);
+                background-repeat: no-repeat;
+                background-size: 1.5em auto;
+                background-position: .5em center;
+                display: block;
+                width: 60px;
+                height: 60px;
+                top: -10px;
+                left: 0;
+            }
+        </style>
+    </xsl:template>
+
+    <xsl:template match="article-meta | front-stub" mode="modal-scimago">
+        <xsl:variable name="id"><xsl:apply-templates select="." mode="modal-id"></xsl:apply-templates></xsl:variable>
+        <div class="modal fade ModalDefault ModalTutors" id="ModalScimago{$id}" tabindex="-1" role="dialog" aria-hidden="true">
+                
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">
+                            SCIMAGO INSTITUTIONS RANKINGS
+                        </h5>
+                        <button class="btn-close" data-bs-dismiss="modal">
+                            <xsl:attribute name="aria-label">
+                                <xsl:apply-templates select="." mode="interface">
+                                    <xsl:with-param name="text">Close</xsl:with-param>
+                                </xsl:apply-templates>
+                            </xsl:attribute>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="info">
+                            <xsl:apply-templates select=".//aff" mode="modal-scimago"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="contrib" mode="modal-contrib">
+        <!--
+            ((contrib-id)*, (anonymous | collab | collab-alternatives | name | name-alternatives | string-name)*, (degrees)*, (address | aff | aff-alternatives | author-comment | bio | email | ext-link | on-behalf-of | role | uri | xref)*)
+        -->
+        
+        <div class="author-card">
+            <div class="author-name">
+                <span class="material-icons-outlined">person</span>
+                <xsl:apply-templates select="anonymous|name|collab|on-behalf-of"/>
+                <xsl:apply-templates select="xref[@ref-type='corresp']"/>
+            </div>
+            <div class="author-roles ms-4 mb-2 scielo__text-color__subtle--light">
+                <xsl:apply-templates select="role | bio" mode="modal-contrib"/>
+            </div>
+            <div class="author-institution ms-4 mb-2 scielo__text-color__subtle--light">
+                <xsl:apply-templates select="xref" mode="modal-contrib"/>
+            </div>
+            <div class="ms-4">
+                <xsl:apply-templates select="contrib-id" mode="modal-contrib"/>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="contrib/xref" mode="modal-contrib">
+        <xsl:variable name="rid" select="@rid"/>
+            <xsl:apply-templates select="$article//aff[@id=$rid]" mode="modal-contrib"/>
+        <xsl:apply-templates select="$article//fn[@id=$rid]" mode="xref"/>
+    </xsl:template>
+    
+    <xsl:template match="role" mode="modal-contrib">
+        <xsl:choose>
+            <xsl:when test="position()=1"></xsl:when>
+            <xsl:otherwise> · </xsl:otherwise>
+        </xsl:choose><xsl:value-of select="."/>
+    </xsl:template>
+
+    <xsl:template match="aff" mode="modal-contrib">
+        <span class="material-icons-outlined">school</span>
+        <span data-aff-display="{@id}">
+            <xsl:apply-templates select="." mode="display"/>
+        </span>
+        <xsl:apply-templates select="." mode="hidden-for-scimago"/>
+    </xsl:template>
+    
+    <xsl:template match="contrib-id" mode="modal-contrib">
+        <xsl:variable name="access_text">
+            <xsl:apply-templates select="." mode="interface">
+                <xsl:with-param name="text">access_contributor</xsl:with-param>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="new_tab_text">
+            <xsl:apply-templates select="." mode="interface">
+                <xsl:with-param name="text">opens_new_tab</xsl:with-param>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="external_resource_text">
+            <xsl:apply-templates select="." mode="interface">
+                <xsl:with-param name="text">external_resource</xsl:with-param>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:variable name="contributor_url">
+            <xsl:apply-templates select="." mode="url"/><xsl:value-of select="."/>
+        </xsl:variable>
+        <xsl:variable name="aria_label">
+            <xsl:value-of select="$access_text"/>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="."/>
+            <xsl:text>. </xsl:text>
+            <xsl:value-of select="$new_tab_text"/>
+            <xsl:text>. </xsl:text>
+            <xsl:value-of select="$external_resource_text"/>
+            <xsl:text>.</xsl:text>
+        </xsl:variable>
+        <a target="_blank" class="btn btn-secondary  {@contrib-id-type}-button" href="{$contributor_url}" aria-label="{normalize-space($aria_label)}">
+            <xsl:value-of select="."/>
+        </a>
+    </xsl:template>
+
+    <xsl:template match="author-notes/*" mode="modal-contrib">
+        <xsl:apply-templates select="*|text()"/>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn/label" mode="modal-contrib">
+        <xsl:variable name="text"><xsl:apply-templates select=".//text()"/></xsl:variable>
+        <xsl:choose>
+            <xsl:when test="contains('123456789',substring(normalize-space($text),1,1))">
+                <sup><strong><xsl:apply-templates select="*|text()"/></strong></sup>
+            </xsl:when>
+            <xsl:otherwise>
+                <strong><xsl:apply-templates select="*|text()"/></strong>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn/label[sup]" mode="modal-contrib">
+        <strong><xsl:apply-templates select="*|text()"/></strong>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn" mode="modal-contrib">
+        <div>
+            <xsl:apply-templates select="." mode="author-notes-fn-class"/>
+            <xsl:apply-templates select="*|text()" mode="modal-contrib"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn" mode="author-notes-fn-class">
+        <xsl:attribute name="class">mb-3</xsl:attribute>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn[@fn-type='con']" mode="author-notes-fn-class">
+        <xsl:attribute name="class">author-contributions mb-3</xsl:attribute>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn[@fn-type='con']/label" mode="modal-contrib">
+        <strong><span class="material-icons-outlined">groups</span> <xsl:apply-templates select="."/></strong>
+    </xsl:template>
+
+    <xsl:template match="author-notes/fn/p | author-notes/fn/text()" mode="modal-contrib">
+        <p class="scielo__text-color__subtle--light mb-0">
+            <xsl:apply-templates select="."/>
+        </p>
+    </xsl:template>
+
+    <xsl:template match="author-notes/corresp" mode="modal-contrib">
+        <xsl:variable name="id"><xsl:value-of select="@id"/></xsl:variable>
+        <a class="" name="{@id}_ref"/>
+        <div class="correspondence mt-3 mb-4">
+            <xsl:apply-templates select="*|text()" mode="modal-contrib"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="author-notes/corresp/label" mode="modal-contrib">
+        <strong>
+            <span class="material-icons-outlined">
+                <xsl:choose>
+                    <xsl:when test="contains(., 'mail')">email</xsl:when>
+                    <xsl:otherwise>person</xsl:otherwise>
+                </xsl:choose>
+            </span><xsl:value-of select="."/>
+        </strong>
+    </xsl:template>
+
+    <xsl:template match="author-notes/corresp/text()" mode="modal-contrib">
+        <xsl:choose>
+            <xsl:when test="normalize-space(.)!=''">
+                <span class="scielo__text-color__subtle--light">
+                    <xsl:value-of select="."/>
+                </span><br/>
+            </xsl:when>
+            <xsl:when test="contains(., 'mail')">1
+                <strong><span class="material-icons-outlined">email</span> </strong>
+            </xsl:when>
+            <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="text()" mode="corresp-texts">
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+    <xsl:template match="author-notes/corresp/email" mode="modal-contrib">
+        <xsl:variable name="text"><xsl:apply-templates select="..//text()" mode="corresp-texts"/></xsl:variable>
+        <xsl:choose>
+            <xsl:when test="contains($text, 'mail')">
+                <xsl:apply-templates select="."/>
+            </xsl:when>
+            <xsl:otherwise>
+                <strong><span class="material-icons-outlined">email</span> </strong><xsl:apply-templates select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/packtools/catalogs/htmlgenerator/v3.0/html-modals-contribs.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/html-modals-contribs.xsl
@@ -76,7 +76,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title">
-                            SCIMAGO INSTITUTIONS RANKINGS
+                            SCImago Institutions Rankings
                         </h5>
                         <button class="btn-close" data-bs-dismiss="modal">
                             <xsl:attribute name="aria-label">


### PR DESCRIPTION
#### O que esse PR faz?

Refatora o modal de autoria (`ModalTutors`) no htmlgenerator v3.0, substituindo a renderização estática via XSLT por uma abordagem JS-driven: os dados de autores e afiliações são emitidos pelo XSL como arrays JavaScript e o DOM do modal é construído dinamicamente no cliente.

Inclui também ajustes no `contrib-group` para exibir a lista de autores inline com botões clicáveis, integrar o botão SCImago ao fluxo do `front`/`front-stub`, e experimentar a exibição do botão `author-notes` colapsável no cabeçalho do artigo. Corrige ainda a capitalização do label "SCImago Institutions Rankings".

#### Onde a revisão poderia começar?

Em `html-modals-contrib-group.xsl`, especificamente nos templates `modal-contrib-js-*` que emitem os dados e funções JS — é o núcleo da mudança. Em seguida, `article-meta-contrib.xsl` para entender como o `contrib-group` foi reorganizado.

#### Como este poderia ser testado manualmente?

Gerar o HTML de um artigo com múltiplos autores usando o htmlgenerator v3.0 e verificar:
- A lista de autores aparece inline no cabeçalho do artigo como botões clicáveis
- Clicar em um autor abre o `ModalTutors` com o card do autor (nome, afiliação, ORCID)
- O botão SCImago aparece corretamente ao lado da lista de autores
- O botão "Author notes" colapsa/expande as notas de autoria inline

#### Algum cenário de contexto que queira dar?

A renderização anterior do `ModalTutors` era inteiramente estática (XSLT → HTML), o que limitava a interatividade. A nova abordagem emite um bloco `<script>` com os dados estruturados (`affiliationMap`, `authors`) e as funções de renderização, permitindo que o modal exiba apenas o card do autor clicado em vez de todos os autores de uma vez.

O botão `author-notes` é experimental neste PR — a exibição inline das notas de autoria (colapsável via Bootstrap) ainda pode ser ajustada dependendo do feedback.

### Screenshots

#### Quais são tickets relevantes?

Fixes #1218 
Fixes #1229

### Referências