### PR TITLE
feat(pubmed): adicionar Suffix e CollectiveName em AuthorList

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -305,10 +305,26 @@ def add_last_name(author_reg, author_tag):
         author_tag.append(last)
 
 
+def add_suffix(author_reg, author_tag):
+    author_suffix = author_reg.get("contrib_name", {}).get("suffix")
+    if author_suffix:
+        suffix = ET.Element("Suffix")
+        suffix.text = author_suffix
+        author_tag.append(suffix)
+
+
+def add_collective_name(author_reg, author_tag):
+    collab = author_reg.get("collab")
+    if collab:
+        collective_name = ET.Element("CollectiveName")
+        collective_name.text = collab
+        author_tag.append(collective_name)
+
+
 def get_affiliations(author_reg, xml_tree):
     affiliations = aff.AffiliationExtractor(xml_tree).get_affiliation_dict(subtag=False)
     affiliation_list = []
-    for item in author_reg.get("affs"):
+    for item in author_reg.get("affs") or []:
         affiliation_list.append(
             affiliations.get(item.get("id"), {}).get("institution", {})[0].get("original")
         )
@@ -342,33 +358,23 @@ def xml_pubmed_author_list(xml_pubmed, xml_tree):
         author_list_tag = ET.Element("AuthorList")
         for author_reg in authors:
             author_tag = ET.Element("Author")
-            add_first_name(author_reg, author_tag)
 
-            # TODO
-            # add_middle_name(author_reg, author_tag)
-            # The Author’s full middle name, or initial if the full name is not available.
-            # Multiple names are allowed in this tag.
-            # There is no example of using this value in the files.
+            # A DTD do PubMed exige que Author tenha nome pessoal
+            # (FirstName/MiddleName/LastName/Suffix) OU CollectiveName,
+            # nunca os dois ao mesmo tempo.
+            if author_reg.get("collab"):
+                add_collective_name(author_reg, author_tag)
+            else:
+                add_first_name(author_reg, author_tag)
 
-            add_last_name(author_reg, author_tag)
+                # TODO
+                # add_middle_name(author_reg, author_tag)
+                # The Author’s full middle name, or initial if the full name is not available.
+                # Multiple names are allowed in this tag.
+                # There is no example of using this value in the files.
 
-            # TODO
-            # add_suffix(author_reg, author_tag)
-            # The Author's suffix, if any, e.g. "Jr", "Sr", "II", "IV". Do not include honorific titles,
-            # e.g. "M.D.", "Ph.D.".
-            # There is no example of using this value in the files
-
-            # TODO
-            # add_collective_name(author_reg, author_tag)
-            # The name of the authoring committee or organization. The CollectiveName tag should be placed within
-            # an Author tag. Omit extraneous text like, “on behalf of.”
-            # Please see the following example:
-            #   <AuthorList>
-            #       <Author>
-            #           <CollectiveName>Plastic Surgery Educational Foundation DATA Committee</CollectiveName>
-            #       </Author>
-            #   </AuthorList>
-            # There is no example of using this value in the files
+                add_last_name(author_reg, author_tag)
+                add_suffix(author_reg, author_tag)
 
             affiliations = get_affiliations(author_reg, xml_tree)
             add_affiliations(affiliations, author_tag)

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -290,7 +290,12 @@ def get_authors(xml_tree):
 
 
 def add_first_name(author_reg, author_tag):
-    author_first_name = author_reg.get("contrib_name", {}).get("given-names")
+    contrib_name = author_reg.get("contrib_name", {})
+    # A DTD do PubMed exige FirstName e LastName juntos (nenhum dos dois é
+    # opcional isoladamente). Quando o XML fonte só tem um dos dois campos
+    # (autores sem <surname>, por exemplo), duplicamos o valor disponível
+    # em ambos para gerar um Author válido em vez de descartar o autor.
+    author_first_name = contrib_name.get("given-names") or contrib_name.get("surname")
     if author_first_name:
         first = ET.Element("FirstName")
         first.text = author_first_name
@@ -298,7 +303,8 @@ def add_first_name(author_reg, author_tag):
 
 
 def add_last_name(author_reg, author_tag):
-    author_last_name = author_reg.get("contrib_name", {}).get("surname")
+    contrib_name = author_reg.get("contrib_name", {})
+    author_last_name = contrib_name.get("surname") or contrib_name.get("given-names")
     if author_last_name:
         last = ET.Element("LastName")
         last.text = author_last_name

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1058,6 +1058,47 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_author_list_without_surname_duplicates_given_names(self):
+        # A DTD do PubMed exige FirstName e LastName juntos; quando o XML
+        # fonte só tem <given-names> (sem <surname>), duplicamos o valor
+        # em ambos os campos em vez de gerar um Author inválido.
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<FirstName>Viviana Alder</FirstName>'
+            '<LastName>Viviana Alder</LastName>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<given-names>Viviana Alder</given-names>'
+            '</name>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_author_list_with_collective_name(self):
         expected = (
             '<Article>'

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1012,6 +1012,88 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_author_list_with_suffix(self):
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<FirstName>Rogerio</FirstName>'
+            '<LastName>Meneghini</LastName>'
+            '<Suffix>Junior</Suffix>'
+            '<Affiliation>Some University</Affiliation>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<surname>Meneghini</surname>'
+            '<given-names>Rogerio</given-names>'
+            '<suffix>Junior</suffix>'
+            '</name>'
+            '<xref ref-type="aff" rid="aff1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '<aff id="aff1">'
+            '<institution content-type="original">Some University</institution>'
+            '</aff>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_author_list_with_collective_name(self):
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<CollectiveName>The SciELO Group</CollectiveName>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author" id="collab">'
+            '<collab>The SciELO Group</collab>'
+            '<xref ref-type="author-notes" rid="fn1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_publication_type(self):
         # TODO
         # Originalmente, espera-se que o valor da tag <PublicationType> seja Journal Article


### PR DESCRIPTION
#### O que esse PR faz?

Implementa `<Suffix>` e `<CollectiveName>` em `<AuthorList>` no conversor SPS → PubMed XML (`packtools/sps/formats/pubmed.py`), fechando 2 dos `# TODO` marcados no código original. Os dados já estavam disponíveis no model `article_contribs.Contrib` (`contrib_name["suffix"]` e `collab`), só faltava conectar.

A DTD do PubMed exige que `<Author>` tenha nome pessoal OU `CollectiveName`, nunca os dois juntos:
```
<!ELEMENT Author (((FirstName, MiddleName?, LastName, Suffix?, Initials?) | CollectiveName), %affiliation;, Identifier*)>
```
`xml_pubmed_author_list` agora respeita essa exclusividade: contribs que só têm `<collab>` (sem `<name>`) — o padrão SPS 1.10 para autoria em grupo — geram `<Author><CollectiveName>...</CollectiveName></Author>`; os demais continuam gerando `FirstName`/`LastName`/`Suffix` como antes.

Também corrige um bug em `get_affiliations`: contribs sem afiliação vinculada (comum justamente no caso de `CollectiveName`, cujo único `xref` costuma apontar para `author-notes`, não para `aff`) não tinham a chave `"affs"` no dicionário, e `for item in author_reg.get("affs")` lançava `TypeError: 'NoneType' object is not iterable`. Sem esse fix, qualquer artigo com autoria em grupo quebraria o pipeline inteiro ao tentar gerar `CollectiveName`.

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`: `add_suffix`, `add_collective_name` (funções novas), `get_affiliations` (fix de uma linha), e `xml_pubmed_author_list` (lógica de exclusividade FirstName/LastName vs. CollectiveName).

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (48 passed: 46 originais + 2 novos).
2. Reproduzir o bug do `get_affiliations` antes do fix (reverter só essa linha) e rodar:
   ```python
   from lxml import etree as ET
   from packtools.sps.formats import pubmed

   xml_tree = ET.fromstring(
       '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
       'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
       'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
       '<front><article-meta>'
       '<contrib-group>'
       '<contrib contrib-type="author" id="collab">'
       '<collab>The SciELO Group</collab>'
       '<xref ref-type="author-notes" rid="fn1">1</xref>'
       '</contrib>'
       '</contrib-group>'
       '</article-meta></front></article>'
   )
   xml_pubmed = ET.fromstring('<Article/>')
   pubmed.xml_pubmed_author_list(xml_pubmed, xml_tree)
   print(ET.tostring(xml_pubmed, pretty_print=True).decode())
   ```
   Sem o fix: `TypeError: 'NoneType' object is not iterable`. Com o fix: `<Author><CollectiveName>The SciELO Group</CollectiveName></Author>`, sem `FirstName`/`LastName` vazios.
3. Rodar contra um artigo real (`tests/samples/0034-7094-rba-69-03-0227.xml`, sem autoria em grupo) para confirmar que o comportamento de autores individuais não mudou.

#### Algum cenário de contexto que queira dar?

Parte da quebra da #1226 em sub-issues. O padrão SPS 1.10 para autoria em grupo (documentado no guia interno da SciELO) é:
```xml
<contrib-group>
   <contrib contrib-type="author" id="collab">
     <collab>The SciELO Group</collab>
   </contrib>
</contrib-group>
<contrib-group content-type="collab-list">
    <contrib contrib-type="author" rid="collab">
      <name>...</name>
    </contrib>
    ...
</contrib-group>
```
Este PR cobre apenas o `<collab>` do primeiro `contrib-group` (o "nome do grupo"). Os membros individuais do `content-type="collab-list"` continuam sendo listados como `Author` comuns em `AuthorList` (comportamento herdado, sem mudança) — mover esses membros para `GroupList`/`IndividualName` é escopo da #1237, que também depende deste PR (mesma função `xml_pubmed_author_list`).

#### Quais são tickets relevantes?

Closes #1236. Relacionado a #1226 (issue-mãe), #1237 (depende deste PR).

### Referências

- DTD oficial do PubMed: https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd (elemento `Author`)
- Guia SciELO SPS 1.10, seção `<contrib>`: `<name>` e `<collab>` — exemplos de autoria em grupo