### PR TITLE
feat(pubmed): implementar CopyrightInformation e CoiStatement

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -14,6 +14,7 @@ from packtools.sps.models import (
     journal_meta,
     kwd_group,
 )
+from packtools.sps.utils.xml_utils import node_plain_text
 
 
 def xml_pubmed_article_pipe():
@@ -508,18 +509,38 @@ def xml_pubmed_history(xml_pubmed, xml_tree):
     xml_pubmed.append(history)
 
 
+def get_copyright_information(xml_tree):
+    copyright_statement = xml_tree.find(".//permissions/copyright-statement")
+    return node_plain_text(copyright_statement) or None
+
+
 def xml_pubmed_copyright_information(xml_pubmed, xml_tree):
-    ...
-    # TODO
-    # The Copyright information associated with this article.
-    # There is no example of using this value in the files.
+    """
+    <CopyrightInformation>Copyright © 2023 The Authors</CopyrightInformation>
+    """
+    copyright_information = get_copyright_information(xml_tree)
+    if copyright_information:
+        el = ET.Element("CopyrightInformation")
+        el.text = copyright_information
+        xml_pubmed.append(el)
+
+
+def get_coi_statement(xml_tree):
+    fn_node = xml_tree.find('.//fn[@fn-type="coi-statement"]')
+    if fn_node is None:
+        return None
+    return node_plain_text(fn_node.find("p")) or node_plain_text(fn_node) or None
 
 
 def xml_pubmed_coi_statement(xml_pubmed, xml_tree):
-    ...
-    # TODO
-    # The Conflict of Interest statement associated with this article.
-    # There is no example of using this value in the files.
+    """
+    <CoiStatement>Não há conflito de interesse entre os autores do artigo.</CoiStatement>
+    """
+    coi_statement = get_coi_statement(xml_tree)
+    if coi_statement:
+        el = ET.Element("CoiStatement")
+        el.text = coi_statement
+        xml_pubmed.append(el)
 
 
 def get_keywords(xml_tree):

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -19,6 +19,8 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_publication_type,
     xml_pubmed_article_id,
     xml_pubmed_history,
+    xml_pubmed_copyright_information,
+    xml_pubmed_coi_statement,
     xml_pubmed_vernacular_title_pipe,
     xml_pubmed_object_list,
     xml_pubmed_title_reference_list,
@@ -1238,6 +1240,119 @@ class PipelinePubmed(unittest.TestCase):
         )
 
         xml_pubmed_history(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_copyright_information(self):
+        expected = (
+            '<Article>'
+            '<CopyrightInformation>Copyright © 2023 The Authors</CopyrightInformation>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<permissions>'
+            '<copyright-statement>Copyright © 2023 The Authors</copyright-statement>'
+            '</permissions>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_copyright_information(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_copyright_information_without_statement(self):
+        expected = (
+            '<Article/>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<permissions>'
+            '</permissions>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_copyright_information(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_coi_statement(self):
+        expected = (
+            '<Article>'
+            '<CoiStatement>Não há conflito de interesse entre os autores do artigo.</CoiStatement>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '<fn fn-type="coi-statement">'
+            '<label>Conflito de Interesses</label>'
+            '<p>Não há conflito de interesse entre os autores do artigo.</p>'
+            '</fn>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_coi_statement(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_coi_statement_without_fn(self):
+        expected = (
+            '<Article/>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<author-notes>'
+            '</author-notes>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_coi_statement(xml_pubmed, xml_tree)
 
         obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
 


### PR DESCRIPTION
#### O que esse PR faz?

Substitui os stubs vazios de `xml_pubmed_copyright_information` e `xml_pubmed_coi_statement` (`packtools/sps/formats/pubmed.py`) por implementações reais:
- `CopyrightInformation`: extraído de `.//permissions/copyright-statement`.
- `CoiStatement`: extraído de `.//fn[@fn-type="coi-statement"]/p`, ignorando o `<label>` (ex. "Conflito de Interesses"), que é só cabeçalho de seção, não parte do conteúdo do statement em si.

Não existe model dedicado para nenhum dos dois campos, então segui o padrão de xpath direto já usado em `xml_pubmed_title_reference_list` neste mesmo arquivo, em vez de criar um novo model. Uso `node_plain_text` (já usado em `article_contribs.py`) para extrair o texto sem subtags.

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`: `get_copyright_information`, `xml_pubmed_copyright_information`, `get_coi_statement`, `xml_pubmed_coi_statement`.

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (50 passed: 46 originais + 4 novos).
2. Testar com o exemplo do guia SPS 1.10 (`<fn fn-type="coi-statement">` com `<label>` + `<p>`):
   ```python
   from lxml import etree as ET
   from packtools.sps.formats import pubmed

   xml_tree = ET.fromstring('''
   <article xmlns:mml="http://www.w3.org/1998/Math/MathML"
            xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article"
            dtd-version="1.1" specific-use="sps-1.9" xml:lang="pt">
     <front><article-meta>
       <permissions>
         <copyright-statement>Copyright © 2023 The Authors</copyright-statement>
       </permissions>
       <author-notes>
         <fn fn-type="coi-statement">
           <label>Conflito de Interesses</label>
           <p>Não há conflito de interesse entre os autores do artigo.</p>
         </fn>
       </author-notes>
     </article-meta></front>
   </article>
   ''')
   xml_pubmed = ET.fromstring('<Article/>')
   pubmed.xml_pubmed_copyright_information(xml_pubmed, xml_tree)
   pubmed.xml_pubmed_coi_statement(xml_pubmed, xml_tree)
   print(ET.tostring(xml_pubmed, pretty_print=True).decode())
   ```
   Resultado esperado: `<CopyrightInformation>Copyright © 2023 The Authors</CopyrightInformation>` e `<CoiStatement>Não há conflito de interesse entre os autores do artigo.</CoiStatement>` (sem o texto do `<label>`).

#### Algum cenário de contexto que queira dar?

Parte da quebra da #1226 em sub-issues. Independente das demais — não depende nem é dependência de nenhuma outra sub-issue em aberto.

#### Quais são tickets relevantes?

Closes #1238. Relacionado a #1226 (issue-mãe).

### Referências

- DTD oficial do PubMed: `CopyrightInformation (#PCDATA)`, `CoiStatement (%data;)*` — https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
- Guia SciELO SPS 1.10, exemplo de `<fn fn-type="coi-statement">` em `<author-notes>`