### PR TITLE
Resolve a apresentação de nota ou seção de disponibilidade de dados no fim da página

### DIFF
--- a/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article-text-section-data-availability.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     version="1.0">
 
-    <xsl:template match="article" mode="data-availability">
+    <xsl:template match="article" mode="bottom-of-the-page-data-availability">
         <xsl:choose>
             <xsl:when test=".//*[@sec-type='data-availability']">
                 <!-- ficará destacado naturalmente por ser uma seção -->
@@ -19,20 +19,20 @@
                         <xsl:apply-templates select="." mode="doc-version-data-availability"/>
                     </xsl:otherwise>
                 </xsl:choose>
-                <xsl:apply-templates select=".//article-meta/supplementary-material" mode="data-availability"/>
-                <xsl:apply-templates select="back//ref-list" mode="data-availability"/>
+                <xsl:apply-templates select=".//article-meta/supplementary-material" mode="bottom-of-the-page-data-availability"/>
+                <xsl:apply-templates select="back//ref-list" mode="bottom-of-the-page-data-availability"/>
             </xsl:when>
         </xsl:choose>
         
     </xsl:template>
 
     <xsl:template match="article | sub-article" mode="doc-version-data-availability">
-        <xsl:apply-templates select="body | back" mode="data-availability"/>
+        <xsl:apply-templates select="body | back" mode="bottom-of-the-page-data-availability"/>
     </xsl:template>
 
-    <xsl:template match="body | back" mode="data-availability">
-        <xsl:apply-templates select=".//sec[@sec-type='supplementary-material']" mode="data-availability"/>
-        <xsl:apply-templates select=".//*[@fn-type='data-availability']" mode="data-availability"/>
+    <xsl:template match="body | back" mode="bottom-of-the-page-data-availability">
+        <xsl:apply-templates select=".//sec[@sec-type='supplementary-material']" mode="bottom-of-the-page-data-availability"/>
+        <xsl:apply-templates select=".//*[@fn-type='data-availability']" mode="bottom-of-the-page-data-availability"/>
     </xsl:template>
 
     <xsl:template match="article" mode="data-availability-menu-title">
@@ -48,16 +48,16 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="ref-list" mode="data-availability">
+    <xsl:template match="ref-list" mode="bottom-of-the-page-data-availability">
         <xsl:if test=".//element-citation[@publication-type='data' or @publication-type='database']">
             <h2><xsl:apply-templates select="." mode="text-labels">
                     <xsl:with-param name="text">Data citations</xsl:with-param>
                 </xsl:apply-templates></h2>
-            <xsl:apply-templates select=".//element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability"/>
+            <xsl:apply-templates select=".//element-citation[@publication-type='data' or @publication-type='database']" mode="bottom-of-the-page-data-availability"/>
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="article-meta/supplementary-material" mode="data-availability">
+    <xsl:template match="article-meta/supplementary-material" mode="bottom-of-the-page-data-availability">
         <div class="row">
             <div class="col-md-12 col-sm-12">
                 <p>
@@ -67,7 +67,7 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability">
+    <xsl:template match="element-citation[@publication-type='data' or @publication-type='database']" mode="bottom-of-the-page-data-availability">
         <div class="row">
             <div class="col-md-12 col-sm-12">
                 <p>
@@ -77,19 +77,19 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="sec[@sec-type='supplementary-material']" mode="data-availability">
+    <xsl:template match="sec[@sec-type='supplementary-material']" mode="bottom-of-the-page-data-availability">
         <xsl:apply-templates select="."/>
     </xsl:template>
 
-    <xsl:template match="fn" mode="data-availability">
+    <xsl:template match="fn" mode="bottom-of-the-page-data-availability">
         <div class="row">
             <div class="col-md-12 col-sm-12">
-                <xsl:apply-templates select="p" mode="data-availability"/>
+                <xsl:apply-templates select="p" mode="bottom-of-the-page-data-availability"/>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template match="fn/*" mode="data-availability">
+    <xsl:template match="fn/*" mode="bottom-of-the-page-data-availability">
         <p>
             <xsl:apply-templates select="*|text()"/>
         </p>

--- a/packtools/catalogs/htmlgenerator/v2.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v2.0/article.xsl
@@ -252,7 +252,7 @@
             <xsl:apply-templates select="." mode="author-notes-as-sections"/>
             <xsl:apply-templates select="." mode="article-text-sub-articles"/>
 
-            <xsl:apply-templates select="." mode="data-availability"/>
+            <xsl:apply-templates select="." mode="bottom-of-the-page-data-availability"/>
 
             <xsl:apply-templates select="front/article-meta" mode="generic-pub-date"/>
             <xsl:apply-templates select="front/article-meta" mode="generic-history"/>

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-section-data-availability.xsl
@@ -39,22 +39,8 @@
     </xsl:template>
 
     <xsl:template match="fn|sec" mode="display-data-availability">
-        <xsl:choose>
-            <xsl:when test="@id and (.//label or .//title)">
-                <div class="row">
-                    <div class="col-md-12 col-sm-12">
-                        <p>
-                            <a href="#{@id}">
-                                <xsl:apply-templates select="label | title" />
-                            </a>
-                        </p>
-                    </div>
-                </div>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:apply-templates select="." mode="data-availability"/>
-            </xsl:otherwise>
-        </xsl:choose>
+        <!-- repete fn ou sec ao final do texto sem o label ou title, antes de Publication Dates e History -->
+        <xsl:apply-templates select="*[name()!='title' and name()!='label']" mode="data-availability"/>
     </xsl:template>
 
     <xsl:template match="sec[@sec-type='data-availability']" mode="data-availability">

--- a/packtools/catalogs/htmlgenerator/v3.0/article-text-section-data-availability.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article-text-section-data-availability.xsl
@@ -6,10 +6,10 @@
     <xsl:include href="../v2.0/article-text-section-data-availability.xsl"/>
 
     <xsl:template match="article | sub-article" mode="doc-version-data-availability">
-        <xsl:apply-templates select="body | back" mode="data-availability"/>
+        <xsl:apply-templates select="body | back" mode="bottom-of-the-page-data-availability"/>
     </xsl:template>
 
-    <xsl:template match="article" mode="data-availability">
+    <xsl:template match="article" mode="bottom-of-the-page-data-availability">
         <xsl:choose>
             <xsl:when test="body/sec[@sec-type='data-availability']">
                 <!-- ficará destacado naturalmente por ser uma seção -->
@@ -26,24 +26,19 @@
                         <xsl:apply-templates select="." mode="doc-version-data-availability"/>
                     </xsl:otherwise>
                 </xsl:choose>
-                <xsl:apply-templates select=".//article-meta/supplementary-material" mode="data-availability"/>
-                <xsl:apply-templates select="back//ref-list" mode="data-availability"/>
+                <xsl:apply-templates select=".//article-meta/supplementary-material" mode="bottom-of-the-page-data-availability"/>
+                <xsl:apply-templates select="back//ref-list" mode="bottom-of-the-page-data-availability"/>
             </xsl:when>
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="body | back" mode="data-availability">
-        <xsl:apply-templates select=".//*[@fn-type='data-availability']" mode="display-data-availability"/>
-        <xsl:apply-templates select="sec//sec[@sec-type='data-availability']" mode="display-data-availability"/>
-        <xsl:apply-templates select=".//sec[@sec-type='supplementary-material']" mode="display-data-availability"/>
+    <xsl:template match="body | back" mode="bottom-of-the-page-data-availability">
+        <!-- Deixa em destaque nota ou seção referente à disponibilidade de dados no final da página -->
+        <xsl:apply-templates select=".//*[@fn-type='data-availability']" mode="bottom-of-the-page-data-availability"/>
+        <xsl:apply-templates select="sec//sec[@sec-type='data-availability']" mode="bottom-of-the-page-data-availability"/>
     </xsl:template>
 
-    <xsl:template match="fn|sec" mode="display-data-availability">
-        <!-- repete fn ou sec ao final do texto sem o label ou title, antes de Publication Dates e History -->
-        <xsl:apply-templates select="*[name()!='title' and name()!='label']" mode="data-availability"/>
-    </xsl:template>
-
-    <xsl:template match="sec[@sec-type='data-availability']" mode="data-availability">
+    <xsl:template match="sec[@sec-type='data-availability']" mode="bottom-of-the-page-data-availability">
         <xsl:apply-templates select="*[name()!='title']|text()"/>
     </xsl:template>
 
@@ -61,29 +56,29 @@
         </div>
     </xsl:template>
 
-    <xsl:template match="ref-list" mode="data-availability">
+    <xsl:template match="ref-list" mode="bottom-of-the-page-data-availability">
         <xsl:if test=".//element-citation[@publication-type='data' or @publication-type='database']">
             <h2 class="h5"><xsl:apply-templates select="." mode="text-labels">
                     <xsl:with-param name="text">Data citations</xsl:with-param>
                 </xsl:apply-templates></h2>
-            <xsl:apply-templates select=".//element-citation[@publication-type='data' or @publication-type='database']" mode="data-availability"/>
+            <xsl:apply-templates select=".//element-citation[@publication-type='data' or @publication-type='database']" mode="bottom-of-the-page-data-availability"/>
         </xsl:if>
     </xsl:template>
 
-    <xsl:template match="fn" mode="data-availability">
+    <xsl:template match="fn" mode="bottom-of-the-page-data-availability">
         <div class="row">
             <div class="col-md-12 col-sm-12">
-                <xsl:apply-templates select="label| p" mode="data-availability"/>
+                <xsl:apply-templates select="p" mode="bottom-of-the-page-data-availability"/>
             </div>
         </div>
     </xsl:template>
 
-    <xsl:template match="fn/label" mode="data-availability">
+    <xsl:template match="fn/label" mode="bottom-of-the-page-data-availability">
         <p>
             <strong><xsl:apply-templates select="*|text()"/></strong>
         </p>
     </xsl:template>
-    <xsl:template match="fn/p" mode="data-availability">
+    <xsl:template match="fn/p" mode="bottom-of-the-page-data-availability">
         <p>
             <xsl:apply-templates select="*|text()"/>
         </p>

--- a/packtools/catalogs/htmlgenerator/v3.0/article.xsl
+++ b/packtools/catalogs/htmlgenerator/v3.0/article.xsl
@@ -227,7 +227,7 @@
             <xsl:apply-templates select="." mode="author-notes-as-sections"/>
             <xsl:apply-templates select="." mode="article-text-sub-articles"/>
 
-            <xsl:apply-templates select="." mode="data-availability"/>
+            <xsl:apply-templates select="." mode="bottom-of-the-page-data-availability"/>
 
             <xsl:apply-templates select="front/article-meta" mode="generic-pub-date"/>
             <xsl:apply-templates select="front/article-meta" mode="generic-history"/>


### PR DESCRIPTION
#### O que esse PR faz?
Resolve a marcação em fn, onde a informação aparece como um link que não leva para página alguma:

https://www.scielo.br/j/rac/a/BByXstgJvVLXZ5K8vDRJ3hD/?lang=en

```
<fn fn-type="data-availability" specific-use="data-not-available" id="fn5a">
<label>Data Availability</label>
<p> RAC encourages data sharing but, in compliance with ethical principles, it does not demand the disclosure of any means of identifying research subjects, preserving the privacy of research subjects. The practice of open data is to enable the reproducibility of results, and to ensure the unrestricted transparency of the results of the published research, without requiring the identity of research subjects.</p>
</fn>
```

<img width="1228" height="562" alt="Image" src="https://github.com/user-attachments/assets/ac37ebab-7b08-4f48-a3dc-72ce7452ab31" />

[exemplos-XML.zip](https://github.com/user-attachments/files/29216031/exemplos-XML.zip)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Use [BByXstgJvVLXZ5K8vDRJ3hD.xml.zip](https://github.com/user-attachments/files/29224208/BByXstgJvVLXZ5K8vDRJ3hD.xml.zip)

Execute:

```console
python packtools/htmlgenerator.py BByXstgJvVLXZ5K8vDRJ3hD.xml --nonetwork --nochecks --css /Users/roberta.takenaka/github.com/scieloorg/opac/opac_5/opac_5/opac/webapp/static/css  --loglevel DEBUG
```

Abra o html resultante em um navegador e observe a seção de disponibilidade de dados ao final da página

#### Algum cenário de contexto que queira dar?
O issue em questão só será resolvido após gerar a release do packtools e atualizá-lo no opac_5.

### Screenshots
Antes, ver no issue #1222 
Depois:
<img width="600" height="393" alt="Captura de Tela 2026-06-22 às 18 04 59" src="https://github.com/user-attachments/assets/fe55490a-49ad-4eb0-a2c5-b63640adecbe" />

html resultantes:
[Arquivo.zip](https://github.com/user-attachments/files/29224181/Arquivo.zip)


#### Quais são tickets relevantes?
#1222

### Referências
Relacionado com https://github.com/scieloorg/opac_5/issues/479
