### PR TITLE
fix(sps_xml): corrige prefixos de namespace (mml/xlink) dependentes de estado global

### DIFF
--- a/packtools/sps/formats/sps_xml/article.py
+++ b/packtools/sps/formats/sps_xml/article.py
@@ -45,15 +45,6 @@ def build_article_node(data, nodes):
                 <sub-article />
             </article>
     """
-    namespaces = {
-        "xlink": "http://www.w3.org/1999/xlink",
-        "mml": "http://www.w3.org/1998/Math/MathML"
-    }
-
-    # Adiciona os namespaces
-    for prefix, uri in namespaces.items():
-        ET.register_namespace(prefix, uri)
-
     try:
         # Cria o elemento <article>
         article_elem = ET.Element("article", {
@@ -61,6 +52,9 @@ def build_article_node(data, nodes):
             "specific-use": data["specific-use"],
             "article-type": data["article-type"],
             "{http://www.w3.org/XML/1998/namespace}lang": data["xml:lang"]
+        }, nsmap={
+            "xlink": "http://www.w3.org/1999/xlink",
+            "mml": "http://www.w3.org/1998/Math/MathML",
         })
     except KeyError as e:
         raise KeyError(f"{e} is required")

--- a/packtools/sps/formats/sps_xml/disp_formula.py
+++ b/packtools/sps/formats/sps_xml/disp_formula.py
@@ -36,12 +36,18 @@ def build_formula(data):
         raise ValueError("A valid codification type is required.")
 
     attributes = {}
-    if cod_type == "graphic":
+    nsmap = {}
+    if cod_type == "{http://www.w3.org/1998/Math/MathML}math":
+        nsmap["mml"] = "http://www.w3.org/1998/Math/MathML"
+        if cod_id:
+            attributes["id"] = cod_id
+    elif cod_type == "graphic":
         attributes["{http://www.w3.org/1999/xlink}href"] = cod_value
+        nsmap["xlink"] = "http://www.w3.org/1999/xlink"
     elif cod_id:
         attributes["id"] = cod_id
 
-    formula_elem = ET.Element(cod_type, attrib=attributes)
+    formula_elem = ET.Element(cod_type, attrib=attributes, nsmap=nsmap or None)
 
     if cod_type != "graphic":
         formula_elem.text = cod_value

--- a/packtools/sps/formats/sps_xml/fig.py
+++ b/packtools/sps/formats/sps_xml/fig.py
@@ -82,7 +82,7 @@ def build_fig(data):
 
     # add xlink
     if xlink := data.get("graphic"):
-        xlink_elem = ET.Element("graphic", attrib={"{http://www.w3.org/1999/xlink}href": xlink})
+        xlink_elem = ET.Element("graphic", attrib={"{http://www.w3.org/1999/xlink}href": xlink}, nsmap={"xlink": "http://www.w3.org/1999/xlink"})
         fig_elem.append(xlink_elem)
 
     # add attrib

--- a/packtools/sps/formats/sps_xml/permissions.py
+++ b/packtools/sps/formats/sps_xml/permissions.py
@@ -34,7 +34,7 @@ def build_permissions(data):
                     "license-type": license_dict["license-type"],
                     "{http://www.w3.org/1999/xlink}href": license_dict["xlink:href"],
                     "{http://www.w3.org/XML/1998/namespace}lang": license_dict["xml:lang"]
-                })
+                }, nsmap={"xlink": "http://www.w3.org/1999/xlink"})
                 text = license_dict.get("license-p")
                 if text:
                     license_elem.text = text

--- a/packtools/sps/formats/sps_xml/ref.py
+++ b/packtools/sps/formats/sps_xml/ref.py
@@ -142,13 +142,14 @@ def build_ref(data, node=None):
 
         if ext_link_text:
             ext_link_attributes = {"ext-link-type": ext_link_type, "{http://www.w3.org/1999/xlink}href": xlink_href}
+            xlink_nsmap = {"xlink": "http://www.w3.org/1999/xlink"}
 
             if comment:
                 comment_elem = ET.SubElement(element_citation_elem, "comment")
                 comment_elem.text = comment
-                ET.SubElement(comment_elem, "ext-link", attrib=ext_link_attributes).text = ext_link_text
+                ET.SubElement(comment_elem, "ext-link", attrib=ext_link_attributes, nsmap=xlink_nsmap).text = ext_link_text
             else:
-                ET.SubElement(element_citation_elem, "ext-link", attrib=ext_link_attributes).text = ext_link_text
+                ET.SubElement(element_citation_elem, "ext-link", attrib=ext_link_attributes, nsmap=xlink_nsmap).text = ext_link_text
 
     for pub_id in data.get("pub-ids") or []:
         pub_id_type = pub_id.get("pub-id-type")

--- a/packtools/sps/formats/sps_xml/table_wrap.py
+++ b/packtools/sps/formats/sps_xml/table_wrap.py
@@ -44,7 +44,8 @@ def build_table(data):
         attributes["id"] = table_id
 
     # Create the XML element with attributes
-    table_elem = ET.Element(table_type, attrib=attributes)
+    nsmap = {"xlink": "http://www.w3.org/1999/xlink"} if table_type == "graphic" else None
+    table_elem = ET.Element(table_type, attrib=attributes, nsmap=nsmap)
 
     # Add text content if it's a table
     if table_type == "table":

--- a/tests/sps/formats/sps_xml/test_article.py
+++ b/tests/sps/formats/sps_xml/test_article.py
@@ -24,9 +24,11 @@ class TestBuildArticleNode(unittest.TestCase):
         )
 
         expected_xml_str = (
-            '<article dtd-version="1.1" specific-use="sps-1.8" article-type="research-article" '
-            'xml:lang="pt"><'
-            'front/>'
+            '<article xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'dtd-version="1.1" specific-use="sps-1.8" article-type="research-article" '
+            'xml:lang="pt">'
+            '<front/>'
             '<body/>'
             '<back/>'
             '<sub-article/>'

--- a/tests/sps/formats/sps_xml/test_disp_formula.py
+++ b/tests/sps/formats/sps_xml/test_disp_formula.py
@@ -17,9 +17,9 @@ class TestBuildDispFormulaId(unittest.TestCase):
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
-            '<ns0:math xmlns:ns0="http://www.w3.org/1998/Math/MathML" id="m1">'
+            '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" id="m1">'
             'fórmula no formato mml'
-            '</ns0:math>'
+            '</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -56,9 +56,9 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
         expected_xml_str = (
             '<disp-formula id="e01">'
             '<label>(1)</label>'
-            '<ns0:math xmlns:ns0="http://www.w3.org/1998/Math/MathML" id="m1">'
+            '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" id="m1">'
             'fórmula no formato mml'
-            '</ns0:math>'
+            '</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -78,9 +78,9 @@ class TestBuildDispFormulaLabel(unittest.TestCase):
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
-            '<ns0:math xmlns:ns0="http://www.w3.org/1998/Math/MathML" id="m1">'
+            '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" id="m1">'
             'fórmula no formato mml'
-            '</ns0:math>'
+            '</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -111,9 +111,9 @@ class TestBuildDispFormula(unittest.TestCase):
         }
         expected_xml_str = (
             '<disp-formula id="e01">'
-            '<ns0:math xmlns:ns0="http://www.w3.org/1998/Math/MathML">'
+            '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">'
             'fórmula no formato mml'
-            '</ns0:math>'
+            '</mml:math>'
             '</disp-formula>'
         )
         disp_formula_elem = build_disp_formula(data)
@@ -160,14 +160,14 @@ class TestBuildDispFormulaAlternatives(unittest.TestCase):
             '<disp-formula id="e01">'
             '<label>(1)</label>'
             '<alternatives>'
-            '<ns0:math xmlns:ns0="http://www.w3.org/1998/Math/MathML" id="m1">'
+            '<mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" id="m1">'
             'fórmula no formato mml'
-            '</ns0:math>'
+            '</mml:math>'
             '<tex-math id="t1">'
             'fórmula no formato tex'
             '</tex-math>'
-            '<graphic xmlns:ns0="http://www.w3.org/1999/xlink" '
-            'ns0:href="0103-507X-rbti-26-02-0089-ee10.svg"/>'
+            '<graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'xlink:href="0103-507X-rbti-26-02-0089-ee10.svg"/>'
             '</alternatives>'
             '</disp-formula>'
         )

--- a/tests/sps/formats/sps_xml/test_fig.py
+++ b/tests/sps/formats/sps_xml/test_fig.py
@@ -77,8 +77,8 @@ class TestBuildFigXlink(unittest.TestCase):
         }
         expected_xml_str = (
             '<fig id="f01">'
-            '<graphic xmlns:ns0="http://www.w3.org/1999/xlink" '
-            'ns0:href="1234-5678-zwy-12-04-0123-gf02.tif"/>'
+            '<graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'xlink:href="1234-5678-zwy-12-04-0123-gf02.tif"/>'
             '</fig>'
         )
         fig_elem = build_fig(data)

--- a/tests/sps/formats/sps_xml/test_permissions.py
+++ b/tests/sps/formats/sps_xml/test_permissions.py
@@ -20,9 +20,9 @@ class TestBuildPermissionsCopyrightStatement(unittest.TestCase):
         expected_xml_str = (
             '<permissions>'
             '<copyright-statement>Copyright © 2014 SciELO</copyright-statement>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
@@ -46,9 +46,9 @@ class TestBuildPermissionsCopyrightStatement(unittest.TestCase):
         }
         expected_xml_str = (
             '<permissions>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
@@ -75,9 +75,9 @@ class TestBuildPermissionsCopyrightYear(unittest.TestCase):
         expected_xml_str = (
             '<permissions>'
             '<copyright-year>2014</copyright-year>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
@@ -101,9 +101,9 @@ class TestBuildPermissionsCopyrightYear(unittest.TestCase):
         }
         expected_xml_str = (
             '<permissions>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
@@ -130,9 +130,9 @@ class TestBuildPermissionsCopyrightHolder(unittest.TestCase):
         expected_xml_str = (
             '<permissions>'
             '<copyright-holder>SciELO</copyright-holder>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" xml:lang="pt">'
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
             '</permissions>'
@@ -155,9 +155,9 @@ class TestBuildPermissionsCopyrightHolder(unittest.TestCase):
         }
         expected_xml_str = (
             '<permissions>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'
@@ -183,9 +183,9 @@ class TestBuildPermissionsLicenses(unittest.TestCase):
         }
         expected_xml_str = (
             '<permissions>'
-            '<license xmlns:ns0="http://www.w3.org/1999/xlink" '
+            '<license xmlns:xlink="http://www.w3.org/1999/xlink" '
             'license-type="open-access" '
-            'ns0:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
+            'xlink:href="http://creativecommons.org/licenses/by-nc-sa/4.0/" '
             'xml:lang="pt">'
             'This is an article published in open access under a Creative Commons license'
             '</license>'

--- a/tests/sps/formats/sps_xml/test_ref.py
+++ b/tests/sps/formats/sps_xml/test_ref.py
@@ -111,8 +111,8 @@ class TestBuildRefExtLink(unittest.TestCase):
         expected_xml_str = (
             '<ref id="B1">'
             '<element-citation publication-type="journal">'
-            '<ext-link xmlns:ns0="http://www.w3.org/1999/xlink" '
-            'ext-link-type="uri" ns0:href="http://socialsciences.scielo.org">'
+            '<ext-link xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'ext-link-type="uri" xlink:href="http://socialsciences.scielo.org">'
             'http://socialsciences.scielo.org</ext-link>'
             '</element-citation>'
             '</ref>'
@@ -190,8 +190,8 @@ class TestBuildRefExtLink(unittest.TestCase):
         expected_xml_str = (
             '<ref id="B1">'
             '<element-citation publication-type="journal">'
-            '<comment>Disponível em: <ext-link xmlns:ns0="http://www.w3.org/1999/xlink" '
-            'ext-link-type="uri" ns0:href="http://socialsciences.scielo.org">'
+            '<comment>Disponível em: <ext-link xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'ext-link-type="uri" xlink:href="http://socialsciences.scielo.org">'
             'http://socialsciences.scielo.org</ext-link></comment>'
             '</element-citation>'
             '</ref>'

--- a/tests/sps/formats/sps_xml/test_table_wrap.py
+++ b/tests/sps/formats/sps_xml/test_table_wrap.py
@@ -204,8 +204,8 @@ class TestBuildTableAlternatives(unittest.TestCase):
         expected_xml_str = (
             '<table-wrap id="t01">'
             '<alternatives>'
-            '<graphic xmlns:ns0="http://www.w3.org/1999/xlink" '
-            'ns0:href="nomedaimagemdatabela.svg" id="g1"/>'
+            '<graphic xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'xlink:href="nomedaimagemdatabela.svg" id="g1"/>'
             '<table>codificação da tabela</table>'
             '</alternatives>'
             '</table-wrap>'


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a geração de prefixos de namespace XML incorretos (`ns0:`) nos builders do módulo `sps_xml`. O problema ocorria porque `ET.register_namespace()` em `build_article` causava efeito colateral global no processo — quando executado em determinada ordem, os prefixos `xlink` e `mml` eram registrados corretamente; em outras ordens (ou em execuções isoladas), o lxml gerava prefixos genéricos como `ns0:href` em vez de `xlink:href` e `ns0:math` em vez de `mml:math`. O PR remove a dependência de estado global e passa `nsmap` explicitamente em cada elemento que usa esses namespaces.

#### Onde a revisão poderia começar?
`packtools/sps/formats/sps_xml/article.py` — onde a chamada a `ET.register_namespace()` foi removida. A partir daí, seguir para `disp_formula.py`, `fig.py`, `permissions.py`, `ref.py` e `table_wrap.py`, onde `nsmap` foi adicionado localmente em cada `ET.Element` / `ET.SubElement` namespaced.

#### Como este poderia ser testado manualmente?
1. Clonar o repositório e instalar as dependências: `pip install -e ".[dev]"`
2. Executar os testes do módulo: `python -m pytest tests/sps/formats/sps_xml/ -v`
3. Verificar que os prefixos `xlink:` e `mml:` aparecem corretamente no XML gerado — e não como `ns0:`.
4. Opcionalmente, alterar a ordem de importação/execução dos builders e confirmar que os prefixos permanecem determinísticos.

#### Algum cenário de contexto que queira dar?
O `xml.etree.ElementTree` (e o lxml quando usado via interface ET) mantém um registro global de prefixos de namespace. A chamada `ET.register_namespace("xlink", ...)` em `build_article` funcionava como efeito colateral acidental: se `build_article` fosse chamado primeiro, os demais builders herdavam os prefixos registrados; caso contrário, o lxml atribuía `ns0`, `ns1`, etc. A correção elimina esse acoplamento implícito passando `nsmap` diretamente em cada elemento, tornando o comportamento independente da ordem de execução.

### Screenshots
Não aplicável (geração de XML sem interface gráfica).

#### Quais são tickets relevantes?
Closes #1216

### Referências
- [lxml — Namespaces](https://lxml.de/tutorial.html#namespaces)
- [xml.etree.ElementTree.register_namespace](https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.register_namespace)