### PR TITLE
feat(pubmed): adicionar Object[@Type=grant] (financiamento) em ObjectList

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -11,6 +11,7 @@ from packtools.sps.models import (
     article_titles,
     dates,
     front_articlemeta_issue,
+    funding_group,
     journal_meta,
     kwd_group,
 )
@@ -526,6 +527,45 @@ def get_keywords(xml_tree):
     return kwd_group.KwdGroup(xml_tree).extract_kwd_data_with_lang_text(subtag=False)
 
 
+def get_award_groups(xml_tree):
+    return funding_group.FundingGroup(xml_tree).award_groups
+
+
+def add_grant_objects(obj_list, xml_tree):
+    """
+    <Object Type="grant">
+      <Param Name="id">RO1DK561234</Param>
+      <Param Name="grantor">National Institutes of Health</Param>
+    </Object>
+    """
+    for award_group in get_award_groups(xml_tree):
+        funding_sources = [
+            source for source in award_group.get("funding-source") or [] if source
+        ]
+        award_ids = [
+            award_id for award_id in award_group.get("award-id") or [] if award_id
+        ]
+        grantor = "; ".join(funding_sources) or None
+
+        # acronym e country não têm fonte nos dados SciELO, ficam de fora.
+        for award_id in award_ids or [None]:
+            if not award_id and not grantor:
+                continue
+            obj = ET.Element("Object")
+            obj.set("Type", "grant")
+            if award_id:
+                param = ET.Element("Param")
+                param.set("Name", "id")
+                param.text = award_id
+                obj.append(param)
+            if grantor:
+                param = ET.Element("Param")
+                param.set("Name", "grantor")
+                param.text = grantor
+                obj.append(param)
+            obj_list.append(obj)
+
+
 def xml_pubmed_object_list(xml_pubmed, xml_tree):
     """
     <ObjectList>
@@ -553,11 +593,9 @@ def xml_pubmed_object_list(xml_pubmed, xml_tree):
        </Object>
      </ObjectList>
     """
-    kwd_list = get_keywords(xml_tree)
-    if not kwd_list:
-        return
     obj_list = ET.Element("ObjectList")
-    for kwd in kwd_list:
+
+    for kwd in get_keywords(xml_tree):
         if kwd.get("lang") == "en":
             obj = ET.Element("Object")
             obj.set("Type", "keyword")
@@ -566,14 +604,11 @@ def xml_pubmed_object_list(xml_pubmed, xml_tree):
             param.text = kwd.get("text")
             obj.append(param)
             obj_list.append(obj)
-    xml_pubmed.append(obj_list)
 
-    # TODO
-    # The Object tag includes the Type attribute, which may include only one of the following values
-    # for each identifier.
-    # Grant, Comment, Dataset, Erratum, Originalreport, Partialretraction, Patientsummary,
-    # Reprint, Republished, Retraction, Update.
-    # There is no example of using this value in the files.
+    add_grant_objects(obj_list, xml_tree)
+
+    if len(obj_list):
+        xml_pubmed.append(obj_list)
 
 
 def xml_pubmed_title_reference_list(xml_pubmed, xml_tree):

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1288,6 +1288,126 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+    def test_xml_pubmed_object_list_grant(self):
+        expected = (
+            '<Article>'
+            '<ObjectList>'
+            '<Object Type="grant">'
+            '<Param Name="id">04/08142-0</Param>'
+            '<Param Name="grantor">Fundação de Amparo à Pesquisa do Estado de São Paulo (FAPESP)</Param>'
+            '</Object>'
+            '<Object Type="grant">'
+            '<Param Name="id">05/07183-0</Param>'
+            '<Param Name="grantor">FAPESP; CAPES</Param>'
+            '</Object>'
+            '</ObjectList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<funding-group>'
+            '<award-group>'
+            '<funding-source>Fundação de Amparo à Pesquisa do Estado de São Paulo (FAPESP)</funding-source>'
+            '<award-id>04/08142-0</award-id>'
+            '</award-group>'
+            '<award-group>'
+            '<funding-source>FAPESP</funding-source>'
+            '<funding-source>CAPES</funding-source>'
+            '<award-id>05/07183-0</award-id>'
+            '</award-group>'
+            '</funding-group>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_object_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_object_list_keyword_and_grant(self):
+        expected = (
+            '<Article>'
+            '<ObjectList>'
+            '<Object Type="keyword">'
+            '<Param Name="value">Arteries Dissection</Param>'
+            '</Object>'
+            '<Object Type="grant">'
+            '<Param Name="id">04/08142-0</Param>'
+            '<Param Name="grantor">FAPESP</Param>'
+            '</Object>'
+            '</ObjectList>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="letter" dtd-version="1.1" '
+            'specific-use="sps-1.9" xml:lang="pt">'
+            '<front>'
+            '<article-meta>'
+            '<kwd-group xml:lang="pt">'
+            '<kwd>Dissecção das Artérias</kwd>'
+            '</kwd-group>'
+            '<funding-group>'
+            '<award-group>'
+            '<funding-source>FAPESP</funding-source>'
+            '<award-id>04/08142-0</award-id>'
+            '</award-group>'
+            '</funding-group>'
+            '</article-meta>'
+            '</front>'
+            '<sub-article article-type="translation" id="TRen" xml:lang="en">'
+            '<front-stub>'
+            '<kwd-group xml:lang="en">'
+            '<kwd>Arteries Dissection</kwd>'
+            '</kwd-group>'
+            '</front-stub>'
+            '</sub-article>'
+            '</article>'
+        )
+
+        xml_pubmed_object_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_object_list_without_keyword_or_grant(self):
+        expected = (
+            '<Article/>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article" '
+            'dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed_object_list(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
     def test_xml_pubmed_title_reference_list(self):
         expected = (
             '<Article>'


### PR DESCRIPTION
#### O que esse PR faz?

Estende `xml_pubmed_object_list` (`packtools/sps/formats/pubmed.py`), que hoje só cobre `Object[@Type="keyword"]`, para também gerar `Object[@Type="grant"]` a partir dos dados de financiamento do artigo, usando o model já existente `funding_group.FundingGroup.award_groups` (expõe `funding-source` e `award-id` por `<award-group>`).

Regras de mapeamento:
- Cada `award-id` de um `<award-group>` vira um `Object[@Type="grant"]` próprio, com `Param[@Name="id"]`.
- Os `funding-source` do mesmo `<award-group>` viram `Param[@Name="grantor"]`; quando há mais de um (comum nos dados SciELO — ex. financiamento conjunto FAPESP+CAPES), são concatenados com `"; "`, já que o `Object` do PubMed só aceita um `grantor` por vez.
- `acronym` e `country` (outros `Param` aceitos pelo PubMed para grants) não têm fonte nos dados SciELO e ficam de fora.

De quebra, corrige um bug latente: `xml_pubmed_object_list` criava `<ObjectList>` sempre que havia alguma keyword no XML, mesmo que nenhuma fosse em inglês (a única condição que efetivamente gera um `Object`) — podendo emitir `<ObjectList/>` vazio. Agora só anexa `ObjectList` se houver pelo menos um `Object` (keyword ou grant).

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`: `get_award_groups`, `add_grant_objects` (novas), e `xml_pubmed_object_list` (reescrita para combinar keywords + grants e só anexar `ObjectList` quando não vazio).

#### Como este poderia ser testado manualmente?

1. Rodar a suíte: `source .venv/bin/activate && python -m pytest tests/sps/formats/test_pubmed.py -v` (49 passed: 46 originais + 3 novos).
2. Testar com o padrão de financiamento do guia SPS 1.10 (múltiplos `funding-source` por `award-group`):
   ```python
   from lxml import etree as ET
   from packtools.sps.formats import pubmed

   xml_tree = ET.fromstring('''
   <article xmlns:mml="http://www.w3.org/1998/Math/MathML"
            xmlns:xlink="http://www.w3.org/1999/xlink" article-type="research-article"
            dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">
     <front><article-meta>
       <funding-group>
         <award-group>
           <funding-source>FAPESP</funding-source>
           <award-id>04/08142-0</award-id>
         </award-group>
         <award-group>
           <funding-source>FAPESP</funding-source>
           <funding-source>CAPES</funding-source>
           <award-id>05/07183-0</award-id>
         </award-group>
       </funding-group>
     </article-meta></front>
   </article>
   ''')
   xml_pubmed = ET.fromstring('<Article/>')
   pubmed.xml_pubmed_object_list(xml_pubmed, xml_tree)
   print(ET.tostring(xml_pubmed, pretty_print=True).decode())
   ```
   Resultado esperado: 2 `Object[@Type="grant"]`, o segundo com `grantor` = `"FAPESP; CAPES"`.
3. Rodar contra um artigo real sem financiamento (`tests/samples/0034-7094-rba-69-03-0227.xml`) para confirmar que `ObjectList` continua só com as keywords, sem mudança de comportamento.

#### Algum cenário de contexto que queira dar?

Parte da quebra da #1226 em sub-issues. Independente das demais.

#### Quais são tickets relevantes?

Closes #1239. Relacionado a #1226 (issue-mãe).

### Referências

- DTD oficial do PubMed: `Object (Param)*`, `Object[@Type]` sem lista fechada de valores, `Param[@Name]` livre — https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
- Guia SciELO SPS 1.10, seção `<funding-group>`/`<award-group>`: exemplos com múltiplos `funding-source` por `award-id`