### PR TITLE
fix: corrige bytes/KeyError em validate_xml_content que quebram serialização JSON

### DIFF
--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -1,10 +1,10 @@
-from lxml import etree
 from langdetect import detect
 from packtools.sps.validation.models.supplementary_material import XmlSupplementaryMaterials
 from packtools.sps.validation.models.media import XmlMedias
 from packtools.sps.validation.graphic import GraphicValidation
 from packtools.sps.validation.media import MediaValidation
 from packtools.sps.validation.utils import build_response
+from packtools.sps.utils.xml_utils import tostring
 
 
 class SupplementaryMaterialValidation:
@@ -102,7 +102,7 @@ class XmlSupplementaryMaterialValidation:
         """
 
         nodes = self.xml_tree.xpath(".//inline-supplementary-material")
-        obtained = etree.tostring(nodes[0], encoding=str) if nodes else "None"
+        obtained = tostring(nodes[0], xml_declaration=False) if nodes else None
         valid = not bool(nodes)
 
         return build_response(

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -102,7 +102,7 @@ class XmlSupplementaryMaterialValidation:
         """
 
         nodes = self.xml_tree.xpath(".//inline-supplementary-material")
-        obtained = etree.tostring(nodes[0]) if nodes else "None"
+        obtained = etree.tostring(nodes[0], encoding=str) if nodes else "None"
         valid = not bool(nodes)
 
         return build_response(

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -22,8 +22,8 @@ class SupplementaryMaterialValidation:
         """
         Executa todas as validações definidas.
         """
-        yield from MediaValidation(self.data, self.params).validate()
-        yield from GraphicValidation(self.data, self.params).validate()
+        yield from MediaValidation(self.data, self.params["media_rules"]).validate()
+        yield from GraphicValidation(self.data, self.params["graphic_rules"]).validate()
         yield self.validate_sec_type()
         yield self.validate_label()
         yield self.validate_not_in_app_group()

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -275,7 +275,7 @@ def validate_journal_meta(xmltree, params):
     validator = PublisherNameValidation(xmltree)
     yield from validator.validate_publisher_names(
         publisher_name_list=journal_data["publisher_name_list"],
-        error_level=journal_rules["publisher_name_list_error_level"],
+        error_level=journal_rules["publisher_name_error_level"],
     )
 
     try:
@@ -341,6 +341,12 @@ def validate_app_group(xmltree, params):
 def validate_supplementary_materials(xmltree, params):
     # TODO
     rules = {}
+    rules.update(params["visual_resource_base_rules"])
+    rules.update(params["graphic_rules"])
+    rules["valid_extension"] = list(
+        set(params["visual_resource_base_rules"]["valid_extension"])
+        | set(params["graphic_rules"]["valid_extension"])
+    )
     rules.update(params["supplementary_materials_rules"])
     validator = XmlSupplementaryMaterialValidation(xmltree, rules)
     yield from validator.validate()

--- a/packtools/sps/validation/xml_validations.py
+++ b/packtools/sps/validation/xml_validations.py
@@ -339,15 +339,9 @@ def validate_app_group(xmltree, params):
 
 
 def validate_supplementary_materials(xmltree, params):
-    # TODO
-    rules = {}
-    rules.update(params["visual_resource_base_rules"])
-    rules.update(params["graphic_rules"])
-    rules["valid_extension"] = list(
-        set(params["visual_resource_base_rules"]["valid_extension"])
-        | set(params["graphic_rules"]["valid_extension"])
-    )
-    rules.update(params["supplementary_materials_rules"])
+    rules = dict(params["supplementary_materials_rules"])
+    rules["media_rules"] = params["visual_resource_base_rules"]
+    rules["graphic_rules"] = params["graphic_rules"]
     validator = XmlSupplementaryMaterialValidation(xmltree, rules)
     yield from validator.validate()
 

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -15,23 +15,37 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             "label_error_level": "CRITICAL",
             "app_group_error_level": "CRITICAL",
             "inline_error_level": "CRITICAL",
-            "mime_types_and_subtypes": [
-                {"mimetype": "video", "mime-subtype": "mp4"},
-                {"mimetype": "audio", "mime-subtype": "mp3"},
-                {"mimetype": "application", "mime-subtype": "zip"},
-                {"mimetype": "application", "mime-subtype": "pdf"},
-                {"mimetype": "application", "mime-subtype": "xlsx"}
-            ],
-            "mime_type_error_level": "CRITICAL",
-            "media_attributes_error_level": "CRITICAL",
-            "valid_extension": "CRITICAL",
-            "xlink_href_error_level": "CRITICAL",
-            "alt_text_exist_error_level": "CRITICAL",
-            "long_desc_exist_error_level": "CRITICAL",
-            "transcript_error_level": "CRITICAL",
-            "speaker_speech_error_level": "CRITICAL",
-            "structure_error_level": "CRITICAL",
-            "parent_suppl_mat_expected": ["app-group", "app"]
+            "parent_suppl_mat_expected": ["app-group", "app"],
+            "media_rules": {
+                "media_attributes_error_level": "CRITICAL",
+                "xlink_href_error_level": "CRITICAL",
+                "valid_extension": ["mp3", "mp4", "zip", "pdf", "xlsx", "docx", "pptx"],
+                "mime_types_and_subtypes": [
+                    {"mimetype": "video", "mime-subtype": "mp4"},
+                    {"mimetype": "audio", "mime-subtype": "mp3"},
+                    {"mimetype": "application", "mime-subtype": "zip"},
+                    {"mimetype": "application", "mime-subtype": "pdf"},
+                    {"mimetype": "application", "mime-subtype": "xlsx"},
+                    {"mimetype": "application", "mime-subtype": "docx"},
+                    {"mimetype": "application", "mime-subtype": "pptx"}
+                ],
+                "mime_type_error_level": "CRITICAL",
+                "alt_text_exist_error_level": "CRITICAL",
+                "alt_text_content_error_level": "CRITICAL",
+                "long_desc_exist_error_level": "CRITICAL",
+                "long_desc_content_error_level": "CRITICAL",
+                "transcript_error_level": "CRITICAL",
+                "content_type_error_level": "CRITICAL",
+                "speaker_speech_error_level": "CRITICAL",
+                "structure_error_level": "CRITICAL",
+                "content_types": ["machine-generated"],
+            },
+            "graphic_rules": {
+                "media_attributes_error_level": "CRITICAL",
+                "xlink_href_error_level": "ERROR",
+                "valid_extension": ["jpg", "jpeg", "png", "tif", "tiff", "svg"],
+                "svg_error_level": "ERROR",
+            },
         }
 
     def test_validate_sec_type(self):

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -5,10 +5,19 @@ from packtools.sps.validation.supplementary_material import (
     XmlSupplementaryMaterialValidation,
 )
 from packtools.sps.models.supplementary_material import XmlSupplementaryMaterials
+from packtools.sps.validation.xml_validator_rules import get_default_rules
+from packtools.sps.validation.media import MediaValidation
+from packtools.sps.validation.graphic import GraphicValidation
 
 
 class TestSupplementaryMaterialValidation(unittest.TestCase):
     def setUp(self):
+        # Regras customizadas (override), com valores deliberadamente
+        # diferentes dos defaults reais de visual_resource_base_rules/
+        # graphic_rules (CRITICAL/ERROR trocados), para deixar explícito
+        # que este fixture testa o cenário de sobreposição de regras, e
+        # não os valores pré-estabelecidos (esses são cobertos em
+        # test_media_rules_and_graphic_rules_default_to_pre_established_sps_values).
         self.params = {
             "sec_type_error_level": "CRITICAL",
             "position_error_level": "CRITICAL",
@@ -17,8 +26,8 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             "inline_error_level": "CRITICAL",
             "parent_suppl_mat_expected": ["app-group", "app"],
             "media_rules": {
-                "media_attributes_error_level": "CRITICAL",
-                "xlink_href_error_level": "CRITICAL",
+                "media_attributes_error_level": "ERROR",
+                "xlink_href_error_level": "ERROR",
                 "valid_extension": ["mp3", "mp4", "zip", "pdf", "xlsx", "docx", "pptx"],
                 "mime_types_and_subtypes": [
                     {"mimetype": "video", "mime-subtype": "mp4"},
@@ -42,9 +51,9 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             },
             "graphic_rules": {
                 "media_attributes_error_level": "CRITICAL",
-                "xlink_href_error_level": "ERROR",
+                "xlink_href_error_level": "CRITICAL",
                 "valid_extension": ["jpg", "jpeg", "png", "tif", "tiff", "svg"],
-                "svg_error_level": "ERROR",
+                "svg_error_level": "CRITICAL",
             },
         }
 
@@ -221,6 +230,72 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertIn("Prohibition of <supplementary-material> inside <app-group> and <app>", titles)
         self.assertIn("Prohibition of inline-supplementary-material", titles)
         self.assertIn("Position of supplementary materials", titles)
+
+    def test_media_rules_and_graphic_rules_are_overridable(self):
+        """
+        Regras customizadas (media_rules/graphic_rules) passadas pelo chamador
+        devem ser efetivamente usadas por MediaValidation/GraphicValidation,
+        e não os valores default de visual_resource_base_rules/graphic_rules.
+        """
+        xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
+                <body>
+                    <sec sec-type="supplementary-material">
+                        <supplementary-material id="supp1">
+                            <label>Supplementary Material</label>
+                            <media id="m1" mimetype="application" mime-subtype="pdf" xlink:href="filenoext"/>
+                        </supplementary-material>
+                    </sec>
+                </body>
+            </article>
+            """
+        )
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)[0]
+
+        media_result = MediaValidation(
+            supplementary_data, self.params["media_rules"]
+        ).validate_xlink_href()
+        graphic_result = GraphicValidation(
+            supplementary_data, self.params["graphic_rules"]
+        ).validate_xlink_href()
+
+        # self.params usa valores deliberadamente diferentes dos defaults reais
+        # (ERROR para media, CRITICAL para graphic — trocados em relação ao SPS)
+        self.assertEqual(media_result["response"], "ERROR")
+        self.assertEqual(graphic_result["response"], "CRITICAL")
+
+    def test_media_rules_and_graphic_rules_default_to_pre_established_sps_values(self):
+        """
+        Quando nenhuma regra customizada é passada, get_default_rules() fornece
+        as regras pré-estabelecidas (SPS): CRITICAL para <media>, ERROR para
+        <graphic>, conforme visual_resource_base_rules.json/graphic_rules.json.
+        """
+        default_rules = get_default_rules()
+        media_rules = default_rules["visual_resource_base_rules"]
+        graphic_rules = default_rules["graphic_rules"]
+
+        xml_tree = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en">
+                <body>
+                    <sec sec-type="supplementary-material">
+                        <supplementary-material id="supp1">
+                            <label>Supplementary Material</label>
+                            <media id="m1" mimetype="application" mime-subtype="pdf" xlink:href="filenoext"/>
+                        </supplementary-material>
+                    </sec>
+                </body>
+            </article>
+            """
+        )
+        supplementary_data = list(XmlSupplementaryMaterials(xml_tree).items)[0]
+
+        media_result = MediaValidation(supplementary_data, media_rules).validate_xlink_href()
+        graphic_result = GraphicValidation(supplementary_data, graphic_rules).validate_xlink_href()
+
+        self.assertEqual(media_result["response"], "CRITICAL")
+        self.assertEqual(graphic_result["response"], "ERROR")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumo

Corrige os 3 bugs reportados em #1231: dois `KeyError` e um `TypeError` (bytes não serializável) em `validate_xml_content`, que quebram a serialização JSON do relatório de validação em qualquer consumidor downstream (ex: [spsvalidator](https://github.com/scieloorg/spsvalidator), [issue #20](https://github.com/scieloorg/spsvalidator/issues/20)).

## Mudanças

**1. `supplementary_material.py` — `etree.tostring()` sem `encoding=str`**
`validate_prohibited_inline` retornava `bytes` em `obtained`/`got_value` ao serializar o nó `<inline-supplementary-material>` proibido.

**2. `xml_validations.py` — `validate_journal_meta`**
Lookup de `journal_rules["publisher_name_list_error_level"]` não batia com a chave real `publisher_name_error_level` definida em `validation_rules/journal_rules.json`. Esse `KeyError` ocorria em **100%** das validações que possuem `journal_data` (ou seja, sempre que o chamador popula esse campo).

**3. `xml_validations.py` — `validate_supplementary_materials`**
Repassava apenas `params["supplementary_materials_rules"]` para `XmlSupplementaryMaterialValidation`, que internamente chama `MediaValidation`/`GraphicValidation` (subclasses de `VisualResourceBaseValidation`). Essas classes sempre acessam `self.params["valid_extension"]`/`xlink_href_error_level`, chaves que só existem em `visual_resource_base_rules`/`graphic_rules`, não em `supplementary_materials_rules`. Só se manifestava quando o XML tinha `<supplementary-material>` real (não-inline).

## Testes

- Suítes existentes `tests/sps/validation/test_supplementary_material.py` e `tests/sps/validation/test_journal_meta.py`: mesmo resultado antes/depois do patch (32 failed, 39 passed — falhas pré-existentes não relacionadas, ex.: `NameError: format_response` em `journal_meta.py`, não tocado neste PR).
- Smoke test end-to-end via `get_validation_results()` com **30 pacotes SPS reais** (material de gestão editorial, variando ~325KB–15.5MB): antes do fix, 30/30 pacotes geravam `KeyError: 'publisher_name_list_error_level'` e 2/30 também `KeyError: 'valid_extension'`; depois do fix, **0 exceptions** nos 30 pacotes, e `json.dumps()` do relatório completo funciona sem erro.

Closes #1231
