### PR TITLE
fix(pubmed): trata ausência de PubDate como erro em vez de gerar Journal inválido

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -16,6 +16,12 @@ from packtools.sps.models import (
 )
 
 
+class MissingRequiredPubDateError(Exception):
+    """Raised when a SciELO article has no usable publication date, so the
+    DTD-required PubMed.dtd `Journal/PubDate` element (`(..., PubDate)`,
+    no `?`) cannot be filled in."""
+
+
 def xml_pubmed_article_pipe():
     return ET.Element("Article")
 
@@ -265,6 +271,11 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed_volume_pipe(xml_pubmed, xml_tree)
     xml_pubmed_issue_pipe(xml_pubmed, xml_tree)
     xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
+    if xml_pubmed.find("Journal/PubDate") is None:
+        raise MissingRequiredPubDateError(
+            "Journal/PubDate é obrigatório na DTD do PubMed e não foi "
+            "possível determinar uma data de publicação para este artigo."
+        )
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
     xml_pubmed_elocation_pipe(xml_pubmed, xml_tree)

--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -16,10 +16,17 @@ from packtools.sps.models import (
 )
 
 
-class MissingRequiredPubDateError(Exception):
-    """Raised when a SciELO article has no usable publication date, so the
-    DTD-required PubMed.dtd `Journal/PubDate` element (`(..., PubDate)`,
-    no `?`) cannot be filled in."""
+class MissingRequiredElementError(Exception):
+    """Raised when a SciELO article has no data for an element the PubMed
+    DTD marks as required (no `?`), so a valid <Article> cannot be built
+    for it. `element_path` identifies which element (e.g. "Journal/PubDate")."""
+
+    def __init__(self, element_path):
+        self.element_path = element_path
+        super().__init__(
+            f"{element_path} é obrigatório na DTD do PubMed e não foi "
+            "possível determinar seu valor para este artigo."
+        )
 
 
 def xml_pubmed_article_pipe():
@@ -133,20 +140,21 @@ def xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree):
     </PubDate>
     """
     date = get_date(xml_tree)
-    if date is not None:
-        dt = ET.Element("PubDate")
-        dt.set("PubStatus", "epublish")
-        for element in ["year", "month", "day"]:
-            # TODO
-            # Season
-            # The season of publication. e.g.,Winter, Spring, Summer, Fall. Do not use if a Month is available.
-            # There is no example of using this value in the files.
+    if date is None:
+        raise MissingRequiredElementError("Journal/PubDate")
+    dt = ET.Element("PubDate")
+    dt.set("PubStatus", "epublish")
+    for element in ["year", "month", "day"]:
+        # TODO
+        # Season
+        # The season of publication. e.g.,Winter, Spring, Summer, Fall. Do not use if a Month is available.
+        # There is no example of using this value in the files.
 
-            if date.get(element):
-                el = ET.Element(element.capitalize())
-                el.text = date.get(element)
-                dt.append(el)
-        xml_pubmed.find("Journal").append(dt)
+        if date.get(element):
+            el = ET.Element(element.capitalize())
+            el.text = date.get(element)
+            dt.append(el)
+    xml_pubmed.find("Journal").append(dt)
 
 
 def xml_pubmed_replaces_pipe(xml_pubmed, xml_tree):
@@ -271,11 +279,6 @@ def pipeline_pubmed(xml_tree, pretty_print=True):
     xml_pubmed_volume_pipe(xml_pubmed, xml_tree)
     xml_pubmed_issue_pipe(xml_pubmed, xml_tree)
     xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
-    if xml_pubmed.find("Journal/PubDate") is None:
-        raise MissingRequiredPubDateError(
-            "Journal/PubDate é obrigatório na DTD do PubMed e não foi "
-            "possível determinar uma data de publicação para este artigo."
-        )
     xml_pubmed_article_title_pipe(xml_pubmed, xml_tree)
     xml_pubmed_first_page_pipe(xml_pubmed, xml_tree)
     xml_pubmed_elocation_pipe(xml_pubmed, xml_tree)

--- a/packtools/sps/formats/pubmed_generator.py
+++ b/packtools/sps/formats/pubmed_generator.py
@@ -30,7 +30,7 @@ def main():
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
     try:
         xml_pubmed = pubmed.pipeline_pubmed(xml_tree)
-    except pubmed.MissingRequiredPubDateError as exc:
+    except pubmed.MissingRequiredElementError as exc:
         print(f"Erro: {exc}", file=sys.stderr)
         raise SystemExit(1)
 

--- a/packtools/sps/formats/pubmed_generator.py
+++ b/packtools/sps/formats/pubmed_generator.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from packtools.sps.formats import pubmed
 from packtools.sps.utils import xml_utils
@@ -27,7 +28,12 @@ def main():
     arguments = parser.parse_args()
 
     xml_tree = xml_utils.get_xml_tree(arguments.path_to_read)
-    xml_pubmed = pubmed.pipeline_pubmed(xml_tree)
+    try:
+        xml_pubmed = pubmed.pipeline_pubmed(xml_tree)
+    except pubmed.MissingRequiredPubDateError as exc:
+        print(f"Erro: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
     with open(arguments.path_to_write, "w", encoding="utf-8") as file:
         file.write(xml_pubmed)
         print(f"Arquivo criado em: {arguments.path_to_write}")

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -25,6 +25,8 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_citations,
     xml_pubmed_abstract,
     xml_pubmed_other_abstract,
+    pipeline_pubmed,
+    MissingRequiredPubDateError,
 )
 
 
@@ -1827,6 +1829,43 @@ class PipelinePubmed(unittest.TestCase):
 
         self.assertEqual(obtained, expected)
 
+
+class PipelinePubmedRequiredPubDate(unittest.TestCase):
+    def test_pipeline_pubmed_raises_when_no_pub_date_is_found(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        with self.assertRaises(MissingRequiredPubDateError):
+            pipeline_pubmed(xml_tree)
+
+    def test_pipeline_pubmed_does_not_raise_when_pub_date_is_found(self):
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '<front>'
+            '<article-meta>'
+            '<pub-date publication-format="electronic" date-type="pub">'
+            '<day>06</day>'
+            '<month>01</month>'
+            '<year>2023</year>'
+            '</pub-date>'
+            '</article-meta>'
+            '</front>'
+            '</article>'
+        )
+
+        xml_pubmed = pipeline_pubmed(xml_tree)
+
+        self.assertIn("<PubDate", xml_pubmed)
 
 
 if __name__ == '__main__':

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -26,7 +26,7 @@ from packtools.sps.formats.pubmed import (
     xml_pubmed_abstract,
     xml_pubmed_other_abstract,
     pipeline_pubmed,
-    MissingRequiredPubDateError,
+    MissingRequiredElementError,
 )
 
 
@@ -508,11 +508,6 @@ class PipelinePubmed(unittest.TestCase):
         self.assertEqual(obtained, expected)
 
     def test_xml_pubmed_pub_date_pipe_without_date(self):
-        expected = (
-            '<Article>'
-            '<Journal/>'
-            '</Article>'
-        )
         xml_pubmed = ET.fromstring(
             '<Article>'
             '<Journal/>'
@@ -529,11 +524,8 @@ class PipelinePubmed(unittest.TestCase):
             '</article>'
         )
 
-        xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
-
-        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
-
-        self.assertEqual(obtained, expected)
+        with self.assertRaises(MissingRequiredElementError):
+            xml_pubmed_pub_date_pipe(xml_pubmed, xml_tree)
 
     def test_xml_pubmed_article_title_pipe(self):
         expected = (
@@ -1843,7 +1835,7 @@ class PipelinePubmedRequiredPubDate(unittest.TestCase):
             '</article>'
         )
 
-        with self.assertRaises(MissingRequiredPubDateError):
+        with self.assertRaises(MissingRequiredElementError):
             pipeline_pubmed(xml_tree)
 
     def test_pipeline_pubmed_does_not_raise_when_pub_date_is_found(self):


### PR DESCRIPTION
#### O que esse PR faz?

Resolve #1242. `Journal/PubDate` é obrigatório na DTD oficial do PubMed (`(PublisherName, JournalTitle, Issn, Volume?, Issue?, PubDate)` — sem `?`), mas `xml_pubmed_pub_date_pipe` só preenche a tag `<PubDate>` quando encontra uma data reconhecida (`dates.ArticleDates(xml_tree).article_date`). Quando o artigo fonte não tem essa data, a tag ficava ausente e o `Journal` gerado era inválido segundo a DTD.

Conforme decisão do responsável pela issue: em vez de tentar um fallback para outra data (`collection_date` etc.) ou gerar XML tecnicamente inválido, o comportamento correto é **não gerar o XML e informar ao usuário a obrigatoriedade da data**.

- `packtools/sps/formats/pubmed.py`: nova exceção `MissingRequiredPubDateError`; `pipeline_pubmed` verifica se `Journal/PubDate` foi preenchido e levanta a exceção com uma mensagem explicando a obrigatoriedade na DTD, caso não encontre data. `xml_pubmed_pub_date_pipe` isolada não muda de comportamento (mantém os testes existentes, incluindo `test_xml_pubmed_pub_date_pipe_without_date`).
- `packtools/sps/formats/pubmed_generator.py`: o CLI captura a exceção, imprime `Erro: ...` em stderr e sai com código 1, sem escrever arquivo de saída.
- 2 novos testes em `tests/sps/formats/test_pubmed.py` cobrindo os dois caminhos (com e sem data).

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`, na função `pipeline_pubmed` (verificação logo após `xml_pubmed_pub_date_pipe`).

#### Como este poderia ser testado manualmente?

```
python -m packtools.sps.formats.pubmed_generator -i <xml sem pub-date> -o saida.xml
```
Deve imprimir `Erro: Journal/PubDate é obrigatório...` em stderr, sair com código 1, e não criar `saida.xml`.

#### Algum cenário de contexto que queira dar?

Encontrado ao validar a saída de `pipeline_pubmed` contra a DTD oficial (`https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd`) via `lxml.etree.DTD`, reproduzido com um artigo sem `pub-date`. Ao reconciliar este PR com #1234/#1241 (`pipeline_pubmed_set`/CLI em lote), a mesma checagem precisará ser replicada em `build_pubmed_article` para que um artigo sem data seja pulado (com aviso) em vez de derrubar o `ArticleSet` inteiro.

#### Quais são tickets relevantes?

Resolve #1242. Parte de #1226.

### Referências

DTD oficial: https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd