### PR TITLE
feat(pubmed): implementar GroupList/Group/GroupName/IndividualName

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -305,10 +305,26 @@ def add_last_name(author_reg, author_tag):
         author_tag.append(last)
 
 
+def add_suffix(author_reg, author_tag):
+    author_suffix = author_reg.get("contrib_name", {}).get("suffix")
+    if author_suffix:
+        suffix = ET.Element("Suffix")
+        suffix.text = author_suffix
+        author_tag.append(suffix)
+
+
+def add_collective_name(author_reg, author_tag):
+    collab = author_reg.get("collab")
+    if collab:
+        collective_name = ET.Element("CollectiveName")
+        collective_name.text = collab
+        author_tag.append(collective_name)
+
+
 def get_affiliations(author_reg, xml_tree):
     affiliations = aff.AffiliationExtractor(xml_tree).get_affiliation_dict(subtag=False)
     affiliation_list = []
-    for item in author_reg.get("affs"):
+    for item in author_reg.get("affs") or []:
         affiliation_list.append(
             affiliations.get(item.get("id"), {}).get("institution", {})[0].get("original")
         )
@@ -342,33 +358,23 @@ def xml_pubmed_author_list(xml_pubmed, xml_tree):
         author_list_tag = ET.Element("AuthorList")
         for author_reg in authors:
             author_tag = ET.Element("Author")
-            add_first_name(author_reg, author_tag)
 
-            # TODO
-            # add_middle_name(author_reg, author_tag)
-            # The Author’s full middle name, or initial if the full name is not available.
-            # Multiple names are allowed in this tag.
-            # There is no example of using this value in the files.
+            # A DTD do PubMed exige que Author tenha nome pessoal
+            # (FirstName/MiddleName/LastName/Suffix) OU CollectiveName,
+            # nunca os dois ao mesmo tempo.
+            if author_reg.get("collab"):
+                add_collective_name(author_reg, author_tag)
+            else:
+                add_first_name(author_reg, author_tag)
 
-            add_last_name(author_reg, author_tag)
+                # TODO
+                # add_middle_name(author_reg, author_tag)
+                # The Author’s full middle name, or initial if the full name is not available.
+                # Multiple names are allowed in this tag.
+                # There is no example of using this value in the files.
 
-            # TODO
-            # add_suffix(author_reg, author_tag)
-            # The Author's suffix, if any, e.g. "Jr", "Sr", "II", "IV". Do not include honorific titles,
-            # e.g. "M.D.", "Ph.D.".
-            # There is no example of using this value in the files
-
-            # TODO
-            # add_collective_name(author_reg, author_tag)
-            # The name of the authoring committee or organization. The CollectiveName tag should be placed within
-            # an Author tag. Omit extraneous text like, “on behalf of.”
-            # Please see the following example:
-            #   <AuthorList>
-            #       <Author>
-            #           <CollectiveName>Plastic Surgery Educational Foundation DATA Committee</CollectiveName>
-            #       </Author>
-            #   </AuthorList>
-            # There is no example of using this value in the files
+                add_last_name(author_reg, author_tag)
+                add_suffix(author_reg, author_tag)
 
             affiliations = get_affiliations(author_reg, xml_tree)
             add_affiliations(affiliations, author_tag)

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -270,6 +270,7 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed_elocation_pipe(xml_pubmed, xml_tree)
     xml_pubmed_language_pipe(xml_pubmed, xml_tree)
     xml_pubmed_author_list(xml_pubmed, xml_tree)
+    xml_pubmed_group_list(xml_pubmed, xml_tree)
     xml_pubmed_publication_type(xml_pubmed, xml_tree)
     xml_pubmed_article_id(xml_pubmed, xml_tree)
     xml_pubmed_history(xml_pubmed, xml_tree)
@@ -353,7 +354,14 @@ def add_orcid(author_reg, author_tag):
 
 
 def xml_pubmed_author_list(xml_pubmed, xml_tree):
-    authors = list(get_authors(xml_tree))
+    # Contribs de contrib-group[@content-type="collab-list"] são os membros
+    # nomeados de um grupo de autoria (ver xml_pubmed_group_list) e não
+    # devem aparecer soltos em AuthorList.
+    authors = [
+        author_reg
+        for author_reg in get_authors(xml_tree)
+        if author_reg.get("contrib-group-type") != "collab-list"
+    ]
     if authors:
         author_list_tag = ET.Element("AuthorList")
         for author_reg in authors:
@@ -381,30 +389,77 @@ def xml_pubmed_author_list(xml_pubmed, xml_tree):
             add_orcid(author_reg, author_tag)
             author_list_tag.append(author_tag)
 
-            # TODO
-            # add_group_list(author_reg, author_tag)
-            # Group information should be enclosed in these tags. If an article has one or more Groups, this tag
-            # must be submitted. Groups should be listed in the same order as in the printed article, and Group name
-            # format should accurately reflect the article. This tag is Required if the tag Group is present.
-            # There is no example of using this value in the files
-
-            # TODO
-            # add_group(author_reg, author_tag)
-            # Information about a single Group must begin with this tag.
-            # There is no example of using this value in the files
-
-            # TODO
-            # add_group_name(author_reg, author_tag)
-            # The name of the authoring committee or organization. Omit extraneous text like, “on behalf of.”
-            # There is no example of using this value in the files
-
-            # TODO
-            # add_individual_name(author_reg, author_tag)
-            # The name of individual members belonging to the authoring committee or organization.
-            # The name should be tagged with the FirstName, MiddleName, LastName, Suffix, and Affiliation tags.
-            # There is no example of using this value in the files
-
         xml_pubmed.append(author_list_tag)
+
+
+def get_group_members(authors):
+    return [
+        author_reg
+        for author_reg in authors
+        if author_reg.get("contrib-group-type") == "collab-list"
+    ]
+
+
+def get_group_name(authors):
+    for author_reg in authors:
+        if author_reg.get("collab") and author_reg.get("contrib-group-type") != "collab-list":
+            return author_reg.get("collab")
+
+
+def add_individual_name(member_reg, xml_tree, group_tag):
+    """
+    <IndividualName>
+        <FirstName>Felipe</FirstName>
+        <LastName>Esteves</LastName>
+        <Affiliation>Universidade Federal do Pará (UFPA)</Affiliation>
+    </IndividualName>
+    """
+    individual_name_tag = ET.Element("IndividualName")
+    add_first_name(member_reg, individual_name_tag)
+    add_last_name(member_reg, individual_name_tag)
+    add_suffix(member_reg, individual_name_tag)
+    affiliations = get_affiliations(member_reg, xml_tree)
+    add_affiliations(affiliations, individual_name_tag)
+    add_orcid(member_reg, individual_name_tag)
+    group_tag.append(individual_name_tag)
+
+
+def xml_pubmed_group_list(xml_pubmed, xml_tree):
+    """
+    <GroupList>
+        <Group>
+            <GroupName>The SciELO Group</GroupName>
+            <IndividualName>
+                <FirstName>Felipe</FirstName>
+                <LastName>Esteves</LastName>
+                <Affiliation>Universidade Federal do Pará (UFPA)</Affiliation>
+            </IndividualName>
+        </Group>
+    </GroupList>
+
+    Membros de contrib-group[@content-type="collab-list"] (ver
+    xml_pubmed_author_list), agrupados sob o nome do grupo declarado no
+    <collab> do contrib-group irmão.
+    """
+    authors = list(get_authors(xml_tree))
+    members = get_group_members(authors)
+    if not members:
+        return
+
+    group_list_tag = ET.Element("GroupList")
+    group_tag = ET.Element("Group")
+
+    group_name = get_group_name(authors)
+    if group_name:
+        group_name_tag = ET.Element("GroupName")
+        group_name_tag.text = group_name
+        group_tag.append(group_name_tag)
+
+    for member_reg in members:
+        add_individual_name(member_reg, xml_tree, group_tag)
+
+    group_list_tag.append(group_tag)
+    xml_pubmed.append(group_list_tag)
 
 
 def get_publication_type(xml_tree):

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -290,7 +290,12 @@ def get_authors(xml_tree):
 
 
 def add_first_name(author_reg, author_tag):
-    author_first_name = author_reg.get("contrib_name", {}).get("given-names")
+    contrib_name = author_reg.get("contrib_name", {})
+    # A DTD do PubMed exige FirstName e LastName juntos (nenhum dos dois é
+    # opcional isoladamente). Quando o XML fonte só tem um dos dois campos
+    # (autores sem <surname>, por exemplo), duplicamos o valor disponível
+    # em ambos para gerar um Author válido em vez de descartar o autor.
+    author_first_name = contrib_name.get("given-names") or contrib_name.get("surname")
     if author_first_name:
         first = ET.Element("FirstName")
         first.text = author_first_name
@@ -298,7 +303,8 @@ def add_first_name(author_reg, author_tag):
 
 
 def add_last_name(author_reg, author_tag):
-    author_last_name = author_reg.get("contrib_name", {}).get("surname")
+    contrib_name = author_reg.get("contrib_name", {})
+    author_last_name = contrib_name.get("surname") or contrib_name.get("given-names")
     if author_last_name:
         last = ET.Element("LastName")
         last.text = author_last_name

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1058,6 +1058,47 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_author_list_without_surname_duplicates_given_names(self):
+        # A DTD do PubMed exige FirstName e LastName juntos; quando o XML
+        # fonte só tem <given-names> (sem <surname>), duplicamos o valor
+        # em ambos os campos em vez de gerar um Author inválido.
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<FirstName>Viviana Alder</FirstName>'
+            '<LastName>Viviana Alder</LastName>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<given-names>Viviana Alder</given-names>'
+            '</name>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_author_list_with_collective_name(self):
         expected = (
             '<Article>'

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1012,6 +1012,88 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_author_list_with_suffix(self):
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<FirstName>Rogerio</FirstName>'
+            '<LastName>Meneghini</LastName>'
+            '<Suffix>Junior</Suffix>'
+            '<Affiliation>Some University</Affiliation>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<surname>Meneghini</surname>'
+            '<given-names>Rogerio</given-names>'
+            '<suffix>Junior</suffix>'
+            '</name>'
+            '<xref ref-type="aff" rid="aff1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '<aff id="aff1">'
+            '<institution content-type="original">Some University</institution>'
+            '</aff>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_author_list_with_collective_name(self):
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<CollectiveName>The SciELO Group</CollectiveName>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author" id="collab">'
+            '<collab>The SciELO Group</collab>'
+            '<xref ref-type="author-notes" rid="fn1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_publication_type(self):
         # TODO
         # Originalmente, espera-se que o valor da tag <PublicationType> seja Journal Article

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -16,6 +16,7 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_elocation_pipe,
     xml_pubmed_language_pipe,
     xml_pubmed_author_list,
+    xml_pubmed_group_list,
     xml_pubmed_publication_type,
     xml_pubmed_article_id,
     xml_pubmed_history,
@@ -1089,6 +1090,149 @@ class PipelinePubmed(unittest.TestCase):
         )
 
         xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_author_list_excludes_collab_list_members(self):
+        expected = (
+            '<Article>'
+            '<AuthorList>'
+            '<Author>'
+            '<CollectiveName>The SciELO Group</CollectiveName>'
+            '</Author>'
+            '</AuthorList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author" id="collab">'
+            '<collab>The SciELO Group</collab>'
+            '<xref ref-type="author-notes" rid="fn1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '<contrib-group content-type="collab-list">'
+            '<contrib contrib-type="author" rid="collab">'
+            '<name>'
+            '<surname>Esteves</surname>'
+            '<given-names>Felipe</given-names>'
+            '</name>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_author_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_group_list(self):
+        expected = (
+            '<Article>'
+            '<GroupList>'
+            '<Group>'
+            '<GroupName>The SciELO Group</GroupName>'
+            '<IndividualName>'
+            '<FirstName>Felipe</FirstName>'
+            '<LastName>Esteves</LastName>'
+            '<Affiliation>Universidade Federal do Pará (UFPA)</Affiliation>'
+            '<Identifier Source="orcid">http://orcid.org/0000-0001-0002-0003</Identifier>'
+            '</IndividualName>'
+            '<IndividualName>'
+            '<FirstName>Joyce</FirstName>'
+            '<LastName>Souza</LastName>'
+            '<Affiliation>Universidade Federal do Pará (UFPA)</Affiliation>'
+            '</IndividualName>'
+            '</Group>'
+            '</GroupList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author" id="collab">'
+            '<collab>The SciELO Group</collab>'
+            '<xref ref-type="author-notes" rid="fn1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '<contrib-group content-type="collab-list">'
+            '<contrib contrib-type="author" rid="collab">'
+            '<contrib-id contrib-id-type="orcid">0000-0001-0002-0003</contrib-id>'
+            '<name>'
+            '<surname>Esteves</surname>'
+            '<given-names>Felipe</given-names>'
+            '</name>'
+            '<xref ref-type="aff" rid="aff1">1</xref>'
+            '</contrib>'
+            '<contrib contrib-type="author" rid="collab">'
+            '<name>'
+            '<surname>Souza</surname>'
+            '<given-names>Joyce</given-names>'
+            '</name>'
+            '<xref ref-type="aff" rid="aff1">1</xref>'
+            '</contrib>'
+            '</contrib-group>'
+            '<aff id="aff1">'
+            '<institution content-type="original">Universidade Federal do Pará (UFPA)</institution>'
+            '</aff>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_group_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_group_list_without_group(self):
+        expected = (
+            '<Article/>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<contrib-group>'
+            '<contrib contrib-type="author">'
+            '<name>'
+            '<surname>Meneghini</surname>'
+            '<given-names>Rogerio</given-names>'
+            '</name>'
+            '</contrib>'
+            '</contrib-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_group_list(xml_pubmed, xml_tree)
 
         obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
 


### PR DESCRIPTION
**Nota**: esta branch parte de `feat/1236-pubmed-suffix-collective-name` (PR #1245, ainda não mergeado), porque depende diretamente da lógica de exclusividade `Author` (nome pessoal vs. `CollectiveName`) implementada lá. O diff abaixo inclui os commits do #1245 até ele ser mergeado em `master` — depois disso, o diff deste PR encolhe automaticamente para só as mudanças novas de `GroupList`.

#### O que esse PR faz?

Implementa `GroupList`/`Group`/`GroupName`/`IndividualName` no conversor SPS → PubMed XML para artigos com autoria em grupo, seguindo o padrão SPS 1.10:
```xml
<contrib-group>
   <contrib contrib-type="author" id="collab">
     <collab>The SciELO Group</collab>
   </contrib>
</contrib-group>
<contrib-group content-type="collab-list">
    <contrib contrib-type="author" rid="collab">
      <name>...</name>
    </contrib>
    ...
</contrib-group>
```

Antes deste PR, `xml_pubmed_author_list` achatava os membros do `collab-list` como `Author` comuns dentro de `AuthorList`, duplicando a autoria do grupo sem nenhuma referência ao grupo em si. Agora:
- `xml_pubmed_author_list` exclui da `AuthorList` os contribs com `contrib-group-type == "collab-list"` (mantém neles apenas o `Author` com `CollectiveName`, do PR #1245).
- Nova função `xml_pubmed_group_list` monta `GroupList/Group/GroupName/IndividualName` a partir desses mesmos contribs, reaproveitando `add_first_name`, `add_last_name`, `add_suffix`, `add_affiliations`, `add_orcid` — o dado já vem com a chave `contrib-group-type` exposta pelo model `article_contribs.TextContribs.main_contribs`, não precisou alterar nenhum model.
- Chamada de `xml_pubmed_group_list` inserida logo após `xml_pubmed_author_list` no pipeline, seguindo a ordem exigida pela DTD do PubMed (`AuthorList?, GroupList?, PublicationType*`).

**Limitação conhecida**: se um artigo tiver mais de um grupo de autoria simultâneo (mais de um `<collab>` isolado), este PR não distingue qual `collab-list` pertence a qual grupo — todos os membros do(s) `collab-list` são colocados sob um único `Group`. Não há exemplo desse cenário nem no guia SPS 1.10 nem nos arquivos de teste; o padrão observado sempre tem um grupo só por artigo.

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`: `xml_pubmed_author_list` (filtro adicionado no início), e as funções novas `get_group_members`, `get_group_name`, `add_individual_name`, `xml_pubmed_group_list`.

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (51 passed: 48 do PR #1245 + 3 novos aqui).
2. Testar o cenário de grupo:
   ```python
   from lxml import etree as ET
   from packtools.sps.formats import pubmed

   xml_tree = ET.fromstring('''
   <article xmlns:mml="http://www.w3.org/1998/Math/MathML"
            xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article"
            dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
     <front><article-meta>
       <contrib-group>
         <contrib contrib-type="author" id="collab">
           <collab>The SciELO Group</collab>
           <xref ref-type="author-notes" rid="fn1">1</xref>
         </contrib>
       </contrib-group>
       <contrib-group content-type="collab-list">
         <contrib contrib-type="author" rid="collab">
           <contrib-id contrib-id-type="orcid">0000-0001-0002-0003</contrib-id>
           <name><surname>Esteves</surname><given-names>Felipe</given-names></name>
           <xref ref-type="aff" rid="aff1">1</xref>
         </contrib>
         <contrib contrib-type="author" rid="collab">
           <name><surname>Souza</surname><given-names>Joyce</given-names></name>
           <xref ref-type="aff" rid="aff1">1</xref>
         </contrib>
       </contrib-group>
       <aff id="aff1"><institution content-type="original">Uni X</institution></aff>
     </article-meta></front>
   </article>
   ''')
   xml_pubmed = ET.fromstring('<Article/>')
   pubmed.xml_pubmed_author_list(xml_pubmed, xml_tree)
   pubmed.xml_pubmed_group_list(xml_pubmed, xml_tree)
   print(ET.tostring(xml_pubmed, pretty_print=True).decode())
   ```
   Resultado esperado: `AuthorList` com um único `Author`/`CollectiveName`, e `GroupList/Group` com `GroupName` + 2 `IndividualName` (Felipe Esteves, Joyce Souza), cada um com afiliação e ORCID quando disponível.
3. Rodar contra um artigo real sem autoria em grupo (`tests/samples/0034-7094-rba-69-03-0227.xml`) para confirmar que `AuthorList` não muda e `GroupList` simplesmente não é gerado.

#### Algum cenário de contexto que queira dar?

Última peça da quebra de autoria da #1226/#1236 em sub-issues.

#### Quais são tickets relevantes?

Closes #1237. Depende de #1245 (#1236). Relacionado a #1226 (issue-mãe).

### Referências

- DTD oficial do PubMed: `GroupList (Group+)`, `Group (GroupName?, IndividualName+)`, `IndividualName (FirstName, MiddleName?, LastName, Suffix?, affiliation, Identifier*)` — https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
- Guia SciELO SPS 1.10, seção `<contrib>`: exemplo "Autores pertencentes a um grupo"