### PR TITLE
fix(pubmed): usar journal-id[nlm-ta] em JournalTitle em vez da abreviação SciELO

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -45,8 +45,18 @@ def xml_pubmed_publisher_name_pipe(xml_pubmed, xml_tree):
 
 
 def get_journal_title(xml_tree):
-    journal_title = journal_meta.Title(xml_tree)
+    """
+    JournalTitle deve ser a abreviação do periódico registrada no PubMed
+    (journal-id[@journal-id-type="nlm-ta"]), presente apenas quando o
+    periódico é indexado no PubMed. Cai para a abreviação genérica da
+    SciELO quando nlm-ta está ausente, já que JournalTitle é obrigatório
+    na DTD do PubMed.
+    """
+    nlm_ta = journal_meta.JournalID(xml_tree).nlm_ta
+    if nlm_ta:
+        return nlm_ta
 
+    journal_title = journal_meta.Title(xml_tree)
     return journal_title.abbreviated_journal_title
 
 

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -179,6 +179,41 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_journal_title_pipe_uses_nlm_ta_over_abbrev(self):
+        expected = (
+            '<Article>'
+            '<Journal>'
+            '<JournalTitle>Rev Saude Publica</JournalTitle>'
+            '</Journal>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article>'
+            '<Journal/>'
+            '</Article>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<journal-meta>'
+            '<journal-id journal-id-type="nlm-ta">Rev Saude Publica</journal-id>'
+            '<journal-title-group>'
+            '<journal-title>Revista de Saúde Pública</journal-title>'
+            '<abbrev-journal-title abbrev-type="publisher">Rev. saúde pública</abbrev-journal-title>'
+            '</journal-title-group>'
+            '</journal-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_journal_title_pipe(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_issn_pipe(self):
         expected = (
             '<Article>'


### PR DESCRIPTION
#### O que esse PR faz?

Corrige `get_journal_title()` em `packtools/sps/formats/pubmed.py`, que gerava a tag `<JournalTitle>` do XML PubMed usando `journal_meta.Title.abbreviated_journal_title` — a abreviação genérica de título registrada na SciELO (`abbrev-journal-title[@abbrev-type="publisher"]`).

O guia SPS 1.10 e a doc oficial do PubMed (NBK3828) especificam que `JournalTitle` deve ser a **abreviação registrada no próprio PubMed** (NLM Title Abbreviation), disponível em `journal-id[@journal-id-type="nlm-ta"]` — presente apenas quando o periódico é indexado no PubMed. O model `journal_meta.JournalID.nlm_ta` já existia no código mas não era usado por este pipeline.

A função passa a priorizar `nlm-ta`, com fallback para `abbreviated_journal_title` quando `nlm-ta` está ausente (necessário porque `JournalTitle` é um elemento obrigatório na DTD do PubMed — omiti-lo geraria XML inválido para periódicos não indexados).

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`, função `get_journal_title` (linha ~47). É a única função alterada; `xml_pubmed_journal_title_pipe`, que a consome, não muda.

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (47 passed: 46 originais + 1 novo, cobrindo a prioridade de `nlm-ta` sobre `abbrev-journal-title`).
2. Comparar antes/depois com um artigo real indexado no PubMed:
   ```python
   from packtools.sps.formats import pubmed
   from packtools.sps.utils import xml_utils

   xml_tree = xml_utils.get_xml_tree('tests/samples/0034-7094-rba-69-03-0227.xml')
   print(pubmed.get_journal_title(xml_tree))
   ```
   Antes deste PR: `'Rev. Bras.\n                    Anestesiol.'` (abreviação genérica da SciELO, com quebras de linha do XML fonte preservadas). Depois: `'Rev Bras Anestesiol'` (valor correto de `journal-id[@journal-id-type="nlm-ta"]`, sem os artefatos de whitespace).

#### Algum cenário de contexto que queira dar?

Parte da quebra da #1226 (conversor SPS 1.10 → PubMed XML) em sub-issues. Este bug foi identificado durante o levantamento inicial de contexto da #1226, antes mesmo de abrir as sub-issues: o model `JournalID.nlm_ta` já existia no código, mas nunca tinha sido conectado a este pipeline. Independente das demais sub-issues (não depende nem é dependência de nenhuma outra).

### Screenshots

Não se aplica — mudança em geração de XML, sem interface gráfica.

#### Quais são tickets relevantes?

Closes #1235. Relacionado a #1226 (issue-mãe).

### Referências

- NCBI — PubMed XML Tagged Format: https://www.ncbi.nlm.nih.gov/books/NBK3828/#publisherhelp.PubMed_XML_Tagged_Format
- Guia SciELO SPS 1.10 (seção `<journal-meta>`): "Usar título abreviado do periódico registrado no PubMed" para `journal-id[@journal-id-type="nlm-ta"]`