### PR TITLE
fix(pubmed): mapeia @article-type para o vocabulário fechado do PublicationType

### DIFF
--- a/packtools/sps/formats/pubmed.py
+++ b/packtools/sps/formats/pubmed.py
@@ -401,12 +401,36 @@ def xml_pubmed_author_list(xml_pubmed, xml_tree):
         xml_pubmed.append(author_list_tag)
 
 
+# Maps SPS `@article-type` to the PubMed closed PublicationType vocabulary
+# (https://www.ncbi.nlm.nih.gov/books/NBK3828/). Only pairs with a clear,
+# unambiguous equivalence are listed here -- see get_publication_type for
+# what happens to the rest.
+PUBLICATION_TYPE_MAPPING = {
+    "research-article": "Journal Article",
+    "case-report": "Case Reports",
+    "review-article": "Review",
+    "letter": "Letter",
+    "editorial": "Editorial",
+    "retraction": "Retraction Notice",
+    "partial-retraction": "Retraction Notice",
+    "correction": "Published Erratum",
+    "data-article": "Journal Article",
+    "expression-of-concern": "Expression of Concern",
+}
+
+
 def get_publication_type(xml_tree):
-    publication_type = article_and_subarticles.ArticleAndSubArticles(
+    """
+    `PublicationType` is optional in the PubMed DTD (`PublicationType*`), so
+    an `@article-type` with no safe mapping (e.g. "obituary", "book-review",
+    "other") is omitted rather than defaulted to "Journal Article" -- forcing
+    a value into this closed vocabulary would misrepresent the document type
+    to PubMed's indexing, which is worse than leaving it out. See issue #1240.
+    """
+    article_type = article_and_subarticles.ArticleAndSubArticles(
         xml_tree
     ).main_article_type
-    if publication_type is not None:
-        return publication_type.replace("-", " ").title()
+    return PUBLICATION_TYPE_MAPPING.get(article_type)
 
 
 def xml_pubmed_publication_type(xml_pubmed, xml_tree):

--- a/tests/sps/formats/test_pubmed.py
+++ b/tests/sps/formats/test_pubmed.py
@@ -1013,12 +1013,9 @@ class PipelinePubmed(unittest.TestCase):
         self.assertEqual(obtained, expected)
 
     def test_xml_pubmed_publication_type(self):
-        # TODO
-        # Originalmente, espera-se que o valor da tag <PublicationType> seja Journal Article
-        # Nos arquivos de exemplo há somente a referencia a Research Article, o qual foi utilizado
         expected = (
             '<Article>'
-            '<PublicationType>Research Article</PublicationType>'
+            '<PublicationType>Journal Article</PublicationType>'
             '</Article>'
         )
         xml_pubmed = ET.fromstring(
@@ -1028,6 +1025,91 @@ class PipelinePubmed(unittest.TestCase):
             '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
             'xmlns:xlink="http://www.w3.org/1999/xlink" '
             'article-type="research-article" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '</article>'
+        )
+
+        xml_pubmed_publication_type(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_publication_type_maps_case_report(self):
+        expected = (
+            '<Article>'
+            '<PublicationType>Case Reports</PublicationType>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="case-report" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '</article>'
+        )
+
+        xml_pubmed_publication_type(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_publication_type_maps_retraction_and_partial_retraction(self):
+        for article_type in ("retraction", "partial-retraction"):
+            with self.subTest(article_type=article_type):
+                xml_pubmed = ET.fromstring('<Article/>')
+                xml_tree = ET.fromstring(
+                    '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+                    'xmlns:xlink="http://www.w3.org/1999/xlink" '
+                    f'article-type="{article_type}" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+                    '</article>'
+                )
+
+                xml_pubmed_publication_type(xml_pubmed, xml_tree)
+
+                obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+                self.assertEqual(
+                    obtained,
+                    '<Article><PublicationType>Retraction Notice</PublicationType></Article>',
+                )
+
+    def test_xml_pubmed_publication_type_maps_expression_of_concern(self):
+        expected = (
+            '<Article>'
+            '<PublicationType>Expression of Concern</PublicationType>'
+            '</Article>'
+        )
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="expression-of-concern" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
+            '</article>'
+        )
+
+        xml_pubmed_publication_type(xml_pubmed, xml_tree)
+
+        obtained = ET.tostring(xml_pubmed, encoding="utf-8").decode("utf-8")
+
+        self.assertEqual(obtained, expected)
+
+    def test_xml_pubmed_publication_type_omits_article_type_without_mapping(self):
+        # "obituary" has no unambiguous PubMed PublicationType equivalent;
+        # PublicationType is optional in the DTD, so it's omitted rather
+        # than defaulted to a possibly-wrong value (see issue #1240).
+        expected = '<Article/>'
+        xml_pubmed = ET.fromstring(
+            '<Article/>'
+        )
+        xml_tree = ET.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink" '
+            'article-type="obituary" dtd-version="1.1" specific-use="sps-1.9" xml:lang="en">'
             '</article>'
         )
 


### PR DESCRIPTION
#### O que esse PR faz?

Fecha #1240. `get_publication_type` em `packtools/sps/formats/pubmed.py` fazia apenas `@article-type.replace("-", " ").title()`, sem checar o vocabulário fechado do `PublicationType` do PubMed (ver [NBK3828](https://www.ncbi.nlm.nih.gov/books/NBK3828/)) — por exemplo, `research-article` virava `"Research Article"`, um valor que não existe nesse vocabulário (o correto é `"Journal Article"`). O teste existente (`test_xml_pubmed_publication_type`) até documentava isso via TODO.

Adiciona `PUBLICATION_TYPE_MAPPING`, um dicionário `@article-type` → `PublicationType`, usando a tabela de correlação direta já proposta no comentário da issue:

| `@article-type` | `PublicationType` |
|---|---|
| `research-article` | `Journal Article` |
| `case-report` | `Case Reports` |
| `review-article` | `Review` |
| `letter` | `Letter` |
| `editorial` | `Editorial` |
| `retraction` / `partial-retraction` | `Retraction Notice` |
| `correction` | `Published Erratum` |
| `data-article` | `Journal Article` |
| `expression-of-concern` | `Expression of Concern` |

Para os `@article-type` sem correlação clara (`obituary`, `brief-report`, `addendum`, `rapid-communication`, `clinical-instruction`, `oration`, `discussion`, `book-review`, `reply`, `article-commentary`, `other`), **omite** `<PublicationType>` em vez de usar um valor-padrão. Justificativa e decisão comentadas em #1240.

A regra de exclusão mútua do PubMed (Editorial/Letter/News não combinam com Journal Article) é satisfeita por construção: o mapeamento sempre produz no máximo um `<PublicationType>` por artigo.

#### Onde a revisão poderia começar?

`packtools/sps/formats/pubmed.py`, função `get_publication_type` (dicionário `PUBLICATION_TYPE_MAPPING` logo acima).

#### Como este poderia ser testado manualmente?

```python
from lxml import etree as ET
from packtools.sps.formats import pubmed

xml_tree = ET.parse("tests/samples/0034-7094-rba-69-03-0227.xml").getroot()
print(pubmed.get_publication_type(xml_tree))  # "Journal Article"
```

Testes automatizados cobrem: mapeamento direto (`research-article`, `case-report`, `retraction`/`partial-retraction`, `expression-of-concern`) e omissão para tipo sem correlação (`obituary`).

#### Algum cenário de contexto que queira dar?

Branch independente, criada a partir de `master` (não depende de #1234). Validado contra a DTD oficial do PubMed combinando localmente com #1234 (necessário só para o envelope `ArticleSet`, exigido pela raiz da DTD) — `VALID: True`.

#### Quais são tickets relevantes?

Fecha #1240. Parte de #1226.

### Referências

- https://www.ncbi.nlm.nih.gov/books/NBK3828/
- https://dtd.nlm.nih.gov/ncbi/pubmed/in/PubMed.dtd
