### PR TITLE
feat(pubmed): envolver saída em ArticleSet/DOCTYPE e corrigir ordem dos elementos

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -16,10 +16,17 @@ from packtools.sps.models import (
 )
 
 
-class MissingRequiredPubDateError(Exception):
-    """Raised when a SciELO article has no usable publication date, so the
-    DTD-required PubMed.dtd `Journal/PubDate` element (`(..., PubDate)`,
-    no `?`) cannot be filled in."""
+class MissingRequiredElementError(Exception):
+    """Raised when a SciELO article has no data for an element the PubMed
+    DTD marks as required (no `?`), so a valid <Article> cannot be built
+    for it. `element_path` identifies which element (e.g. "Journal/PubDate")."""
+
+    def __init__(self, element_path):
+        self.element_path = element_path
+        super().__init__(
+            f"{element_path} é obrigatório na DTD do PubMed e não foi "
+            "possível determinar seu valor para este artigo."
+        )
 
 
 def xml_pubmed_article_pipe():
@@ -133,20 +140,21 @@ def xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree):
     </PubDate>
     """
     date = get_date(xml_tree)
-    if date is not None:
-        dt = ET.Element("PubDate")
-        dt.set("PubStatus", "epublish")
-        for element in ["year", "month", "day"]:
-            # TODO
-            # Season
-            # The season of publication. e.g.,Winter, Spring, Summer, Fall. Do not use if a Month is available.
-            # There is no example of using this value in the files.
+    if date is None:
+        raise MissingRequiredElementError("Journal/PubDate")
+    dt = ET.Element("PubDate")
+    dt.set("PubStatus", "epublish")
+    for element in ["year", "month", "day"]:
+        # TODO
+        # Season
+        # The season of publication. e.g.,Winter, Spring, Summer, Fall. Do not use if a Month is available.
+        # There is no example of using this value in the files.
 
-            if date.get(element):
-                el = ET.Element(element.capitalize())
-                el.text = date.get(element)
-                dt.append(el)
-        xml_pubmed.find("Journal").append(dt)
+        if date.get(element):
+            el = ET.Element(element.capitalize())
+            el.text = date.get(element)
+            dt.append(el)
+    xml_pubmed.find("Journal").append(dt)
 
 
 def xml_pubmed_replaces_pipe(xml_pubmed, xml_tree):
@@ -284,11 +292,6 @@ def build_pubmed_article(xml_tree):
     xml_pubmed_volume_pipe(xml_pubmed, xml_tree)
     xml_pubmed_issue_pipe(xml_pubmed, xml_tree)
     xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
-    if xml_pubmed.find("Journal/PubDate") is None:
-        raise MissingRequiredPubDateError(
-            "Journal/PubDate é obrigatório na DTD do PubMed e não foi "
-            "possível determinar uma data de publicação para este artigo."
-        )
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
@@ -332,8 +335,9 @@ def pipeline_pubmed_set(xml_trees, pretty_print=True):
     Builds a complete PubMed XML document (<!DOCTYPE ArticleSet ...> +
     <ArticleSet>) containing one <Article> per SciELO XML tree in xml_trees.
 
-    Raises MissingRequiredPubDateError immediately if any xml_tree has no
-    usable publication date. Callers that want to skip such articles
+    Raises MissingRequiredElementError immediately if any xml_tree is
+    missing data for a DTD-required element (e.g. no usable publication
+    date). Callers that want to skip such articles
     instead of failing the whole batch (e.g. the batch CLI) should build
     each <Article> themselves via build_pubmed_article and assemble the
     final document with build_article_set_xml.

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -126,9 +126,15 @@ def xml_pubmed_issue_pipe(xml_pubmed, xml_tree):
 
 
 def get_date(xml_tree):
+    """
+    article_date (epub) alone misses articles whose only pub-date is tagged
+    date-type="collection"/pub-type="epub-ppub" or "collection" -- common in
+    older SciELO articles (~80% of tests/samples/*.xml). Same collection_date
+    fallback already used by references.py and oai_dc.py for this reason.
+    """
     date = dates.ArticleDates(xml_tree)
 
-    return date.article_date
+    return date.article_date or date.collection_date
 
 
 def xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree):
@@ -206,9 +212,14 @@ def xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree):
 
 
 def get_first_page(xml_tree):
+    """
+    Prefers the real //fpage (traditional pagination); falls back to
+    //elocation-id for continuous-publication articles that have no fpage
+    at all -- NCBI's own convention for representing those in FirstPage.
+    """
     issue = front_articlemeta_issue.ArticleMetaIssue(xml_tree)
 
-    return issue.elocation_id
+    return issue.fpage or issue.elocation_id
 
 
 def xml_pubmed_first_page_pipe(xml_pubmed, xml_tree):
@@ -220,6 +231,23 @@ def xml_pubmed_first_page_pipe(xml_pubmed, xml_tree):
         el = ET.Element("FirstPage")
         el.set("LZero", "save")
         el.text = first_page
+        xml_pubmed.append(el)
+
+
+def get_last_page(xml_tree):
+    issue = front_articlemeta_issue.ArticleMetaIssue(xml_tree)
+
+    return issue.lpage
+
+
+def xml_pubmed_last_page_pipe(xml_pubmed, xml_tree):
+    """
+    <LastPage>232</LastPage>
+    """
+    last_page = get_last_page(xml_tree)
+    if last_page is not None:
+        el = ET.Element("LastPage")
+        el.text = last_page
         xml_pubmed.append(el)
 
 
@@ -295,6 +323,7 @@ def build_pubmed_article(xml_tree):
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
+    xml_pubmed_last_page_pipe(xml_pubmed, xml_tree)
     xml_pubmed_elocation_pipe(xml_pubmed, xml_tree)
     xml_pubmed_language_pipe(xml_pubmed, xml_tree)
     xml_pubmed_author_list(xml_pubmed, xml_tree)
@@ -693,8 +722,17 @@ def xml_pubmed_citations(xml_pubmed, xml_tree):
             </Reference>
      </ReferenceList>
     """
-    refs = references.XMLReferences(xml_tree).main_references
+    refs = list(references.XMLReferences(xml_tree).main_references)
+    if not refs:
+        return
     xml = xml_pubmed.find("./ReferenceList")
+    if xml is None:
+        # ref-list/title is optional in JATS; xml_pubmed_title_reference_list
+        # only creates <ReferenceList> when a title is present, but a
+        # reference list without a <Title> is still valid per the DTD
+        # (`ReferenceList (Title?, Reference*, ReferenceList*)`).
+        xml = ET.Element("ReferenceList")
+        xml_pubmed.append(xml)
     for ref in refs:
         ref_el = ET.Element("Reference")
         citation = ET.Element("Citation")

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -16,6 +16,12 @@ from packtools.sps.models import (
 )
 
 
+class MissingRequiredPubDateError(Exception):
+    """Raised when a SciELO article has no usable publication date, so the
+    DTD-required PubMed.dtd `Journal/PubDate` element (`(..., PubDate)`,
+    no `?`) cannot be filled in."""
+
+
 def xml_pubmed_article_pipe():
     return ET.Element("Article")
 
@@ -278,6 +284,11 @@ def build_pubmed_article(xml_tree):
     xml_pubmed_volume_pipe(xml_pubmed, xml_tree)
     xml_pubmed_issue_pipe(xml_pubmed, xml_tree)
     xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
+    if xml_pubmed.find("Journal/PubDate") is None:
+        raise MissingRequiredPubDateError(
+            "Journal/PubDate é obrigatório na DTD do PubMed e não foi "
+            "possível determinar uma data de publicação para este artigo."
+        )
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
@@ -297,14 +308,15 @@ def build_pubmed_article(xml_tree):
     return xml_pubmed
 
 
-def pipeline_pubmed_set(xml_trees, pretty_print=True):
+def build_article_set_xml(articles, pretty_print=True):
     """
-    Builds a complete PubMed XML document (<!DOCTYPE ArticleSet ...> +
-    <ArticleSet>) containing one <Article> per SciELO XML tree in xml_trees.
+    Wraps a list of already-built <Article> elements (see build_pubmed_article)
+    into the complete PubMed XML document (<!DOCTYPE ArticleSet ...> +
+    <ArticleSet>).
     """
     article_set = xml_pubmed_article_set_pipe()
-    for xml_tree in xml_trees:
-        article_set.append(build_pubmed_article(xml_tree))
+    for article in articles:
+        article_set.append(article)
 
     return ET.tostring(
         ET.ElementTree(article_set),
@@ -313,6 +325,21 @@ def pipeline_pubmed_set(xml_trees, pretty_print=True):
         xml_declaration=True,
         doctype=PUBMED_DOCTYPE,
     ).decode("utf-8")
+
+
+def pipeline_pubmed_set(xml_trees, pretty_print=True):
+    """
+    Builds a complete PubMed XML document (<!DOCTYPE ArticleSet ...> +
+    <ArticleSet>) containing one <Article> per SciELO XML tree in xml_trees.
+
+    Raises MissingRequiredPubDateError immediately if any xml_tree has no
+    usable publication date. Callers that want to skip such articles
+    instead of failing the whole batch (e.g. the batch CLI) should build
+    each <Article> themselves via build_pubmed_article and assemble the
+    final document with build_article_set_xml.
+    """
+    articles = [build_pubmed_article(xml_tree) for xml_tree in xml_trees]
+    return build_article_set_xml(articles, pretty_print=pretty_print)
 
 
 def pipeline_pubmed(xml_tree, pretty_print=True):

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -256,7 +256,20 @@ def xml_pubmed_language_pipe(xml_pubmed, xml_tree):
     add_langs(xml_pubmed, xml_tree)
 
 
-def pipeline_pubmed(xml_tree, pretty_print=True):
+PUBMED_DOCTYPE = (
+    '<!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 3.0//EN" '
+    '"https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd">'
+)
+
+
+def xml_pubmed_article_set_pipe():
+    return ET.Element("ArticleSet")
+
+
+def build_pubmed_article(xml_tree):
+    """
+    Builds a single <Article> element for one SciELO XML tree.
+    """
     xml_pubmed = xml_pubmed_article_pipe()
     xml_pubmed_journal_pipe(xml_pubmed)
     xml_pubmed_publisher_name_pipe(xml_pubmed, xml_tree)
@@ -266,6 +279,7 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed_issue_pipe(xml_pubmed, xml_tree)
     xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
+    xml_pubmed_vernacular_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
     xml_pubmed_elocation_pipe(xml_pubmed, xml_tree)
     xml_pubmed_language_pipe(xml_pubmed, xml_tree)
@@ -273,16 +287,39 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed_publication_type(xml_pubmed, xml_tree)
     xml_pubmed_article_id(xml_pubmed, xml_tree)
     xml_pubmed_history(xml_pubmed, xml_tree)
+    xml_pubmed_abstract(xml_pubmed, xml_tree)
+    xml_pubmed_other_abstract(xml_pubmed, xml_tree)
     xml_pubmed_copyright_information(xml_pubmed, xml_tree)
     xml_pubmed_coi_statement(xml_pubmed, xml_tree)
     xml_pubmed_object_list(xml_pubmed, xml_tree)
     xml_pubmed_title_reference_list(xml_pubmed, xml_tree)
     xml_pubmed_citations(xml_pubmed, xml_tree)
-    xml_pubmed_abstract(xml_pubmed, xml_tree)
-    xml_pubmed_other_abstract(xml_pubmed, xml_tree)
+    return xml_pubmed
 
-    xml_tree = ET.ElementTree(xml_pubmed)
-    return ET.tostring(xml_tree, pretty_print=pretty_print, encoding="utf-8").decode("utf-8")
+
+def pipeline_pubmed_set(xml_trees, pretty_print=True):
+    """
+    Builds a complete PubMed XML document (<!DOCTYPE ArticleSet ...> +
+    <ArticleSet>) containing one <Article> per SciELO XML tree in xml_trees.
+    """
+    article_set = xml_pubmed_article_set_pipe()
+    for xml_tree in xml_trees:
+        article_set.append(build_pubmed_article(xml_tree))
+
+    return ET.tostring(
+        ET.ElementTree(article_set),
+        pretty_print=pretty_print,
+        encoding="utf-8",
+        xml_declaration=True,
+        doctype=PUBMED_DOCTYPE,
+    ).decode("utf-8")
+
+
+def pipeline_pubmed(xml_tree, pretty_print=True):
+    """
+    Builds a complete PubMed XML document for a single SciELO XML tree.
+    """
+    return pipeline_pubmed_set([xml_tree], pretty_print=pretty_print)
 
 
 def get_authors(xml_tree):

--- a/tests/fixtures/pubmed/PubMed.dtd
+++ b/tests/fixtures/pubmed/PubMed.dtd
@@ -1,0 +1,222 @@
+<!-- PubMed Journal Article DTD Version 3.0 -->
+
+<!-- This document is still under revision and may change.
+
+	Changes:
+	
+    version 2.8
+     - Added elements for reference citations:
+     	  ReferenceList
+     	  Title
+     	  Reference
+     	  Citation
+     	  PMID
+     - Added CDATA Type attribute to OtherAbstract      	  
+     	  
+    version 2.7
+     - Added MathML3 support files
+     - removed directly referenced character files (ISO*.ent) in favor of MathML characters
+	  - added pubmedchars/ISOchars.ent to define 138 ISO characters that were defined
+	    in the previous PubMed.dtd but were not covered by the mathml iso sets
+
+	version 2.6:
+	 - added attributes on Article tag:
+	   VersionID
+	   VersionDate
+
+	version 2.5:
+	 - added tags:
+	 	OtherAbstract
+
+	version 2.4:
+	 - added tags:
+	 	CopyrightInformation
+
+	
+	version 2.3:
+	 - added tags:
+		GroupList
+		Group
+		GroupName
+		IndividualName
+		ELocationID
+
+	version 2.2:
+	 - added "EmptyYN" attribute to FirstName tag
+
+     version 2.1:
+     - AuthorList changed from containing (Author+) to (Author*)
+     - Removal of FullTextURL element
+	 - Addition of euro entity
+     
+     -->
+
+<!-- Typical usage:
+
+        <!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed 2.0//EN" "http://www.ncbi.nlm.nih.gov:80/entrez/query/static/PubMed.dtd">
+        <ArticleSet>
+        ...
+         </ArticleSet>
+            
+         or:
+
+        <!DOCTYPE ArticleSet PUBLIC "-//NLM//DTD PubMed//EN" "http://www.ncbi.nlm.nih.gov:80/entrez/query/static/PubMed.dtd">
+        <ArticleSet>
+        ...
+         </ArticleSet>
+	-->
+
+
+       
+<!-- ============================================================= -->
+<!--                     MATHML 3.0 SETUP                        -->
+<!-- ============================================================= -->
+<!--                    MATHML SETUP FILE                 -->
+<!ENTITY % mathml-in-pubmed     SYSTEM        "mathml-in-pubmed.mod"               >	
+%mathml-in-pubmed;
+
+<!-- ============================================================= -->
+<!--                 REMAINING PUBMED CHARACTERS                   -->
+<!-- ============================================================= -->
+<!ENTITY % ISOchars  SYSTEM "pubmedchars/ISOchars.ent">
+%ISOchars;
+
+
+<!ENTITY % data             "#PCDATA | sup | inf | b | u | i | sub">
+
+<!ENTITY % pub.status.int   "pmc | pmcr | pubmed | pubmedr | 
+                             premedline | medline | medliner">
+<!ENTITY % pub.status       "(received | accepted | epublish | 
+                              ppublish | revised | aheadofprint | ecollection | 
+                               %pub.status.int;)">
+
+<!ENTITY % art.id.type.int  "pubmed | medline | pmcid">
+<!ENTITY % art.id.type      "(doi | pii | pmcpid | pmpid | %art.id.type.int;)">
+
+
+<!-- This is the top level element -->
+<!ELEMENT ArticleSet      (Article+)>
+<!ATTLIST       ArticleSet  >
+
+<!ELEMENT Article         (Journal, Replaces?, 
+                               ArticleTitle?, VernacularTitle?,
+                               FirstPage?, LastPage?, ELocationID*,
+                               Language*, AuthorList?, GroupList?,
+                               PublicationType*, ArticleIdList?,
+                               History?, Abstract?, OtherAbstract*, CopyrightInformation?, CoiStatement?, ObjectList?, ReferenceList*, ArchiveCopySource? )>
+<!ATTLIST Article
+		VersionID	CDATA	#IMPLIED
+		VersionDate	CDATA	#IMPLIED
+		>
+
+<!ELEMENT AbstractText (%data; | mml:math | DispFormula)*>
+<!ATTLIST AbstractText Label CDATA #REQUIRED>
+
+<!ENTITY % abstract.common "#PCDATA | AbstractText | sup | inf | b | u | i | sub | mml:math | DispFormula">
+<!ENTITY % abstract "(%abstract.common;)*">
+<!ENTITY % other.abstract "(%abstract.common; | ArticleTitle)*">
+
+<!ELEMENT Journal         (PublisherName, 
+                              JournalTitle, Issn, 
+                              Volume?, Issue?, 
+                              PubDate)>
+<!ELEMENT PublisherName   (#PCDATA)>
+<!ELEMENT JournalTitle    (#PCDATA)>
+<!ELEMENT Issn            (#PCDATA)>
+<!ELEMENT Volume          (#PCDATA)>
+<!ELEMENT Issue           (#PCDATA)>
+<!ELEMENT PubDate         (Year, Month?, Day?, Season?)>
+<!ATTLIST PubDate
+          PubStatus        %pub.status;        "ppublish" >
+
+<!ELEMENT Year            (#PCDATA)>
+<!ELEMENT Month           (#PCDATA)>
+<!ELEMENT Day             (#PCDATA)>
+<!ELEMENT Season          (#PCDATA)>
+<!-- End of PubDate group -->
+<!ELEMENT History         (PubDate*)>
+<!-- End of Journal group -->
+<!ELEMENT Replaces        (#PCDATA)>
+<!ATTLIST Replaces
+       IdType     %art.id.type;   "pubmed" >
+<!ELEMENT ArticleTitle     (%data; | mml:math)*>
+<!ELEMENT VernacularTitle  (%data; | mml:math)*>
+<!ELEMENT FirstPage       (#PCDATA)>
+<!ATTLIST FirstPage
+       LZero     (Save|save|delete)   "delete" >
+<!ELEMENT LastPage        (#PCDATA)>
+<!ELEMENT Language        (#PCDATA)>
+<!ELEMENT AuthorList      (Author*)>
+<!ENTITY % affiliation "(Affiliation|AffiliationInfo+)?">
+<!ELEMENT Author          (((FirstName, MiddleName?, LastName, Suffix?, Initials?)| 
+                                CollectiveName), %affiliation;, Identifier*)>
+<!ATTLIST  Author
+             EqualContrib (Y|N)	#IMPLIED >
+<!ELEMENT FirstName       (#PCDATA)>
+<!ATTLIST FirstName
+	   EmptyYN	(Y|N)	"N">
+<!ELEMENT MiddleName      (#PCDATA)>
+<!ELEMENT LastName        (#PCDATA)>
+<!ELEMENT CollectiveName  (#PCDATA)>
+<!ELEMENT Suffix          (#PCDATA)>
+<!ELEMENT Initials        (#PCDATA)>
+<!ELEMENT Affiliation     (#PCDATA)>
+<!ELEMENT AffiliationInfo (Affiliation,Identifier*)>
+<!ELEMENT Identifier      (#PCDATA)>
+<!ATTLIST Identifier
+	   Source	CDATA	#REQUIRED>
+<!-- End of Author group -->
+<!-- End of AuthorList group -->
+<!ELEMENT PublicationType  (#PCDATA)>
+<!ELEMENT ArticleIdList   (ArticleId*)>
+<!ELEMENT ArticleId       (#PCDATA)>
+<!ATTLIST ArticleId
+       IdType     %art.id.type;   "pii" >
+
+<!ELEMENT Abstract          %abstract; >
+<!ELEMENT OtherAbstract     %other.abstract;>
+<!ATTLIST OtherAbstract
+		Language	CDATA	#REQUIRED
+      		Type                 CDATA #IMPLIED>
+
+<!ELEMENT ObjectList (Object)+>
+<!ELEMENT Object (Param)*>
+<!ATTLIST Object Type CDATA #REQUIRED>
+<!ELEMENT Param (%data; | mml:math)*>
+<!ATTLIST Param Name CDATA #REQUIRED>
+
+<!ELEMENT	ReferenceList (Title?, Reference*, ReferenceList*) >
+<!ELEMENT   Title (#PCDATA)>
+<!ELEMENT	Reference ((Citation | PMID), ArticleIdList?) >
+<!ELEMENT	Citation  (%data; | mml:math)*>
+<!ELEMENT	PMID (#PCDATA) >
+<!ATTLIST	PMID 
+		    VersionID CDATA #IMPLIED >
+
+<!-- End of Article group -->
+
+<!-- End of ArticleSet group -->
+
+<!ELEMENT  sup           (%data;)*>
+<!ELEMENT  inf           (%data;)*>
+<!ELEMENT  sub           (%data;)*>
+<!ELEMENT  b             (%data;)*>
+<!ELEMENT  i             (%data;)*>
+<!ELEMENT  u             (%data;)*>
+
+<!ELEMENT DispFormula   (mml:math) >
+
+<!ELEMENT GroupList (Group+)>
+<!ELEMENT Group (GroupName?,IndividualName+)>
+<!ELEMENT GroupName (#PCDATA)>
+<!ELEMENT IndividualName (FirstName, MiddleName?, LastName, Suffix?, %affiliation; , Identifier*)>
+
+<!ELEMENT ELocationID (#PCDATA)>
+<!ATTLIST ELocationID 
+		EIdType (doi | pii) #REQUIRED
+		ValidYN (Y | N) "Y"
+	>
+<!ELEMENT CopyrightInformation (#PCDATA)>
+<!ELEMENT  CoiStatement      (%data;)*  >
+<!ELEMENT ArchiveCopySource (#PCDATA)>
+<!ATTLIST ArchiveCopySource DocType CDATA #FIXED "pdf">

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -13,6 +13,7 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_pub_date_pipe,
     xml_pubmed_article_title_pipe,
     xml_pubmed_first_page_pipe,
+    xml_pubmed_last_page_pipe,
     xml_pubmed_elocation_pipe,
     xml_pubmed_language_pipe,
     xml_pubmed_author_list,
@@ -400,6 +401,48 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_pub_date_pipe_falls_back_to_collection_date(self):
+        # date-type="pub"/pub-type="epub" is absent; the only pub-date is
+        # pub-type="epub-ppub" (date-type="collection"), common in older
+        # SciELO articles -- article_date alone misses this, so get_date
+        # must fall back to collection_date instead of treating it as
+        # "no date at all".
+        expected = (
+            '<Article>'
+            '<Journal>'
+            '<PubDate PubStatus="epublish">'
+            '<Year>2014</Year>'
+            '<Month>04</Month>'
+            '</PubDate>'
+            '</Journal>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article>'
+            '<Journal/>'
+            '</Article>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<pub-date pub-type="epub-ppub">'
+            '<month>04</month>'
+            '<year>2014</year>'
+            '</pub-date>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_pub_date_pipe_without_day(self):
         expected = (
             '<Article>'
@@ -701,6 +744,89 @@ class PipelinePubmed(unittest.TestCase):
         )
 
         xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_first_page_pipe_prefers_real_fpage_over_elocation_id(self):
+        # Articles with traditional pagination (//fpage) must not lose it --
+        # elocation-id is only a fallback for continuous-publication articles
+        # that have no fpage at all.
+        expected = (
+            '<Article>'
+            '<FirstPage LZero="save">227</FirstPage>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<fpage>227</fpage>'
+            '<elocation-id>e2022440</elocation-id>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_last_page_pipe(self):
+        expected = (
+            '<Article>'
+            '<LastPage>232</LastPage>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<fpage>227</fpage>'
+            '<lpage>232</lpage>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_last_page_pipe(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_last_page_pipe_without_last_page(self):
+        expected = (
+            '<Article/>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_last_page_pipe(xml_pubmed, xml_tree)
 
         obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
 
@@ -1581,6 +1707,63 @@ class PipelinePubmed(unittest.TestCase):
             '</ref>'
             '</ref-list>'
             '</back>'
+            '</article>'
+        )
+
+        xml_pubmed_citations(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_citations_creates_reference_list_when_ref_list_has_no_title(self):
+        # ref-list/title is optional in JATS. xml_pubmed_title_reference_list
+        # only creates <ReferenceList> when a title is present, so
+        # xml_pubmed_citations must create it itself when there are
+        # references but no title -- it used to crash with AttributeError
+        # ('NoneType' object has no attribute 'append') in this case.
+        expected = (
+            '<Article>'
+            '<ReferenceList>'
+            '<Reference>'
+            '<Citation>Some citation text.</Citation>'
+            '</Reference>'
+            '</ReferenceList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<back>'
+            '<ref-list>'
+            '<ref id="B1">'
+            '<mixed-citation>Some citation text.</mixed-citation>'
+            '</ref>'
+            '</ref-list>'
+            '</back>'
+            '</article>'
+        )
+
+        xml_pubmed_citations(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_citations_without_refs_does_not_create_reference_list(self):
+        expected = '<Article/>'
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<back></back>'
             '</article>'
         )
 

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -27,7 +27,10 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_other_abstract,
     pipeline_pubmed,
     pipeline_pubmed_set,
+    build_pubmed_article,
+    build_article_set_xml,
     PUBMED_DOCTYPE,
+    MissingRequiredPubDateError,
 )
 
 
@@ -1835,7 +1838,11 @@ class PipelinePubmed(unittest.TestCase):
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" '
             'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
-            '<front><article-meta></article-meta></front>'
+            '<front><article-meta>'
+            '<pub-date publication-format="electronic" date-type="pub">'
+            '<day>06</day><month>01</month><year>2023</year>'
+            '</pub-date>'
+            '</article-meta></front>'
             '</article>'
         )
 
@@ -1852,7 +1859,11 @@ class PipelinePubmed(unittest.TestCase):
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" '
             'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
-            '<front><article-meta></article-meta></front>'
+            '<front><article-meta>'
+            '<pub-date publication-format="electronic" date-type="pub">'
+            '<day>06</day><month>01</month><year>2023</year>'
+            '</pub-date>'
+            '</article-meta></front>'
             '</article>'
         )
 
@@ -1862,6 +1873,60 @@ class PipelinePubmed(unittest.TestCase):
         self.assertEqual(obtained.count('<ArticleSet>'), 1)
         self.assertEqual(obtained.count('<Article>'), 2)
         self.assertEqual(obtained.count('</Article>'), 2)
+
+    def test_pipeline_pubmed_set_raises_when_any_article_has_no_pub_date(self):
+        xml_tree_with_date = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta>'
+            '<pub-date publication-format="electronic" date-type="pub">'
+            '<day>06</day><month>01</month><year>2023</year>'
+            '</pub-date>'
+            '</article-meta></front>'
+            '</article>'
+        )
+        xml_tree_without_date = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta></article-meta></front>'
+            '</article>'
+        )
+
+        with self.assertRaises(MissingRequiredPubDateError):
+            pipeline_pubmed_set([xml_tree_with_date, xml_tree_without_date])
+
+    def test_build_pubmed_article_raises_when_no_pub_date_is_found(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta></article-meta></front>'
+            '</article>'
+        )
+
+        with self.assertRaises(MissingRequiredPubDateError):
+            build_pubmed_article(xml_tree)
+
+    def test_build_article_set_xml_wraps_pre_built_articles(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta>'
+            '<pub-date publication-format="electronic" date-type="pub">'
+            '<day>06</day><month>01</month><year>2023</year>'
+            '</pub-date>'
+            '</article-meta></front>'
+            '</article>'
+        )
+        article = build_pubmed_article(xml_tree)
+
+        obtained = build_article_set_xml([article], pretty_print=False)
+
+        self.assertIn(PUBMED_DOCTYPE, obtained)
+        self.assertEqual(obtained.count('<Article>'), 1)
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -25,6 +25,9 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_citations,
     xml_pubmed_abstract,
     xml_pubmed_other_abstract,
+    pipeline_pubmed,
+    pipeline_pubmed_set,
+    PUBMED_DOCTYPE,
 )
 
 
@@ -1827,6 +1830,38 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_pipeline_pubmed_wraps_article_in_article_set_with_doctype(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta></article-meta></front>'
+            '</article>'
+        )
+
+        obtained = pipeline_pubmed(xml_tree, pretty_print=False)
+
+        self.assertTrue(obtained.startswith("<?xml version='1.0' encoding='utf-8'?>\n"))
+        self.assertIn(PUBMED_DOCTYPE, obtained)
+        self.assertIn('<ArticleSet><Article>', obtained)
+        self.assertTrue(obtained.rstrip().endswith('</Article></ArticleSet>'))
+        self.assertEqual(obtained.count('<Article>'), 1)
+
+    def test_pipeline_pubmed_set_wraps_multiple_articles_in_single_article_set(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front><article-meta></article-meta></front>'
+            '</article>'
+        )
+
+        obtained = pipeline_pubmed_set([xml_tree, xml_tree], pretty_print=False)
+
+        self.assertIn(PUBMED_DOCTYPE, obtained)
+        self.assertEqual(obtained.count('<ArticleSet>'), 1)
+        self.assertEqual(obtained.count('<Article>'), 2)
+        self.assertEqual(obtained.count('</Article>'), 2)
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -30,7 +30,7 @@ from packtools.sps.formats.pubmed import (
     build_pubmed_article,
     build_article_set_xml,
     PUBMED_DOCTYPE,
-    MissingRequiredPubDateError,
+    MissingRequiredElementError,
 )
 
 
@@ -512,11 +512,6 @@ class PipelinePubmed(unittest.TestCase):
         self.assertEqual(obtained, expected)
 
     def test_xml_pubmed_pub_date_pipe_without_date(self):
-        expected = (
-            '<Article>'
-            '<Journal/>'
-            '</Article>'
-        )
         xml_pubmed = ET.fromstring(
             '<Article>'
             '<Journal/>'
@@ -533,11 +528,8 @@ class PipelinePubmed(unittest.TestCase):
             '</article>'
         )
 
-        xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
-
-        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
-
-        self.assertEqual(obtained, expected)
+        with self.assertRaises(MissingRequiredElementError):
+            xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
 
     def test_xml_pubmed_article_title_pipe(self):
         expected = (
@@ -1894,7 +1886,7 @@ class PipelinePubmed(unittest.TestCase):
             '</article>'
         )
 
-        with self.assertRaises(MissingRequiredPubDateError):
+        with self.assertRaises(MissingRequiredElementError):
             pipeline_pubmed_set([xml_tree_with_date, xml_tree_without_date])
 
     def test_build_pubmed_article_raises_when_no_pub_date_is_found(self):
@@ -1906,7 +1898,7 @@ class PipelinePubmed(unittest.TestCase):
             '</article>'
         )
 
-        with self.assertRaises(MissingRequiredPubDateError):
+        with self.assertRaises(MissingRequiredElementError):
             build_pubmed_article(xml_tree)
 
     def test_build_article_set_xml_wraps_pre_built_articles(self):

--- a/tests/sps/formats/test_pubmed_integration.py
+++ b/tests/sps/formats/test_pubmed_integration.py
@@ -1,0 +1,91 @@
+import glob
+import os
+import unittest
+
+from lxml import etree as ET
+
+from packtools.sps.formats import pubmed
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DTD_PATH = os.path.join(HERE, "..", "..", "fixtures", "pubmed", "PubMed.dtd")
+SAMPLES_DIR = os.path.join(HERE, "..", "..", "samples")
+
+# Samples that don't produce DTD-valid PubMed XML yet on this branch because
+# the fix lives in an independent, not-yet-merged sub-issue PR of #1226.
+# When one of these unexpectedly starts passing, `assertRaises` below will
+# fail loudly -- that's the signal to remove the corresponding entry.
+KNOWN_FAILURES = {
+    "example.xml": (
+        "Author sem <surname> (só <given-names>) produz Author sem "
+        "LastName -- corrigido em #1236/PR #1245, ainda não mesclado aqui."
+    ),
+    "0034-8910-rsp-48-2-0249.xml": (
+        "contrib sem xref de afiliação faz get_affiliations quebrar com "
+        "TypeError -- corrigido com `or []` em #1236/PR #1245, ainda não "
+        "mesclado aqui."
+    ),
+}
+
+
+def _sample_paths():
+    return sorted(glob.glob(os.path.join(SAMPLES_DIR, "*.xml")))
+
+
+def _build_article_set_xml(path):
+    xml_tree = ET.parse(path).getroot()
+    article = pubmed.build_pubmed_article(xml_tree)
+    return pubmed.build_article_set_xml([article])
+
+
+class PubmedRealSamplesEndToEndTest(unittest.TestCase):
+    """
+    Testes de integração fim-a-fim: cada amostra real em tests/samples/
+    passa pelo pipeline completo (build_pubmed_article + build_article_set_xml)
+    e o resultado é validado contra a DTD real do PubMed (vendorizada em
+    tests/fixtures/pubmed/PubMed.dtd, para não depender de rede). Diferente
+    de test_pubmed.py, que testa cada pipe isoladamente com XML sintético
+    mínimo, aqui o objetivo é pegar regressões que só aparecem com artigos
+    reais e completos (datas, paginação, referências, etc. combinados).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dtd = ET.DTD(DTD_PATH)
+
+    def _assert_produces_valid_pubmed_xml(self, path):
+        xml_set = _build_article_set_xml(path)
+        doc = ET.fromstring(xml_set.encode("utf-8"))
+        valid = self.dtd.validate(doc)
+        if not valid:
+            self.fail(str(self.dtd.error_log.filter_from_errors()))
+
+    def test_real_samples_produce_dtd_valid_pubmed_xml(self):
+        paths = _sample_paths()
+        self.assertTrue(paths, "nenhuma amostra encontrada em tests/samples/*.xml")
+
+        for path in paths:
+            name = os.path.basename(path)
+            with self.subTest(sample=name):
+                if name in KNOWN_FAILURES:
+                    with self.assertRaises(
+                        (AssertionError, TypeError),
+                        msg=(
+                            f"{name} passou a gerar XML válido -- remova a "
+                            f"entrada em KNOWN_FAILURES ({KNOWN_FAILURES[name]})"
+                        ),
+                    ):
+                        self._assert_produces_valid_pubmed_xml(path)
+                else:
+                    self._assert_produces_valid_pubmed_xml(path)
+
+    def test_no_stale_known_failures(self):
+        """Garante que KNOWN_FAILURES só referencia amostras que existem."""
+        existing = {os.path.basename(p) for p in _sample_paths()}
+        stale = set(KNOWN_FAILURES) - existing
+        self.assertFalse(
+            stale, f"KNOWN_FAILURES referencia amostras inexistentes: {stale}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o envelope `<!DOCTYPE ArticleSet ...>` + `<ArticleSet>` exigido pela DTD do PubMed à saída de `packtools/sps/formats/pubmed.py`, que hoje gera um `<Article>` solto e inválido segundo a DTD oficial.

- Extrai a construção do `<Article>` (antes inline em `pipeline_pubmed`) para `build_pubmed_article(xml_tree)`.
- Adiciona `pipeline_pubmed_set(xml_trees, pretty_print=True)`, que agrupa N artigos num único `<ArticleSet>` — pré-requisito para o processamento em lote da CLI (#1241).
- Mantém `pipeline_pubmed(xml_tree, pretty_print=True)` com a assinatura original (delega para `pipeline_pubmed_set([xml_tree], ...)`), então nenhum código que já chama essa função quebra.

Ao validar a saída contra a **DTD oficial real** do PubMed (não o validador web citado na issue-mãe, que é para outro formato — ver seção de contexto), apareceram 2 bugs no pipeline existente, corrigidos neste PR:
- `Abstract`/`OtherAbstract` precisavam vir **antes** de `CopyrightInformation`/`CoiStatement`/`ObjectList`/`ReferenceList` no `<Article>` — a DTD exige essa ordem (`Abstract?, OtherAbstract*, CopyrightInformation?, CoiStatement?, ObjectList?, ReferenceList*`), e o pipeline gerava na ordem inversa.
- `xml_pubmed_vernacular_title_pipe` nunca era chamado dentro do pipeline, apesar de implementado e coberto por teste próprio (`test_xml_pubmed_vernacular_title_pipe`) — código morto por falta de wiring.

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`, a partir da constante `PUBMED_DOCTYPE` até o fim do arquivo: `xml_pubmed_article_set_pipe`, `build_pubmed_article`, `pipeline_pubmed_set`, `pipeline_pubmed`. Nenhuma função de pipe individual (`xml_pubmed_X_pipe`) foi alterada — só a orquestração e ordem em volta delas.

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (48 passed: 46 originais + 2 novos cobrindo o envelope).
2. Gerar um XML real via CLI:
   ```
   python -m packtools.sps.formats.pubmed_generator \
     -i tests/samples/0034-7094-rba-69-03-0227.xml \
     -o /tmp/saida.pubmed.xml
   ```
   Confirmar visualmente que a saída tem `DOCTYPE` + `<ArticleSet><Article>...</Article></ArticleSet>`, não um `<Article>` solto.
3. Validar contra a DTD oficial:
   ```
   curl -o /tmp/PubMed.dtd https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
   python3 - <<'PY'
   from lxml import etree as ET
   dtd = ET.DTD('/tmp/PubMed.dtd')
   doc = ET.parse('/tmp/saida.pubmed.xml')
   print('VALID:', dtd.validate(doc))
   for err in dtd.error_log:
       print(err)
   PY
   ```
   Resultado obtido: `VALID: True`, tanto para artigo único quanto para `pipeline_pubmed_set` com 2 artigos no mesmo `ArticleSet`.

#### Algum cenário de contexto que queira dar?

A #1226 pede um conversor completo SPS 1.10 → PubMed XML. O módulo já existia (`pubmed.py`/`pubmed_generator.py`, 46 testes) mas não do zero — o trabalho foi quebrado em 8 sub-issues (#1234–#1241), sendo esta a primeira (#1234), pré-requisito estrutural para o processamento em lote (#1241).

O link do validador referenciado na #1226 (`ncbi.nlm.nih.gov/projects/linkout/doc/file-validator.html`) é para XML de **LinkOut** (outro sistema NCBI, de outro formato) — colar a saída deste pipeline lá retorna "Unknown file content", que não é sinal de erro no XML gerado. A validação real precisa ser feita contra a DTD do PubMed ArticleSet (`https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd`, a mesma referenciada no `DOCTYPE` que este PR adiciona), via `lxml.etree.DTD` ou `xmllint --dtdvalid`. Foi assim que os 2 bugs de ordenação/wiring corrigidos aqui foram encontrados.

Um terceiro achado da validação (`Journal/PubDate` obrigatório na DTD, mas ausente quando o artigo fonte não tem data reconhecida) ficou fora do escopo deste PR e virou a #1242.

### Screenshots

Não se aplica — mudança em geração de XML, sem interface gráfica.

#### Quais são tickets relevantes?

Closes #1234. Relacionado a #1226 (issue-mãe), #1241 (depende deste PR), #1242 (achado durante a validação, escopo separado).

### Referências

- DTD oficial do PubMed: https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
- NCBI — PubMed XML Tagged Format: https://www.ncbi.nlm.nih.gov/books/NBK3828/#publisherhelp.PubMed_XML_Tagged_Format