### PR TITLE
fix(pubmed): corrige geração de <ArticleIdList/> vazio para referências sem IDs

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -633,7 +633,7 @@ def xml_pubmed_citations(xml_pubmed, xml_tree):
         citation.text = ref.get("mixed_citation")
         ref_el.append(citation)
         ids = ref.get("citation_ids")
-        if ids is not None:
+        if ids:
             ref_el.append(add_element_citation_id(ids))
         xml.append(ref_el)
 


### PR DESCRIPTION
#### O que esse PR faz?

Corrige o bug reportado na issue #1214. Na função `xml_pubmed_citations`, quando uma referência bibliográfica não possui identificadores (`pub-id` como DOI, PMID, etc.), o modelo de dados retornava um dicionário vazio (`{}`). A condição anterior `if ids is not None:` avaliava um dicionário vazio como verdadeiro, resultando na geração de um elemento `<ArticleIdList/>` vazio no XML de saída. A correção substitui `if ids is not None:` por `if ids:`, fazendo com que referências sem identificadores não gerem o elemento `<ArticleIdList>`.

---

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`, função `xml_pubmed_citations` (linha 635).

---

#### Como este poderia ser testado manualmente?

1. Utilize um XML SPS que contenha referências bibliográficas sem identificadores (`pub-id`) no `<element-citation>` — apenas `<mixed-citation>`.
2. Execute o pipeline: `pipeline_pubmed(xml_tree)`.
3. Verifique que o XML gerado **não** contém elementos `<ArticleIdList/>` vazios nas referências sem identificadores.
4. Verifique que referências **com** identificadores continuam gerando `<ArticleIdList>` corretamente.

Para rodar os testes automatizados:
```bash
.venv/bin/python -m pytest tests/sps/formats/test_pubmed.py -v
```

---

#### Algum cenário de contexto que queira dar?

Artigos cujas referências foram citadas sem DOI, PMID ou outros identificadores são comuns na literatura científica latino-americana indexada no SciELO. Nesse cenário, o campo `citation_ids` retornado por `XMLReferences` é um dicionário vazio, não `None`. A verificação original não distinguia esse caso, gerando XML malformado que poderia causar rejeição na ingestão pelo PubMed.

---

### Screenshots

Não aplicável — alteração de geração de XML.

---

#### Quais são tickets relevantes?

Closes #1214

---

### Referências

- Documentação de submissão de dados ao PubMed (formato XML de citações): https://www.ncbi.nlm.nih.gov/books/NBK3828/