### PR TITLE
Internacionaliza as mensagens das validações SPS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include packtools *.xsd *.sch *.xml *.ent *.dtd *.mod *.xslt *.json *.xsl *.html *.ico *.css *.txt *.png *.js
+recursive-include packtools/sps/locale *.mo
 recursive-exclude tests *
 include README.md HISTORY.md
 exclude tox.ini

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,2 @@
+[python: packtools/sps/validation/**.py]
+encoding = utf-8

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 Flask-WTF==1.1.0
 MarkupSafe==2.1.1
 flask-babel==3.0.0
+Babel>=2.14

--- a/packtools/sps/i18n.py
+++ b/packtools/sps/i18n.py
@@ -1,0 +1,27 @@
+import gettext
+from contextvars import ContextVar
+from pathlib import Path
+
+
+DOMAIN = "packtools_sps"
+LOCALE_DIR = Path(__file__).resolve().parent / "locale"
+
+_translation = ContextVar(
+    "packtools_sps_translation",
+    default=gettext.NullTranslations(),
+)
+
+
+def set_locale(lang="en"):
+    translation = gettext.translation(
+        DOMAIN,
+        localedir=str(LOCALE_DIR),
+        languages=[lang],
+        fallback=True,
+    )
+
+    _translation.set(translation)
+
+
+def _(message):
+    return _translation.get().gettext(message)

--- a/packtools/sps/locale/es/LC_MESSAGES/packtools_sps.po
+++ b/packtools/sps/locale/es/LC_MESSAGES/packtools_sps.po
@@ -1,0 +1,1906 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-29 11:03-0300\n"
+"PO-Revision-Date: 2026-07-29 11:32-0300\n"
+"Last-Translator: Rafael JPD / Pitanga Innovare <rafael@pitangainnovare.com.br>\n"
+"Language-Team: es <LL@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: packtools/sps/validation/accessibility_data.py:106
+#, python-brace-format
+msgid "<alt-text> is incorrectly located inside <{parent_tag}>. According to SPS 1.9/1.10, <alt-text> must be inside one of these elements: {expected_elements}. Move the <alt-text> element inside the appropriate <graphic> or <media> element."
+msgstr "<alt-text> está ubicado incorrectamente dentro de <{parent_tag}>. Según SPS 1.9/1.10, <alt-text> debe estar dentro de uno de estos elementos: {expected_elements}. Mueva el elemento <alt-text> dentro del elemento <graphic> o <media> apropiado."
+
+#: packtools/sps/validation/accessibility_data.py:157
+msgid "Missing <alt-text>. Provide a concise textual description of the visual element content."
+msgstr "Falta <alt-text>. Proporcione una descripción textual concisa del contenido del elemento visual."
+
+#: packtools/sps/validation/accessibility_data.py:164
+#, python-brace-format
+msgid "alt-text has {length} characters in {xml}. Provide text with up to {max_length} characters."
+msgstr "alt-text tiene {length} caracteres en {xml}. Proporcione un texto de hasta {max_length} caracteres."
+
+#: packtools/sps/validation/accessibility_data.py:189
+#, python-brace-format
+msgid "Got {obtained}, expected up to {max_length} characters"
+msgstr "Se obtuvo {obtained}, se esperaba un máximo de {max_length} caracteres"
+
+#: packtools/sps/validation/accessibility_data.py:205
+#: packtools/sps/validation/accessibility_data.py:462
+#, python-brace-format
+msgid "The value {value} is invalid in {xml}. Replace it with one of the accepted values: {accepted_values}."
+msgstr "El valor {value} no es válido en {xml}. Reemplácelo con uno de los valores aceptados: {accepted_values}."
+
+#: packtools/sps/validation/accessibility_data.py:277
+#, python-brace-format
+msgid "In <{tag}>, <alt-text> should only be used for video (mp4) or audio (mp3) files. Current mime-type is {mimetype} with mime-subtype {mime_subtype}. For other file types (PDF, ZIP, XLSX), remove <alt-text> or consider using <long-desc> instead. Refer to SPS 1.10 documentation for details."
+msgstr "En <{tag}>, <alt-text> solo debe usarse para archivos de video (mp4) o audio (mp3). El tipo mime actual es {mimetype} con el subtipo mime {mime_subtype}. Para otros tipos de archivos (PDF, ZIP, XLSX), elimine <alt-text> o considere usar <long-desc> en su lugar. Consulte la documentación de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:352
+#, python-brace-format
+msgid "<alt-text> content duplicates {duplicated_element}. According to SPS 1.9/1.10, <alt-text> should not copy content from <label> or <caption>. Provide a unique, descriptive text for the visual element instead."
+msgstr "El contenido <alt-text> duplica {duplicated_element}. Según SPS 1.9/1.10, <alt-text> no debe copiar contenido de <label> o <caption>. En su lugar, proporcione un texto descriptivo único para el elemento visual."
+
+#: packtools/sps/validation/accessibility_data.py:410
+msgid "<alt-text>null</alt-text> indicates a decorative figure. Ensure this is an editorial decision and the image is truly decorative (not essential for understanding the content). Refer to SPS 1.10 documentation for decorative images guidance."
+msgstr "<alt-text>null</alt-text> indica una figura decorativa. Asegúrese de que se trate de una decisión editorial y que la imagen sea verdaderamente decorativa (no es esencial para comprender el contenido). Consulte la documentación de SPS 1.10 para obtener orientación sobre imágenes decorativas."
+
+#: packtools/sps/validation/accessibility_data.py:522
+#, python-brace-format
+msgid "<long-desc> has only {length} characters. According to SPS 1.9/1.10, <long-desc> must have MORE than 120 characters. Use <alt-text> for descriptions up to 120 characters, or expand this <long-desc> to provide more detail."
+msgstr "<long-desc> solo tiene {length} caracteres. Según SPS 1.9/1.10, <long-desc> debe tener MÁS de 120 caracteres. Utilice <alt-text> para descripciones de hasta 120 caracteres o amplíe <long-desc> para proporcionar más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:593
+#, python-brace-format
+msgid "In <{tag}>, <long-desc> should only be used for video (mp4) or audio (mp3) files. Current mime-type is {mimetype} with mime-subtype {mime_subtype}. For other file types, <long-desc> is not appropriate. Refer to SPS 1.10 documentation for details."
+msgstr "En <{tag}>, <long-desc> solo debe usarse para archivos de video (mp4) o audio (mp3). El tipo mime actual es {mimetype} con el subtipo mime {mime_subtype}. Para otros tipos de archivos, <long-desc> no es apropiado. Consulte la documentación de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:668
+#, python-brace-format
+msgid "<long-desc> content duplicates {duplicated_element}. According to SPS 1.9/1.10, <long-desc> should not copy content from <label> or <caption>. Provide a detailed, unique description that adds value beyond the label or caption."
+msgstr "El contenido <long-desc> duplica {duplicated_element}. Según SPS 1.9/1.10, <long-desc> no debe copiar contenido de <label> o <caption>. Proporcione una descripción detallada y única que agregue valor más allá de la etiqueta o el título."
+
+#: packtools/sps/validation/accessibility_data.py:723
+#, python-brace-format
+msgid "Found {count} <long-desc> elements. Only one <long-desc> is allowed per graphic/media element. Remove duplicate <long-desc> elements. Refer to SPS 1.10 documentation for details."
+msgstr "Se encontraron {count} elementos <long-desc>. Solo se permite un <long-desc> por elemento graphic/media. Elimine los elementos <long-desc> duplicados. Consulte la documentación SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:751
+#, python-brace-format
+msgid "Found {count} <long-desc> elements; expected at most one"
+msgstr "Se encontraron {count} elementos <long-desc>; se esperaba como máximo uno"
+
+#: packtools/sps/validation/accessibility_data.py:790
+msgid "Found <alt-text>null</alt-text> combined with <long-desc>. When using <long-desc>, do not use <alt-text>null</alt-text>. Either remove <alt-text> or provide meaningful content instead of 'null'. Refer to SPS 1.10 documentation for combined markup guidance."
+msgstr "Se encontró <alt-text>null</alt-text> combinado con <long-desc>. Cuando utilice <long-desc>, no utilice <alt-text>null</alt-text>. Elimine <alt-text> o proporcione contenido significativo en lugar de 'null'. Consulte la documentación de SPS 1.10 para obtener orientación sobre el marcado combinado."
+
+#: packtools/sps/validation/accessibility_data.py:816
+msgid "<alt-text> must not be 'null' when <long-desc> is present"
+msgstr "<alt-text> no debe ser 'null' cuando <long-desc> está presente"
+
+#: packtools/sps/validation/accessibility_data.py:857
+#, python-brace-format
+msgid "<{tag}> with {mimetype} is missing <xref ref-type=\"sec\"> linking to transcript section. According to SPS 1.9/1.10, audio and video elements should include a reference to their transcript section. Add: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> inside <{tag}>. Refer to SPS 1.10 documentation for details."
+msgstr "A <{tag}> con {mimetype} le falta el enlace <xref ref-type=\"sec\"> a la sección de transcripción. Según SPS 1.9/1.10, los elementos de audio y vídeo deben incluir una referencia a su sección de transcripción. Agregue: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> dentro de <{tag}>. Consulte la documentación de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:918
+#, python-brace-format
+msgid "The transcript is missing in the {tag} element. Add a <sec sec-type=\"transcript\"> section to provide accessible text alternatives. Refer to SPS 1.10 docs for details."
+msgstr "Falta la transcripción en el elemento {tag}. Agregue una sección <sec sec-type=\"transcript\"> para proporcionar alternativas de texto accesibles. Consulte los documentos de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:982
+msgid "Dialog elements are missing in the <sec sec-type='transcript'> section. Use <speaker> and <speech> to represent the dialogue. Refer to SPS 1.10 docs for details."
+msgstr "Faltan elementos de diálogo en la sección <sec sec-type='transcript'>. Utilice <speaker> y <speech> para representar el diálogo. Consulte los documentos de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/accessibility_data.py:1030
+#, python-brace-format
+msgid "Accessibility data is located in an invalid element: <{tag}>. Use one of the valid elements: {valid_elements}. Refer to SPS 1.10 docs for details."
+msgstr "Los datos de accesibilidad se encuentran en un elemento no válido: <{tag}>. Utilice uno de los elementos válidos: {valid_elements}. Consulte los documentos de SPS 1.10 para obtener más detalles."
+
+#: packtools/sps/validation/aff.py:112
+#, python-brace-format
+msgid "Ensure translation has same number of affiliations ({expected_count}) as main text"
+msgstr "Asegúrese de que la traducción tenga la misma cantidad de afiliaciones ({expected_count}) que el texto principal"
+
+#: packtools/sps/validation/aff.py:296
+msgid "Mark the complete original affiliation text with <institution content-type=\"original\"> in <aff>"
+msgstr "Marque el texto de afiliación original completo con <institution content-type=\"original\"> en <aff>"
+
+#: packtools/sps/validation/aff.py:320
+#, python-brace-format
+msgid "Mark the main institution with <institution content-type=\"orgname\"> in <aff> for {original}"
+msgstr "Marque la institución principal con <institution content-type=\"orgname\"> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:340
+#, python-brace-format
+msgid "Mark the first hierarchical subdivision with <institution content-type=\"orgdiv1\"> in <aff> for {original}"
+msgstr "Marque la primera subdivisión jerárquica con <institution content-type=\"orgdiv1\"> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:360
+#, python-brace-format
+msgid "Mark the second hierarchical subdivision with <institution content-type=\"orgdiv2\"> in <aff> for {original}"
+msgstr "Marque la segunda subdivisión jerárquica con <institution content-type=\"orgdiv2\"> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:380
+#, python-brace-format
+msgid "Mark affiliation label with <label> in <aff> for {original}"
+msgstr "Marque etiqueta de afiliación con <label> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:400
+#, python-brace-format
+msgid "Mark affiliation country with <country> in <aff> for {original}"
+msgstr "Marque país de afiliación con <country> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:430
+#, python-brace-format
+msgid "Complete <country country=\"\"> in <aff> with a valid value from the ISO 3166 list: {codes} for {original}"
+msgstr "Complete <country country=\"\"> en <aff> con un valor válido de la lista ISO 3166: {codes} para {original}"
+
+#: packtools/sps/validation/aff.py:453
+#, python-brace-format
+msgid "Mark affiliation state with <addr-line><state> in <aff> for {original}"
+msgstr "Marque el estado de afiliación con <addr-line><state> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:473
+#, python-brace-format
+msgid "Mark affiliation city with <addr-line><city> in <aff> for {original}"
+msgstr "Marque ciudad de afiliación con <addr-line><city> en <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:493
+msgid "Complete <aff id=\"\"> with affiliation identifier"
+msgstr "Complete <aff id=\"\"> con identificador de afiliación"
+
+#: packtools/sps/validation/aff.py:547
+#, python-brace-format
+msgid "Add email {email} to <institution content-type=\"original\"> in <aff>. The email present in <email> must also be present in the original affiliation text"
+msgstr "Agregue el correo electrónico {email} a <institution content-type=\"original\"> en <aff>. El correo electrónico presente en <email> también debe estar presente en el texto de afiliación original."
+
+#: packtools/sps/validation/aff.py:636
+#, python-brace-format
+msgid "Compare {main_id} and {trans_id}. Make sure they are corresponding. Low similarity found in: {differences}"
+msgstr "Compare {main_id} y {trans_id}. Asegúrate de que sean correspondientes. Baja similitud encontrada en: {differences}"
+
+#: packtools/sps/validation/aff.py:671 packtools/sps/validation/aff.py:708
+#, python-brace-format
+msgid "Got {obtained}, expected {component} to be marked"
+msgstr "Se obtuvo {obtained}, se esperaba que {component} estuviera marcado"
+
+#: packtools/sps/validation/aff.py:689
+#, python-brace-format
+msgid "{info}: {value} ({key}) not found in {original}"
+msgstr "{info}: {value} ({key}) no encontrado en {original}"
+
+#: packtools/sps/validation/aff.py:698
+#, python-brace-format
+msgid "{info}: {key} was not marked. Check whether {key} appears in {original}"
+msgstr "{info}: {key} no fue marcado. Compruebe si {key} aparece en {original}"
+
+#: packtools/sps/validation/aff.py:716
+#, python-brace-format
+msgid "No value was found for {component}; expected {component} to be marked"
+msgstr "No se encontró ningún valor para {component}; se esperaba que {component} estuviera marcado"
+
+#: packtools/sps/validation/alternatives.py:64
+#, python-brace-format
+msgid "Add {expected} as sub-elements of {parent}/alternatives"
+msgstr "Agregue {expected} como subelementos de {parent}/alternativas"
+
+#: packtools/sps/validation/alternatives.py:118
+#, python-brace-format
+msgid "Use SVG format for graphic in {parent}/alternatives. Got: {obtained}"
+msgstr "Utilice el formato SVG para gráficos en {parent}/alternatives. Obtenido: {obtained}"
+
+#: packtools/sps/validation/alternatives.py:158
+#, python-brace-format
+msgid "Remove <alt-text> from graphic in {parent}/alternatives. Alternative images do not require alt-text because the coded version ({coded_version}) is already accessible."
+msgstr "Elimine <alt-text> del gráfico en {parent}/alternatives. Las imágenes alternativas no requieren texto alternativo porque ya se puede acceder a la versión codificada ({coded_version})."
+
+#: packtools/sps/validation/alternatives.py:202
+#, python-brace-format
+msgid "Remove <long-desc> from graphic in {parent}/alternatives. Alternative images do not require long-desc because the coded version ({coded_version}) is already accessible."
+msgstr "Elimine <long-desc> del gráfico en {parent}/alternatives. Las imágenes alternativas no requieren descripción larga porque ya se puede acceder a la versión codificada ({coded_version})."
+
+#: packtools/sps/validation/alternatives.py:281
+#, python-brace-format
+msgid "Add both coded version ({coded}) and image ({image}) to {parent}/alternatives"
+msgstr "Agregue la versión codificada ({coded}) y la imagen ({image}) a {parent}/alternatives"
+
+#: packtools/sps/validation/app_group.py:52
+msgid "Consider adding an <app> element to include additional content such as appendices."
+msgstr "Considere agregar un elemento <app> para incluir contenido adicional, como apéndices."
+
+#: packtools/sps/validation/app_group.py:54
+msgid "No <app> element was found"
+msgstr "No se encontró ningún elemento <app>"
+
+#: packtools/sps/validation/app_group.py:100
+msgid "Add @id attribute to <app>. Example: <app id=\"app1\">"
+msgstr "Agregue el atributo @id a <app>. Ejemplo: <app id=\"app1\">"
+
+#: packtools/sps/validation/app_group.py:132
+#, python-brace-format
+msgid "Add <label> element to <app id=\"{app_id_or_placeholder}\">. Example: <app id=\"{app_id_or_example_fix}\"><label>Appendix 1</label></app>"
+msgstr "Agregue el elemento <label> a <app id=\"{app_id_or_placeholder}\">. Ejemplo: <app id=\"{app_id_or_example_fix}\"><label>Apéndice 1</label></app>"
+
+#: packtools/sps/validation/app_group.py:187
+#, python-brace-format
+msgid "Wrap <app id=\"{app_id}\"> with <app-group>. Example: <back><app-group><app id=\"{app_id}\">...</app></app-group></back>"
+msgstr "Envuelva <app id=\"{app_id}\"> con <app-group>. Ejemplo: <back><app-group><app id=\"{app_id}\">...</app></app-group></back>"
+
+#: packtools/sps/validation/app_group.py:224
+#, python-brace-format
+msgid "Merge all {count} <app-group> elements into a single <app-group>."
+msgstr "Combine los {count} elementos <app-group> en un solo <app-group>."
+
+#: packtools/sps/validation/app_group.py:229
+#, python-brace-format
+msgid "Found {count} <app-group> elements in <back>; expected at most one"
+msgstr "Se encontraron {count} elementos <app-group> en <back>; se esperaba como máximo uno"
+
+#: packtools/sps/validation/article_abstract.py:181
+#, python-brace-format
+msgid "Replace {value} in {element} by a valid value: {valid_values}"
+msgstr "Reemplace {value} en {element} por un valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_abstract.py:189
+#, python-brace-format
+msgid "Add abstract type in {element}. Valid values: {valid_values}"
+msgstr "Agregue tipo abstracto en {element}. Valores válidos: {valid_values}"
+
+#: packtools/sps/validation/article_abstract.py:238
+#, python-brace-format
+msgid "Mark {element} in {container}"
+msgstr "Marque {element} en {container}"
+
+#: packtools/sps/validation/article_abstract.py:272
+#, python-brace-format
+msgid "Add {element} as sibling of {container}"
+msgstr "Agregue {element} como hermano de {container}"
+
+#: packtools/sps/validation/article_abstract.py:310
+#, python-brace-format
+msgid "Remove {element} which is associated with {container} by language"
+msgstr "Elimine {element} que está asociado con {container} por idioma"
+
+#: packtools/sps/validation/article_abstract.py:350
+#, python-brace-format
+msgid "Mark abstract title with {element} in {container}"
+msgstr "Marque título abstracto con {element} en {container}"
+
+#: packtools/sps/validation/article_abstract.py:380
+#, python-brace-format
+msgid "Replace {wrong_element} inside {container} by {correct_element}"
+msgstr "Reemplace {wrong_element} dentro de {container} por {correct_element}"
+
+#: packtools/sps/validation/article_abstract.py:414
+#, python-brace-format
+msgid "Provide more than one {element} in {container}"
+msgstr "Proporcione más de un {element} en {container}"
+
+#: packtools/sps/validation/article_abstract.py:527
+#, python-brace-format
+msgid "Mark abstract which is required for {article_type}"
+msgstr "Marque el resumen que se requiere para {article_type}"
+
+#: packtools/sps/validation/article_abstract.py:534
+#, python-brace-format
+msgid "Abstract is not expected for {article_type}"
+msgstr "No se espera ningún resumen para {article_type}"
+
+#: packtools/sps/validation/article_and_subarticles.py:97
+#, python-brace-format
+msgid "Replace {lang} in {xml} with one of {lang_list}"
+msgstr "Reemplace {lang} en {xml} con uno de {lang_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:104
+#, python-brace-format
+msgid "Add xml:lang=\"VALUE\" in {xml}: {xml2} and replace VALUE with one of {lang_list}"
+msgstr "Agregue xml:lang=\"VALUE\" en {xml}: {xml2} y reemplace VALOR con uno de {lang_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:179
+#, python-brace-format
+msgid "Complete {name} article-type {xml} with valid value {type_list}"
+msgstr "Complete el article-type de {name} en {xml} con un valor válido de {type_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:262
+#, python-brace-format
+msgid "Check {xml_article_type} and {xml_subject}. Other values for article-type seems to be more suitable: {choices}. "
+msgstr "Verifique {xml_article_type} y {xml_subject}. Otros valores para el tipo de artículo parecen ser más adecuados: {choices}."
+
+#: packtools/sps/validation/article_and_subarticles.py:338
+#, python-brace-format
+msgid "Fix the table of contents article order {order} in <article-id pub-id-type=\"other\">{order}</article-id>. It must be {expected}"
+msgstr "Corrija el orden del artículo de la tabla de contenido {order} en <article-id pub-id-type=\"other\">{order}</article-id>. Debe ser {expected}"
+
+#: packtools/sps/validation/article_and_subarticles.py:391
+#, python-brace-format
+msgid "Complete SPS version <article specific-use=\"\"/> with valid value: {versions}"
+msgstr "Versión SPS completa <article specific-use=\"\"/> con valor válido: {versions}"
+
+#: packtools/sps/validation/article_and_subarticles.py:397
+#, python-brace-format
+msgid "Complete SPS (specific-use=\"\") and JATS (dtd-version=\"\") versions in {xml} with compatible values: {versions}"
+msgstr "Complete las versiones SPS (specific-use=\"\") y JATS (dtd-version=\"\") en {xml} con valores compatibles: {versions}"
+
+#: packtools/sps/validation/article_contribs.py:76
+#, python-brace-format
+msgid "{info}: Add @contrib-type attribute to <contrib>. Valid values: {values}"
+msgstr "{info}: Agregue el atributo @contrib-type a <contrib>. Valores válidos: {values}"
+
+#: packtools/sps/validation/article_contribs.py:107
+#, python-brace-format
+msgid "{info}: @contrib-type=\"{obtained}\" is invalid. Use: {expected}"
+msgstr "{info}: @contrib-type=\"{obtained}\" no es válido. Use: {expected}"
+
+#: packtools/sps/validation/article_contribs.py:137
+#, python-brace-format
+msgid "{info}: @contrib-type must be \"author\" for this document type (except reviewer reports)"
+msgstr "{info}: @contrib-type debe ser \"author\" para este tipo de documento (excepto informes de revisores)"
+
+#: packtools/sps/validation/article_contribs.py:169
+#, python-brace-format
+msgid "{info}: Mark the contrib role. Consult SPS documentation for detailed instructions"
+msgstr "{info}: Marque el rol de contribución. Consulte la documentación de SPS para obtener instrucciones detalladas."
+
+#: packtools/sps/validation/article_contribs.py:230
+#, python-brace-format
+msgid "{info}: Do not use URLs. Extract only the alphanumeric identifier from {orcid}"
+msgstr "{info}: No utilice URL. Extraiga solo el identificador alfanumérico de {orcid}"
+
+#: packtools/sps/validation/article_contribs.py:261
+#, python-brace-format
+msgid "Fix ORCID format <contrib-id contrib-id-type=\"orcid\">{orcid}</contrib-id>"
+msgstr "Corrija formato ORCID <contrib-id contrib-id-type=\"orcid\">{orcid}</contrib-id>"
+
+#: packtools/sps/validation/article_contribs.py:269
+#, python-brace-format
+msgid "{info}: Add ORCID <contrib-id contrib-id-type=\"orcid\"></contrib-id> in <contrib>"
+msgstr "{info}: Agregue ORCID <contrib-id contrib-id-type=\"orcid\"></contrib-id> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:290
+#, python-brace-format
+msgid "ORCID {orcid} is valid"
+msgstr "El ORCID {orcid} es válido"
+
+#: packtools/sps/validation/article_contribs.py:294
+#, python-brace-format
+msgid "ORCID {orcid} is invalid; expected format XXXX-XXXX-XXXX-XXXX"
+msgstr "El ORCID {orcid} no es válido; se esperaba el formato XXXX-XXXX-XXXX-XXXX"
+
+#: packtools/sps/validation/article_contribs.py:298
+msgid "A valid ORCID is required"
+msgstr "Es obligatorio proporcionar un ORCID válido"
+
+#: packtools/sps/validation/article_contribs.py:337
+#, python-brace-format
+msgid "{info}: Unable to automatically check the {orcid}. Check it manually"
+msgstr "{info}: No se puede verificar automáticamente el {orcid}. Compruébelo manualmente"
+
+#: packtools/sps/validation/article_contribs.py:376
+#, python-brace-format
+msgid "{info}: Add <xref ref-type=\"aff\" rid=\"\"> in <contrib>"
+msgstr "{info}: Agregue <xref ref-type=\"aff\" rid=\"\"> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:405
+#, python-brace-format
+msgid "{info}: Mark contributor name with <name> in <contrib>"
+msgstr "{info}: Marque el nombre del colaborador con <name> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:434
+#, python-brace-format
+msgid "{info}: Mark institutional contributor with <collab> in <contrib>"
+msgstr "{info}: Marque al colaborador institucional con <collab> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:470
+#, python-brace-format
+msgid "{info}: Mark contributor with <name> and anonymous contributor with <anonymous/> in <contrib>"
+msgstr "{info}: Marque al colaborador con <name> y al colaborador anónimo con <anonymous/> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:480
+#, python-brace-format
+msgid "{info}: Mark contributor with <name> and institutional contributor with <collab> in <contrib>"
+msgstr "{info}: Marque al colaborador con <name> y al colaborador institucional con <collab> en <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:543
+#, python-brace-format
+msgid "ORCID must be unique. {questions}"
+msgstr "ORCID debe ser único. {questions}"
+
+#: packtools/sps/validation/article_contribs.py:635
+#, python-brace-format
+msgid "Add person authors, members of {collab}, with <contrib><name>...</name></contrib> in <contrib-group content-type=\"collab-list\"></contrib-group>"
+msgstr "Agregue autores personales, miembros de {collab}, con <contrib><name>...</name></contrib> en <contrib-group content-type=\"collab-list\"></contrib-group>"
+
+#: packtools/sps/validation/article_contribs.py:644
+#, python-brace-format
+msgid "Remove content-type=\"{type}\" from <contrib-group content-type=\"{type}\">"
+msgstr "Elimine content-type=\"{type}\" de <contrib-group content-type=\"{type}\">"
+
+#: packtools/sps/validation/article_contribs.py:711
+msgid "All members of collaboration group must have name <name> in <contrib-group content-type='collab-list'>"
+msgstr "Todos los miembros del grupo de colaboración deben tener el nombre <name> en <contrib-group content-type='collab-list'>."
+
+#: packtools/sps/validation/article_contribs.py:747
+msgid "All members of collaboration group must have complete affiliation <xref ref-type='aff'> (described in PDF)"
+msgstr "Todos los miembros del grupo de colaboración deben tener afiliación completa <xref ref-type='aff'> (descrita en PDF)"
+
+#: packtools/sps/validation/article_contribs.py:775
+msgid "All members of collaboration group MUST have ORCID (described in PDF). Without ORCID identification, authors cannot assign DOI as their work in curriculum databases"
+msgstr "Todos los miembros del grupo de colaboración DEBEN tener ORCID (descrito en PDF). Sin identificación ORCID, los autores no pueden asignar DOI como su trabajo en las bases de datos curriculares"
+
+#: packtools/sps/validation/article_contribs.py:870
+msgid "Do not mix CRediT taxonomy with other taxonomies in the same contributor. All roles for a contributor must use the same taxonomy."
+msgstr "No mezcle la taxonomía CRediT con otras taxonomías en el mismo colaborador. Todos los roles de un colaborador deben utilizar la misma taxonomía."
+
+#: packtools/sps/validation/article_contribs.py:901
+msgid "CRediT taxonomy must be used consistently: either ALL contributors use CRediT or NONE use it. Do not mix taxonomies in the document. SciELO Rule: 'tudo ou nada' (all or nothing)."
+msgstr "La taxonomía CRediT debe usarse de manera consistente: TODOS los contribuyentes usan CRediT o NINGUNO la usa. No mezcle taxonomías en el documento. Regla SciELO: 'tudo ou nada' (todo o nada)."
+
+#: packtools/sps/validation/article_contribs.py:1007
+#, python-brace-format
+msgid "Sub-article {sub_id} uses same @id as main article: {collisions}. If article uses id='collab', sub-article should use id='collab1'"
+msgstr "El subartículo {sub_id} utiliza el mismo @id que el artículo principal: {collisions}. Si el artículo usa id='collab', el subartículo debe usar id='collab1'"
+
+#: packtools/sps/validation/article_contribs.py:1042
+#, python-brace-format
+msgid "Sub-article {sub_id} uses same @rid as main article: {collisions}. If article uses rid='collab', sub-article should use rid='collab1'"
+msgstr "El subartículo {sub_id} utiliza el mismo @rid que el artículo principal: {collisions}. Si el artículo usa rid='collab', el subartículo debe usar rid='collab1'"
+
+#: packtools/sps/validation/article_contribs.py:1172
+#, python-brace-format
+msgid "{info}: replace <role content-type=\"{uri}\"> by <role content-type=\"{expected_uri}\">"
+msgstr "{info}: reemplaza <role content-type=\"{uri}\"> por <role content-type=\"{expected_uri}\">"
+
+#: packtools/sps/validation/article_contribs.py:1176
+#, python-brace-format
+msgid "{info}: replace <role>{text}</role> by <role content-type=\"{expected_uri}\">{text}</role>"
+msgstr "{info}: reemplaza <role>{text}</role> por <role content-type=\"{expected_uri}\">{text}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1181
+#, python-brace-format
+msgid "{info}: check if <role content-type=\"{uri}\">{text}</role> has corresponding CRediT URI"
+msgstr "{info}: compruebe si <role content-type=\"{uri}\">{text}</role> tiene el URI CRediT correspondiente"
+
+#: packtools/sps/validation/article_contribs.py:1186
+#, python-brace-format
+msgid "{info}: check if <role>{text}</role> has corresponding CRediT URI"
+msgstr "{info}: compruebe si <role>{text}</role> tiene el URI CRediT correspondiente"
+
+#: packtools/sps/validation/article_contribs.py:1212
+#, python-brace-format
+msgid "{info}: replace <role{content_type}>{text}</role> by <role{content_type}>{expected_term}</role>"
+msgstr "{info}: reemplaza <role{content_type}>{text}</role> por <role{content_type}>{expected_term}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1216
+#, python-brace-format
+msgid "{info}: replace <role{content_type}></role> by <role{content_type}>{expected_term}</role>"
+msgstr "{info}: reemplaza <role{content_type}></role> por <role{content_type}>{expected_term}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1221
+#: packtools/sps/validation/article_contribs.py:1226
+#, python-brace-format
+msgid "{info}: check if <role{content_type}>{text}</role> has corresponding CRediT term"
+msgstr "{info}: compruebe si <role{content_type}>{text}</role> tiene el término CRediT correspondiente"
+
+#: packtools/sps/validation/article_contribs.py:1266
+#, python-brace-format
+msgid "{info}: add <role specific-use=\"\"> with {expected}"
+msgstr "{info}: agregue <role specific-use=\"\"> con {expected}"
+
+#: packtools/sps/validation/article_contribs.py:1293
+#, python-brace-format
+msgid "{info}: replace <role specific-use=\"{specific_use}\"> with {expected}"
+msgstr "{info}: reemplace <role specific-use=\"{specific_use}\"> con {expected}"
+
+#: packtools/sps/validation/article_data_availability.py:122
+#, python-brace-format
+msgid "Complete  specific-use=\"\" in {xml} with valid value: {valid_values}"
+msgstr "Complete specific-use=\"\" en {xml} con un valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_data_availability.py:182
+#, python-brace-format
+msgid "Mark in {xml} the data availability statement in footnote with <fn fn-type=\"data-availability\" specific-use=\"\"> or in text with <sec sec-type=\"data-availability\" specific-use=\"\">. And complete specific-use=\"\" with valid value: {valid_values}"
+msgstr "Marque en {xml} la declaración de disponibilidad de datos en nota al pie con <fn fn-type=\"data-availability\" specific-use=\"\"> o en texto con <sec sec-type=\"data-availability\" specific-use=\"\">. Y complete specific-use=\"\" con un valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_data_availability.py:204
+#, python-brace-format
+msgid "Remove from {xml} the data availability statement (<{tag} {tag}-type=\"data-availability\">) because it is unexpected for {article_type}"
+msgstr "Elimine de {xml} la declaración de disponibilidad de datos (<{tag} {tag}-type=\"data-availability\">) porque es inesperada para {article_type}"
+
+#: packtools/sps/validation/article_doi.py:47
+#: packtools/sps/validation/article_doi.py:105
+#, python-brace-format
+msgid "Mark DOI for {text} with <article-id pub-id-type=\"doi\"></article-id>"
+msgstr "Marque DOI para {text} con <article-id pub-id-type=\"doi\"></article-id>"
+
+#: packtools/sps/validation/article_doi.py:155
+#, python-brace-format
+msgid "Fix doi to be unique. Found repetition: {diff}"
+msgstr "Arregla doi para que sea único. Repetición encontrada: {diff}"
+
+#: packtools/sps/validation/article_doi.py:214
+#, python-brace-format
+msgid "The DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) is not registered for {expected}. It is registered for {registered}"
+msgstr "El DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) no está registrado para {expected}. Está registrado para {registered}"
+
+#: packtools/sps/validation/article_doi.py:223
+#, python-brace-format
+msgid "Unable to check if {xml_doi} is registered for {expected}"
+msgstr "No se puede comprobar si {xml_doi} está registrado para {expected}"
+
+#: packtools/sps/validation/article_doi.py:251
+#, python-brace-format
+msgid "Got {obtained}, expected DOI registered for {metadata}"
+msgstr "Se obtuvo {obtained}, se esperaba un DOI registrado para {metadata}"
+
+#: packtools/sps/validation/article_doi.py:293
+#, python-brace-format
+msgid "Change {doi} in {xml} for a DOI different from {doi_list}"
+msgstr "Cambiar {doi} en {xml} por un DOI diferente a {doi_list}"
+
+#: packtools/sps/validation/article_license.py:134
+#, python-brace-format
+msgid "Provide license data that is consistent with the language: {lang} and standard adopted by the journal"
+msgstr "Proporcionar datos de licencia que sean consistentes con el idioma: {lang} y el estándar adoptado por la revista."
+
+#: packtools/sps/validation/article_license.py:148
+#, python-brace-format
+msgid "Mark license information with <license license-type=\"open-access\" xlink:href={link} xml:lang={lang}><license-p>{license_p}</license-p></license>"
+msgstr "Marque información de licencia con <license license-type=\"open-access\" xlink:href={link} xml:lang={lang}><license-p>{license_p}</license-p></license>"
+
+#: packtools/sps/validation/article_license.py:252
+#, python-brace-format
+msgid "add <permissions><license xlink:href=\"http://creativecommons.org/licenses/VALUE/4.0/\"> and replace VALUE with {code}"
+msgstr "agregue <permissions><license xlink:href=\"http://creativecommons.org/licenses/VALUE/4.0/\"> y reemplace VALOR con {code}"
+
+#: packtools/sps/validation/article_toc_sections.py:90
+#, python-brace-format
+msgid "Remove <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable"
+msgstr "Elimine <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group> porque es inesperado, solo se acepta un grupo de sujetos"
+
+#: packtools/sps/validation/article_toc_sections.py:93
+#, python-brace-format
+msgid "Remove <subject-group><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable"
+msgstr "Elimine <subject-group><subject>{subject}</subject></subject-group> porque es inesperado, solo se acepta un grupo de sujetos"
+
+#: packtools/sps/validation/article_toc_sections.py:121
+#, python-brace-format
+msgid "Replace <subject-group subj-group-type=\"{subj_group_type}\"><subject>{subject}</subject></subject-group> by <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+msgstr "Reemplazar <subject-group subj-group-type=\"{subj_group_type}\"><subject>{subject}</subject></subject-group> por <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:128
+#, python-brace-format
+msgid "Replace <subject-group><subject>{subject}</subject></subject-group> by <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+msgstr "Reemplace <subject-group><subject>{subject}</subject></subject-group> por <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:132
+msgid "Mark table of contents section with  <subject-group subj-group-type=\"heading\"><subject>table of contents section</subject></subject-group>"
+msgstr "Marque la sección de la tabla de contenido con <subject-group subj-group-type=\"heading\"><subject>sección de la tabla de contenido</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:175
+#, python-brace-format
+msgid "Write section and subsection in one subject: <subject-group subj-group-type=\"heading\"><subject>{subject}: {subsection}</subject></subject-group>. Remove <subject-group><subject>{subsection}</subject></subject-group>"
+msgstr "Escriba la sección y la subsección en un solo asunto: <subject-group subj-group-type=\"heading\"><subject>{subject}: {subsection}</subject></subject-group>. Quite <subject-group><subject>{subsection}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:216
+#, python-brace-format
+msgid "{subject} is not registered as a table of contents section. Valid values: {valid_values}"
+msgstr "{subject} no está registrado como una sección de la tabla de contenido. Valores válidos: {valid_values}"
+
+#: packtools/sps/validation/article_toc_sections.py:224
+#, python-brace-format
+msgid "Unable to check whether {subject} (<subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>) is a valid table of contents section because no sections were provided for the journal {journal}"
+msgstr "No se puede comprobar si {subject} (<subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>) es una sección válida de la tabla de contenido porque no se informaron secciones para la revista {journal}"
+
+#: packtools/sps/validation/article_toc_sections.py:232
+msgid "Mark table of contents section with <subject-group subj-group-type=\"heading\"><subject></subject></subject-group>"
+msgstr "Marque la sección de la tabla de contenido con <subject-group subj-group-type=\"heading\"><subject></subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:247
+#, python-brace-format
+msgid "Got {subject}, but the registered table of contents sections could not be checked"
+msgstr "Se obtuvo {subject}, pero no se pudieron comprobar las secciones registradas de la tabla de contenido"
+
+#: packtools/sps/validation/article_toc_sections.py:291
+#, python-brace-format
+msgid "The article title ({article_title}) must represent its contents and must be different from the section title ({section_title}) to get a better ranking in search results"
+msgstr "El título del artículo ({article_title}) debe representar su contenido y debe ser diferente del título de la sección ({section_title}) para obtener una mejor clasificación en los resultados de búsqueda."
+
+#: packtools/sps/validation/article_xref.py:114
+msgid "Provide a valid @rid attribute for <xref>"
+msgstr "Proporcione un atributo @rid válido para <xref>"
+
+#: packtools/sps/validation/article_xref.py:143
+msgid "Provide a valid @ref-type attribute for <xref>"
+msgstr "Proporcione un atributo @ref-type válido para <xref>"
+
+#: packtools/sps/validation/article_xref.py:175
+#, python-brace-format
+msgid "Replace \"{ref_type}\" with one of the allowed values: {ref_type_list}"
+msgstr "Reemplace \"{ref_type}\" con uno de los valores permitidos: {ref_type_list}"
+
+#: packtools/sps/validation/article_xref.py:205
+msgid "Add at least one <xref ref-type=\"bibr\"> to the document (SciELO Brasil criterion)"
+msgstr "Agregue al menos un <xref ref-type=\"bibr\"> al documento (criterio SciELO Brasil)"
+
+#: packtools/sps/validation/article_xref.py:238
+#, python-brace-format
+msgid "@rid=\"{rid}\" in <xref> has no corresponding @id in the document"
+msgstr "@rid=\"{rid}\" en <xref> no tiene un @id correspondiente en el documento"
+
+#: packtools/sps/validation/article_xref.py:277
+#, python-brace-format
+msgid "Add <xref ref-type=\"sec\" rid=\"{sec_id}\"> to reference the transcript section"
+msgstr "Agregue <xref ref-type=\"sec\" rid=\"{sec_id}\"> para hacer referencia a la sección de transcripción"
+
+#: packtools/sps/validation/article_xref.py:314
+#, python-brace-format
+msgid "For @ref-type=\"aff\" without text content, use self-closing: <xref ref-type=\"aff\" rid=\"{rid}\"/>"
+msgstr "Para @ref-type=\"aff\" sin contenido de texto, utilice el cierre automático: <xref ref-type=\"aff\" rid=\"{rid}\"/>"
+
+#: packtools/sps/validation/article_xref.py:357
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but not found the corresponding {elem_xml}"
+msgstr "Se encontró {tag_and_attribs}, pero no se encontró el {elem_xml} correspondiente."
+
+#: packtools/sps/validation/article_xref.py:397
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. Mark {label}, mention to {tag_and_attribs}, with {xref_xml}"
+msgstr "Se encontró {tag_and_attribs}, pero no se encontró ningún {xref_xml} correspondiente. Marca {label}, mención a {tag_and_attribs}, con {xref_xml}"
+
+#: packtools/sps/validation/article_xref.py:410
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. "
+msgstr "Se encontró {tag_and_attribs}, pero no se encontró ningún {xref_xml} correspondiente."
+
+#: packtools/sps/validation/article_xref.py:493
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. Mark the {tag_and_attribs} cross-references using {xref_xml}"
+msgstr "Se encontró {tag_and_attribs}, pero no se encontró ningún {xref_xml} correspondiente. Marque las referencias cruzadas {tag_and_attribs} usando {xref_xml}"
+
+#: packtools/sps/validation/author_notes.py:22
+#, python-brace-format
+msgid "Add mandatory @fn-type attribute to <fn> in <author-notes>. Valid values for author notes: {values}"
+msgstr "Agregue el atributo obligatorio @fn-type a <fn> en <author-notes>. Valores válidos para notas de autor: {values}"
+
+#: packtools/sps/validation/author_notes.py:80
+#, python-brace-format
+msgid "@fn-type=\"{fn_type}\" is not valid for <fn> in <author-notes>. Use one of: {values}"
+msgstr "@fn-type=\"{fn_type}\" no es válido para <fn> en <author-notes>. Utilice uno de: {values}"
+
+#: packtools/sps/validation/author_notes.py:112
+msgid "For corresponding author information, use <corresp> element instead of <fn fn-type=\"corresp\">"
+msgstr "Para obtener información sobre el autor correspondiente, utilice el elemento <corresp> en lugar de <fn fn-type=\"corresp\">."
+
+#: packtools/sps/validation/author_notes.py:143
+msgid "<fn fn-type=\"current-aff\"> is deprecated. Use <fn fn-type=\"bio\"> instead."
+msgstr "<fn fn-type=\"current-aff\"> está en desuso. Utilice <fn fn-type=\"bio\"> en su lugar."
+
+#: packtools/sps/validation/author_notes.py:163
+msgid "<fn fn-type=\"con\"> is deprecated. Use <role content-type=\"http://credit.niso.org/contributor-roles/CONTRIBUTION/\"> inside <contrib> instead. Replace CONTRIBUTION with the author's contribution type."
+msgstr "<fn fn-type=\"con\"> está en desuso. Utilice <role content-type=\"http://credit.niso.org/contributor-roles/CONTRIBUTION/\"> dentro de <contrib> en su lugar. Reemplace CONTRIBUCIÓN con el tipo de contribución del autor."
+
+#: packtools/sps/validation/author_notes.py:243
+#, python-brace-format
+msgid "<author-notes> element should appear at most once in the article. Found {count} occurrences."
+msgstr "El elemento <author-notes> debe aparecer como máximo una vez en el artículo. Se encontraron ocurrencias de {count}."
+
+#: packtools/sps/validation/author_notes.py:269
+#, python-brace-format
+msgid "<author-notes> element should appear at most once in sub-article (id={id}). Found {count} occurrences."
+msgstr "El elemento <author-notes> debe aparecer como máximo una vez en el subartículo (id={id}). Se encontraron ocurrencias de {count}."
+
+#: packtools/sps/validation/author_notes.py:357
+msgid "Mark corresp label with <corresp><label>"
+msgstr "Marque la etiqueta correspondiente con <corresp><label>"
+
+#: packtools/sps/validation/author_notes.py:379
+msgid "Replace <corresp><title> with <corresp><label>"
+msgstr "Reemplace <corresp><title> con <corresp><label>"
+
+#: packtools/sps/validation/author_notes.py:401
+msgid "Replace <corresp><bold> with <corresp><label>"
+msgstr "Reemplace <corresp><bold> con <corresp><label>"
+
+#: packtools/sps/validation/basefn.py:44
+msgid "Mark footnote label with <fn><label>"
+msgstr "Marque etiqueta de nota al pie con <fn><label>"
+
+#: packtools/sps/validation/basefn.py:66
+msgid "Replace <fn><title> with <fn><label>"
+msgstr "Reemplace <fn><title> con <fn><label>"
+
+#: packtools/sps/validation/basefn.py:88
+msgid "Replace <fn><bold> with <fn><label>"
+msgstr "Reemplace <fn><bold> con <fn><label>"
+
+#: packtools/sps/validation/basefn.py:115
+#, python-brace-format
+msgid "Complete fn-type=\"\" in <fn fn-type=\"\"> with a valid values: {expected}"
+msgstr "Complete fn-type=\"\" en <fn fn-type=\"\"> con valores válidos: {expected}"
+
+#: packtools/sps/validation/basefn.py:143
+msgid "Use <fn fn-type=\"conflict\"> for JATS < 1.3 and <fn fn-type=\"coi-statement\"> for JATS ≥ 1.3."
+msgstr "Utilice <fn fn-type=\"conflict\"> para JATS < 1,3 y <fn fn-type=\"coi-statement\"> para JATS ≥ 1,3."
+
+#: packtools/sps/validation/dates.py:81
+#, python-brace-format
+msgid "Complete <{tag} date-type=\"{date_type}\"><{label}> with {number}-digits"
+msgstr "Complete <{tag} date-type=\"{date_type}\"><{label}> con dígitos {number}"
+
+#: packtools/sps/validation/dates.py:117
+#, python-brace-format
+msgid "Complete <{tag} date-type=\"{date_type}\"><year> with an year previous or equal to {limit_year}"
+msgstr "Completar <{tag} date-type=\"{date_type}\"><year> con un año anterior o igual a {limit_year}"
+
+#: packtools/sps/validation/dates.py:154
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({parts}) is invalid: {error}"
+msgstr "<date date-type=\"{date_type}\"> ({parts}) no es válido: {error}"
+
+#: packtools/sps/validation/dates.py:195
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({formatted_date}) must be previous to {max_date_label} ({max_date})"
+msgstr "<date date-type=\"{date_type}\"> ({formatted_date}) debe ser anterior a {max_date_label} ({max_date})"
+
+#: packtools/sps/validation/dates.py:217
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({parts}) must be a date with year, month (2-digits) and day (2-digits)"
+msgstr "<date date-type=\"{date_type}\"> ({parts}) debe ser una fecha con año, mes (2 dígitos) y día (2 dígitos)"
+
+#: packtools/sps/validation/dates.py:367
+msgid "Add <pub-date publication-format=\"electronic\" date-type=\"pub\"> with <day>, <month> and <year>"
+msgstr "Agregue <pub-date publication-format=\"electronic\" date-type=\"pub\"> con <day>, <month> y <year>."
+
+#: packtools/sps/validation/dates.py:390
+msgid "Add <pub-date publication-format=\"electronic\" date-type=\"collection\"> with <year>"
+msgstr "Agregue <pub-date publication-format=\"electronic\" date-type=\"collection\"> con <year>"
+
+#: packtools/sps/validation/dates.py:411
+#, python-brace-format
+msgid "Set @publication-format=\"electronic\" in <pub-date date-type=\"{date_type}\">"
+msgstr "Establecer @publication-format=\"electronic\" en <pub-date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/dates.py:434
+#, python-brace-format
+msgid "Add <{element}> to <pub-date date-type=\"pub\">"
+msgstr "Agregue <{element}> a <pub-date date-type=\"pub\">"
+
+#: packtools/sps/validation/dates.py:456
+msgid "Add <year> to <pub-date date-type=\"collection\">"
+msgstr "Agregue <year> a <pub-date date-type=\"collection\">"
+
+#: packtools/sps/validation/dates.py:479
+msgid "Remove <day> from <pub-date date-type=\"collection\">"
+msgstr "Quitar <day> de <pub-date date-type=\"collection\">"
+
+#: packtools/sps/validation/dates.py:501
+#, python-brace-format
+msgid "Ensure there is at most one <pub-date date-type=\"{date_type}\">"
+msgstr "Asegúrese de que haya como máximo un <pub-date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/dates.py:529
+#, python-brace-format
+msgid "Fix <day> value in <pub-date date-type=\"{date_type}\">. Must be between 00 and 31"
+msgstr "Se corrigió el valor de <day> en <pub-date date-type=\"{date_type}\">. Debe estar entre 00 y 31"
+
+#: packtools/sps/validation/dates.py:550
+#, python-brace-format
+msgid "Fix <month> value in <pub-date date-type=\"{date_type}\">. Must be between 00 and 12"
+msgstr "Se corrigió el valor de <month> en <pub-date date-type=\"{date_type}\">. Debe ser entre 00 y 12"
+
+#: packtools/sps/validation/dates.py:632
+#, python-brace-format
+msgid "History dates found: {date_types}. Exclude unexpected dates: {unexpected_events}"
+msgstr "Fechas del historial encontradas: {date_types}. Excluir fechas inesperadas: {unexpected_events}"
+
+#: packtools/sps/validation/dates.py:651
+#, python-brace-format
+msgid "History dates found: {date_types}. Add missing dates: {missing_events}"
+msgstr "Fechas del historial encontradas: {date_types}. Agregue fechas faltantes: {missing_events}"
+
+#: packtools/sps/validation/dates.py:677
+#, python-brace-format
+msgid "History dates ({date_types}) must be in chronological order: {expected}"
+msgstr "Las fechas del historial ({date_types}) deben estar en orden cronológico: {expected}"
+
+#: packtools/sps/validation/ext_link.py:100
+#, python-brace-format
+msgid "Add @ext-link-type attribute to <ext-link> with text \"{text}\". Valid values: {allowed_values}"
+msgstr "Agregue el atributo @ext-link-type a <ext-link> con el texto \"{text}\". Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/ext_link.py:131
+msgid "The @ext-link-type attribute is present"
+msgstr "El atributo @ext-link-type está presente"
+
+#: packtools/sps/validation/ext_link.py:133
+#: packtools/sps/validation/related_articles.py:198
+msgid "The @ext-link-type attribute is required"
+msgstr "El atributo @ext-link-type es obligatorio"
+
+#: packtools/sps/validation/ext_link.py:163
+#, python-brace-format
+msgid "Add @xlink:href attribute to <ext-link> with text \"{text}\""
+msgstr "Agregue el atributo @xlink:href a <ext-link> con el texto \"{text}\""
+
+#: packtools/sps/validation/ext_link.py:189
+msgid "The @xlink:href attribute is present"
+msgstr "El atributo @xlink:href está presente"
+
+#: packtools/sps/validation/ext_link.py:191
+#: packtools/sps/validation/related_articles.py:248
+msgid "The @xlink:href attribute is required"
+msgstr "El atributo @xlink:href es obligatorio"
+
+#: packtools/sps/validation/ext_link.py:224
+#, python-brace-format
+msgid "URL in @xlink:href=\"{xlink_href}\" must start with http:// or https://"
+msgstr "La URL en @xlink:href=\"{xlink_href}\" debe comenzar con http:// o https://"
+
+#: packtools/sps/validation/ext_link.py:250
+#, python-brace-format
+msgid "URL {url} must start with http:// or https://"
+msgstr "La URL {url} debe comenzar con http:// o https://"
+
+#: packtools/sps/validation/ext_link.py:283
+#, python-brace-format
+msgid "Replace @ext-link-type=\"{ext_link_type}\" with one of: {allowed_values}"
+msgstr "Reemplace @ext-link-type=\"{ext_link_type}\" con uno de: {allowed_values}"
+
+#: packtools/sps/validation/ext_link.py:346
+#, python-brace-format
+msgid "Replace generic text \"{text}\" in <ext-link> with descriptive text, or add @xlink:title attribute"
+msgstr "Reemplace el texto genérico \"{text}\" en <ext-link> con texto descriptivo o agregue el atributo @xlink:title"
+
+#: packtools/sps/validation/ext_link.py:426
+#, python-brace-format
+msgid "Add @xlink:title attribute to <ext-link> with generic text \"{text}\" to describe the link destination"
+msgstr "Agregue el atributo @xlink:title a <ext-link> con el texto genérico \"{text}\" para describir el destino del enlace."
+
+#: packtools/sps/validation/ext_link.py:435
+#, python-brace-format
+msgid "Add @xlink:title attribute to <ext-link> where the text is the URL \"{text}\" to describe the link destination"
+msgstr "Agregue el atributo @xlink:title a <ext-link> donde el texto es la URL \"{text}\" para describir el destino del enlace."
+
+#: packtools/sps/validation/ext_link.py:463
+msgid "The @xlink:title attribute is required when the link text is generic or a URL"
+msgstr "El atributo @xlink:title es obligatorio cuando el texto del enlace es genérico o una URL"
+
+#: packtools/sps/validation/fig.py:32
+#, python-brace-format
+msgid "article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct"
+msgstr "article-type={article_type} requiere <fig>. Se encontraron 0. Identifique la figura o compruebe si article-type es correcto"
+
+#: packtools/sps/validation/fig.py:111
+msgid "Add @id attribute to <fig>. Example: <fig id=\"f01\">. The @id attribute is mandatory."
+msgstr "Agregue el atributo @id a <fig>. Ejemplo: <fig id=\"f01\">. El atributo @id es obligatorio."
+
+#: packtools/sps/validation/fig.py:130
+msgid "Add <graphic> element inside <fig>. Example: <graphic xlink:href=\"image.jpg\"/>. Every <fig> must contain at least one <graphic> element."
+msgstr "Agregue el elemento <graphic> dentro de <fig>. Ejemplo: <graphic xlink:href=\"image.jpg\"/>. Cada <fig> debe contener al menos un elemento <graphic>."
+
+#: packtools/sps/validation/fig.py:155
+msgid "Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href=\"image.jpg\"/>. The @xlink:href attribute is mandatory in <graphic>."
+msgstr "Agregue el atributo @xlink:href a <graphic>. Ejemplo: <graphic xlink:href=\"image.jpg\"/>. El atributo @xlink:href es obligatorio en <graphic>."
+
+#: packtools/sps/validation/fig.py:189
+#, python-brace-format
+msgid "SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>."
+msgstr "Los archivos SVG sólo se permiten dentro de <alternatives>. Utilice un formato diferente ({allowed_formats}) o ajuste el gráfico en <alternatives>."
+
+#: packtools/sps/validation/fig.py:199
+#, python-brace-format
+msgid "File extension \"{file_extension}\" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>."
+msgstr "La extensión de archivo \"{file_extension}\" no está permitida. Utilice uno de: {allowed_formats}. Si usa SVG, debe estar dentro de <alternatives>."
+
+#: packtools/sps/validation/fig.py:203
+#, python-brace-format
+msgid "File \"{graphic_href}\" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>."
+msgstr "El archivo \"{graphic_href}\" debe tener una extensión válida. Permitido: {allowed_formats}. SVG solo se permite dentro de <alternatives>."
+
+#: packtools/sps/validation/fig.py:244
+#, python-brace-format
+msgid "Invalid @fig-type value \"{fig_type}\". Use one of: {allowed_types}."
+msgstr "Valor @fig-type no válido \"{fig_type}\". Utilice uno de: {allowed_types}."
+
+#: packtools/sps/validation/fig.py:265
+msgid "When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang=\"en\">."
+msgstr "Cuando <fig> está dentro de <fig-group>, el atributo @xml:lang es obligatorio. Agregue el atributo xml:lang a <fig>. Ejemplo: <fig xml:lang=\"en\">."
+
+#: packtools/sps/validation/fig.py:275
+msgid "Accessibility description is present"
+msgstr "La descripción de accesibilidad está presente"
+
+#: packtools/sps/validation/fig.py:278
+msgid "No accessibility description was found; expected <alt-text> or <long-desc>"
+msgstr "No se encontró ninguna descripción de accesibilidad; se esperaba <alt-text> o <long-desc>"
+
+#: packtools/sps/validation/fig.py:294
+msgid "For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href=\"image.jpg\"><alt-text>Brief description</alt-text></graphic>."
+msgstr "Para accesibilidad, agregue <alt-text> o <long-desc> dentro de <graphic>. Ejemplo: <graphic xlink:href=\"image.jpg\"><alt-text>Breve descripción</alt-text></graphic>."
+
+#: packtools/sps/validation/fig.py:319
+#, python-brace-format
+msgid "The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description."
+msgstr "El contenido de <alt-text> tiene {current_length} caracteres y supera el máximo recomendado de {max_length}. Acorte la descripción."
+
+#: packtools/sps/validation/fn.py:25
+msgid "Add mandatory @fn-type attribute to <fn> in <fn-group>"
+msgstr "Agregue el atributo obligatorio @fn-type a <fn> en <fn-group>"
+
+#: packtools/sps/validation/fn.py:140
+#, python-brace-format
+msgid "<fn-group> element should appear at most once in the article. Found {count} occurrences."
+msgstr "El elemento <fn-group> debe aparecer como máximo una vez en el artículo. Se encontraron ocurrencias de {count}."
+
+#: packtools/sps/validation/fn.py:166
+#, python-brace-format
+msgid "<fn-group> element should appear at most once in sub-article (id={id}). Found {count} occurrences."
+msgstr "El elemento <fn-group> debe aparecer como máximo una vez en el subartículo (id={id}). Se encontraron ocurrencias de {count}."
+
+#: packtools/sps/validation/fn.py:216
+msgid "Make the responsible editor with <fn fn-type=\"edited-by\">"
+msgstr "Conviértete en el editor responsable con <fn fn-type=\"edited-by\">"
+
+#: packtools/sps/validation/formula.py:51
+msgid "No <disp-formula> found in XML"
+msgstr "No se encontró ningún <disp-formula> en XML"
+
+#: packtools/sps/validation/formula.py:132
+msgid "Add the formula ID with id=\"\" in <disp-formula>: <disp-formula id=\"\">. Consult SPS documentation for more detail."
+msgstr "Agregue el ID de fórmula con id=\"\" en <disp-formula>: <disp-formula id=\"\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:164
+#, python-brace-format
+msgid "The @id of <disp-formula> must start with prefix \"e\". Change {id} to e{id} in <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "El @id de <disp-formula> debe comenzar con el prefijo \"e\". Cambie {id} a e{id} en <disp-formula id=\"{id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:192
+#, python-brace-format
+msgid "Mark each label with <label> inside <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "Marque cada etiqueta con <label> dentro de <disp-formula id=\"{id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:229
+#, python-brace-format
+msgid "Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "Marque cada codificación de fórmula con <mml:math> o <tex-math> dentro de <disp-formula id=\"{id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:260
+#, python-brace-format
+msgid "Add the @id attribute in <mml:math> inside <disp-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consult SPS documentation for more detail."
+msgstr "Agregue el atributo @id en <mml:math> dentro de <disp-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:292
+#, python-brace-format
+msgid "The @id of <mml:math> must start with prefix \"m\". Change {mml_id} to m{mml_id} in <mml:math id=\"{mml_id}\"> inside <disp-formula id=\"{formula_id}\">. Consult SPS documentation for more detail."
+msgstr "El @id de <mml:math> debe comenzar con el prefijo \"m\". Cambie {mml_id} a m{mml_id} en <mml:math id=\"{mml_id}\"> dentro de <disp-formula id=\"{formula_id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:343
+#, python-brace-format
+msgid "For accessibility, consider adding <mml:math> in <disp-formula id=\"{formula_id}\">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail."
+msgstr "Para accesibilidad, considere agregar <mml:math> en <disp-formula id=\"{formula_id}\">. MathML mejora la accesibilidad para los lectores de pantalla. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:383
+msgid "Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>"
+msgstr "Envuelva <tex-math> y <mml:math> con <alternatives> dentro de <disp-formula>"
+
+#: packtools/sps/validation/formula.py:390
+#: packtools/sps/validation/formula.py:397
+#, python-brace-format
+msgid "Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>"
+msgstr "Retire el <alternatives> de <disp-formula> y mantenga el <{found}> dentro de <disp-formula>."
+
+#: packtools/sps/validation/formula.py:469
+msgid "No <inline-formula> found in XML"
+msgstr "No se encontró ningún <inline-formula> en XML"
+
+#: packtools/sps/validation/formula.py:551
+msgid "Add the formula ID with id=\"\" in <inline-formula>: <inline-formula id=\"\">. Consult SPS documentation for more detail."
+msgstr "Agregue el ID de fórmula con id=\"\" en <inline-formula>: <inline-formula id=\"\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:583
+#, python-brace-format
+msgid "The @id of <inline-formula> must start with prefix \"e\". Change {id} to e{id} in <inline-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "El @id de <inline-formula> debe comenzar con el prefijo \"e\". Cambie {id} a e{id} en <inline-formula id=\"{id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:621
+msgid "Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail."
+msgstr "Marque cada codificación de fórmula con <mml:math> o <tex-math> dentro de <inline-formula>. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:652
+#, python-brace-format
+msgid "Add the @id attribute in <mml:math> inside <inline-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consult SPS documentation for more detail."
+msgstr "Agregue el atributo @id en <mml:math> dentro de <inline-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:684
+#, python-brace-format
+msgid "The @id of <mml:math> must start with prefix \"m\". Change {mml_id} to m{mml_id} in <mml:math id=\"{mml_id}\"> inside <inline-formula id=\"{formula_id}\">. Consult SPS documentation for more detail."
+msgstr "El @id de <mml:math> debe comenzar con el prefijo \"m\". Cambie {mml_id} a m{mml_id} en <mml:math id=\"{mml_id}\"> dentro de <inline-formula id=\"{formula_id}\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:735
+#, python-brace-format
+msgid "For accessibility, consider adding <mml:math> in <inline-formula id=\"{formula_id}\">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail."
+msgstr "Para accesibilidad, considere agregar <mml:math> en <inline-formula id=\"{formula_id}\">. MathML mejora la accesibilidad para los lectores de pantalla. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/formula.py:775
+msgid "Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>"
+msgstr "Envuelva <tex-math> y <mml:math> con <alternatives> dentro de <inline-formula>"
+
+#: packtools/sps/validation/formula.py:782
+#: packtools/sps/validation/formula.py:789
+#, python-brace-format
+msgid "Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>"
+msgstr "Retire el <alternatives> de <inline-formula> y mantenga el <{found}> dentro de <inline-formula>."
+
+#: packtools/sps/validation/front_articlemeta_issue.py:77
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><volume> with {expected}"
+msgstr "Reemplace {obtained} en <article-meta><volume> con {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:111
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><issue> with {expected}"
+msgstr "Reemplace {obtained} en <article-meta><issue> con {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:145
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><supplement> with {expected}"
+msgstr "Reemplace {obtained} en <article-meta><supplement> con {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:209
+#, python-brace-format
+msgid "Replace {issue} in <article-meta><issue> with one of {expected}"
+msgstr "Reemplace {issue} en <article-meta><issue> con uno de {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:251
+#, python-brace-format
+msgid "Got {issue}, but the registered journal issue could not be checked"
+msgstr "Se obtuvo {issue}, pero no se pudo comprobar el fascículo registrado"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:255
+msgid "Unable to check if issue is registered"
+msgstr "No se puede comprobar si el fascículo está registrado"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:271
+#, python-brace-format
+msgid "Replace {issue} in <article-meta> with one of {expected_issues}"
+msgstr "Reemplace {issue} en <article-meta> con uno de {expected_issues}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:302
+#, python-brace-format
+msgid "Remove duplicate <issue> elements from <article-meta>. Found {count} elements, expected at most 1."
+msgstr "Elimine los elementos <issue> duplicados de <article-meta>. Se encontraron {count} elementos; se esperaba como máximo 1."
+
+#: packtools/sps/validation/front_articlemeta_issue.py:335
+#, python-brace-format
+msgid "Remove punctuation marks {found_punctuation} from <issue> value '{issue_value}'"
+msgstr "Eliminar los signos de puntuación {found_punctuation} del valor <issue> '{issue_value}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:369
+#, python-brace-format
+msgid "Convert uppercase letters to lowercase in <issue> value '{issue_value}'. Expected: '{expected}'"
+msgstr "Convierta letras mayúsculas a minúsculas en el valor <issue> '{issue_value}'. Esperado: '{expected}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:419
+#, python-brace-format
+msgid "Use 'suppl' for supplement nomenclature in <issue> value '{issue_value}'. Invalid terms found: {invalid_patterns}"
+msgstr "Utilice 'suppl' para la nomenclatura de suplementos en el valor <issue> '{issue_value}'. Se encontraron términos no válidos: {invalid_patterns}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:476
+#, python-brace-format
+msgid "Use 'spe' for special issue nomenclature in <issue> value '{issue_value}'. Invalid terms found: {found_invalid}"
+msgstr "Utilice 'spe' para la nomenclatura de números especiales en el valor <issue> '{issue_value}'. Se encontraron términos no válidos: {found_invalid}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:508
+msgid "Remove <supplement> element(s) from <article-meta>. Use <issue> element to indicate supplements (e.g., '4 suppl 1')."
+msgstr "Retire los elementos <supplement> de <article-meta>. Utilice el elemento <issue> para indicar suplementos (por ejemplo, '4 suppl 1')."
+
+#: packtools/sps/validation/front_articlemeta_issue.py:563
+#, python-brace-format
+msgid "Remove leading zeros from numeric parts in <issue> value '{issue_value}'. Expected: '{expected_value}'"
+msgstr "Elimine los ceros iniciales de las partes numéricas en el valor <issue> '{issue_value}'. Esperado: '{expected_value}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:653
+msgid "Mark elocation id with <elocation-id> or first page with <fpage> and last page with <lpage>"
+msgstr "Marque la identificación de ubicación con <elocation-id> o la primera página con <fpage> y la última página con <lpage>."
+
+#: packtools/sps/validation/funding_group.py:65
+#, python-brace-format
+msgid "Mark the sponsor institution with <funding-source> for <award-id> ({award_ids}). Consult SPS documentation for more detail"
+msgstr "Marque la institución patrocinadora con <funding-source> para <award-id> ({award_ids}). Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/funding_group.py:70
+#, python-brace-format
+msgid "Mark the contract number with <award-id> for <funding-source> ({funding_sources}). Consult SPS documentation for more detail"
+msgstr "Marque el número de contrato con <award-id> para <funding-source> ({funding_sources}). Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/funding_group.py:75
+msgid "Mark the contract number with <award-id> and the funding institution with <funding-source> insider <award-group>. Consult SPS documentation for more detail"
+msgstr "Marque el número de contrato con <award-id> y la institución financiadora con <funding-source> insider <award-group>. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/funding_group.py:92
+msgid "<award-group> contains both <award-id> and <funding-source>"
+msgstr "<award-group> contiene <award-id> y <funding-source>"
+
+#: packtools/sps/validation/funding_group.py:97
+msgid "<award-group> must contain both <award-id> and <funding-source>"
+msgstr "<award-group> debe contener <award-id> y <funding-source>"
+
+#: packtools/sps/validation/funding_group.py:128
+#, python-brace-format
+msgid "Found {missing} in {text} ({context}), if {missing} is a contract number, add <award-id>{missing}</award-id> and the corresponding funding institution with <funding-source> inside <award-group>. Consult the SPS documentation for more detail"
+msgstr "Encontré {missing} en {text} ({context}), si {missing} es un número de contrato, agregue <award-id>{missing}</award-id> y la institución financiadora correspondiente con <funding-source> dentro. <award-group>. Consulte la documentación de SPS para más detalles."
+
+#: packtools/sps/validation/funding_group.py:222
+#, python-brace-format
+msgid "Replace <funding-statement>{funding_statement}</funding-statement> by <funding-statement>{reference_text}</funding-statement>"
+msgstr "Reemplazar <funding-statement>{funding_statement}</funding-statement> por <funding-statement>{reference_text}</funding-statement>"
+
+#: packtools/sps/validation/funding_group.py:236
+msgid "No reference texts (fn/ack elements) were found to compare with <funding-statement>. Verify manually that the statement is correct."
+msgstr "No se encontraron textos de referencia (elementos fn/ack) para comparar con <funding-statement>. Verifique manualmente que la declaración sea correcta."
+
+#: packtools/sps/validation/funding_group.py:243
+#, python-brace-format
+msgid "Add <funding-statement>{reference_text}</funding-statement> in <funding-group>. Consult SPS documentation for more detail"
+msgstr "Agregue <funding-statement>{reference_text}</funding-statement> en <funding-group>. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/funding_group.py:251
+msgid "Add funding statement with <funding-statement> inside <funding-group>. Consult SPS documentation for more detail"
+msgstr "Agregue una declaración de financiación con <funding-statement> dentro de <funding-group>. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/funding_group.py:327
+#, python-brace-format
+msgid "Found {count} <funding-group> elements in <article-meta>. Only one is allowed. Merge them into a single <funding-group>."
+msgstr "Se encontraron {count} elementos <funding-group> en <article-meta>. Solo se permite uno. Combínelos en un único <funding-group>."
+
+#: packtools/sps/validation/funding_group.py:394
+#, python-brace-format
+msgid "Add <funding-statement> element inside <funding-group> (index {index}). It is mandatory according to SPS 1.10."
+msgstr "Agregue el elemento <funding-statement> dentro de <funding-group> (índice {index}). Es obligatorio según SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:397
+msgid "<funding-statement> is present in <funding-group>"
+msgstr "<funding-statement> está presente en <funding-group>"
+
+#: packtools/sps/validation/funding_group.py:400
+msgid "<funding-statement> is required in <funding-group>"
+msgstr "<funding-statement> es obligatorio en <funding-group>"
+
+#: packtools/sps/validation/funding_group.py:451
+msgid "Add at least one <funding-source> element inside this <award-group>. It is mandatory when <award-group> exists."
+msgstr "Agregue al menos un elemento <funding-source> dentro de este <award-group>. Es obligatorio cuando existe <award-group>."
+
+#: packtools/sps/validation/funding_group.py:499
+#, python-brace-format
+msgid "Remove {count} <label> element(s) from <funding-group>. <label> is not allowed according to SPS 1.10."
+msgstr "Retire los elementos {count} <label> de <funding-group>. <label> no está permitido según SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:555
+#, python-brace-format
+msgid "Remove {count} <title> element(s) from <funding-group>. <title> is not allowed according to SPS 1.10."
+msgstr "Retire los elementos {count} <title> de <funding-group>. <title> no está permitido según SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:621
+#, python-brace-format
+msgid "Inconsistent quantities: {num_sources} <funding-source>(s) but {num_awards} <award-id>(s). When multiple <award-id> elements exist, they should typically match the number of <funding-source> elements, or use separate <award-group> elements."
+msgstr "Cantidades inconsistentes: {num_sources} <funding-source>(s) pero {num_awards} <award-id>(s). Cuando existen varios elementos <award-id>, normalmente deben coincidir con el número de elementos <funding-source> o utilizar elementos <award-group> separados."
+
+#: packtools/sps/validation/graphic.py:55
+#: packtools/sps/validation/visual_resource_base.py:42
+#, python-brace-format
+msgid "Add id=\"\" to {element}"
+msgstr "Agregue id=\"\" a {element}"
+
+#: packtools/sps/validation/graphic.py:58
+#, python-brace-format
+msgid "The @id attribute is present in <{element}>"
+msgstr "El atributo @id está presente en <{element}>"
+
+#: packtools/sps/validation/graphic.py:60
+#, python-brace-format
+msgid "The @id attribute is required in <{element}>"
+msgstr "El atributo @id es obligatorio en <{element}>"
+
+#: packtools/sps/validation/graphic.py:95
+#, python-brace-format
+msgid "Add xlink:href=\"filename.ext\" to <{tag}> (valid extensions: jpg, jpeg, png, tif, tiff, svg)"
+msgstr "Agregue xlink:href=\"filename.ext\" a <{tag}> (extensiones válidas: jpg, jpeg, png, tif, tiff, svg)"
+
+#: packtools/sps/validation/graphic.py:143
+#, python-brace-format
+msgid "SVG files are only allowed inside <alternatives>. The file '{xlink_href}' is currently in <{parent_tag}>. Either move this <graphic> inside <alternatives> or use a different format (.jpg, .png, .tif)."
+msgstr "Los archivos SVG sólo se permiten dentro de <alternatives>. El archivo '{xlink_href}' se encuentra actualmente en <{parent_tag}>. Mueva este <graphic> dentro de <alternatives> o use un formato diferente (.jpg, .png, .tif)."
+
+#: packtools/sps/validation/history.py:230
+#, python-brace-format
+msgid "Remove duplicate <history> elements. Found {count} occurrences, expected at most 1."
+msgstr "Elimine los elementos <history> duplicados. Se encontraron ocurrencias de {count}, se esperaban como máximo 1."
+
+#: packtools/sps/validation/history.py:279
+#, python-brace-format
+msgid "Add @date-type attribute to <date> element. Date parts: {date_parts}"
+msgstr "Agregue el atributo @date-type al elemento <date>. Partes de fecha: {date_parts}"
+
+#: packtools/sps/validation/history.py:284
+msgid "The @date-type attribute is present"
+msgstr "El atributo @date-type está presente"
+
+#: packtools/sps/validation/history.py:286
+msgid "The @date-type attribute is required"
+msgstr "El atributo @date-type es obligatorio"
+
+#: packtools/sps/validation/history.py:344
+#, python-brace-format
+msgid "Change @date-type='{date_type}' to one of the allowed values: {allowed_values}"
+msgstr "Cambie @date-type='{date_type}' a uno de los valores permitidos: {allowed_values}"
+
+#: packtools/sps/validation/history.py:400
+#, python-brace-format
+msgid "The required <date date-type=\"{date_type}\"> is present"
+msgstr "El elemento obligatorio <date date-type=\"{date_type}\"> está presente"
+
+#: packtools/sps/validation/history.py:404
+#, python-brace-format
+msgid "The required <date date-type=\"{date_type}\"> is missing"
+msgstr "Falta el elemento obligatorio <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/history.py:408
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> is not required for article type {article_type}"
+msgstr "<date date-type=\"{date_type}\"> no es obligatorio para el tipo de artículo {article_type}"
+
+#: packtools/sps/validation/history.py:426
+#, python-brace-format
+msgid "Add <date date-type=\"{date_type}\"> to <history>"
+msgstr "Agregue <date date-type=\"{date_type}\"> a <history>"
+
+#: packtools/sps/validation/history.py:509
+#, python-brace-format
+msgid "Add missing elements to <date date-type=\"{date_type}\">: {missing_parts}"
+msgstr "Agregue elementos faltantes a <date date-type=\"{date_type}\">: {missing_parts}"
+
+#: packtools/sps/validation/history.py:565
+#, python-brace-format
+msgid "Add <year> element to <date date-type=\"{date_type}\">"
+msgstr "Agregue el elemento <year> a <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/history.py:569
+#, python-brace-format
+msgid "<year> is present in <date date-type=\"{date_type}\">"
+msgstr "<year> está presente en <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/history.py:574
+#, python-brace-format
+msgid "<year> is required in <date date-type=\"{date_type}\">"
+msgstr "<year> es obligatorio en <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/journal_meta.py:95
+#, python-brace-format
+msgid "Mark {name} ISSN with <issn pub-type=\"{tp}\">{issn}</issn> inside <journal-meta>"
+msgstr "Marque {name} ISSN con <issn pub-type=\"{tp}\">{issn}</issn> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:126
+#, python-brace-format
+msgid "Mark journal acronym with <journal-id journal-id-type=\"publisher-id\">{acronym}</journal-id> inside <journal-meta>"
+msgstr "Marque el acrónimo de la revista con <journal-id journal-id-type=\"publisher-id\">{acronym}</journal-id> dentro de <journal-meta>."
+
+#: packtools/sps/validation/journal_meta.py:160
+msgid "Mark journal title with <journal-title> inside <journal-title-group>"
+msgstr "Marque el título de la revista con <journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:188
+msgid "Mark abbreviated journal title with <abbrev-journal-title> inside <journal-title-group>"
+msgstr "Marque el título abreviado de la revista con <abbrev-journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:270
+#, python-brace-format
+msgid "Mark publisher name with <publisher><publisher-name>{name}</publisher-name></publisher> inside <journal-meta>"
+msgstr "Marque el nombre del editor con <publisher><publisher-name>{name}</publisher-name></publisher> dentro de <journal-meta>."
+
+#: packtools/sps/validation/journal_meta.py:305
+#, python-brace-format
+msgid "{action} the following items {in_from} the XML: {items}"
+msgstr "{action} los siguientes elementos {in_from} el XML: {items}"
+
+#: packtools/sps/validation/journal_meta.py:378
+#, python-brace-format
+msgid "Mark an nlm-ta value with <journal-id journal-id-type=\"nlm-ta\">{nlm_ta}</journal-id> inside <journal-meta>"
+msgstr "Marque un valor nlm-ta con <journal-id journal-id-type=\"nlm-ta\">{nlm_ta}</journal-id> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:452
+msgid "Add <journal-meta> element inside <front>"
+msgstr "Añada el elemento <journal-meta> dentro de <front>"
+
+#: packtools/sps/validation/journal_meta.py:491
+msgid "Ensure exactly one <journal-meta> element exists inside <front>"
+msgstr "Asegúrese de que exista exactamente un elemento <journal-meta> dentro de <front>"
+
+#: packtools/sps/validation/journal_meta.py:522
+msgid "Add <journal-id journal-id-type=\"publisher-id\">ACRONYM</journal-id> inside <journal-meta>"
+msgstr "Agregue <journal-id journal-id-type=\"publisher-id\">ACRONYM</journal-id> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:553
+msgid "Add <journal-title>Title</journal-title> inside <journal-title-group>"
+msgstr "Agregue <journal-title>Title</journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:584
+msgid "Add <abbrev-journal-title abbrev-type=\"publisher\">Abbrev. Title</abbrev-journal-title> inside <journal-title-group>"
+msgstr "Agregue <abbrev-journal-title abbrev-type=\"publisher\">Abrev. Título</abbrev-journal-title> inside <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:617
+msgid "Add at least one <issn pub-type=\"epub\">XXXX-XXXX</issn> or <issn pub-type=\"ppub\">XXXX-XXXX</issn> inside <journal-meta>"
+msgstr "Agregue al menos un <issn pub-type=\"epub\">XXXX-XXXX</issn> o <issn pub-type=\"ppub\">XXXX-XXXX</issn> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:648
+msgid "Add <publisher><publisher-name>Publisher Name</publisher-name></publisher> inside <journal-meta>"
+msgstr "Agregue <publisher><publisher-name>Nombre del editor</publisher-name></publisher> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:697
+#, python-brace-format
+msgid "Correct ISSN format to XXXX-XXXX pattern. Current value: {issn_value}"
+msgstr "Corrija el formato del ISSN al patrón XXXX-XXXX. Valor actual: {issn_value}"
+
+#: packtools/sps/validation/journal_meta.py:743
+#, python-brace-format
+msgid "Set @journal-id-type to one of {allowed_types}. Current value: {id_type}"
+msgstr "Establezca @journal-id-type en uno de {allowed_types}. Valor actual: {id_type}"
+
+#: packtools/sps/validation/journal_meta.py:783
+#, python-brace-format
+msgid "Set @pub-type to one of {allowed_types}. Current value: {pub_type}"
+msgstr "Establezca @pub-type en uno de {allowed_types}. Valor actual: {pub_type}"
+
+#: packtools/sps/validation/journal_meta.py:831
+#, python-brace-format
+msgid "Remove duplicate ISSN elements with same pub-type. Duplicates: {duplicates}"
+msgstr "Elimine elementos ISSN duplicados con el mismo tipo de publicación. Duplicados: {duplicates}"
+
+#: packtools/sps/validation/list.py:62
+#, python-brace-format
+msgid "Add list-type attribute to <list> element. Use one of: {values}"
+msgstr "Agregue el atributo de tipo de lista al elemento <list>. Utilice uno de: {values}"
+
+#: packtools/sps/validation/list.py:66
+#, python-brace-format
+msgid "The @list-type attribute cannot be empty. Use one of: {values}"
+msgstr "El atributo @list-type no puede estar vacío. Utilice uno de: {values}"
+
+#: packtools/sps/validation/list.py:120
+#, python-brace-format
+msgid "Value \"{list_type}\" is not allowed for @list-type. Use one of: {allowed_types}"
+msgstr "El valor \"{list_type}\" no está permitido para @list-type. Utilice uno de: {allowed_types}"
+
+#: packtools/sps/validation/list.py:155
+#, python-brace-format
+msgid "<list> must contain at least {min_items} <list-item> elements. Found {count}"
+msgstr "<list> debe contener al menos {min_items} elementos <list-item>. Se encontraron {count}."
+
+#: packtools/sps/validation/list.py:189
+msgid "For accessibility, do not use <label> in <list-item>. The @list-type attribute generates labels automatically"
+msgstr "Para accesibilidad, no utilice <label> en <list-item>. El atributo @list-type genera etiquetas automáticamente"
+
+#: packtools/sps/validation/list.py:220
+#, python-brace-format
+msgid "Found {count} empty <list-item> element(s). Each <list-item> should contain at least one child element (typically <p>)"
+msgstr "Se encontraron {count} elementos <list-item> vacíos. Cada <list-item> debe contener al menos un elemento hijo (normalmente <p>)."
+
+#: packtools/sps/validation/list.py:251
+msgid "Consider adding a <title> element if the list has a descriptive heading"
+msgstr "Considere agregar un elemento <title> si la lista tiene un encabezado descriptivo"
+
+#: packtools/sps/validation/list.py:256
+msgid "<title> is present in the list"
+msgstr "<title> está presente en la lista"
+
+#: packtools/sps/validation/list.py:259
+msgid "<title> is recommended when the list has a descriptive heading"
+msgstr "<title> se recomienda cuando la lista tiene un título descriptivo"
+
+#: packtools/sps/validation/media.py:32
+#, python-brace-format
+msgid "Use expected values: {expected_values}"
+msgstr "Utilice los valores esperados: {expected_values}"
+
+#: packtools/sps/validation/metadata_langs.py:133
+#, python-brace-format
+msgid "Mark {element} for {language} language"
+msgstr "Marque {element} para el idioma {language}"
+
+#: packtools/sps/validation/peer_review.py:34
+msgid "Mark peer review name with <custom-meta><meta-name>."
+msgstr "Marque el nombre de la revisión por pares con <custom-meta><meta-name>."
+
+#: packtools/sps/validation/peer_review.py:57
+msgid "Mark peer review recommendation value with <custom-meta><meta-value>."
+msgstr "Marque el valor de recomendación de la revisión por pares con <custom-meta><meta-value>."
+
+#: packtools/sps/validation/peer_review.py:170
+#, python-brace-format
+msgid "Add article_type in <article article-type='VALUE'> and replace VALUE with {article_types}"
+msgstr "Agregue tipo_artículo en <article article-type='VALUE'> y reemplace VALOR con {article_types}"
+
+#: packtools/sps/validation/peer_review.py:206
+#, python-brace-format
+msgid "Add date-type in <history><date date-type=\"VALUE\"> and replace VALUE with : {event}"
+msgstr "Agregue tipo de fecha en <history><date date-type=\"VALUE\"> y reemplace VALOR con: {event}"
+
+#: packtools/sps/validation/permissions.py:101
+msgid "Add <permissions> element to <article-meta> with a Creative Commons license declaration"
+msgstr "Agregue el elemento <permissions> a <article-meta> con una declaración de licencia Creative Commons"
+
+#: packtools/sps/validation/permissions.py:127
+msgid "Remove duplicate <permissions> elements. Only one <permissions> should exist in <article-meta>"
+msgstr "Elimine los elementos <permissions> duplicados. Sólo debe existir un <permissions> en <article-meta>"
+
+#: packtools/sps/validation/permissions.py:154
+msgid "Add <license> element to <permissions> with Creative Commons CC-BY attributes"
+msgstr "Agregue el elemento <license> a <permissions> con atributos Creative Commons CC-BY"
+
+#: packtools/sps/validation/permissions.py:180
+#, python-brace-format
+msgid "Set license-type=\"{license_type}\" in <license> element"
+msgstr "Establezca license-type=\"{license_type}\" en el elemento <license>"
+
+#: packtools/sps/validation/permissions.py:208
+msgid "Add xlink:href attribute with a valid Creative Commons CC-BY URL to <license>"
+msgstr "Agregue el atributo xlink:href con una URL CC-BY de Creative Commons válida a <license>"
+
+#: packtools/sps/validation/permissions.py:236
+msgid "Add xml:lang attribute to <license> element indicating the language of the license text"
+msgstr "Agregue el atributo xml:lang al elemento <license> que indica el idioma del texto de la licencia"
+
+#: packtools/sps/validation/permissions.py:264
+msgid "Add <license-p> element with the license text to <license>"
+msgstr "Agregue el elemento <license-p> con el texto de la licencia a <license>"
+
+#: packtools/sps/validation/permissions.py:299
+msgid "Use a valid Creative Commons CC-BY 4.0 URL, e.g. https://creativecommons.org/licenses/by/4.0/"
+msgstr "Utilice una URL válida de Creative Commons CC-BY 4.0, p. https://creativecommons.org/licenses/by/4.0/"
+
+#: packtools/sps/validation/permissions.py:302
+#, python-brace-format
+msgid "URL {url} must start with one of the valid Creative Commons CC-BY prefixes: {valid_prefixes}"
+msgstr "La URL {url} debe comenzar con uno de los prefijos Creative Commons CC-BY válidos: {valid_prefixes}"
+
+#: packtools/sps/validation/permissions.py:356
+#, python-brace-format
+msgid "For xml:lang=\"{language}\", use a URL ending with '{expected_deed}', e.g. https://creativecommons.org/licenses/by/4.0/{expected_deed}"
+msgstr "Para xml:lang=\"{language}\", utilice una URL que termine en '{expected_deed}', p. https://creativecommons.org/licenses/by/4.0/{expected_deed}"
+
+#: packtools/sps/validation/permissions.py:401
+#, python-brace-format
+msgid "Add <copyright-year>{year}</copyright-year> to <permissions> since the copyright statement mentions the year '{year}'"
+msgstr "Agregue <copyright-year>{year}</copyright-year> a <permissions> ya que la declaración de derechos de autor menciona el año '{year}'"
+
+#: packtools/sps/validation/permissions.py:407
+msgid "<copyright-year> is required when <copyright-statement> mentions a year"
+msgstr "<copyright-year> es obligatorio cuando <copyright-statement> menciona un año"
+
+#: packtools/sps/validation/preprint.py:71
+msgid "Provide the publication date of the preprint"
+msgstr "Proporcione la fecha de publicación de la preimpresión."
+
+#: packtools/sps/validation/preprint.py:84
+msgid "The article does not reference the preprint, provide it as in the example: <related-article id=\"pp1\" related-article-type=\"preprint\" ext-link-type=\"doi\" xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+msgstr "El artículo no hace referencia a la preimpresión; proporciónela como en el ejemplo: <related-article id=\"pp1\" related-article-type=\"preprint\" ext-link-type=\"doi\" xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+
+#: packtools/sps/validation/preprint.py:100
+#: packtools/sps/validation/utils.py:101 packtools/sps/validation/utils.py:199
+#, python-brace-format
+msgid "Got {obtained}, expected {expected}"
+msgstr "Se obtuvo {obtained}, se esperaba {expected}"
+
+#: packtools/sps/validation/product.py:66
+msgid "Add @product-type=\"book\" attribute to <product>."
+msgstr "Agregue el atributo @product-type=\"book\" a <product>."
+
+#: packtools/sps/validation/product.py:74
+msgid "@product-type is present but empty. Set the value to \"book\"."
+msgstr "@product-type está presente pero vacío. Establezca el valor en \"book\"."
+
+#: packtools/sps/validation/product.py:95
+msgid "The @product-type attribute is present with value \"book\""
+msgstr "El atributo @product-type está presente con el valor \"book\""
+
+#: packtools/sps/validation/product.py:99
+msgid "The @product-type attribute with value \"book\" is required"
+msgstr "El atributo @product-type con el valor \"book\" es obligatorio"
+
+#: packtools/sps/validation/product.py:137
+#, python-brace-format
+msgid "Replace @product-type=\"{product_type}\" with one of: {allowed_values}."
+msgstr "Reemplace @product-type=\"{product_type}\" con uno de: {allowed_values}."
+
+#: packtools/sps/validation/product.py:178
+msgid "Add <source> element with the book title inside <product>"
+msgstr "Agregue el elemento <source> con el título del libro dentro de <product>"
+
+#: packtools/sps/validation/product.py:220
+#, python-brace-format
+msgid "<product> is present but @article-type=\"{article_type}\". For book reviews, use @article-type=\"book-review\" in <article>"
+msgstr "<product> está presente pero @article-type=\"{article_type}\". Para reseñas de libros, utilice @article-type=\"book-review\" en <article>."
+
+#: packtools/sps/validation/product.py:261
+msgid "Add <person-group person-group-type=\"author\"> with the author(s) of the reviewed book inside <product>"
+msgstr "Agregue <person-group person-group-type=\"author\"> con los autores del libro reseñado dentro de <product>"
+
+#: packtools/sps/validation/product.py:301
+msgid "Add <publisher-name> element with the publisher name inside <product> for bibliographic completeness"
+msgstr "Agregue el elemento <publisher-name> con el nombre del editor dentro de <product> para completar la bibliografía."
+
+#: packtools/sps/validation/product.py:341
+msgid "Add <year> element with the publication year inside <product> for bibliographic completeness"
+msgstr "Agregue el elemento <year> con el año de publicación dentro de <product> para completar la bibliografía."
+
+#: packtools/sps/validation/references.py:69
+#, python-brace-format
+msgid "Mark {label} with <{element_name}>"
+msgstr "Marque {label} con <{element_name}>"
+
+#: packtools/sps/validation/references.py:117
+#, python-brace-format
+msgid "Mark the reference year ({year}) with <year>; it must be earlier than or equal to {end_year}"
+msgstr "Marque el año de la referencia ({year}) con <year>; debe ser anterior o igual a {end_year}"
+
+#: packtools/sps/validation/references.py:127
+#, python-brace-format
+msgid "Mark the reference year with <year>; it must be earlier than or equal to {end_year}"
+msgstr "Marque el año de la referencia con <year>; debe ser anterior o igual a {end_year}"
+
+#: packtools/sps/validation/references.py:143
+#, python-brace-format
+msgid "Reference year {year} must be numeric and no later than {end_year}"
+msgstr "El año de la referencia {year} debe ser numérico y no posterior a {end_year}"
+
+#: packtools/sps/validation/references.py:177
+msgid "Mark reference authors with <name> (person) or <collab> (institutional)"
+msgstr "Marque autores de referencia con <name> (persona) o <collab> (institucional)"
+
+#: packtools/sps/validation/references.py:198
+#, python-brace-format
+msgid "Complete publication-type=\"\" in <element-citation publication-type=\"\"> with valid value: {publication_type_list}"
+msgstr "Complete publication-type=\"\" en <element-citation publication-type=\"\"> con un valor válido: {publication_type_list}"
+
+#: packtools/sps/validation/references.py:223
+#, python-brace-format
+msgid "{info}: Wrap {text_before_extlink}{ext_link_xml} with <comment> tag"
+msgstr "{info}: Envolver {text_before_extlink}{ext_link_xml} con etiqueta <comment>"
+
+#: packtools/sps/validation/references.py:235
+#: packtools/sps/validation/references.py:256
+#, python-brace-format
+msgid "{info}: Analyze and decide to remove <comment> or mark the text between <comment> and {ext_link_tag_with_attrib}"
+msgstr "{info}: Analiza y decide eliminar <comment> o marca el texto entre <comment> y {ext_link_tag_with_attrib}."
+
+#: packtools/sps/validation/references.py:246
+#, python-brace-format
+msgid "{info}: Wrap the {text_before_extlink}{ext_link_xml} with <comment> tag"
+msgstr "{info}: Envuelva el {text_before_extlink}{ext_link_xml} con la etiqueta <comment>"
+
+#: packtools/sps/validation/references.py:304
+#, python-brace-format
+msgid "remove {remaining_tags} from mixed-citation"
+msgstr "eliminar {remaining_tags} de la cita mixta"
+
+#: packtools/sps/validation/references.py:323
+#, python-brace-format
+msgid "{info}: mark the full reference with <mixed-citation>"
+msgstr "{info}: marcar la referencia completa con <mixed-citation>"
+
+#: packtools/sps/validation/references.py:347
+#, python-brace-format
+msgid "{info}: replace <chapter-title> by <part-title>"
+msgstr "{info}: reemplaza <chapter-title> por <part-title>"
+
+#: packtools/sps/validation/references.py:367
+#, python-brace-format
+msgid "{info}: {text} ({tag}) not found in <mixed-citation>{mixed_citation}</mixed-citation>"
+msgstr "{info}: {text} ({tag}) no encontrado en <mixed-citation>{mixed_citation}</mixed-citation>"
+
+#: packtools/sps/validation/references.py:392
+#, python-brace-format
+msgid "{info}: \"{item}\" was not marked, analyze it and mark it with a corresponding tag"
+msgstr "{info}: \"{item}\" no fue marcado, analícelo y márquelo con la etiqueta correspondiente"
+
+#: packtools/sps/validation/references.py:414
+#, python-brace-format
+msgid "{info}: mark the structured reference with <element-citation>"
+msgstr "{info}: marcar la referencia estructurada con <element-citation>"
+
+#: packtools/sps/validation/references.py:433
+#, python-brace-format
+msgid "{info}: remove extra <ext-link> from <element-citation>, keep at most one"
+msgstr "{info}: eliminar <ext-link> extra de <element-citation>, conservar como máximo uno"
+
+#: packtools/sps/validation/references.py:452
+#, python-brace-format
+msgid "{info}: remove extra <ext-link> from <mixed-citation>, keep at most one"
+msgstr "{info}: eliminar <ext-link> extra de <mixed-citation>, conservar como máximo uno"
+
+#: packtools/sps/validation/references.py:472
+#, python-brace-format
+msgid "{info}: add <lpage> because <fpage> is present"
+msgstr "{info}: agregue <lpage> porque <fpage> está presente"
+
+#: packtools/sps/validation/references.py:475
+msgid "<lpage> is required when <fpage> is present"
+msgstr "<lpage> es obligatorio cuando <fpage> está presente"
+
+#: packtools/sps/validation/references.py:497
+#, python-brace-format
+msgid "{info}: set @units=\"pages\" in <size>"
+msgstr "{info}: establezca @units=\"pages\" en <size>"
+
+#: packtools/sps/validation/references.py:517
+#, python-brace-format
+msgid "{info}: set @content-type=\"access-date\" in <date-in-citation>"
+msgstr "{info}: establezca @content-type=\"access-date\" en <date-in-citation>"
+
+#: packtools/sps/validation/references.py:536
+#, python-brace-format
+msgid "{info}: add <surname> to <name> in <person-group>"
+msgstr "{info}: agregue <surname> a <name> en <person-group>"
+
+#: packtools/sps/validation/references.py:600
+msgid "Add <ref-list> to <back> with at least one <ref>"
+msgstr "Agregue <ref-list> a <back> con al menos un <ref>"
+
+#: packtools/sps/validation/references.py:622
+msgid "Add at least one <ref> to <ref-list>"
+msgstr "Agregue al menos un <ref> a <ref-list>"
+
+#: packtools/sps/validation/related_articles.py:129
+#, python-brace-format
+msgid "Add @related-article-type attribute to <related-article>. Valid values: {allowed_values}"
+msgstr "Agregue el atributo @related-article-type a <related-article>. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:153
+msgid "The @related-article-type attribute is required"
+msgstr "El atributo @related-article-type es obligatorio"
+
+#: packtools/sps/validation/related_articles.py:174
+#, python-brace-format
+msgid "Add @ext-link-type attribute to <related-article>. Valid values: {allowed_values}"
+msgstr "Agregue el atributo @ext-link-type a <related-article>. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:223
+#, python-brace-format
+msgid "Value \"{obtained}\" is not allowed for @related-article-type. Valid values: {allowed_values}"
+msgstr "El valor \"{obtained}\" no está permitido para @related-article-type. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:269
+msgid "Add @xlink:href attribute to <related-article>. Provide a valid DOI or URI."
+msgstr "Agregue el atributo @xlink:href a <related-article>. Proporcione un DOI o URI válido."
+
+#: packtools/sps/validation/related_articles.py:312
+#, python-brace-format
+msgid "Value \"{obtained}\" is not allowed for @ext-link-type. Valid values: {allowed_values}"
+msgstr "El valor \"{obtained}\" no está permitido para @ext-link-type. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:364
+#, python-brace-format
+msgid "For @related-article-type=\"{related_type}\", use @ext-link-type=\"doi\". Value \"uri\" is only recommended for: {uri_types}"
+msgstr "Para @related-article-type=\"{related_type}\", utilice @ext-link-type=\"doi\". El valor \"uri\" solo se recomienda para: {uri_types}"
+
+#: packtools/sps/validation/related_articles.py:399
+#: packtools/sps/validation/related_articles.py:429
+#, python-brace-format
+msgid "The article-type \"{article_type}\" does not match the related-article-type \"{obtained_type}\". Provide one of: {expected_values}"
+msgstr "El tipo de artículo \"{article_type}\" no coincide con el tipo de artículo relacionado \"{obtained_type}\". Proporcione uno de: {expected_values}"
+
+#: packtools/sps/validation/related_articles.py:463
+#, python-brace-format
+msgid "The @ext-link-type should be one of {allowed_values} for related article with id=\"{related_id}\""
+msgstr "@ext-link-type debe ser uno de {allowed_values} para el artículo relacionado con id=\"{related_id}\""
+
+#: packtools/sps/validation/related_articles.py:496
+#: packtools/sps/validation/related_articles.py:556
+#, python-brace-format
+msgid "Provide a valid {link_type} for <related-article id=\"{related_id}\" />"
+msgstr "Proporcione un {link_type} válido para <related-article id=\"{related_id}\" />"
+
+#: packtools/sps/validation/related_articles.py:525
+#: packtools/sps/validation/related_articles.py:586
+#, python-brace-format
+msgid "Invalid {link_type} format for link: {link}"
+msgstr "Formato {link_type} no válido para el enlace: {link}"
+
+#: packtools/sps/validation/related_articles.py:624
+msgid "Add @id attribute to <related-article>. The @id must be a non-empty unique identifier."
+msgstr "Agregue el atributo @id a <related-article>. El @id debe ser un identificador único que no esté vacío."
+
+#: packtools/sps/validation/related_articles.py:676
+#, python-brace-format
+msgid "Set related-article attributes in this order: {expected_order}"
+msgstr "Establezca los atributos de artículos relacionados en este orden: {expected_order}"
+
+#: packtools/sps/validation/related_articles.py:840
+#, python-brace-format
+msgid "Article type \"{article_type}\" requires related articles of types: {missing_types}"
+msgstr "El tipo de artículo \"{article_type}\" requiere artículos relacionados de tipos: {missing_types}"
+
+#: packtools/sps/validation/response.py:136
+msgid "Add @response-type=\"reply\" to <response>."
+msgstr "Agregue @response-type=\"reply\" a <response>."
+
+#: packtools/sps/validation/response.py:164
+msgid "Replace @response-type with \"reply\" in <response>."
+msgstr "Reemplace @response-type con \"reply\" en <response>."
+
+#: packtools/sps/validation/response.py:194
+msgid "Add @xml:lang to <response>."
+msgstr "Agregue @xml:lang a <response>."
+
+#: packtools/sps/validation/response.py:222
+msgid "Add @id to <response>."
+msgstr "Agregue @id a <response>."
+
+#: packtools/sps/validation/response.py:264
+#, python-brace-format
+msgid "Replace duplicate @id=\"{response_id}\" with a unique value in <response>."
+msgstr "Reemplace el duplicado @id=\"{response_id}\" con un valor único en <response>."
+
+#: packtools/sps/validation/response.py:293
+msgid "Add <front-stub> with response metadata inside <response>."
+msgstr "Agregue <front-stub> con metadatos de respuesta dentro de <response>."
+
+#: packtools/sps/validation/response.py:320
+msgid "Add <body> with response content inside <response>."
+msgstr "Agregue <body> con contenido de respuesta dentro de <response>."
+
+#: packtools/sps/validation/sec.py:44
+msgid "Add <title> element to <sec> for accessibility"
+msgstr "Agregue el elemento <title> a <sec> para accesibilidad"
+
+#: packtools/sps/validation/sec.py:81
+#, python-brace-format
+msgid "Replace @sec-type=\"{sec_type}\" with a valid value: {valid_types}"
+msgstr "Reemplace @sec-type=\"{sec_type}\" con un valor válido: {valid_types}"
+
+#: packtools/sps/validation/sec.py:109
+msgid "Add @id attribute to <sec sec-type=\"transcript\">"
+msgstr "Agregue el atributo @id a <sec sec-type=\"transcript\">"
+
+#: packtools/sps/validation/sec.py:141
+#, python-brace-format
+msgid "Use pipe \"|\" as separator in @sec-type=\"{sec_type}\" (e.g., \"materials|methods\")"
+msgstr "Utilice la tubería \"|\" como separador en @sec-type=\"{sec_type}\" (por ejemplo, \"materials|methods\")"
+
+#: packtools/sps/validation/sec.py:177
+#, python-brace-format
+msgid "Do not combine \"{non_combinable}\" with other types in @sec-type=\"{sec_type}\""
+msgstr "No combine \"{non_combinable}\" con otros tipos en @sec-type=\"{sec_type}\""
+
+#: packtools/sps/validation/sec.py:201
+msgid "Add at least one <p> element to <sec>"
+msgstr "Agregue al menos un elemento <p> a <sec>"
+
+#: packtools/sps/validation/sec.py:204
+#, python-brace-format
+msgid "Found {count} paragraphs in <sec>; expected at least one <p>"
+msgstr "Se encontraron {count} párrafos en <sec>; se esperaba al menos un <p>"
+
+#: packtools/sps/validation/sec.py:292
+msgid "Data availability statement is missing; expected <sec sec-type=\"data-availability\"> in <body> or <back>, or <fn fn-type=\"data-availability\">"
+msgstr "Falta la declaración de disponibilidad de datos; se esperaba <sec sec-type=\"data-availability\"> en <body> o <back>, o <fn fn-type=\"data-availability\">"
+
+#: packtools/sps/validation/sec.py:303
+#, python-brace-format
+msgid "Add <sec sec-type=\"data-availability\" specific-use=\"...\"> to <body> or <back>, or <fn fn-type=\"data-availability\"> (required for article-type=\"{article_type}\")"
+msgstr "Agregue <sec sec-type=\"data-availability\" specific-use=\"...\"> a <body> o <back>, o <fn fn-type=\"data-availability\"> (requerido para article-type=\"{article_type}\")"
+
+#: packtools/sps/validation/supplementary_material.py:49
+#, python-brace-format
+msgid "In <sec sec-type=\"{sec_type}\"><supplementary-material> replace \"{sec_type}\" with \"supplementary-material\"."
+msgstr "En <sec sec-type=\"{sec_type}\"><supplementary-material> reemplace \"{sec_type}\" por \"supplementary-material\"."
+
+#: packtools/sps/validation/supplementary_material.py:71
+msgid "Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail."
+msgstr "Agregue etiqueta en <supplementary-material>: <supplementary-material><label>. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/supplementary_material.py:92
+msgid "Do not use <supplementary-material> inside <app-group> or <app>."
+msgstr "No utilice <supplementary-material> dentro de <app-group> o <app>."
+
+#: packtools/sps/validation/supplementary_material.py:125
+msgid "The use of <inline-supplementary-material> is prohibited."
+msgstr "Está prohibido el uso de <inline-supplementary-material>."
+
+#: packtools/sps/validation/supplementary_material.py:128
+msgid "The <inline-supplementary-material> element is not allowed"
+msgstr "El elemento <inline-supplementary-material> no está permitido"
+
+#: packtools/sps/validation/supplementary_material.py:179
+msgid "The supplementary materials section must be at the end of <body> or inside <back>."
+msgstr "La sección de materiales complementarios debe estar al final de <body> o dentro de <back>."
+
+#: packtools/sps/validation/supplementary_material.py:182
+msgid "The supplementary materials section must be the last section of <body> or be inside <back>"
+msgstr "La sección de materiales suplementarios debe ser la última sección de <body> o estar dentro de <back>"
+
+#: packtools/sps/validation/tablewrap.py:53
+#, python-brace-format
+msgid "({article_type}) No <table-wrap> found in XML"
+msgstr "({article_type}) No se encontró ningún <table-wrap> en XML"
+
+#: packtools/sps/validation/tablewrap.py:138
+msgid "Add the table ID with id=\"\" in <table-wrap>: <table-wrap id=\"\">. Consult SPS documentation for more detail."
+msgstr "Agregue el ID de la tabla con id=\"\" en <table-wrap>: <table-wrap id=\"\">. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/tablewrap.py:189
+#, python-brace-format
+msgid "Add <label> or <caption> with <title> inside {xml}. Consult SPS documentation for more detail."
+msgstr "Agregue <label> o <caption> con <title> dentro de {xml}. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/tablewrap.py:192
+msgid "Expected <label> or <caption> with <title> inside <table-wrap>"
+msgstr "Se esperaba <label> o <caption> con <title> dentro de <table-wrap>"
+
+#: packtools/sps/validation/tablewrap.py:223
+#, python-brace-format
+msgid "Wrap each table with <table> inside {xml}. Consult SPS documentation for more detail."
+msgstr "Envuelva cada mesa con <table> dentro de {xml}. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/tablewrap.py:242
+#, python-brace-format
+msgid "Wrap <table> and <graphic> with <alternatives> inside {xml} "
+msgstr "Envuelva <table> y <graphic> con <alternatives> dentro de {xml}"
+
+#: packtools/sps/validation/tablewrap.py:249
+#, python-brace-format
+msgid "Remove the <alternatives> from {xml}."
+msgstr "Retire el <alternatives> de {xml}."
+
+#: packtools/sps/validation/tablewrap.py:310
+#, python-brace-format
+msgid "Remove <tr> as a direct child of <table> in {xml}. Use <thead> or <tbody> to wrap <tr> elements."
+msgstr "Elimine <tr> como hijo directo de <table> en {xml}. Utilice <thead> o <tbody> para envolver elementos <tr>."
+
+#: packtools/sps/validation/tablewrap.py:342
+#, python-brace-format
+msgid "Move <th> elements to be inside <thead> in {xml}. Consult SPS documentation for more detail."
+msgstr "Mueva los elementos <th> para que estén dentro de <thead> en {xml}. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/tablewrap.py:374
+#, python-brace-format
+msgid "Move <td> elements to be inside <tbody> in {xml}. Consult SPS documentation for more detail."
+msgstr "Mueva los elementos <td> para que estén dentro de <tbody> en {xml}. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/tablewrap.py:406
+#, python-brace-format
+msgid "Add <tbody> inside <table> in {xml}. Consult SPS documentation for more detail."
+msgstr "Agregue <tbody> dentro de <table> en {xml}. Consulte la documentación de SPS para obtener más detalles."
+
+#: packtools/sps/validation/utils.py:97 packtools/sps/validation/utils.py:195
+#, python-brace-format
+msgid "Got {obtained}, expected one of {expected}"
+msgstr "Se obtuvo {obtained}, se esperaba uno de los siguientes valores: {expected}"
+
+#: packtools/sps/validation/visual_resource_base.py:69
+#, python-brace-format
+msgid "In @xlink:href, provide a valid file name with its extension in {valid_extensions}."
+msgstr "En @xlink:href, proporcione un nombre de archivo válido con su extensión en {valid_extensions}."
+
+#: packtools/sps/validation/xml_structure.py:92
+#, python-brace-format
+msgid "Unknown {identifier}: {value}"
+msgstr "Desconocido {identifier}: {value}"
+
+#: packtools/sps/validation/xml_structure.py:111
+#, python-brace-format
+msgid "Unmatched {identifier}: {value}. Expected one of {expected}"
+msgstr "{identifier} inigualable: {value}. Se esperaba uno de {expected}"
+
+#: packtools/sps/validation/xml_structure.py:134
+#: packtools/sps/validation/xml_structure.py:154
+#, python-brace-format
+msgid "Unmatched {identifier}: {value}. Expected {expected}"
+msgstr "{identifier} inigualable: {value}. Esperado {expected}"

--- a/packtools/sps/locale/pt_BR/LC_MESSAGES/packtools_sps.po
+++ b/packtools/sps/locale/pt_BR/LC_MESSAGES/packtools_sps.po
@@ -1,0 +1,1906 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-07-29 11:03-0300\n"
+"PO-Revision-Date: 2026-07-29 11:32-0300\n"
+"Last-Translator: Rafael JPD / Pitanga Innovare <rafael@pitangainnovare.com.br>\n"
+"Language-Team: pt_BR <LL@li.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: packtools/sps/validation/accessibility_data.py:106
+#, python-brace-format
+msgid "<alt-text> is incorrectly located inside <{parent_tag}>. According to SPS 1.9/1.10, <alt-text> must be inside one of these elements: {expected_elements}. Move the <alt-text> element inside the appropriate <graphic> or <media> element."
+msgstr "<alt-text> está localizado incorretamente dentro de <{parent_tag}>. De acordo com SPS 1.9/1.10, <alt-text> deve estar dentro de um destes elementos: {expected_elements}. Mova o elemento <alt-text> dentro do elemento <graphic> ou <media> apropriado."
+
+#: packtools/sps/validation/accessibility_data.py:157
+msgid "Missing <alt-text>. Provide a concise textual description of the visual element content."
+msgstr "Falta o elemento <alt-text>. Forneça uma descrição textual concisa do conteúdo do elemento visual."
+
+#: packtools/sps/validation/accessibility_data.py:164
+#, python-brace-format
+msgid "alt-text has {length} characters in {xml}. Provide text with up to {max_length} characters."
+msgstr "alt-text tem {length} caracteres em {xml}. Forneça um texto com até {max_length} caracteres."
+
+#: packtools/sps/validation/accessibility_data.py:189
+#, python-brace-format
+msgid "Got {obtained}, expected up to {max_length} characters"
+msgstr "Obtido {obtained}, esperado no máximo {max_length} caracteres"
+
+#: packtools/sps/validation/accessibility_data.py:205
+#: packtools/sps/validation/accessibility_data.py:462
+#, python-brace-format
+msgid "The value {value} is invalid in {xml}. Replace it with one of the accepted values: {accepted_values}."
+msgstr "O valor {value} é inválido em {xml}. Substitua-o por um dos valores aceitos: {accepted_values}."
+
+#: packtools/sps/validation/accessibility_data.py:277
+#, python-brace-format
+msgid "In <{tag}>, <alt-text> should only be used for video (mp4) or audio (mp3) files. Current mime-type is {mimetype} with mime-subtype {mime_subtype}. For other file types (PDF, ZIP, XLSX), remove <alt-text> or consider using <long-desc> instead. Refer to SPS 1.10 documentation for details."
+msgstr "Em <{tag}>, <alt-text> deve ser usado apenas para arquivos de vídeo (mp4) ou áudio (mp3). O tipo mime atual é {mimetype} com o subtipo mime {mime_subtype}. Para outros tipos de arquivo (PDF, ZIP, XLSX), remova <alt-text> ou considere usar <long-desc>. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:352
+#, python-brace-format
+msgid "<alt-text> content duplicates {duplicated_element}. According to SPS 1.9/1.10, <alt-text> should not copy content from <label> or <caption>. Provide a unique, descriptive text for the visual element instead."
+msgstr "O conteúdo <alt-text> duplica {duplicated_element}. De acordo com SPS 1.9/1.10, <alt-text> não deve copiar conteúdo de <label> ou <caption>. Em vez disso, forneça um texto descritivo exclusivo para o elemento visual."
+
+#: packtools/sps/validation/accessibility_data.py:410
+msgid "<alt-text>null</alt-text> indicates a decorative figure. Ensure this is an editorial decision and the image is truly decorative (not essential for understanding the content). Refer to SPS 1.10 documentation for decorative images guidance."
+msgstr "<alt-text>null</alt-text> indica uma figura decorativa. Certifique-se de que esta é uma decisão editorial e que a imagem é verdadeiramente decorativa (não essencial para a compreensão do conteúdo). Consulte a documentação do SPS 1.10 para orientação sobre imagens decorativas."
+
+#: packtools/sps/validation/accessibility_data.py:522
+#, python-brace-format
+msgid "<long-desc> has only {length} characters. According to SPS 1.9/1.10, <long-desc> must have MORE than 120 characters. Use <alt-text> for descriptions up to 120 characters, or expand this <long-desc> to provide more detail."
+msgstr "<long-desc> tem apenas {length} caracteres. De acordo com SPS 1.9/1.10, <long-desc> deve ter MAIS de 120 caracteres. Use <alt-text> para descrições com até 120 caracteres ou amplie <long-desc> para fornecer mais detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:593
+#, python-brace-format
+msgid "In <{tag}>, <long-desc> should only be used for video (mp4) or audio (mp3) files. Current mime-type is {mimetype} with mime-subtype {mime_subtype}. For other file types, <long-desc> is not appropriate. Refer to SPS 1.10 documentation for details."
+msgstr "Em <{tag}>, <long-desc> deve ser usado apenas para arquivos de vídeo (mp4) ou áudio (mp3). O tipo mime atual é {mimetype} com o subtipo mime {mime_subtype}. Para outros tipos de arquivo, <long-desc> não é apropriado. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:668
+#, python-brace-format
+msgid "<long-desc> content duplicates {duplicated_element}. According to SPS 1.9/1.10, <long-desc> should not copy content from <label> or <caption>. Provide a detailed, unique description that adds value beyond the label or caption."
+msgstr "O conteúdo <long-desc> duplica {duplicated_element}. De acordo com SPS 1.9/1.10, <long-desc> não deve copiar conteúdo de <label> ou <caption>. Forneça uma descrição detalhada e exclusiva que agregue valor além do rótulo ou legenda."
+
+#: packtools/sps/validation/accessibility_data.py:723
+#, python-brace-format
+msgid "Found {count} <long-desc> elements. Only one <long-desc> is allowed per graphic/media element. Remove duplicate <long-desc> elements. Refer to SPS 1.10 documentation for details."
+msgstr "Foram encontrados {count} elementos <long-desc>. Apenas um <long-desc> é permitido por elemento graphic/media. Remova os elementos <long-desc> duplicados. Consulte a documentação SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:751
+#, python-brace-format
+msgid "Found {count} <long-desc> elements; expected at most one"
+msgstr "Encontrados {count} elementos <long-desc>; esperado no máximo um"
+
+#: packtools/sps/validation/accessibility_data.py:790
+msgid "Found <alt-text>null</alt-text> combined with <long-desc>. When using <long-desc>, do not use <alt-text>null</alt-text>. Either remove <alt-text> or provide meaningful content instead of 'null'. Refer to SPS 1.10 documentation for combined markup guidance."
+msgstr "Encontrado <alt-text>null</alt-text> combinado com <long-desc>. Ao usar <long-desc>, não use <alt-text>null</alt-text>. Remova <alt-text> ou forneça conteúdo significativo em vez de 'null'. Consulte a documentação do SPS 1.10 para orientação de marcação combinada."
+
+#: packtools/sps/validation/accessibility_data.py:816
+msgid "<alt-text> must not be 'null' when <long-desc> is present"
+msgstr "<alt-text> não deve ser 'null' quando <long-desc> estiver presente"
+
+#: packtools/sps/validation/accessibility_data.py:857
+#, python-brace-format
+msgid "<{tag}> with {mimetype} is missing <xref ref-type=\"sec\"> linking to transcript section. According to SPS 1.9/1.10, audio and video elements should include a reference to their transcript section. Add: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> inside <{tag}>. Refer to SPS 1.10 documentation for details."
+msgstr "<{tag}> com {mimetype} está faltando <xref ref-type=\"sec\"> vinculando à seção de transcrição. De acordo com SPS 1.9/1.10, os elementos de áudio e vídeo devem incluir uma referência à sua secção de transcrição. Adicione: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> dentro de <{tag}>. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:918
+#, python-brace-format
+msgid "The transcript is missing in the {tag} element. Add a <sec sec-type=\"transcript\"> section to provide accessible text alternatives. Refer to SPS 1.10 docs for details."
+msgstr "A transcrição está faltando no elemento {tag}. Adicione uma seção <sec sec-type=\"transcript\"> para fornecer alternativas de texto acessíveis. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:982
+msgid "Dialog elements are missing in the <sec sec-type='transcript'> section. Use <speaker> and <speech> to represent the dialogue. Refer to SPS 1.10 docs for details."
+msgstr "Os elementos da caixa de diálogo estão faltando na seção <sec sec-type='transcript'>. Use <speaker> e <speech> para representar o diálogo. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/accessibility_data.py:1030
+#, python-brace-format
+msgid "Accessibility data is located in an invalid element: <{tag}>. Use one of the valid elements: {valid_elements}. Refer to SPS 1.10 docs for details."
+msgstr "Os dados de acessibilidade estão localizados em um elemento inválido: <{tag}>. Use um dos elementos válidos: {valid_elements}. Consulte a documentação do SPS 1.10 para obter detalhes."
+
+#: packtools/sps/validation/aff.py:112
+#, python-brace-format
+msgid "Ensure translation has same number of affiliations ({expected_count}) as main text"
+msgstr "Certifique-se de que a tradução tenha o mesmo número de afiliações ({expected_count}) que o texto principal"
+
+#: packtools/sps/validation/aff.py:296
+msgid "Mark the complete original affiliation text with <institution content-type=\"original\"> in <aff>"
+msgstr "Marque o texto de afiliação original completo com <institution content-type=\"original\"> em <aff>"
+
+#: packtools/sps/validation/aff.py:320
+#, python-brace-format
+msgid "Mark the main institution with <institution content-type=\"orgname\"> in <aff> for {original}"
+msgstr "Marque a instituição principal com <institution content-type=\"orgname\"> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:340
+#, python-brace-format
+msgid "Mark the first hierarchical subdivision with <institution content-type=\"orgdiv1\"> in <aff> for {original}"
+msgstr "Marque a primeira subdivisão hierárquica com <institution content-type=\"orgdiv1\"> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:360
+#, python-brace-format
+msgid "Mark the second hierarchical subdivision with <institution content-type=\"orgdiv2\"> in <aff> for {original}"
+msgstr "Marque a segunda subdivisão hierárquica com <institution content-type=\"orgdiv2\"> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:380
+#, python-brace-format
+msgid "Mark affiliation label with <label> in <aff> for {original}"
+msgstr "Marque o rótulo de afiliação com <label> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:400
+#, python-brace-format
+msgid "Mark affiliation country with <country> in <aff> for {original}"
+msgstr "Marque o país de afiliação com <country> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:430
+#, python-brace-format
+msgid "Complete <country country=\"\"> in <aff> with a valid value from the ISO 3166 list: {codes} for {original}"
+msgstr "Preencha <country country=\"\"> em <aff> com um valor válido da lista ISO 3166: {codes} para {original}"
+
+#: packtools/sps/validation/aff.py:453
+#, python-brace-format
+msgid "Mark affiliation state with <addr-line><state> in <aff> for {original}"
+msgstr "Marque o estado de afiliação com <addr-line><state> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:473
+#, python-brace-format
+msgid "Mark affiliation city with <addr-line><city> in <aff> for {original}"
+msgstr "Marque a cidade de afiliação com <addr-line><city> em <aff> para {original}"
+
+#: packtools/sps/validation/aff.py:493
+msgid "Complete <aff id=\"\"> with affiliation identifier"
+msgstr "Preencha <aff id=\"\"> com identificador de afiliação"
+
+#: packtools/sps/validation/aff.py:547
+#, python-brace-format
+msgid "Add email {email} to <institution content-type=\"original\"> in <aff>. The email present in <email> must also be present in the original affiliation text"
+msgstr "Adicione o e-mail {email} a <institution content-type=\"original\"> em <aff>. O email presente em <email> também deve estar presente no texto original da afiliação"
+
+#: packtools/sps/validation/aff.py:636
+#, python-brace-format
+msgid "Compare {main_id} and {trans_id}. Make sure they are corresponding. Low similarity found in: {differences}"
+msgstr "Compare {main_id} e {trans_id}. Certifique-se de que eles sejam correspondentes. Baixa similaridade encontrada em: {differences}"
+
+#: packtools/sps/validation/aff.py:671 packtools/sps/validation/aff.py:708
+#, python-brace-format
+msgid "Got {obtained}, expected {component} to be marked"
+msgstr "Obtido {obtained}, esperado que {component} esteja marcado"
+
+#: packtools/sps/validation/aff.py:689
+#, python-brace-format
+msgid "{info}: {value} ({key}) not found in {original}"
+msgstr "{info}: {value} ({key}) não encontrado em {original}"
+
+#: packtools/sps/validation/aff.py:698
+#, python-brace-format
+msgid "{info}: {key} was not marked. Check whether {key} appears in {original}"
+msgstr "{info}: {key} não foi marcado. Verifique se {key} aparece em {original}"
+
+#: packtools/sps/validation/aff.py:716
+#, python-brace-format
+msgid "No value was found for {component}; expected {component} to be marked"
+msgstr "Nenhum valor foi encontrado para {component}; esperado que {component} esteja marcado"
+
+#: packtools/sps/validation/alternatives.py:64
+#, python-brace-format
+msgid "Add {expected} as sub-elements of {parent}/alternatives"
+msgstr "Adicione {expected} como subelementos de {parent}/alternativas"
+
+#: packtools/sps/validation/alternatives.py:118
+#, python-brace-format
+msgid "Use SVG format for graphic in {parent}/alternatives. Got: {obtained}"
+msgstr "Use o formato SVG para gráficos em {parent}/alternatives. Obteve: {obtained}"
+
+#: packtools/sps/validation/alternatives.py:158
+#, python-brace-format
+msgid "Remove <alt-text> from graphic in {parent}/alternatives. Alternative images do not require alt-text because the coded version ({coded_version}) is already accessible."
+msgstr "Remova <alt-text> do gráfico em {parent}/alternatives. Imagens alternativas não requerem texto alternativo porque a versão codificada ({coded_version}) já está acessível."
+
+#: packtools/sps/validation/alternatives.py:202
+#, python-brace-format
+msgid "Remove <long-desc> from graphic in {parent}/alternatives. Alternative images do not require long-desc because the coded version ({coded_version}) is already accessible."
+msgstr "Remova <long-desc> do gráfico em {parent}/alternatives. Imagens alternativas não requerem descrição longa porque a versão codificada ({coded_version}) já está acessível."
+
+#: packtools/sps/validation/alternatives.py:281
+#, python-brace-format
+msgid "Add both coded version ({coded}) and image ({image}) to {parent}/alternatives"
+msgstr "Adicione a versão codificada ({coded}) e a imagem ({image}) a {parent}/alternatives"
+
+#: packtools/sps/validation/app_group.py:52
+msgid "Consider adding an <app> element to include additional content such as appendices."
+msgstr "Considere adicionar um elemento <app> para incluir conteúdo adicional, como apêndices."
+
+#: packtools/sps/validation/app_group.py:54
+msgid "No <app> element was found"
+msgstr "Nenhum elemento <app> foi encontrado"
+
+#: packtools/sps/validation/app_group.py:100
+msgid "Add @id attribute to <app>. Example: <app id=\"app1\">"
+msgstr "Adicione o atributo @id a <app>. Exemplo: <app id=\"app1\">"
+
+#: packtools/sps/validation/app_group.py:132
+#, python-brace-format
+msgid "Add <label> element to <app id=\"{app_id_or_placeholder}\">. Example: <app id=\"{app_id_or_example_fix}\"><label>Appendix 1</label></app>"
+msgstr "Adicione o elemento <label> a <app id=\"{app_id_or_placeholder}\">. Exemplo: <app id=\"{app_id_or_example_fix}\"><label>Apêndice 1</label></app>"
+
+#: packtools/sps/validation/app_group.py:187
+#, python-brace-format
+msgid "Wrap <app id=\"{app_id}\"> with <app-group>. Example: <back><app-group><app id=\"{app_id}\">...</app></app-group></back>"
+msgstr "Enrole <app id=\"{app_id}\"> com <app-group>. Exemplo: <back><app-group><app id=\"{app_id}\">...</app></app-group></back>"
+
+#: packtools/sps/validation/app_group.py:224
+#, python-brace-format
+msgid "Merge all {count} <app-group> elements into a single <app-group>."
+msgstr "Mescle todos os {count} elementos <app-group> em um único <app-group>."
+
+#: packtools/sps/validation/app_group.py:229
+#, python-brace-format
+msgid "Found {count} <app-group> elements in <back>; expected at most one"
+msgstr "Encontrados {count} elementos <app-group> em <back>; esperado no máximo um"
+
+#: packtools/sps/validation/article_abstract.py:181
+#, python-brace-format
+msgid "Replace {value} in {element} by a valid value: {valid_values}"
+msgstr "Substitua {value} em {element} por um valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_abstract.py:189
+#, python-brace-format
+msgid "Add abstract type in {element}. Valid values: {valid_values}"
+msgstr "Adicione o tipo abstrato em {element}. Valores válidos: {valid_values}"
+
+#: packtools/sps/validation/article_abstract.py:238
+#, python-brace-format
+msgid "Mark {element} in {container}"
+msgstr "Marque {element} em {container}"
+
+#: packtools/sps/validation/article_abstract.py:272
+#, python-brace-format
+msgid "Add {element} as sibling of {container}"
+msgstr "Adicione {element} como irmão de {container}"
+
+#: packtools/sps/validation/article_abstract.py:310
+#, python-brace-format
+msgid "Remove {element} which is associated with {container} by language"
+msgstr "Remova {element} que está associado a {container} por idioma"
+
+#: packtools/sps/validation/article_abstract.py:350
+#, python-brace-format
+msgid "Mark abstract title with {element} in {container}"
+msgstr "Marque o título do resumo com {element} em {container}"
+
+#: packtools/sps/validation/article_abstract.py:380
+#, python-brace-format
+msgid "Replace {wrong_element} inside {container} by {correct_element}"
+msgstr "Substitua {wrong_element} dentro de {container} por {correct_element}"
+
+#: packtools/sps/validation/article_abstract.py:414
+#, python-brace-format
+msgid "Provide more than one {element} in {container}"
+msgstr "Forneça mais de um {element} em {container}"
+
+#: packtools/sps/validation/article_abstract.py:527
+#, python-brace-format
+msgid "Mark abstract which is required for {article_type}"
+msgstr "Marque o resumo que é necessário para {article_type}"
+
+#: packtools/sps/validation/article_abstract.py:534
+#, python-brace-format
+msgid "Abstract is not expected for {article_type}"
+msgstr "Resumo não é esperado para {article_type}"
+
+#: packtools/sps/validation/article_and_subarticles.py:97
+#, python-brace-format
+msgid "Replace {lang} in {xml} with one of {lang_list}"
+msgstr "Substitua {lang} em {xml} por um de {lang_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:104
+#, python-brace-format
+msgid "Add xml:lang=\"VALUE\" in {xml}: {xml2} and replace VALUE with one of {lang_list}"
+msgstr "Adicione xml:lang=\"VALUE\" em {xml}: {xml2} e substitua VALUE por um de {lang_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:179
+#, python-brace-format
+msgid "Complete {name} article-type {xml} with valid value {type_list}"
+msgstr "Preencha o article-type de {name} em {xml} com um valor válido de {type_list}"
+
+#: packtools/sps/validation/article_and_subarticles.py:262
+#, python-brace-format
+msgid "Check {xml_article_type} and {xml_subject}. Other values for article-type seems to be more suitable: {choices}. "
+msgstr "Verifique {xml_article_type} e {xml_subject}. Outros valores para tipo de artigo parecem ser mais adequados: {choices}."
+
+#: packtools/sps/validation/article_and_subarticles.py:338
+#, python-brace-format
+msgid "Fix the table of contents article order {order} in <article-id pub-id-type=\"other\">{order}</article-id>. It must be {expected}"
+msgstr "Corrija a ordem do artigo do índice {order} em <article-id pub-id-type=\"other\">{order}</article-id>. Deve ser {expected}"
+
+#: packtools/sps/validation/article_and_subarticles.py:391
+#, python-brace-format
+msgid "Complete SPS version <article specific-use=\"\"/> with valid value: {versions}"
+msgstr "Versão completa do SPS <article specific-use=\"\"/> com valor válido: {versions}"
+
+#: packtools/sps/validation/article_and_subarticles.py:397
+#, python-brace-format
+msgid "Complete SPS (specific-use=\"\") and JATS (dtd-version=\"\") versions in {xml} with compatible values: {versions}"
+msgstr "Preencha as versões SPS (specific-use=\"\") e JATS (dtd-version=\"\") em {xml} com valores compatíveis: {versions}"
+
+#: packtools/sps/validation/article_contribs.py:76
+#, python-brace-format
+msgid "{info}: Add @contrib-type attribute to <contrib>. Valid values: {values}"
+msgstr "{info}: Adicione o atributo @contrib-type a <contrib>. Valores válidos: {values}"
+
+#: packtools/sps/validation/article_contribs.py:107
+#, python-brace-format
+msgid "{info}: @contrib-type=\"{obtained}\" is invalid. Use: {expected}"
+msgstr "{info}: @contrib-type=\"{obtained}\" é inválido. Use: {expected}"
+
+#: packtools/sps/validation/article_contribs.py:137
+#, python-brace-format
+msgid "{info}: @contrib-type must be \"author\" for this document type (except reviewer reports)"
+msgstr "{info}: @contrib-type deve ser \"author\" para este tipo de documento (exceto relatórios de revisores)"
+
+#: packtools/sps/validation/article_contribs.py:169
+#, python-brace-format
+msgid "{info}: Mark the contrib role. Consult SPS documentation for detailed instructions"
+msgstr "{info}: Marque a função de contribuição. Consulte a documentação do SPS para obter instruções detalhadas"
+
+#: packtools/sps/validation/article_contribs.py:230
+#, python-brace-format
+msgid "{info}: Do not use URLs. Extract only the alphanumeric identifier from {orcid}"
+msgstr "{info}: Não use URLs. Extraia apenas o identificador alfanumérico de {orcid}"
+
+#: packtools/sps/validation/article_contribs.py:261
+#, python-brace-format
+msgid "Fix ORCID format <contrib-id contrib-id-type=\"orcid\">{orcid}</contrib-id>"
+msgstr "Corrija formato ORCID <contrib-id contrib-id-type=\"orcid\">{orcid}</contrib-id>"
+
+#: packtools/sps/validation/article_contribs.py:269
+#, python-brace-format
+msgid "{info}: Add ORCID <contrib-id contrib-id-type=\"orcid\"></contrib-id> in <contrib>"
+msgstr "{info}: Adicione ORCID <contrib-id contrib-id-type=\"orcid\"></contrib-id> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:290
+#, python-brace-format
+msgid "ORCID {orcid} is valid"
+msgstr "O ORCID {orcid} é válido"
+
+#: packtools/sps/validation/article_contribs.py:294
+#, python-brace-format
+msgid "ORCID {orcid} is invalid; expected format XXXX-XXXX-XXXX-XXXX"
+msgstr "O ORCID {orcid} é inválido; esperado o formato XXXX-XXXX-XXXX-XXXX"
+
+#: packtools/sps/validation/article_contribs.py:298
+msgid "A valid ORCID is required"
+msgstr "É obrigatório informar um ORCID válido"
+
+#: packtools/sps/validation/article_contribs.py:337
+#, python-brace-format
+msgid "{info}: Unable to automatically check the {orcid}. Check it manually"
+msgstr "{info}: Não é possível verificar automaticamente o {orcid}. Verifique manualmente"
+
+#: packtools/sps/validation/article_contribs.py:376
+#, python-brace-format
+msgid "{info}: Add <xref ref-type=\"aff\" rid=\"\"> in <contrib>"
+msgstr "{info}: Adicione <xref ref-type=\"aff\" rid=\"\"> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:405
+#, python-brace-format
+msgid "{info}: Mark contributor name with <name> in <contrib>"
+msgstr "{info}: Marque o nome do colaborador com <name> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:434
+#, python-brace-format
+msgid "{info}: Mark institutional contributor with <collab> in <contrib>"
+msgstr "{info}: Marque o contribuidor institucional com <collab> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:470
+#, python-brace-format
+msgid "{info}: Mark contributor with <name> and anonymous contributor with <anonymous/> in <contrib>"
+msgstr "{info}: Marque o contribuidor com <name> e o contribuidor anônimo com <anonymous/> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:480
+#, python-brace-format
+msgid "{info}: Mark contributor with <name> and institutional contributor with <collab> in <contrib>"
+msgstr "{info}: Marque o contribuidor com <name> e o contribuidor institucional com <collab> em <contrib>"
+
+#: packtools/sps/validation/article_contribs.py:543
+#, python-brace-format
+msgid "ORCID must be unique. {questions}"
+msgstr "ORCID deve ser único. {questions}"
+
+#: packtools/sps/validation/article_contribs.py:635
+#, python-brace-format
+msgid "Add person authors, members of {collab}, with <contrib><name>...</name></contrib> in <contrib-group content-type=\"collab-list\"></contrib-group>"
+msgstr "Adicione autores pessoais, membros de {collab}, com <contrib><name>...</name></contrib> em <contrib-group content-type=\"collab-list\"></contrib-group>"
+
+#: packtools/sps/validation/article_contribs.py:644
+#, python-brace-format
+msgid "Remove content-type=\"{type}\" from <contrib-group content-type=\"{type}\">"
+msgstr "Remover content-type=\"{type}\" de <contrib-group content-type=\"{type}\">"
+
+#: packtools/sps/validation/article_contribs.py:711
+msgid "All members of collaboration group must have name <name> in <contrib-group content-type='collab-list'>"
+msgstr "Todos os membros do grupo de colaboração devem ter o nome <name> em <contrib-group content-type='collab-list'>"
+
+#: packtools/sps/validation/article_contribs.py:747
+msgid "All members of collaboration group must have complete affiliation <xref ref-type='aff'> (described in PDF)"
+msgstr "Todos os membros do grupo de colaboração devem ter afiliação completa <xref ref-type='aff'> (descrita em PDF)"
+
+#: packtools/sps/validation/article_contribs.py:775
+msgid "All members of collaboration group MUST have ORCID (described in PDF). Without ORCID identification, authors cannot assign DOI as their work in curriculum databases"
+msgstr "Todos os membros do grupo de colaboração DEVEM ter ORCID (descrito em PDF). Sem identificação ORCID, os autores não podem atribuir DOI como seu trabalho em bases de dados curriculares"
+
+#: packtools/sps/validation/article_contribs.py:870
+msgid "Do not mix CRediT taxonomy with other taxonomies in the same contributor. All roles for a contributor must use the same taxonomy."
+msgstr "Não misture a taxonomia CRediT com outras taxonomias no mesmo contribuidor. Todas as funções de um colaborador devem usar a mesma taxonomia."
+
+#: packtools/sps/validation/article_contribs.py:901
+msgid "CRediT taxonomy must be used consistently: either ALL contributors use CRediT or NONE use it. Do not mix taxonomies in the document. SciELO Rule: 'tudo ou nada' (all or nothing)."
+msgstr "A taxonomia CRediT deve ser usada de forma consistente: TODOS os contribuidores usam CRediT ou NENHUM o usa. Não misture taxonomias no documento. Regra SciELO: 'tudo ou nada' (tudo ou nada)."
+
+#: packtools/sps/validation/article_contribs.py:1007
+#, python-brace-format
+msgid "Sub-article {sub_id} uses same @id as main article: {collisions}. If article uses id='collab', sub-article should use id='collab1'"
+msgstr "O subartigo {sub_id} usa o mesmo @id do artigo principal: {collisions}. Se o artigo usar id='collab', o subartigo deverá usar id='collab1'"
+
+#: packtools/sps/validation/article_contribs.py:1042
+#, python-brace-format
+msgid "Sub-article {sub_id} uses same @rid as main article: {collisions}. If article uses rid='collab', sub-article should use rid='collab1'"
+msgstr "O subartigo {sub_id} usa o mesmo @rid do artigo principal: {collisions}. Se o artigo usar rid='collab', o subartigo deverá usar rid='collab1'"
+
+#: packtools/sps/validation/article_contribs.py:1172
+#, python-brace-format
+msgid "{info}: replace <role content-type=\"{uri}\"> by <role content-type=\"{expected_uri}\">"
+msgstr "{info}: substitua <role content-type=\"{uri}\"> por <role content-type=\"{expected_uri}\">"
+
+#: packtools/sps/validation/article_contribs.py:1176
+#, python-brace-format
+msgid "{info}: replace <role>{text}</role> by <role content-type=\"{expected_uri}\">{text}</role>"
+msgstr "{info}: substitua <role>{text}</role> por <role content-type=\"{expected_uri}\">{text}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1181
+#, python-brace-format
+msgid "{info}: check if <role content-type=\"{uri}\">{text}</role> has corresponding CRediT URI"
+msgstr "{info}: verifique se <role content-type=\"{uri}\">{text}</role> tem URI CRediT correspondente"
+
+#: packtools/sps/validation/article_contribs.py:1186
+#, python-brace-format
+msgid "{info}: check if <role>{text}</role> has corresponding CRediT URI"
+msgstr "{info}: verifique se <role>{text}</role> tem URI CRediT correspondente"
+
+#: packtools/sps/validation/article_contribs.py:1212
+#, python-brace-format
+msgid "{info}: replace <role{content_type}>{text}</role> by <role{content_type}>{expected_term}</role>"
+msgstr "{info}: substitua <role{content_type}>{text}</role> por <role{content_type}>{expected_term}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1216
+#, python-brace-format
+msgid "{info}: replace <role{content_type}></role> by <role{content_type}>{expected_term}</role>"
+msgstr "{info}: substitua <role{content_type}></role> por <role{content_type}>{expected_term}</role>"
+
+#: packtools/sps/validation/article_contribs.py:1221
+#: packtools/sps/validation/article_contribs.py:1226
+#, python-brace-format
+msgid "{info}: check if <role{content_type}>{text}</role> has corresponding CRediT term"
+msgstr "{info}: verifique se <role{content_type}>{text}</role> tem o termo CRediT correspondente"
+
+#: packtools/sps/validation/article_contribs.py:1266
+#, python-brace-format
+msgid "{info}: add <role specific-use=\"\"> with {expected}"
+msgstr "{info}: adicionar <role specific-use=\"\"> com {expected}"
+
+#: packtools/sps/validation/article_contribs.py:1293
+#, python-brace-format
+msgid "{info}: replace <role specific-use=\"{specific_use}\"> with {expected}"
+msgstr "{info}: substitua <role specific-use=\"{specific_use}\"> por {expected}"
+
+#: packtools/sps/validation/article_data_availability.py:122
+#, python-brace-format
+msgid "Complete  specific-use=\"\" in {xml} with valid value: {valid_values}"
+msgstr "Preencha specific-use=\"\" em {xml} com um valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_data_availability.py:182
+#, python-brace-format
+msgid "Mark in {xml} the data availability statement in footnote with <fn fn-type=\"data-availability\" specific-use=\"\"> or in text with <sec sec-type=\"data-availability\" specific-use=\"\">. And complete specific-use=\"\" with valid value: {valid_values}"
+msgstr "Marque em {xml} a declaração de disponibilidade de dados em nota de rodapé com <fn fn-type=\"data-availability\" specific-use=\"\"> ou em texto com <sec sec-type=\"data-availability\" specific-use=\"\">. E preencha specific-use=\"\" com um valor válido: {valid_values}"
+
+#: packtools/sps/validation/article_data_availability.py:204
+#, python-brace-format
+msgid "Remove from {xml} the data availability statement (<{tag} {tag}-type=\"data-availability\">) because it is unexpected for {article_type}"
+msgstr "Remova de {xml} a declaração de disponibilidade de dados (<{tag} {tag}-type=\"data-availability\">) porque ela é inesperada para {article_type}"
+
+#: packtools/sps/validation/article_doi.py:47
+#: packtools/sps/validation/article_doi.py:105
+#, python-brace-format
+msgid "Mark DOI for {text} with <article-id pub-id-type=\"doi\"></article-id>"
+msgstr "Marque DOI para {text} com <article-id pub-id-type=\"doi\"></article-id>"
+
+#: packtools/sps/validation/article_doi.py:155
+#, python-brace-format
+msgid "Fix doi to be unique. Found repetition: {diff}"
+msgstr "Corrija doi para ser único. Repetição encontrada: {diff}"
+
+#: packtools/sps/validation/article_doi.py:214
+#, python-brace-format
+msgid "The DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) is not registered for {expected}. It is registered for {registered}"
+msgstr "O DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) não está registrado para {expected}. Ele está registrado para {registered}"
+
+#: packtools/sps/validation/article_doi.py:223
+#, python-brace-format
+msgid "Unable to check if {xml_doi} is registered for {expected}"
+msgstr "Não foi possível verificar se {xml_doi} está registrado para {expected}"
+
+#: packtools/sps/validation/article_doi.py:251
+#, python-brace-format
+msgid "Got {obtained}, expected DOI registered for {metadata}"
+msgstr "Obtido {obtained}, esperado DOI registrado para {metadata}"
+
+#: packtools/sps/validation/article_doi.py:293
+#, python-brace-format
+msgid "Change {doi} in {xml} for a DOI different from {doi_list}"
+msgstr "Alterar {doi} em {xml} para um DOI diferente de {doi_list}"
+
+#: packtools/sps/validation/article_license.py:134
+#, python-brace-format
+msgid "Provide license data that is consistent with the language: {lang} and standard adopted by the journal"
+msgstr "Fornecer dados de licença que sejam consistentes com o idioma: {lang} e padrão adotado pela revista"
+
+#: packtools/sps/validation/article_license.py:148
+#, python-brace-format
+msgid "Mark license information with <license license-type=\"open-access\" xlink:href={link} xml:lang={lang}><license-p>{license_p}</license-p></license>"
+msgstr "Marque as informações de licença com <license license-type=\"open-access\" xlink:href={link} xml:lang={lang}><license-p>{license_p}</license-p></license>"
+
+#: packtools/sps/validation/article_license.py:252
+#, python-brace-format
+msgid "add <permissions><license xlink:href=\"http://creativecommons.org/licenses/VALUE/4.0/\"> and replace VALUE with {code}"
+msgstr "adicione <permissions><license xlink:href=\"http://creativecommons.org/licenses/VALUE/4.0/\"> e substitua VALUE por {code}"
+
+#: packtools/sps/validation/article_toc_sections.py:90
+#, python-brace-format
+msgid "Remove <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable"
+msgstr "Remova <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group> porque é inesperado, apenas um grupo de assuntos é aceitável"
+
+#: packtools/sps/validation/article_toc_sections.py:93
+#, python-brace-format
+msgid "Remove <subject-group><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable"
+msgstr "Remova <subject-group><subject>{subject}</subject></subject-group> porque é inesperado, apenas um grupo de assuntos é aceitável"
+
+#: packtools/sps/validation/article_toc_sections.py:121
+#, python-brace-format
+msgid "Replace <subject-group subj-group-type=\"{subj_group_type}\"><subject>{subject}</subject></subject-group> by <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+msgstr "Substitua <subject-group subj-group-type=\"{subj_group_type}\"><subject>{subject}</subject></subject-group> por <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:128
+#, python-brace-format
+msgid "Replace <subject-group><subject>{subject}</subject></subject-group> by <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+msgstr "Substitua <subject-group><subject>{subject}</subject></subject-group> por <subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:132
+msgid "Mark table of contents section with  <subject-group subj-group-type=\"heading\"><subject>table of contents section</subject></subject-group>"
+msgstr "Marque a seção do sumário com <subject-group subj-group-type=\"heading\"><subject>seção do sumário</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:175
+#, python-brace-format
+msgid "Write section and subsection in one subject: <subject-group subj-group-type=\"heading\"><subject>{subject}: {subsection}</subject></subject-group>. Remove <subject-group><subject>{subsection}</subject></subject-group>"
+msgstr "Escreva seção e subseção em um assunto: <subject-group subj-group-type=\"heading\"><subject>{subject}: {subsection}</subject></subject-group>. Remova <subject-group><subject>{subsection}</subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:216
+#, python-brace-format
+msgid "{subject} is not registered as a table of contents section. Valid values: {valid_values}"
+msgstr "{subject} não está registrado como uma seção de sumário. Valores válidos: {valid_values}"
+
+#: packtools/sps/validation/article_toc_sections.py:224
+#, python-brace-format
+msgid "Unable to check whether {subject} (<subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>) is a valid table of contents section because no sections were provided for the journal {journal}"
+msgstr "Não foi possível verificar se {subject} (<subject-group subj-group-type=\"heading\"><subject>{subject}</subject></subject-group>) é uma seção de sumário válida porque não foram informadas seções para o periódico {journal}"
+
+#: packtools/sps/validation/article_toc_sections.py:232
+msgid "Mark table of contents section with <subject-group subj-group-type=\"heading\"><subject></subject></subject-group>"
+msgstr "Marque a seção do sumário com <subject-group subj-group-type=\"heading\"><subject></subject></subject-group>"
+
+#: packtools/sps/validation/article_toc_sections.py:247
+#, python-brace-format
+msgid "Got {subject}, but the registered table of contents sections could not be checked"
+msgstr "Obtido {subject}, mas não foi possível verificar as seções de sumário cadastradas"
+
+#: packtools/sps/validation/article_toc_sections.py:291
+#, python-brace-format
+msgid "The article title ({article_title}) must represent its contents and must be different from the section title ({section_title}) to get a better ranking in search results"
+msgstr "O título do artigo ({article_title}) deve representar seu conteúdo e deve ser diferente do título da seção ({section_title}) para obter uma melhor classificação nos resultados de pesquisa"
+
+#: packtools/sps/validation/article_xref.py:114
+msgid "Provide a valid @rid attribute for <xref>"
+msgstr "Forneça um atributo @rid válido para <xref>"
+
+#: packtools/sps/validation/article_xref.py:143
+msgid "Provide a valid @ref-type attribute for <xref>"
+msgstr "Forneça um atributo @ref-type válido para <xref>"
+
+#: packtools/sps/validation/article_xref.py:175
+#, python-brace-format
+msgid "Replace \"{ref_type}\" with one of the allowed values: {ref_type_list}"
+msgstr "Substitua \"{ref_type}\" por um dos valores permitidos: {ref_type_list}"
+
+#: packtools/sps/validation/article_xref.py:205
+msgid "Add at least one <xref ref-type=\"bibr\"> to the document (SciELO Brasil criterion)"
+msgstr "Adicione pelo menos um <xref ref-type=\"bibr\"> ao documento (critério SciELO Brasil)"
+
+#: packtools/sps/validation/article_xref.py:238
+#, python-brace-format
+msgid "@rid=\"{rid}\" in <xref> has no corresponding @id in the document"
+msgstr "@rid=\"{rid}\" em <xref> não possui @id correspondente no documento"
+
+#: packtools/sps/validation/article_xref.py:277
+#, python-brace-format
+msgid "Add <xref ref-type=\"sec\" rid=\"{sec_id}\"> to reference the transcript section"
+msgstr "Adicione <xref ref-type=\"sec\" rid=\"{sec_id}\"> para fazer referência à seção de transcrição"
+
+#: packtools/sps/validation/article_xref.py:314
+#, python-brace-format
+msgid "For @ref-type=\"aff\" without text content, use self-closing: <xref ref-type=\"aff\" rid=\"{rid}\"/>"
+msgstr "Para @ref-type=\"aff\" sem conteúdo de texto, use fechamento automático: <xref ref-type=\"aff\" rid=\"{rid}\"/>"
+
+#: packtools/sps/validation/article_xref.py:357
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but not found the corresponding {elem_xml}"
+msgstr "{tag_and_attribs} encontrado, mas não encontrado o {elem_xml} correspondente"
+
+#: packtools/sps/validation/article_xref.py:397
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. Mark {label}, mention to {tag_and_attribs}, with {xref_xml}"
+msgstr "{tag_and_attribs} encontrado, mas nenhum {xref_xml} correspondente foi encontrado. Marca {label}, menção a {tag_and_attribs}, com {xref_xml}"
+
+#: packtools/sps/validation/article_xref.py:410
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. "
+msgstr "{tag_and_attribs} encontrado, mas nenhum {xref_xml} correspondente foi encontrado."
+
+#: packtools/sps/validation/article_xref.py:493
+#, python-brace-format
+msgid "Found {tag_and_attribs}, but no corresponding {xref_xml} was found. Mark the {tag_and_attribs} cross-references using {xref_xml}"
+msgstr "{tag_and_attribs} encontrado, mas nenhum {xref_xml} correspondente foi encontrado. Marque as referências cruzadas {tag_and_attribs} usando {xref_xml}"
+
+#: packtools/sps/validation/author_notes.py:22
+#, python-brace-format
+msgid "Add mandatory @fn-type attribute to <fn> in <author-notes>. Valid values for author notes: {values}"
+msgstr "Adicione o atributo obrigatório @fn-type a <fn> em <author-notes>. Valores válidos para notas do autor: {values}"
+
+#: packtools/sps/validation/author_notes.py:80
+#, python-brace-format
+msgid "@fn-type=\"{fn_type}\" is not valid for <fn> in <author-notes>. Use one of: {values}"
+msgstr "@fn-type=\"{fn_type}\" não é válido para <fn> em <author-notes>. Use um dos: {values}"
+
+#: packtools/sps/validation/author_notes.py:112
+msgid "For corresponding author information, use <corresp> element instead of <fn fn-type=\"corresp\">"
+msgstr "Para obter informações do autor correspondente, use o elemento <corresp> em vez de <fn fn-type=\"corresp\">"
+
+#: packtools/sps/validation/author_notes.py:143
+msgid "<fn fn-type=\"current-aff\"> is deprecated. Use <fn fn-type=\"bio\"> instead."
+msgstr "<fn fn-type=\"current-aff\"> está obsoleto. Use <fn fn-type=\"bio\">."
+
+#: packtools/sps/validation/author_notes.py:163
+msgid "<fn fn-type=\"con\"> is deprecated. Use <role content-type=\"http://credit.niso.org/contributor-roles/CONTRIBUTION/\"> inside <contrib> instead. Replace CONTRIBUTION with the author's contribution type."
+msgstr "<fn fn-type=\"con\"> está obsoleto. Use <role content-type=\"http://credit.niso.org/contributor-roles/CONTRIBUTION/\"> dentro de <contrib>. Substitua CONTRIBUTION pelo tipo de contribuição do autor."
+
+#: packtools/sps/validation/author_notes.py:243
+#, python-brace-format
+msgid "<author-notes> element should appear at most once in the article. Found {count} occurrences."
+msgstr "O elemento <author-notes> deverá aparecer no máximo uma vez no artigo. Ocorrências {count} encontradas."
+
+#: packtools/sps/validation/author_notes.py:269
+#, python-brace-format
+msgid "<author-notes> element should appear at most once in sub-article (id={id}). Found {count} occurrences."
+msgstr "O elemento <author-notes> deverá aparecer no máximo uma vez no subartigo (id={id}). Ocorrências {count} encontradas."
+
+#: packtools/sps/validation/author_notes.py:357
+msgid "Mark corresp label with <corresp><label>"
+msgstr "Marque a etiqueta correspondente com <corresp><label>"
+
+#: packtools/sps/validation/author_notes.py:379
+msgid "Replace <corresp><title> with <corresp><label>"
+msgstr "Substitua <corresp><title> por <corresp><label>"
+
+#: packtools/sps/validation/author_notes.py:401
+msgid "Replace <corresp><bold> with <corresp><label>"
+msgstr "Substitua <corresp><bold> por <corresp><label>"
+
+#: packtools/sps/validation/basefn.py:44
+msgid "Mark footnote label with <fn><label>"
+msgstr "Marque a etiqueta da nota de rodapé com <fn><label>"
+
+#: packtools/sps/validation/basefn.py:66
+msgid "Replace <fn><title> with <fn><label>"
+msgstr "Substitua <fn><title> por <fn><label>"
+
+#: packtools/sps/validation/basefn.py:88
+msgid "Replace <fn><bold> with <fn><label>"
+msgstr "Substitua <fn><bold> por <fn><label>"
+
+#: packtools/sps/validation/basefn.py:115
+#, python-brace-format
+msgid "Complete fn-type=\"\" in <fn fn-type=\"\"> with a valid values: {expected}"
+msgstr "Preencha fn-type=\"\" em <fn fn-type=\"\"> com valores válidos: {expected}"
+
+#: packtools/sps/validation/basefn.py:143
+msgid "Use <fn fn-type=\"conflict\"> for JATS < 1.3 and <fn fn-type=\"coi-statement\"> for JATS ≥ 1.3."
+msgstr "Use <fn fn-type=\"conflict\"> para JATS < 1,3 e <fn fn-type=\"coi-statement\"> para JATS ≥ 1,3."
+
+#: packtools/sps/validation/dates.py:81
+#, python-brace-format
+msgid "Complete <{tag} date-type=\"{date_type}\"><{label}> with {number}-digits"
+msgstr "Complete <{tag} date-type=\"{date_type}\"><{label}> com dígitos {number}"
+
+#: packtools/sps/validation/dates.py:117
+#, python-brace-format
+msgid "Complete <{tag} date-type=\"{date_type}\"><year> with an year previous or equal to {limit_year}"
+msgstr "Complete <{tag} date-type=\"{date_type}\"><year> com um ano anterior ou igual a {limit_year}"
+
+#: packtools/sps/validation/dates.py:154
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({parts}) is invalid: {error}"
+msgstr "<date date-type=\"{date_type}\"> ({parts}) é inválido: {error}"
+
+#: packtools/sps/validation/dates.py:195
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({formatted_date}) must be previous to {max_date_label} ({max_date})"
+msgstr "<date date-type=\"{date_type}\"> ({formatted_date}) deve ser anterior a {max_date_label} ({max_date})"
+
+#: packtools/sps/validation/dates.py:217
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> ({parts}) must be a date with year, month (2-digits) and day (2-digits)"
+msgstr "<date date-type=\"{date_type}\"> ({parts}) deve ser uma data com ano, mês (2 dígitos) e dia (2 dígitos)"
+
+#: packtools/sps/validation/dates.py:367
+msgid "Add <pub-date publication-format=\"electronic\" date-type=\"pub\"> with <day>, <month> and <year>"
+msgstr "Adicione <pub-date publication-format=\"electronic\" date-type=\"pub\"> com <day>, <month> e <year>"
+
+#: packtools/sps/validation/dates.py:390
+msgid "Add <pub-date publication-format=\"electronic\" date-type=\"collection\"> with <year>"
+msgstr "Adicione <pub-date publication-format=\"electronic\" date-type=\"collection\"> com <year>"
+
+#: packtools/sps/validation/dates.py:411
+#, python-brace-format
+msgid "Set @publication-format=\"electronic\" in <pub-date date-type=\"{date_type}\">"
+msgstr "Defina @publication-format=\"electronic\" em <pub-date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/dates.py:434
+#, python-brace-format
+msgid "Add <{element}> to <pub-date date-type=\"pub\">"
+msgstr "Adicione <{element}> a <pub-date date-type=\"pub\">"
+
+#: packtools/sps/validation/dates.py:456
+msgid "Add <year> to <pub-date date-type=\"collection\">"
+msgstr "Adicione <year> a <pub-date date-type=\"collection\">"
+
+#: packtools/sps/validation/dates.py:479
+msgid "Remove <day> from <pub-date date-type=\"collection\">"
+msgstr "Remover <day> de <pub-date date-type=\"collection\">"
+
+#: packtools/sps/validation/dates.py:501
+#, python-brace-format
+msgid "Ensure there is at most one <pub-date date-type=\"{date_type}\">"
+msgstr "Certifique-se de que haja no máximo um <pub-date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/dates.py:529
+#, python-brace-format
+msgid "Fix <day> value in <pub-date date-type=\"{date_type}\">. Must be between 00 and 31"
+msgstr "Corrija o valor <day> em <pub-date date-type=\"{date_type}\">. Deve estar entre 00 e 31"
+
+#: packtools/sps/validation/dates.py:550
+#, python-brace-format
+msgid "Fix <month> value in <pub-date date-type=\"{date_type}\">. Must be between 00 and 12"
+msgstr "Corrija o valor <month> em <pub-date date-type=\"{date_type}\">. Deve ser entre 00 e 12"
+
+#: packtools/sps/validation/dates.py:632
+#, python-brace-format
+msgid "History dates found: {date_types}. Exclude unexpected dates: {unexpected_events}"
+msgstr "Datas históricas encontradas: {date_types}. Excluir datas inesperadas: {unexpected_events}"
+
+#: packtools/sps/validation/dates.py:651
+#, python-brace-format
+msgid "History dates found: {date_types}. Add missing dates: {missing_events}"
+msgstr "Datas históricas encontradas: {date_types}. Adicione datas faltantes: {missing_events}"
+
+#: packtools/sps/validation/dates.py:677
+#, python-brace-format
+msgid "History dates ({date_types}) must be in chronological order: {expected}"
+msgstr "As datas do histórico ({date_types}) devem estar em ordem cronológica: {expected}"
+
+#: packtools/sps/validation/ext_link.py:100
+#, python-brace-format
+msgid "Add @ext-link-type attribute to <ext-link> with text \"{text}\". Valid values: {allowed_values}"
+msgstr "Adicione o atributo @ext-link-type a <ext-link> com o texto \"{text}\". Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/ext_link.py:131
+msgid "The @ext-link-type attribute is present"
+msgstr "O atributo @ext-link-type está presente"
+
+#: packtools/sps/validation/ext_link.py:133
+#: packtools/sps/validation/related_articles.py:198
+msgid "The @ext-link-type attribute is required"
+msgstr "O atributo @ext-link-type é obrigatório"
+
+#: packtools/sps/validation/ext_link.py:163
+#, python-brace-format
+msgid "Add @xlink:href attribute to <ext-link> with text \"{text}\""
+msgstr "Adicione o atributo @xlink:href a <ext-link> com o texto \"{text}\""
+
+#: packtools/sps/validation/ext_link.py:189
+msgid "The @xlink:href attribute is present"
+msgstr "O atributo @xlink:href está presente"
+
+#: packtools/sps/validation/ext_link.py:191
+#: packtools/sps/validation/related_articles.py:248
+msgid "The @xlink:href attribute is required"
+msgstr "O atributo @xlink:href é obrigatório"
+
+#: packtools/sps/validation/ext_link.py:224
+#, python-brace-format
+msgid "URL in @xlink:href=\"{xlink_href}\" must start with http:// or https://"
+msgstr "O URL em @xlink:href=\"{xlink_href}\" deve começar com http:// ou https://"
+
+#: packtools/sps/validation/ext_link.py:250
+#, python-brace-format
+msgid "URL {url} must start with http:// or https://"
+msgstr "O URL {url} deve começar com http:// ou https://"
+
+#: packtools/sps/validation/ext_link.py:283
+#, python-brace-format
+msgid "Replace @ext-link-type=\"{ext_link_type}\" with one of: {allowed_values}"
+msgstr "Substitua @ext-link-type=\"{ext_link_type}\" por um de: {allowed_values}"
+
+#: packtools/sps/validation/ext_link.py:346
+#, python-brace-format
+msgid "Replace generic text \"{text}\" in <ext-link> with descriptive text, or add @xlink:title attribute"
+msgstr "Substitua o texto genérico \"{text}\" em <ext-link> por texto descritivo ou adicione o atributo @xlink:title"
+
+#: packtools/sps/validation/ext_link.py:426
+#, python-brace-format
+msgid "Add @xlink:title attribute to <ext-link> with generic text \"{text}\" to describe the link destination"
+msgstr "Adicione o atributo @xlink:title a <ext-link> com texto genérico \"{text}\" para descrever o destino do link"
+
+#: packtools/sps/validation/ext_link.py:435
+#, python-brace-format
+msgid "Add @xlink:title attribute to <ext-link> where the text is the URL \"{text}\" to describe the link destination"
+msgstr "Adicione o atributo @xlink:title a <ext-link> onde o texto é o URL \"{text}\" para descrever o destino do link"
+
+#: packtools/sps/validation/ext_link.py:463
+msgid "The @xlink:title attribute is required when the link text is generic or a URL"
+msgstr "O atributo @xlink:title é obrigatório quando o texto do link é genérico ou um URL"
+
+#: packtools/sps/validation/fig.py:32
+#, python-brace-format
+msgid "article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct"
+msgstr "article-type={article_type} requer <fig>. Encontrado 0. Identifique a fig ou verifique se o tipo de artigo está correto"
+
+#: packtools/sps/validation/fig.py:111
+msgid "Add @id attribute to <fig>. Example: <fig id=\"f01\">. The @id attribute is mandatory."
+msgstr "Adicione o atributo @id a <fig>. Exemplo: <fig id=\"f01\">. O atributo @id é obrigatório."
+
+#: packtools/sps/validation/fig.py:130
+msgid "Add <graphic> element inside <fig>. Example: <graphic xlink:href=\"image.jpg\"/>. Every <fig> must contain at least one <graphic> element."
+msgstr "Adicione o elemento <graphic> dentro de <fig>. Exemplo: <graphic xlink:href=\"image.jpg\"/>. Cada <fig> deve conter pelo menos um elemento <graphic>."
+
+#: packtools/sps/validation/fig.py:155
+msgid "Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href=\"image.jpg\"/>. The @xlink:href attribute is mandatory in <graphic>."
+msgstr "Adicione o atributo @xlink:href a <graphic>. Exemplo: <graphic xlink:href=\"image.jpg\"/>. O atributo @xlink:href é obrigatório em <graphic>."
+
+#: packtools/sps/validation/fig.py:189
+#, python-brace-format
+msgid "SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>."
+msgstr "Arquivos SVG só são permitidos dentro de <alternatives>. Use um formato diferente ({allowed_formats}) ou envolva o gráfico em <alternatives>."
+
+#: packtools/sps/validation/fig.py:199
+#, python-brace-format
+msgid "File extension \"{file_extension}\" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>."
+msgstr "A extensão de arquivo \"{file_extension}\" não é permitida. Use um dos: {allowed_formats}. Se estiver usando SVG, ele deve estar dentro de <alternatives>."
+
+#: packtools/sps/validation/fig.py:203
+#, python-brace-format
+msgid "File \"{graphic_href}\" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>."
+msgstr "O arquivo \"{graphic_href}\" deve ter uma extensão válida. Permitido: {allowed_formats}. SVG só é permitido dentro de <alternatives>."
+
+#: packtools/sps/validation/fig.py:244
+#, python-brace-format
+msgid "Invalid @fig-type value \"{fig_type}\". Use one of: {allowed_types}."
+msgstr "Valor inválido de @fig-type \"{fig_type}\". Use um dos seguintes valores: {allowed_types}."
+
+#: packtools/sps/validation/fig.py:265
+msgid "When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang=\"en\">."
+msgstr "Quando <fig> está dentro de <fig-group>, o atributo @xml:lang é obrigatório. Adicione o atributo xml:lang a <fig>. Exemplo: <fig xml:lang=\"en\">."
+
+#: packtools/sps/validation/fig.py:275
+msgid "Accessibility description is present"
+msgstr "A descrição de acessibilidade está presente"
+
+#: packtools/sps/validation/fig.py:278
+msgid "No accessibility description was found; expected <alt-text> or <long-desc>"
+msgstr "Nenhuma descrição de acessibilidade foi encontrada; esperado <alt-text> ou <long-desc>"
+
+#: packtools/sps/validation/fig.py:294
+msgid "For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href=\"image.jpg\"><alt-text>Brief description</alt-text></graphic>."
+msgstr "Para acessibilidade, adicione <alt-text> ou <long-desc> dentro de <graphic>. Exemplo: <graphic xlink:href=\"image.jpg\"><alt-text>Breve descrição</alt-text></graphic>."
+
+#: packtools/sps/validation/fig.py:319
+#, python-brace-format
+msgid "The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description."
+msgstr "O conteúdo de <alt-text> tem {current_length} caracteres e excede o máximo recomendado de {max_length}. Reduza a descrição."
+
+#: packtools/sps/validation/fn.py:25
+msgid "Add mandatory @fn-type attribute to <fn> in <fn-group>"
+msgstr "Adicione o atributo obrigatório @fn-type a <fn> em <fn-group>"
+
+#: packtools/sps/validation/fn.py:140
+#, python-brace-format
+msgid "<fn-group> element should appear at most once in the article. Found {count} occurrences."
+msgstr "O elemento <fn-group> deverá aparecer no máximo uma vez no artigo. Ocorrências {count} encontradas."
+
+#: packtools/sps/validation/fn.py:166
+#, python-brace-format
+msgid "<fn-group> element should appear at most once in sub-article (id={id}). Found {count} occurrences."
+msgstr "O elemento <fn-group> deverá aparecer no máximo uma vez no subartigo (id={id}). Ocorrências {count} encontradas."
+
+#: packtools/sps/validation/fn.py:216
+msgid "Make the responsible editor with <fn fn-type=\"edited-by\">"
+msgstr "Torne-se o editor responsável com <fn fn-type=\"edited-by\">"
+
+#: packtools/sps/validation/formula.py:51
+msgid "No <disp-formula> found in XML"
+msgstr "Nenhum <disp-formula> encontrado em XML"
+
+#: packtools/sps/validation/formula.py:132
+msgid "Add the formula ID with id=\"\" in <disp-formula>: <disp-formula id=\"\">. Consult SPS documentation for more detail."
+msgstr "Adicione o ID da fórmula com id=\"\" em <disp-formula>: <disp-formula id=\"\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:164
+#, python-brace-format
+msgid "The @id of <disp-formula> must start with prefix \"e\". Change {id} to e{id} in <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "O @id de <disp-formula> deve começar com o prefixo \"e\". Altere {id} para e{id} em <disp-formula id=\"{id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:192
+#, python-brace-format
+msgid "Mark each label with <label> inside <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "Marque cada etiqueta com <label> dentro de <disp-formula id=\"{id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:229
+#, python-brace-format
+msgid "Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "Marque cada codificação de fórmula com <mml:math> ou <tex-math> dentro de <disp-formula id=\"{id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:260
+#, python-brace-format
+msgid "Add the @id attribute in <mml:math> inside <disp-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consult SPS documentation for more detail."
+msgstr "Adicione o atributo @id em <mml:math> dentro de <disp-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:292
+#, python-brace-format
+msgid "The @id of <mml:math> must start with prefix \"m\". Change {mml_id} to m{mml_id} in <mml:math id=\"{mml_id}\"> inside <disp-formula id=\"{formula_id}\">. Consult SPS documentation for more detail."
+msgstr "O @id de <mml:math> deve começar com o prefixo \"m\". Altere {mml_id} para m{mml_id} em <mml:math id=\"{mml_id}\"> dentro de <disp-formula id=\"{formula_id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:343
+#, python-brace-format
+msgid "For accessibility, consider adding <mml:math> in <disp-formula id=\"{formula_id}\">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail."
+msgstr "Para acessibilidade, considere adicionar <mml:math> em <disp-formula id=\"{formula_id}\">. MathML melhora a acessibilidade para leitores de tela. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:383
+msgid "Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>"
+msgstr "Enrole <tex-math> e <mml:math> com <alternatives> dentro de <disp-formula>"
+
+#: packtools/sps/validation/formula.py:390
+#: packtools/sps/validation/formula.py:397
+#, python-brace-format
+msgid "Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>"
+msgstr "Remova o <alternatives> de <disp-formula> e mantenha <{found}> dentro de <disp-formula>"
+
+#: packtools/sps/validation/formula.py:469
+msgid "No <inline-formula> found in XML"
+msgstr "Nenhum <inline-formula> encontrado em XML"
+
+#: packtools/sps/validation/formula.py:551
+msgid "Add the formula ID with id=\"\" in <inline-formula>: <inline-formula id=\"\">. Consult SPS documentation for more detail."
+msgstr "Adicione o ID da fórmula com id=\"\" em <inline-formula>: <inline-formula id=\"\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:583
+#, python-brace-format
+msgid "The @id of <inline-formula> must start with prefix \"e\". Change {id} to e{id} in <inline-formula id=\"{id}\">. Consult SPS documentation for more detail."
+msgstr "O @id de <inline-formula> deve começar com o prefixo \"e\". Altere {id} para e{id} em <inline-formula id=\"{id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:621
+msgid "Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail."
+msgstr "Marque cada codificação de fórmula com <mml:math> ou <tex-math> dentro de <inline-formula>. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:652
+#, python-brace-format
+msgid "Add the @id attribute in <mml:math> inside <inline-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consult SPS documentation for more detail."
+msgstr "Adicione o atributo @id em <mml:math> dentro de <inline-formula id=\"{formula_id}\">: <mml:math id=\"\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:684
+#, python-brace-format
+msgid "The @id of <mml:math> must start with prefix \"m\". Change {mml_id} to m{mml_id} in <mml:math id=\"{mml_id}\"> inside <inline-formula id=\"{formula_id}\">. Consult SPS documentation for more detail."
+msgstr "O @id de <mml:math> deve começar com o prefixo \"m\". Altere {mml_id} para m{mml_id} em <mml:math id=\"{mml_id}\"> dentro de <inline-formula id=\"{formula_id}\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:735
+#, python-brace-format
+msgid "For accessibility, consider adding <mml:math> in <inline-formula id=\"{formula_id}\">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail."
+msgstr "Para acessibilidade, considere adicionar <mml:math> em <inline-formula id=\"{formula_id}\">. MathML melhora a acessibilidade para leitores de tela. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/formula.py:775
+msgid "Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>"
+msgstr "Enrole <tex-math> e <mml:math> com <alternatives> dentro de <inline-formula>"
+
+#: packtools/sps/validation/formula.py:782
+#: packtools/sps/validation/formula.py:789
+#, python-brace-format
+msgid "Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>"
+msgstr "Remova o <alternatives> de <inline-formula> e mantenha <{found}> dentro de <inline-formula>"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:77
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><volume> with {expected}"
+msgstr "Substitua {obtained} em <article-meta><volume> por {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:111
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><issue> with {expected}"
+msgstr "Substitua {obtained} em <article-meta><issue> por {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:145
+#, python-brace-format
+msgid "Replace {obtained} in <article-meta><supplement> with {expected}"
+msgstr "Substitua {obtained} em <article-meta><supplement> por {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:209
+#, python-brace-format
+msgid "Replace {issue} in <article-meta><issue> with one of {expected}"
+msgstr "Substitua {issue} em <article-meta><issue> por um de {expected}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:251
+#, python-brace-format
+msgid "Got {issue}, but the registered journal issue could not be checked"
+msgstr "Obtido {issue}, mas não foi possível verificar o fascículo cadastrado"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:255
+msgid "Unable to check if issue is registered"
+msgstr "Não é possível verificar se o fascículo está cadastrado"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:271
+#, python-brace-format
+msgid "Replace {issue} in <article-meta> with one of {expected_issues}"
+msgstr "Substitua {issue} em <article-meta> por um de {expected_issues}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:302
+#, python-brace-format
+msgid "Remove duplicate <issue> elements from <article-meta>. Found {count} elements, expected at most 1."
+msgstr "Remova os elementos <issue> duplicados de <article-meta>. Foram encontrados {count} elementos; esperava-se no máximo 1."
+
+#: packtools/sps/validation/front_articlemeta_issue.py:335
+#, python-brace-format
+msgid "Remove punctuation marks {found_punctuation} from <issue> value '{issue_value}'"
+msgstr "Remova os sinais de pontuação {found_punctuation} do valor <issue> '{issue_value}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:369
+#, python-brace-format
+msgid "Convert uppercase letters to lowercase in <issue> value '{issue_value}'. Expected: '{expected}'"
+msgstr "Converta letras maiúsculas em minúsculas no valor <issue> '{issue_value}'. Esperado: '{expected}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:419
+#, python-brace-format
+msgid "Use 'suppl' for supplement nomenclature in <issue> value '{issue_value}'. Invalid terms found: {invalid_patterns}"
+msgstr "Utilize 'suppl' para nomenclatura do suplemento no valor <issue> '{issue_value}'. Termos inválidos encontrados: {invalid_patterns}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:476
+#, python-brace-format
+msgid "Use 'spe' for special issue nomenclature in <issue> value '{issue_value}'. Invalid terms found: {found_invalid}"
+msgstr "Use 'spe' para nomenclatura de emissão especial no valor <issue> '{issue_value}'. Termos inválidos encontrados: {found_invalid}"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:508
+msgid "Remove <supplement> element(s) from <article-meta>. Use <issue> element to indicate supplements (e.g., '4 suppl 1')."
+msgstr "Remova o(s) elemento(s) <supplement> de <article-meta>. Use o elemento <issue> para indicar suplementos (por exemplo, '4 suppl 1')."
+
+#: packtools/sps/validation/front_articlemeta_issue.py:563
+#, python-brace-format
+msgid "Remove leading zeros from numeric parts in <issue> value '{issue_value}'. Expected: '{expected_value}'"
+msgstr "Remova os zeros à esquerda das partes numéricas no valor <issue> '{issue_value}'. Esperado: '{expected_value}'"
+
+#: packtools/sps/validation/front_articlemeta_issue.py:653
+msgid "Mark elocation id with <elocation-id> or first page with <fpage> and last page with <lpage>"
+msgstr "Marque o ID de localização com <elocation-id> ou a primeira página com <fpage> e a última página com <lpage>"
+
+#: packtools/sps/validation/funding_group.py:65
+#, python-brace-format
+msgid "Mark the sponsor institution with <funding-source> for <award-id> ({award_ids}). Consult SPS documentation for more detail"
+msgstr "Marque a instituição patrocinadora com <funding-source> para <award-id> ({award_ids}). Consulte a documentação SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:70
+#, python-brace-format
+msgid "Mark the contract number with <award-id> for <funding-source> ({funding_sources}). Consult SPS documentation for more detail"
+msgstr "Marque o número do contrato com <award-id> para <funding-source> ({funding_sources}). Consulte a documentação SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:75
+msgid "Mark the contract number with <award-id> and the funding institution with <funding-source> insider <award-group>. Consult SPS documentation for more detail"
+msgstr "Marque o número do contrato com <award-id> e a instituição financiadora com <funding-source> insider <award-group>. Consulte a documentação SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:92
+msgid "<award-group> contains both <award-id> and <funding-source>"
+msgstr "<award-group> contém <award-id> e <funding-source>"
+
+#: packtools/sps/validation/funding_group.py:97
+msgid "<award-group> must contain both <award-id> and <funding-source>"
+msgstr "<award-group> deve conter <award-id> e <funding-source>"
+
+#: packtools/sps/validation/funding_group.py:128
+#, python-brace-format
+msgid "Found {missing} in {text} ({context}), if {missing} is a contract number, add <award-id>{missing}</award-id> and the corresponding funding institution with <funding-source> inside <award-group>. Consult the SPS documentation for more detail"
+msgstr "Encontrado {missing} em {text} ({context}), se {missing} for um número de contrato, adicione <award-id>{missing}</award-id> e a instituição financiadora correspondente com <funding-source> dentro <award-group>. Consulte a documentação do SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:222
+#, python-brace-format
+msgid "Replace <funding-statement>{funding_statement}</funding-statement> by <funding-statement>{reference_text}</funding-statement>"
+msgstr "Substitua <funding-statement>{funding_statement}</funding-statement> por <funding-statement>{reference_text}</funding-statement>"
+
+#: packtools/sps/validation/funding_group.py:236
+msgid "No reference texts (fn/ack elements) were found to compare with <funding-statement>. Verify manually that the statement is correct."
+msgstr "Nenhum texto de referência (elementos fn/ack) foi encontrado para comparar com <funding-statement>. Verifique manualmente se a afirmação está correta."
+
+#: packtools/sps/validation/funding_group.py:243
+#, python-brace-format
+msgid "Add <funding-statement>{reference_text}</funding-statement> in <funding-group>. Consult SPS documentation for more detail"
+msgstr "Adicione <funding-statement>{reference_text}</funding-statement> em <funding-group>. Consulte a documentação SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:251
+msgid "Add funding statement with <funding-statement> inside <funding-group>. Consult SPS documentation for more detail"
+msgstr "Adicione o extrato de financiamento com <funding-statement> dentro de <funding-group>. Consulte a documentação SPS para mais detalhes"
+
+#: packtools/sps/validation/funding_group.py:327
+#, python-brace-format
+msgid "Found {count} <funding-group> elements in <article-meta>. Only one is allowed. Merge them into a single <funding-group>."
+msgstr "Foram encontrados {count} elementos <funding-group> em <article-meta>. Apenas um é permitido. Mescle-os em um único <funding-group>."
+
+#: packtools/sps/validation/funding_group.py:394
+#, python-brace-format
+msgid "Add <funding-statement> element inside <funding-group> (index {index}). It is mandatory according to SPS 1.10."
+msgstr "Adicione o elemento <funding-statement> dentro de <funding-group> (índice {index}). É obrigatório de acordo com SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:397
+msgid "<funding-statement> is present in <funding-group>"
+msgstr "<funding-statement> está presente em <funding-group>"
+
+#: packtools/sps/validation/funding_group.py:400
+msgid "<funding-statement> is required in <funding-group>"
+msgstr "<funding-statement> é obrigatório em <funding-group>"
+
+#: packtools/sps/validation/funding_group.py:451
+msgid "Add at least one <funding-source> element inside this <award-group>. It is mandatory when <award-group> exists."
+msgstr "Adicione pelo menos um elemento <funding-source> dentro deste <award-group>. É obrigatório quando <award-group> existe."
+
+#: packtools/sps/validation/funding_group.py:499
+#, python-brace-format
+msgid "Remove {count} <label> element(s) from <funding-group>. <label> is not allowed according to SPS 1.10."
+msgstr "Remova o(s) elemento(s) {count} <label> de <funding-group>. <label> não é permitido de acordo com SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:555
+#, python-brace-format
+msgid "Remove {count} <title> element(s) from <funding-group>. <title> is not allowed according to SPS 1.10."
+msgstr "Remova o(s) elemento(s) {count} <title> de <funding-group>. <title> não é permitido de acordo com SPS 1.10."
+
+#: packtools/sps/validation/funding_group.py:621
+#, python-brace-format
+msgid "Inconsistent quantities: {num_sources} <funding-source>(s) but {num_awards} <award-id>(s). When multiple <award-id> elements exist, they should typically match the number of <funding-source> elements, or use separate <award-group> elements."
+msgstr "Quantidades inconsistentes: {num_sources} <funding-source>(s), mas {num_awards} <award-id>(s). Quando existem vários elementos <award-id>, eles normalmente devem corresponder ao número de elementos <funding-source> ou usar elementos <award-group> separados."
+
+#: packtools/sps/validation/graphic.py:55
+#: packtools/sps/validation/visual_resource_base.py:42
+#, python-brace-format
+msgid "Add id=\"\" to {element}"
+msgstr "Adicione id=\"\" a {element}"
+
+#: packtools/sps/validation/graphic.py:58
+#, python-brace-format
+msgid "The @id attribute is present in <{element}>"
+msgstr "O atributo @id está presente em <{element}>"
+
+#: packtools/sps/validation/graphic.py:60
+#, python-brace-format
+msgid "The @id attribute is required in <{element}>"
+msgstr "O atributo @id é obrigatório em <{element}>"
+
+#: packtools/sps/validation/graphic.py:95
+#, python-brace-format
+msgid "Add xlink:href=\"filename.ext\" to <{tag}> (valid extensions: jpg, jpeg, png, tif, tiff, svg)"
+msgstr "Adicione xlink:href=\"filename.ext\" a <{tag}> (extensões válidas: jpg, jpeg, png, tif, tiff, svg)"
+
+#: packtools/sps/validation/graphic.py:143
+#, python-brace-format
+msgid "SVG files are only allowed inside <alternatives>. The file '{xlink_href}' is currently in <{parent_tag}>. Either move this <graphic> inside <alternatives> or use a different format (.jpg, .png, .tif)."
+msgstr "Arquivos SVG só são permitidos dentro de <alternatives>. O arquivo '{xlink_href}' está atualmente em <{parent_tag}>. Mova este <graphic> para dentro de <alternatives> ou use um formato diferente (.jpg, .png, .tif)."
+
+#: packtools/sps/validation/history.py:230
+#, python-brace-format
+msgid "Remove duplicate <history> elements. Found {count} occurrences, expected at most 1."
+msgstr "Remova elementos <history> duplicados. Ocorrências {count} encontradas, esperadas no máximo 1."
+
+#: packtools/sps/validation/history.py:279
+#, python-brace-format
+msgid "Add @date-type attribute to <date> element. Date parts: {date_parts}"
+msgstr "Adicione o atributo @date-type ao elemento <date>. Peças de data: {date_parts}"
+
+#: packtools/sps/validation/history.py:284
+msgid "The @date-type attribute is present"
+msgstr "O atributo @date-type está presente"
+
+#: packtools/sps/validation/history.py:286
+msgid "The @date-type attribute is required"
+msgstr "O atributo @date-type é obrigatório"
+
+#: packtools/sps/validation/history.py:344
+#, python-brace-format
+msgid "Change @date-type='{date_type}' to one of the allowed values: {allowed_values}"
+msgstr "Altere @date-type='{date_type}' para um dos valores permitidos: {allowed_values}"
+
+#: packtools/sps/validation/history.py:400
+#, python-brace-format
+msgid "The required <date date-type=\"{date_type}\"> is present"
+msgstr "O elemento obrigatório <date date-type=\"{date_type}\"> está presente"
+
+#: packtools/sps/validation/history.py:404
+#, python-brace-format
+msgid "The required <date date-type=\"{date_type}\"> is missing"
+msgstr "O elemento obrigatório <date date-type=\"{date_type}\"> está ausente"
+
+#: packtools/sps/validation/history.py:408
+#, python-brace-format
+msgid "<date date-type=\"{date_type}\"> is not required for article type {article_type}"
+msgstr "<date date-type=\"{date_type}\"> não é obrigatório para o tipo de artigo {article_type}"
+
+#: packtools/sps/validation/history.py:426
+#, python-brace-format
+msgid "Add <date date-type=\"{date_type}\"> to <history>"
+msgstr "Adicione <date date-type=\"{date_type}\"> a <history>"
+
+#: packtools/sps/validation/history.py:509
+#, python-brace-format
+msgid "Add missing elements to <date date-type=\"{date_type}\">: {missing_parts}"
+msgstr "Adicione elementos ausentes a <date date-type=\"{date_type}\">: {missing_parts}"
+
+#: packtools/sps/validation/history.py:565
+#, python-brace-format
+msgid "Add <year> element to <date date-type=\"{date_type}\">"
+msgstr "Adicione o elemento <year> a <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/history.py:569
+#, python-brace-format
+msgid "<year> is present in <date date-type=\"{date_type}\">"
+msgstr "<year> está presente em <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/history.py:574
+#, python-brace-format
+msgid "<year> is required in <date date-type=\"{date_type}\">"
+msgstr "<year> é obrigatório em <date date-type=\"{date_type}\">"
+
+#: packtools/sps/validation/journal_meta.py:95
+#, python-brace-format
+msgid "Mark {name} ISSN with <issn pub-type=\"{tp}\">{issn}</issn> inside <journal-meta>"
+msgstr "Marque {name} ISSN com <issn pub-type=\"{tp}\">{issn}</issn> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:126
+#, python-brace-format
+msgid "Mark journal acronym with <journal-id journal-id-type=\"publisher-id\">{acronym}</journal-id> inside <journal-meta>"
+msgstr "Marque o acrônimo do periódico com <journal-id journal-id-type=\"publisher-id\">{acronym}</journal-id> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:160
+msgid "Mark journal title with <journal-title> inside <journal-title-group>"
+msgstr "Marque o título do periódico com <journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:188
+msgid "Mark abbreviated journal title with <abbrev-journal-title> inside <journal-title-group>"
+msgstr "Marque o título abreviado do periódico com <abbrev-journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:270
+#, python-brace-format
+msgid "Mark publisher name with <publisher><publisher-name>{name}</publisher-name></publisher> inside <journal-meta>"
+msgstr "Marque o nome do editor com <publisher><publisher-name>{name}</publisher-name></publisher> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:305
+#, python-brace-format
+msgid "{action} the following items {in_from} the XML: {items}"
+msgstr "{action} os seguintes itens {in_from} o XML: {items}"
+
+#: packtools/sps/validation/journal_meta.py:378
+#, python-brace-format
+msgid "Mark an nlm-ta value with <journal-id journal-id-type=\"nlm-ta\">{nlm_ta}</journal-id> inside <journal-meta>"
+msgstr "Marque um valor nlm-ta com <journal-id journal-id-type=\"nlm-ta\">{nlm_ta}</journal-id> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:452
+msgid "Add <journal-meta> element inside <front>"
+msgstr "Adicione o elemento <journal-meta> dentro de <front>"
+
+#: packtools/sps/validation/journal_meta.py:491
+msgid "Ensure exactly one <journal-meta> element exists inside <front>"
+msgstr "Certifique-se de que exista exatamente um elemento <journal-meta> dentro de <front>"
+
+#: packtools/sps/validation/journal_meta.py:522
+msgid "Add <journal-id journal-id-type=\"publisher-id\">ACRONYM</journal-id> inside <journal-meta>"
+msgstr "Adicione <journal-id journal-id-type=\"publisher-id\">ACRONYM</journal-id> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:553
+msgid "Add <journal-title>Title</journal-title> inside <journal-title-group>"
+msgstr "Adicione <journal-title>Title</journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:584
+msgid "Add <abbrev-journal-title abbrev-type=\"publisher\">Abbrev. Title</abbrev-journal-title> inside <journal-title-group>"
+msgstr "Adicione <abbrev-journal-title abbrev-type=\"publisher\">Abrev. Título</abbrev-journal-title> dentro de <journal-title-group>"
+
+#: packtools/sps/validation/journal_meta.py:617
+msgid "Add at least one <issn pub-type=\"epub\">XXXX-XXXX</issn> or <issn pub-type=\"ppub\">XXXX-XXXX</issn> inside <journal-meta>"
+msgstr "Adicione pelo menos um <issn pub-type=\"epub\">XXXX-XXXX</issn> ou <issn pub-type=\"ppub\">XXXX-XXXX</issn> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:648
+msgid "Add <publisher><publisher-name>Publisher Name</publisher-name></publisher> inside <journal-meta>"
+msgstr "Adicione <publisher><publisher-name>Nome do editor</publisher-name></publisher> dentro de <journal-meta>"
+
+#: packtools/sps/validation/journal_meta.py:697
+#, python-brace-format
+msgid "Correct ISSN format to XXXX-XXXX pattern. Current value: {issn_value}"
+msgstr "Corrija o formato do ISSN para o padrão XXXX-XXXX. Valor atual: {issn_value}"
+
+#: packtools/sps/validation/journal_meta.py:743
+#, python-brace-format
+msgid "Set @journal-id-type to one of {allowed_types}. Current value: {id_type}"
+msgstr "Defina @journal-id-type como {allowed_types}. Valor atual: {id_type}"
+
+#: packtools/sps/validation/journal_meta.py:783
+#, python-brace-format
+msgid "Set @pub-type to one of {allowed_types}. Current value: {pub_type}"
+msgstr "Defina @pub-type como {allowed_types}. Valor atual: {pub_type}"
+
+#: packtools/sps/validation/journal_meta.py:831
+#, python-brace-format
+msgid "Remove duplicate ISSN elements with same pub-type. Duplicates: {duplicates}"
+msgstr "Remova elementos ISSN duplicados com o mesmo tipo de publicação. Duplicados: {duplicates}"
+
+#: packtools/sps/validation/list.py:62
+#, python-brace-format
+msgid "Add list-type attribute to <list> element. Use one of: {values}"
+msgstr "Adicione o atributo do tipo lista ao elemento <list>. Use um dos: {values}"
+
+#: packtools/sps/validation/list.py:66
+#, python-brace-format
+msgid "The @list-type attribute cannot be empty. Use one of: {values}"
+msgstr "O atributo @list-type não pode estar vazio. Use um dos: {values}"
+
+#: packtools/sps/validation/list.py:120
+#, python-brace-format
+msgid "Value \"{list_type}\" is not allowed for @list-type. Use one of: {allowed_types}"
+msgstr "O valor \"{list_type}\" não é permitido para @list-type. Use um dos: {allowed_types}"
+
+#: packtools/sps/validation/list.py:155
+#, python-brace-format
+msgid "<list> must contain at least {min_items} <list-item> elements. Found {count}"
+msgstr "<list> deve conter pelo menos {min_items} elementos <list-item>. Foram encontrados {count}."
+
+#: packtools/sps/validation/list.py:189
+msgid "For accessibility, do not use <label> in <list-item>. The @list-type attribute generates labels automatically"
+msgstr "Para acessibilidade, não use <label> em <list-item>. O atributo @list-type gera rótulos automaticamente"
+
+#: packtools/sps/validation/list.py:220
+#, python-brace-format
+msgid "Found {count} empty <list-item> element(s). Each <list-item> should contain at least one child element (typically <p>)"
+msgstr "Foram encontrados {count} elementos <list-item> vazios. Cada <list-item> deve conter pelo menos um elemento filho (normalmente <p>)."
+
+#: packtools/sps/validation/list.py:251
+msgid "Consider adding a <title> element if the list has a descriptive heading"
+msgstr "Considere adicionar um elemento <title> se a lista tiver um título descritivo"
+
+#: packtools/sps/validation/list.py:256
+msgid "<title> is present in the list"
+msgstr "<title> está presente na lista"
+
+#: packtools/sps/validation/list.py:259
+msgid "<title> is recommended when the list has a descriptive heading"
+msgstr "<title> é recomendado quando a lista tem um título descritivo"
+
+#: packtools/sps/validation/media.py:32
+#, python-brace-format
+msgid "Use expected values: {expected_values}"
+msgstr "Use valores esperados: {expected_values}"
+
+#: packtools/sps/validation/metadata_langs.py:133
+#, python-brace-format
+msgid "Mark {element} for {language} language"
+msgstr "Marque {element} para idioma {language}"
+
+#: packtools/sps/validation/peer_review.py:34
+msgid "Mark peer review name with <custom-meta><meta-name>."
+msgstr "Marque o nome da revisão por pares com <custom-meta><meta-name>."
+
+#: packtools/sps/validation/peer_review.py:57
+msgid "Mark peer review recommendation value with <custom-meta><meta-value>."
+msgstr "Marque o valor da recomendação de revisão por pares com <custom-meta><meta-value>."
+
+#: packtools/sps/validation/peer_review.py:170
+#, python-brace-format
+msgid "Add article_type in <article article-type='VALUE'> and replace VALUE with {article_types}"
+msgstr "Adicione article_type em <article article-type='VALUE'> e substitua VALUE por {article_types}"
+
+#: packtools/sps/validation/peer_review.py:206
+#, python-brace-format
+msgid "Add date-type in <history><date date-type=\"VALUE\"> and replace VALUE with : {event}"
+msgstr "Adicione o tipo de data em <history><date date-type=\"VALUE\"> e substitua VALUE por: {event}"
+
+#: packtools/sps/validation/permissions.py:101
+msgid "Add <permissions> element to <article-meta> with a Creative Commons license declaration"
+msgstr "Adicione o elemento <permissions> a <article-meta> com uma declaração de licença Creative Commons"
+
+#: packtools/sps/validation/permissions.py:127
+msgid "Remove duplicate <permissions> elements. Only one <permissions> should exist in <article-meta>"
+msgstr "Remova elementos <permissions> duplicados. Apenas um <permissions> deve existir em <article-meta>"
+
+#: packtools/sps/validation/permissions.py:154
+msgid "Add <license> element to <permissions> with Creative Commons CC-BY attributes"
+msgstr "Adicione elemento <license> a <permissions> com atributos Creative Commons CC-BY"
+
+#: packtools/sps/validation/permissions.py:180
+#, python-brace-format
+msgid "Set license-type=\"{license_type}\" in <license> element"
+msgstr "Defina license-type=\"{license_type}\" no elemento <license>"
+
+#: packtools/sps/validation/permissions.py:208
+msgid "Add xlink:href attribute with a valid Creative Commons CC-BY URL to <license>"
+msgstr "Adicione o atributo xlink:href com um URL Creative Commons CC-BY válido a <license>"
+
+#: packtools/sps/validation/permissions.py:236
+msgid "Add xml:lang attribute to <license> element indicating the language of the license text"
+msgstr "Adicione o atributo xml:lang ao elemento <license> indicando o idioma do texto da licença"
+
+#: packtools/sps/validation/permissions.py:264
+msgid "Add <license-p> element with the license text to <license>"
+msgstr "Adicione o elemento <license-p> com o texto da licença a <license>"
+
+#: packtools/sps/validation/permissions.py:299
+msgid "Use a valid Creative Commons CC-BY 4.0 URL, e.g. https://creativecommons.org/licenses/by/4.0/"
+msgstr "Use um URL válido do Creative Commons CC-BY 4.0, por exemplo. https://creativecommons.org/licenses/by/4.0/"
+
+#: packtools/sps/validation/permissions.py:302
+#, python-brace-format
+msgid "URL {url} must start with one of the valid Creative Commons CC-BY prefixes: {valid_prefixes}"
+msgstr "O URL {url} deve começar com um dos prefixos Creative Commons CC-BY válidos: {valid_prefixes}"
+
+#: packtools/sps/validation/permissions.py:356
+#, python-brace-format
+msgid "For xml:lang=\"{language}\", use a URL ending with '{expected_deed}', e.g. https://creativecommons.org/licenses/by/4.0/{expected_deed}"
+msgstr "Para xml:lang=\"{language}\", use um URL que termine com '{expected_deed}', por exemplo https://creativecommons.org/licenses/by/4.0/{expected_deed}"
+
+#: packtools/sps/validation/permissions.py:401
+#, python-brace-format
+msgid "Add <copyright-year>{year}</copyright-year> to <permissions> since the copyright statement mentions the year '{year}'"
+msgstr "Adicione <copyright-year>{year}</copyright-year> a <permissions>, pois a declaração de direitos autorais menciona o ano '{year}'"
+
+#: packtools/sps/validation/permissions.py:407
+msgid "<copyright-year> is required when <copyright-statement> mentions a year"
+msgstr "<copyright-year> é obrigatório quando <copyright-statement> menciona um ano"
+
+#: packtools/sps/validation/preprint.py:71
+msgid "Provide the publication date of the preprint"
+msgstr "Forneça a data de publicação da pré-impressão"
+
+#: packtools/sps/validation/preprint.py:84
+msgid "The article does not reference the preprint, provide it as in the example: <related-article id=\"pp1\" related-article-type=\"preprint\" ext-link-type=\"doi\" xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+msgstr "O artigo não faz referência ao preprint, forneça-o como no exemplo: <related-article id=\"pp1\" related-article-type=\"preprint\" ext-link-type=\"doi\" xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+
+#: packtools/sps/validation/preprint.py:100
+#: packtools/sps/validation/utils.py:101 packtools/sps/validation/utils.py:199
+#, python-brace-format
+msgid "Got {obtained}, expected {expected}"
+msgstr "Obtido {obtained}, esperado {expected}"
+
+#: packtools/sps/validation/product.py:66
+msgid "Add @product-type=\"book\" attribute to <product>."
+msgstr "Adicione o atributo @product-type=\"book\" a <product>."
+
+#: packtools/sps/validation/product.py:74
+msgid "@product-type is present but empty. Set the value to \"book\"."
+msgstr "@product-type está presente, mas vazio. Configure o valor como \"book\"."
+
+#: packtools/sps/validation/product.py:95
+msgid "The @product-type attribute is present with value \"book\""
+msgstr "O atributo @product-type está presente com o valor \"book\""
+
+#: packtools/sps/validation/product.py:99
+msgid "The @product-type attribute with value \"book\" is required"
+msgstr "O atributo @product-type com o valor \"book\" é obrigatório"
+
+#: packtools/sps/validation/product.py:137
+#, python-brace-format
+msgid "Replace @product-type=\"{product_type}\" with one of: {allowed_values}."
+msgstr "Substitua @product-type=\"{product_type}\" por um de: {allowed_values}."
+
+#: packtools/sps/validation/product.py:178
+msgid "Add <source> element with the book title inside <product>"
+msgstr "Adicione o elemento <source> com o título do livro dentro de <product>"
+
+#: packtools/sps/validation/product.py:220
+#, python-brace-format
+msgid "<product> is present but @article-type=\"{article_type}\". For book reviews, use @article-type=\"book-review\" in <article>"
+msgstr "<product> está presente, mas @article-type=\"{article_type}\". Para resenhas de livros, use @article-type=\"book-review\" em <article>"
+
+#: packtools/sps/validation/product.py:261
+msgid "Add <person-group person-group-type=\"author\"> with the author(s) of the reviewed book inside <product>"
+msgstr "Adicione <person-group person-group-type=\"author\"> com o(s) autor(es) do livro resenhado dentro de <product>"
+
+#: packtools/sps/validation/product.py:301
+msgid "Add <publisher-name> element with the publisher name inside <product> for bibliographic completeness"
+msgstr "Adicione o elemento <publisher-name> com o nome do editor dentro de <product> para integridade bibliográfica"
+
+#: packtools/sps/validation/product.py:341
+msgid "Add <year> element with the publication year inside <product> for bibliographic completeness"
+msgstr "Adicione o elemento <year> com o ano de publicação dentro de <product> para integridade bibliográfica"
+
+#: packtools/sps/validation/references.py:69
+#, python-brace-format
+msgid "Mark {label} with <{element_name}>"
+msgstr "Marque {label} com <{element_name}>"
+
+#: packtools/sps/validation/references.py:117
+#, python-brace-format
+msgid "Mark the reference year ({year}) with <year>; it must be earlier than or equal to {end_year}"
+msgstr "Marque o ano da referência ({year}) com <year>; ele deve ser anterior ou igual a {end_year}"
+
+#: packtools/sps/validation/references.py:127
+#, python-brace-format
+msgid "Mark the reference year with <year>; it must be earlier than or equal to {end_year}"
+msgstr "Marque o ano da referência com <year>; ele deve ser anterior ou igual a {end_year}"
+
+#: packtools/sps/validation/references.py:143
+#, python-brace-format
+msgid "Reference year {year} must be numeric and no later than {end_year}"
+msgstr "O ano da referência {year} deve ser numérico e não posterior a {end_year}"
+
+#: packtools/sps/validation/references.py:177
+msgid "Mark reference authors with <name> (person) or <collab> (institutional)"
+msgstr "Marque autores de referência com <name> (pessoa) ou <collab> (institucional)"
+
+#: packtools/sps/validation/references.py:198
+#, python-brace-format
+msgid "Complete publication-type=\"\" in <element-citation publication-type=\"\"> with valid value: {publication_type_list}"
+msgstr "Preencha publication-type=\"\" em <element-citation publication-type=\"\"> com um valor válido: {publication_type_list}"
+
+#: packtools/sps/validation/references.py:223
+#, python-brace-format
+msgid "{info}: Wrap {text_before_extlink}{ext_link_xml} with <comment> tag"
+msgstr "{info}: Enrole {text_before_extlink}{ext_link_xml} com etiqueta <comment>"
+
+#: packtools/sps/validation/references.py:235
+#: packtools/sps/validation/references.py:256
+#, python-brace-format
+msgid "{info}: Analyze and decide to remove <comment> or mark the text between <comment> and {ext_link_tag_with_attrib}"
+msgstr "{info}: Analise e decida remover <comment> ou marcar o texto entre <comment> e {ext_link_tag_with_attrib}"
+
+#: packtools/sps/validation/references.py:246
+#, python-brace-format
+msgid "{info}: Wrap the {text_before_extlink}{ext_link_xml} with <comment> tag"
+msgstr "{info}: envolva o {text_before_extlink}{ext_link_xml} com a tag <comment>"
+
+#: packtools/sps/validation/references.py:304
+#, python-brace-format
+msgid "remove {remaining_tags} from mixed-citation"
+msgstr "remova {remaining_tags} da citação mista"
+
+#: packtools/sps/validation/references.py:323
+#, python-brace-format
+msgid "{info}: mark the full reference with <mixed-citation>"
+msgstr "{info}: marque a referência completa com <mixed-citation>"
+
+#: packtools/sps/validation/references.py:347
+#, python-brace-format
+msgid "{info}: replace <chapter-title> by <part-title>"
+msgstr "{info}: substitua <chapter-title> por <part-title>"
+
+#: packtools/sps/validation/references.py:367
+#, python-brace-format
+msgid "{info}: {text} ({tag}) not found in <mixed-citation>{mixed_citation}</mixed-citation>"
+msgstr "{info}: {text} ({tag}) não encontrado em <mixed-citation>{mixed_citation}</mixed-citation>"
+
+#: packtools/sps/validation/references.py:392
+#, python-brace-format
+msgid "{info}: \"{item}\" was not marked, analyze it and mark it with a corresponding tag"
+msgstr "{info}: \"{item}\" não foi marcado, analise-o e marque-o com uma tag correspondente"
+
+#: packtools/sps/validation/references.py:414
+#, python-brace-format
+msgid "{info}: mark the structured reference with <element-citation>"
+msgstr "{info}: marque a referência estruturada com <element-citation>"
+
+#: packtools/sps/validation/references.py:433
+#, python-brace-format
+msgid "{info}: remove extra <ext-link> from <element-citation>, keep at most one"
+msgstr "{info}: remova <ext-link> extra de <element-citation>, mantenha no máximo um"
+
+#: packtools/sps/validation/references.py:452
+#, python-brace-format
+msgid "{info}: remove extra <ext-link> from <mixed-citation>, keep at most one"
+msgstr "{info}: remova <ext-link> extra de <mixed-citation>, mantenha no máximo um"
+
+#: packtools/sps/validation/references.py:472
+#, python-brace-format
+msgid "{info}: add <lpage> because <fpage> is present"
+msgstr "{info}: adicione <lpage> porque <fpage> está presente"
+
+#: packtools/sps/validation/references.py:475
+msgid "<lpage> is required when <fpage> is present"
+msgstr "<lpage> é obrigatório quando <fpage> está presente"
+
+#: packtools/sps/validation/references.py:497
+#, python-brace-format
+msgid "{info}: set @units=\"pages\" in <size>"
+msgstr "{info}: defina @units=\"pages\" em <size>"
+
+#: packtools/sps/validation/references.py:517
+#, python-brace-format
+msgid "{info}: set @content-type=\"access-date\" in <date-in-citation>"
+msgstr "{info}: definir @content-type=\"access-date\" em <date-in-citation>"
+
+#: packtools/sps/validation/references.py:536
+#, python-brace-format
+msgid "{info}: add <surname> to <name> in <person-group>"
+msgstr "{info}: adicione <surname> a <name> em <person-group>"
+
+#: packtools/sps/validation/references.py:600
+msgid "Add <ref-list> to <back> with at least one <ref>"
+msgstr "Adicione <ref-list> a <back> com pelo menos um <ref>"
+
+#: packtools/sps/validation/references.py:622
+msgid "Add at least one <ref> to <ref-list>"
+msgstr "Adicione pelo menos um <ref> a <ref-list>"
+
+#: packtools/sps/validation/related_articles.py:129
+#, python-brace-format
+msgid "Add @related-article-type attribute to <related-article>. Valid values: {allowed_values}"
+msgstr "Adicione o atributo @related-article-type a <related-article>. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:153
+msgid "The @related-article-type attribute is required"
+msgstr "O atributo @related-article-type é obrigatório"
+
+#: packtools/sps/validation/related_articles.py:174
+#, python-brace-format
+msgid "Add @ext-link-type attribute to <related-article>. Valid values: {allowed_values}"
+msgstr "Adicione o atributo @ext-link-type a <related-article>. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:223
+#, python-brace-format
+msgid "Value \"{obtained}\" is not allowed for @related-article-type. Valid values: {allowed_values}"
+msgstr "O valor \"{obtained}\" não é permitido para @related-article-type. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:269
+msgid "Add @xlink:href attribute to <related-article>. Provide a valid DOI or URI."
+msgstr "Adicione o atributo @xlink:href a <related-article>. Forneça um DOI ou URI válido."
+
+#: packtools/sps/validation/related_articles.py:312
+#, python-brace-format
+msgid "Value \"{obtained}\" is not allowed for @ext-link-type. Valid values: {allowed_values}"
+msgstr "O valor \"{obtained}\" não é permitido para @ext-link-type. Valores válidos: {allowed_values}"
+
+#: packtools/sps/validation/related_articles.py:364
+#, python-brace-format
+msgid "For @related-article-type=\"{related_type}\", use @ext-link-type=\"doi\". Value \"uri\" is only recommended for: {uri_types}"
+msgstr "Para @related-article-type=\"{related_type}\", use @ext-link-type=\"doi\". O valor \"uri\" é recomendado apenas para: {uri_types}"
+
+#: packtools/sps/validation/related_articles.py:399
+#: packtools/sps/validation/related_articles.py:429
+#, python-brace-format
+msgid "The article-type \"{article_type}\" does not match the related-article-type \"{obtained_type}\". Provide one of: {expected_values}"
+msgstr "O tipo de artigo \"{article_type}\" não corresponde ao tipo de artigo relacionado \"{obtained_type}\". Forneça um dos seguintes: {expected_values}"
+
+#: packtools/sps/validation/related_articles.py:463
+#, python-brace-format
+msgid "The @ext-link-type should be one of {allowed_values} for related article with id=\"{related_id}\""
+msgstr "O @ext-link-type deve ser {allowed_values} para artigo relacionado com id=\"{related_id}\""
+
+#: packtools/sps/validation/related_articles.py:496
+#: packtools/sps/validation/related_articles.py:556
+#, python-brace-format
+msgid "Provide a valid {link_type} for <related-article id=\"{related_id}\" />"
+msgstr "Forneça um {link_type} válido para <related-article id=\"{related_id}\" />"
+
+#: packtools/sps/validation/related_articles.py:525
+#: packtools/sps/validation/related_articles.py:586
+#, python-brace-format
+msgid "Invalid {link_type} format for link: {link}"
+msgstr "Formato {link_type} inválido para link: {link}"
+
+#: packtools/sps/validation/related_articles.py:624
+msgid "Add @id attribute to <related-article>. The @id must be a non-empty unique identifier."
+msgstr "Adicione o atributo @id a <related-article>. O @id deve ser um identificador exclusivo não vazio."
+
+#: packtools/sps/validation/related_articles.py:676
+#, python-brace-format
+msgid "Set related-article attributes in this order: {expected_order}"
+msgstr "Defina atributos de artigos relacionados nesta ordem: {expected_order}"
+
+#: packtools/sps/validation/related_articles.py:840
+#, python-brace-format
+msgid "Article type \"{article_type}\" requires related articles of types: {missing_types}"
+msgstr "O tipo de artigo \"{article_type}\" requer artigos relacionados dos tipos: {missing_types}"
+
+#: packtools/sps/validation/response.py:136
+msgid "Add @response-type=\"reply\" to <response>."
+msgstr "Adicione @response-type=\"reply\" a <response>."
+
+#: packtools/sps/validation/response.py:164
+msgid "Replace @response-type with \"reply\" in <response>."
+msgstr "Substitua @response-type por \"reply\" em <response>."
+
+#: packtools/sps/validation/response.py:194
+msgid "Add @xml:lang to <response>."
+msgstr "Adicione @xml:lang a <response>."
+
+#: packtools/sps/validation/response.py:222
+msgid "Add @id to <response>."
+msgstr "Adicione @id a <response>."
+
+#: packtools/sps/validation/response.py:264
+#, python-brace-format
+msgid "Replace duplicate @id=\"{response_id}\" with a unique value in <response>."
+msgstr "Substitua @id=\"{response_id}\" duplicado por um valor exclusivo em <response>."
+
+#: packtools/sps/validation/response.py:293
+msgid "Add <front-stub> with response metadata inside <response>."
+msgstr "Adicione <front-stub> com metadados de resposta dentro de <response>."
+
+#: packtools/sps/validation/response.py:320
+msgid "Add <body> with response content inside <response>."
+msgstr "Adicione <body> com conteúdo de resposta dentro de <response>."
+
+#: packtools/sps/validation/sec.py:44
+msgid "Add <title> element to <sec> for accessibility"
+msgstr "Adicione o elemento <title> a <sec> para acessibilidade"
+
+#: packtools/sps/validation/sec.py:81
+#, python-brace-format
+msgid "Replace @sec-type=\"{sec_type}\" with a valid value: {valid_types}"
+msgstr "Substitua @sec-type=\"{sec_type}\" por um valor válido: {valid_types}"
+
+#: packtools/sps/validation/sec.py:109
+msgid "Add @id attribute to <sec sec-type=\"transcript\">"
+msgstr "Adicione o atributo @id a <sec sec-type=\"transcript\">"
+
+#: packtools/sps/validation/sec.py:141
+#, python-brace-format
+msgid "Use pipe \"|\" as separator in @sec-type=\"{sec_type}\" (e.g., \"materials|methods\")"
+msgstr "Use o tubo \"|\" como separador em @sec-type=\"{sec_type}\" (por exemplo, \"materials|methods\")"
+
+#: packtools/sps/validation/sec.py:177
+#, python-brace-format
+msgid "Do not combine \"{non_combinable}\" with other types in @sec-type=\"{sec_type}\""
+msgstr "Não combine \"{non_combinable}\" com outros tipos em @sec-type=\"{sec_type}\""
+
+#: packtools/sps/validation/sec.py:201
+msgid "Add at least one <p> element to <sec>"
+msgstr "Adicione pelo menos um elemento <p> a <sec>"
+
+#: packtools/sps/validation/sec.py:204
+#, python-brace-format
+msgid "Found {count} paragraphs in <sec>; expected at least one <p>"
+msgstr "Encontrados {count} parágrafos em <sec>; esperado pelo menos um <p>"
+
+#: packtools/sps/validation/sec.py:292
+msgid "Data availability statement is missing; expected <sec sec-type=\"data-availability\"> in <body> or <back>, or <fn fn-type=\"data-availability\">"
+msgstr "A declaração de disponibilidade de dados está ausente; esperava-se <sec sec-type=\"data-availability\"> em <body> ou <back>, ou <fn fn-type=\"data-availability\">"
+
+#: packtools/sps/validation/sec.py:303
+#, python-brace-format
+msgid "Add <sec sec-type=\"data-availability\" specific-use=\"...\"> to <body> or <back>, or <fn fn-type=\"data-availability\"> (required for article-type=\"{article_type}\")"
+msgstr "Adicione <sec sec-type=\"data-availability\" specific-use=\"...\"> a <body> ou <back> ou <fn fn-type=\"data-availability\"> (obrigatório para article-type=\"{article_type}\")"
+
+#: packtools/sps/validation/supplementary_material.py:49
+#, python-brace-format
+msgid "In <sec sec-type=\"{sec_type}\"><supplementary-material> replace \"{sec_type}\" with \"supplementary-material\"."
+msgstr "Em <sec sec-type=\"{sec_type}\"><supplementary-material> substitua \"{sec_type}\" por \"supplementary-material\"."
+
+#: packtools/sps/validation/supplementary_material.py:71
+msgid "Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail."
+msgstr "Adicione rótulo em <supplementary-material>: <supplementary-material><label>. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/supplementary_material.py:92
+msgid "Do not use <supplementary-material> inside <app-group> or <app>."
+msgstr "Não use <supplementary-material> dentro de <app-group> ou <app>."
+
+#: packtools/sps/validation/supplementary_material.py:125
+msgid "The use of <inline-supplementary-material> is prohibited."
+msgstr "O uso de <inline-supplementary-material> é proibido."
+
+#: packtools/sps/validation/supplementary_material.py:128
+msgid "The <inline-supplementary-material> element is not allowed"
+msgstr "O elemento <inline-supplementary-material> não é permitido"
+
+#: packtools/sps/validation/supplementary_material.py:179
+msgid "The supplementary materials section must be at the end of <body> or inside <back>."
+msgstr "A seção de materiais suplementares deve estar no final de <body> ou dentro de <back>."
+
+#: packtools/sps/validation/supplementary_material.py:182
+msgid "The supplementary materials section must be the last section of <body> or be inside <back>"
+msgstr "A seção de materiais suplementares deve ser a última seção de <body> ou estar dentro de <back>"
+
+#: packtools/sps/validation/tablewrap.py:53
+#, python-brace-format
+msgid "({article_type}) No <table-wrap> found in XML"
+msgstr "({article_type}) Nenhum <table-wrap> encontrado em XML"
+
+#: packtools/sps/validation/tablewrap.py:138
+msgid "Add the table ID with id=\"\" in <table-wrap>: <table-wrap id=\"\">. Consult SPS documentation for more detail."
+msgstr "Adicione o ID da tabela com id=\"\" em <table-wrap>: <table-wrap id=\"\">. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/tablewrap.py:189
+#, python-brace-format
+msgid "Add <label> or <caption> with <title> inside {xml}. Consult SPS documentation for more detail."
+msgstr "Adicione <label> ou <caption> com <title> dentro de {xml}. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/tablewrap.py:192
+msgid "Expected <label> or <caption> with <title> inside <table-wrap>"
+msgstr "Esperado <label> ou <caption> com <title> dentro de <table-wrap>"
+
+#: packtools/sps/validation/tablewrap.py:223
+#, python-brace-format
+msgid "Wrap each table with <table> inside {xml}. Consult SPS documentation for more detail."
+msgstr "Envolva cada tabela com <table> dentro de {xml}. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/tablewrap.py:242
+#, python-brace-format
+msgid "Wrap <table> and <graphic> with <alternatives> inside {xml} "
+msgstr "Enrole <table> e <graphic> com <alternatives> dentro de {xml}"
+
+#: packtools/sps/validation/tablewrap.py:249
+#, python-brace-format
+msgid "Remove the <alternatives> from {xml}."
+msgstr "Remova o <alternatives> de {xml}."
+
+#: packtools/sps/validation/tablewrap.py:310
+#, python-brace-format
+msgid "Remove <tr> as a direct child of <table> in {xml}. Use <thead> or <tbody> to wrap <tr> elements."
+msgstr "Remova <tr> como filho direto de <table> em {xml}. Use <thead> ou <tbody> para agrupar elementos <tr>."
+
+#: packtools/sps/validation/tablewrap.py:342
+#, python-brace-format
+msgid "Move <th> elements to be inside <thead> in {xml}. Consult SPS documentation for more detail."
+msgstr "Mova os elementos <th> para dentro de <thead> em {xml}. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/tablewrap.py:374
+#, python-brace-format
+msgid "Move <td> elements to be inside <tbody> in {xml}. Consult SPS documentation for more detail."
+msgstr "Mova os elementos <td> para dentro de <tbody> em {xml}. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/tablewrap.py:406
+#, python-brace-format
+msgid "Add <tbody> inside <table> in {xml}. Consult SPS documentation for more detail."
+msgstr "Adicione <tbody> dentro de <table> em {xml}. Consulte a documentação do SPS para obter mais detalhes."
+
+#: packtools/sps/validation/utils.py:97 packtools/sps/validation/utils.py:195
+#, python-brace-format
+msgid "Got {obtained}, expected one of {expected}"
+msgstr "Obtido {obtained}, esperado um dos seguintes valores: {expected}"
+
+#: packtools/sps/validation/visual_resource_base.py:69
+#, python-brace-format
+msgid "In @xlink:href, provide a valid file name with its extension in {valid_extensions}."
+msgstr "Em @xlink:href, forneça um nome de arquivo válido com extensão em {valid_extensions}."
+
+#: packtools/sps/validation/xml_structure.py:92
+#, python-brace-format
+msgid "Unknown {identifier}: {value}"
+msgstr "{identifier} desconhecido: {value}"
+
+#: packtools/sps/validation/xml_structure.py:111
+#, python-brace-format
+msgid "Unmatched {identifier}: {value}. Expected one of {expected}"
+msgstr "{identifier} incomparável: {value}. Esperado um de {expected}"
+
+#: packtools/sps/validation/xml_structure.py:134
+#: packtools/sps/validation/xml_structure.py:154
+#, python-brace-format
+msgid "Unmatched {identifier}: {value}. Expected {expected}"
+msgstr "{identifier} incomparável: {value}. {expected} esperado"

--- a/packtools/sps/validation/accessibility_data.py
+++ b/packtools/sps/validation/accessibility_data.py
@@ -1,8 +1,7 @@
-import gettext
+from packtools.sps import i18n
 from packtools.sps.validation.models.accessibility_data import XMLAccessibilityData
 from packtools.sps.validation.utils import build_response
 
-_ = gettext.gettext
 
 
 class XMLAccessibilityDataValidation:
@@ -103,7 +102,7 @@ class AccessibilityDataValidation:
         if parent_id:
             advice += f" (Found in <{parent_tag} id=\"{parent_id}\">)"
 
-        advice_text = _(
+        advice_text = i18n._(
             "<alt-text> is incorrectly located inside <{parent_tag}>. "
             "According to SPS 1.9/1.10, <alt-text> must be inside one of these elements: "
             "{expected_elements}. "
@@ -155,14 +154,14 @@ class AccessibilityDataValidation:
             valid = False
             validation_type = "exist"
             advice = "Missing <alt-text>. Provide a concise textual description of the visual element content."
-            advice_text = _("Missing <alt-text>. Provide a concise textual description of the visual element content.")
+            advice_text = i18n._("Missing <alt-text>. Provide a concise textual description of the visual element content.")
             advice_params = {}
         elif len(alt_text) > 120:
             error_level = self.params["alt_text_content_error_level"]
             valid = False
             validation_type = "format"
             advice = f"alt-text has {len(alt_text)} characters in {xml}. Provide text with up to 120 characters."
-            advice_text = _("alt-text has {length} characters in {xml}. Provide text with up to {max_length} characters.")
+            advice_text = i18n._("alt-text has {length} characters in {xml}. Provide text with up to {max_length} characters.")
             advice_params = {"length": len(alt_text), "xml": xml, "max_length": 120}
         else:
             error_level = None
@@ -186,6 +185,13 @@ class AccessibilityDataValidation:
             data=self.data,
             advice_text=advice_text,
             advice_params=advice_params,
+            message_text=i18n._(
+                "Got {obtained}, expected up to {max_length} characters"
+            ),
+            message_params={
+                "obtained": alt_text,
+                "max_length": 120,
+            },
         )
 
         # Valida @content-type quando presente
@@ -196,7 +202,7 @@ class AccessibilityDataValidation:
             if not valid:
                 advice = (f'The value \'{alt_text_content_type}\' is invalid in {self.data.get("alt_text_xml")}. '
                          f'Replace it with one of the accepted values: {self.params["content_types"]}.')
-                advice_text = _('The value {value} is invalid in {xml}. Replace it with one of the accepted values: {accepted_values}.')
+                advice_text = i18n._('The value {value} is invalid in {xml}. Replace it with one of the accepted values: {accepted_values}.')
                 advice_params = {
                     "value": alt_text_content_type,
                     "xml": self.data.get("alt_text_xml"),
@@ -267,7 +273,7 @@ class AccessibilityDataValidation:
                 f"For other file types (PDF, ZIP, XLSX), remove <alt-text> or consider using <long-desc> instead. "
                 f"Refer to SPS 1.10 documentation for details."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "In <{tag}>, <alt-text> should only be used for video (mp4) or audio (mp3) files. "
                 "Current mime-type is {mimetype} with mime-subtype {mime_subtype}. "
                 "For other file types (PDF, ZIP, XLSX), remove <alt-text> or consider using <long-desc> instead. "
@@ -342,7 +348,7 @@ class AccessibilityDataValidation:
                 f"According to SPS 1.9/1.10, <alt-text> should not copy content from <label> or <caption>. "
                 f"Provide a unique, descriptive text for the visual element instead."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "<alt-text> content duplicates {duplicated_element}. "
                 "According to SPS 1.9/1.10, <alt-text> should not copy content from <label> or <caption>. "
                 "Provide a unique, descriptive text for the visual element instead."
@@ -400,7 +406,7 @@ class AccessibilityDataValidation:
                 "(not essential for understanding the content). "
                 "Refer to SPS 1.10 documentation for decorative images guidance."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "<alt-text>null</alt-text> indicates a decorative figure. "
                 "Ensure this is an editorial decision and the image is truly decorative "
                 "(not essential for understanding the content). "
@@ -452,7 +458,7 @@ class AccessibilityDataValidation:
                     f'The value \'{long_desc_content_type}\' is invalid in {self.data.get("long_desc_xml")}. '
                     f'Replace it with one of the accepted values: {self.params["content_types"]}.'
                 )
-                advice_text = _(
+                advice_text = i18n._(
                     'The value {value} is invalid in {xml}. '
                     'Replace it with one of the accepted values: {accepted_values}.'
                 )
@@ -512,7 +518,7 @@ class AccessibilityDataValidation:
                 f"According to SPS 1.9/1.10, <long-desc> must have MORE than 120 characters. "
                 f"Use <alt-text> for descriptions up to 120 characters, or expand this <long-desc> to provide more detail."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "<long-desc> has only {length} characters. "
                 "According to SPS 1.9/1.10, <long-desc> must have MORE than 120 characters. "
                 "Use <alt-text> for descriptions up to 120 characters, or expand this <long-desc> to provide more detail."
@@ -583,7 +589,7 @@ class AccessibilityDataValidation:
                 f"For other file types, <long-desc> is not appropriate. "
                 f"Refer to SPS 1.10 documentation for details."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "In <{tag}>, <long-desc> should only be used for video (mp4) or audio (mp3) files. "
                 "Current mime-type is {mimetype} with mime-subtype {mime_subtype}. "
                 "For other file types, <long-desc> is not appropriate. "
@@ -658,7 +664,7 @@ class AccessibilityDataValidation:
                 f"According to SPS 1.9/1.10, <long-desc> should not copy content from <label> or <caption>. "
                 f"Provide a detailed, unique description that adds value beyond the label or caption."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "<long-desc> content duplicates {duplicated_element}. "
                 "According to SPS 1.9/1.10, <long-desc> should not copy content from <label> or <caption>. "
                 "Provide a detailed, unique description that adds value beyond the label or caption."
@@ -713,7 +719,7 @@ class AccessibilityDataValidation:
                 f"Remove duplicate <long-desc> elements. "
                 f"Refer to SPS 1.10 documentation for details."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "Found {count} <long-desc> elements. "
                 "Only one <long-desc> is allowed per graphic/media element. "
                 "Remove duplicate <long-desc> elements. "
@@ -741,6 +747,10 @@ class AccessibilityDataValidation:
             data=self.data,
             advice_text=advice_text,
             advice_params=advice_params,
+            message_text=i18n._(
+                "Found {count} <long-desc> elements; expected at most one"
+            ),
+            message_params={"count": long_desc_count},
         )
 
     def validate_long_desc_incompatible_with_null_alt(self):
@@ -776,7 +786,7 @@ class AccessibilityDataValidation:
                 f"Either remove <alt-text> or provide meaningful content instead of 'null'. "
                 f"Refer to SPS 1.10 documentation for combined markup guidance."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "Found <alt-text>null</alt-text> combined with <long-desc>. "
                 "When using <long-desc>, do not use <alt-text>null</alt-text>. "
                 "Either remove <alt-text> or provide meaningful content instead of 'null'. "
@@ -802,6 +812,10 @@ class AccessibilityDataValidation:
             data=self.data,
             advice_text=advice_text,
             advice_params=advice_params,
+            message_text=i18n._(
+                "<alt-text> must not be 'null' when <long-desc> is present"
+            ),
+            message_params={},
         )
 
     def validate_media_xref_to_transcript(self):
@@ -839,7 +853,7 @@ class AccessibilityDataValidation:
                 f"Add: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> inside <{tag}>. "
                 f"Refer to SPS 1.10 documentation for details."
             )
-            advice_text = _(
+            advice_text = i18n._(
                 "<{tag}> with {mimetype} is missing <xref ref-type=\"sec\"> linking to transcript section. "
                 "According to SPS 1.9/1.10, audio and video elements should include a reference to their transcript section. "
                 "Add: <xref ref-type=\"sec\" rid=\"TRANSCRIPT_ID\"/> inside <{tag}>. "
@@ -901,7 +915,7 @@ class AccessibilityDataValidation:
         if not valid:
             advice = (f'The transcript is missing in the {tag} element. '
                      'Add a <sec sec-type="transcript"> section to provide accessible text alternatives. Refer to SPS 1.10 docs for details.')
-            advice_text = _('The transcript is missing in the {tag} element. Add a <sec sec-type="transcript"> section to provide accessible text alternatives. Refer to SPS 1.10 docs for details.')
+            advice_text = i18n._('The transcript is missing in the {tag} element. Add a <sec sec-type="transcript"> section to provide accessible text alternatives. Refer to SPS 1.10 docs for details.')
             advice_params = {"tag": tag}
         else:
             advice = None
@@ -965,7 +979,7 @@ class AccessibilityDataValidation:
             obtained = "Missing"
             advice = ("Dialog elements are missing in the <sec sec-type='transcript'> section. "
                      "Use <speaker> and <speech> to represent the dialogue. Refer to SPS 1.10 docs for details.")
-            advice_text = _("Dialog elements are missing in the <sec sec-type='transcript'> section. Use <speaker> and <speech> to represent the dialogue. Refer to SPS 1.10 docs for details.")
+            advice_text = i18n._("Dialog elements are missing in the <sec sec-type='transcript'> section. Use <speaker> and <speech> to represent the dialogue. Refer to SPS 1.10 docs for details.")
             advice_params = {}
         else:
             valid = True
@@ -1013,7 +1027,7 @@ class AccessibilityDataValidation:
         if not valid:
             advice = (f"Accessibility data is located in an invalid element: <{tag}>. "
                      f"Use one of the valid elements: {valid_tags}. Refer to SPS 1.10 docs for details.")
-            advice_text = _("Accessibility data is located in an invalid element: <{tag}>. Use one of the valid elements: {valid_elements}. Refer to SPS 1.10 docs for details.")
+            advice_text = i18n._("Accessibility data is located in an invalid element: <{tag}>. Use one of the valid elements: {valid_elements}. Refer to SPS 1.10 docs for details.")
             advice_params = {"tag": tag, "valid_elements": str(valid_tags)}
         else:
             advice = None

--- a/packtools/sps/validation/aff.py
+++ b/packtools/sps/validation/aff.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from difflib import SequenceMatcher
-from gettext import gettext as _
 
+from packtools.sps import i18n
 from packtools.sps.models.v2.aff import FulltextAffiliations
 from packtools.sps.validation.utils import build_response
 
@@ -100,16 +100,16 @@ class FulltextAffiliationsValidation:
                     sub_item="quantity",
                     validation_type="match",
                     is_valid=False,
-                    expected=_("{} affiliations").format(len(main_affs)),
-                    obtained=_("{} affiliations").format(len(trans_affs)),
-                    advice=_("Ensure translation has same number of affiliations as main text"),
+                    expected="{} affiliations".format(len(main_affs)),
+                    obtained="{} affiliations".format(len(trans_affs)),
+                    advice="Ensure translation has same number of affiliations as main text",
                     error_level=self.params["translation_qty_error_level"],
                     data={
                         "main_count": len(main_affs),
                         "translation_count": len(trans_affs),
                         "language": lang,
                     },
-                    advice_text=_('Ensure translation has same number of affiliations ({expected_count}) as main text'),
+                    advice_text=i18n._('Ensure translation has same number of affiliations ({expected_count}) as main text'),
                     advice_params={
                         "expected_count": len(main_affs),
                         "obtained_count": len(trans_affs),
@@ -288,12 +288,12 @@ class AffiliationValidation:
             sub_item='@content-type="original"',
             validation_type="exist",
             is_valid=bool(self.original),
-            expected=_("original affiliation"),
+            expected="original affiliation",
             obtained=self.original,
-            advice=_('Mark the complete original affiliation text with <institution content-type="original"> in <aff> for {}').format(self.original),
+            advice='Mark the complete original affiliation text with <institution content-type="original"> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark the complete original affiliation text with <institution content-type="original"> in <aff>'),
+            advice_text=i18n._('Mark the complete original affiliation text with <institution content-type="original"> in <aff>'),
             advice_params={}
         )
 
@@ -314,10 +314,10 @@ class AffiliationValidation:
             is_valid=bool(orgname),
             expected="orgname",
             obtained=orgname,
-            advice=_('Mark the main institution with <institution content-type="orgname"> in <aff> for {}').format(self.original),
+            advice='Mark the main institution with <institution content-type="orgname"> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark the main institution with <institution content-type="orgname"> in <aff> for {original}'),
+            advice_text=i18n._('Mark the main institution with <institution content-type="orgname"> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -332,12 +332,12 @@ class AffiliationValidation:
             sub_item='@content-type="orgdiv1"',
             validation_type="exist",
             is_valid=bool(orgdiv1),
-            expected=_("orgdiv1 affiliation"),
+            expected="orgdiv1 affiliation",
             obtained=orgdiv1,
-            advice=_('Mark the first hierarchical subdivision with <institution content-type="orgdiv1"> in <aff> for {}').format(self.original),
+            advice='Mark the first hierarchical subdivision with <institution content-type="orgdiv1"> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark the first hierarchical subdivision with <institution content-type="orgdiv1"> in <aff> for {original}'),
+            advice_text=i18n._('Mark the first hierarchical subdivision with <institution content-type="orgdiv1"> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -352,12 +352,12 @@ class AffiliationValidation:
             sub_item='@content-type="orgdiv2"',
             validation_type="exist",
             is_valid=bool(orgdiv2),
-            expected=_("orgdiv2 affiliation"),
+            expected="orgdiv2 affiliation",
             obtained=orgdiv2,
-            advice=_('Mark the second hierarchical subdivision with <institution content-type="orgdiv2"> in <aff> for {}').format(self.original),
+            advice='Mark the second hierarchical subdivision with <institution content-type="orgdiv2"> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark the second hierarchical subdivision with <institution content-type="orgdiv2"> in <aff> for {original}'),
+            advice_text=i18n._('Mark the second hierarchical subdivision with <institution content-type="orgdiv2"> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -374,10 +374,10 @@ class AffiliationValidation:
             is_valid=bool(label),
             expected="label",
             obtained=label,
-            advice=_('Mark affiliation label with <label> in <aff> for {}').format(self.original),
+            advice='Mark affiliation label with <label> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark affiliation label with <label> in <aff> for {original}'),
+            advice_text=i18n._('Mark affiliation label with <label> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -392,12 +392,12 @@ class AffiliationValidation:
             sub_item="country",
             validation_type="exist",
             is_valid=bool(country),
-            expected=_("country name"),
+            expected="country name",
             obtained=country,
-            advice=_('Mark affiliation country with <country> in <aff> for {}').format(self.original),
+            advice='Mark affiliation country with <country> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark affiliation country with <country> in <aff> for {original}'),
+            advice_text=i18n._('Mark affiliation country with <country> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -411,7 +411,7 @@ class AffiliationValidation:
         # Format country codes list for display (max 5 examples)
         codes_display = ", ".join(country_codes_list[:5])
         if len(country_codes_list) > 5:
-            codes_display += _(", ... ({} codes total)").format(len(country_codes_list))
+            codes_display += ", ... ({} codes total)".format(len(country_codes_list))
 
         yield build_response(
             title="country code",
@@ -421,13 +421,13 @@ class AffiliationValidation:
             validation_type="value in list",
             is_valid=is_valid,
             expected=(
-                country_code if is_valid else _("one of {}").format(country_codes_list)
+                country_code if is_valid else "one of {}".format(country_codes_list)
             ),
             obtained=country_code,
-            advice=_('Complete <country country=""> in <aff> with a valid value: {} for {}').format(country_codes_list, self.original),
+            advice='Complete <country country=""> in <aff> with a valid value: {} for {}'.format(country_codes_list, self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Complete <country country=""> in <aff> with a valid value from the ISO 3166 list: {codes} for {original}'),
+            advice_text=i18n._('Complete <country country=""> in <aff> with a valid value from the ISO 3166 list: {codes} for {original}'),
             advice_params={
                 "codes": codes_display,
                 "original": self.original or ""
@@ -447,10 +447,10 @@ class AffiliationValidation:
             is_valid=bool(state),
             expected="state",
             obtained=state,
-            advice=_('Mark affiliation state with <addr-line><state> in <aff> for {}').format(self.original),
+            advice='Mark affiliation state with <addr-line><state> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark affiliation state with <addr-line><state> in <aff> for {original}'),
+            advice_text=i18n._('Mark affiliation state with <addr-line><state> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -467,10 +467,10 @@ class AffiliationValidation:
             is_valid=bool(city),
             expected="city",
             obtained=city,
-            advice=_('Mark affiliation city with <addr-line><city> in <aff> for {}').format(self.original),
+            advice='Mark affiliation city with <addr-line><city> in <aff> for {}'.format(self.original),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Mark affiliation city with <addr-line><city> in <aff> for {original}'),
+            advice_text=i18n._('Mark affiliation city with <addr-line><city> in <aff> for {original}'),
             advice_params={"original": self.original or ""}
         )
 
@@ -485,12 +485,12 @@ class AffiliationValidation:
             sub_item="@id",
             validation_type="exist",
             is_valid=bool(aff_id),
-            expected=_("affiliation ID"),
+            expected="affiliation ID",
             obtained=aff_id,
-            advice=_('Complete <aff id=""> with affiliation identifier. Consult the documentation of SPS of the current version'),
+            advice='Complete <aff id=""> with affiliation identifier. Consult the documentation of SPS of the current version',
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Complete <aff id=""> with affiliation identifier'),
+            advice_text=i18n._('Complete <aff id=""> with affiliation identifier'),
             advice_params={}
         )
 
@@ -539,12 +539,12 @@ class AffiliationValidation:
             sub_item='@content-type="original"',
             validation_type="exist",
             is_valid=is_valid,
-            expected=_("email {} in original").format(email),
-            obtained=_("email {} {} in original").format(email, _('found') if is_valid else _('not found')),
-            advice=_('Add email {} to <institution content-type="original"> in <aff>. The email present in <email> must also be present in the original affiliation text').format(email),
+            expected="email {} in original".format(email),
+            obtained="email {} {} in original".format(email, 'found' if is_valid else 'not found'),
+            advice='Add email {} to <institution content-type="original"> in <aff>. The email present in <email> must also be present in the original affiliation text'.format(email),
             data=self.affiliation,
             error_level=error_level,
-            advice_text=_('Add email {email} to <institution content-type="original"> in <aff>. The email present in <email> must also be present in the original affiliation text'),
+            advice_text=i18n._('Add email {email} to <institution content-type="original"> in <aff>. The email present in <email> must also be present in the original affiliation text'),
             advice_params={"email": email}
         )
 
@@ -620,7 +620,7 @@ class AffiliationValidation:
             aff_info = self.affiliation.get("id") or self.affiliation
             main_info = main_aff.get("id") or main_aff
 
-            advice = _('Compare {} and {}. Make sure they are corresponding').format(main_info, aff_info)
+            advice = 'Compare {} and {}. Make sure they are corresponding'.format(main_info, aff_info)
             yield build_response(
                 title="low similarity",
                 parent=self.affiliation,
@@ -628,12 +628,12 @@ class AffiliationValidation:
                 sub_item="translation",
                 validation_type="similarity",
                 is_valid=False,
-                expected=_('{} and {} are similar').format(main_info, aff_info),
-                obtained=_('{} and {} are not similar').format(main_info, aff_info),
+                expected='{} and {} are similar'.format(main_info, aff_info),
+                obtained='{} and {} are not similar'.format(main_info, aff_info),
                 advice=advice,
                 error_level=self.params["translation_similarity_error_level"],
                 data=items,
-                advice_text=_('Compare {main_id} and {trans_id}. Make sure they are corresponding. Low similarity found in: {differences}'),
+                advice_text=i18n._('Compare {main_id} and {trans_id}. Make sure they are corresponding. Low similarity found in: {differences}'),
                 advice_params={
                     "main_id": str(main_info),
                     "trans_id": str(aff_info),
@@ -662,9 +662,18 @@ class AffiliationValidation:
                     sub_item='@content-type="original"',
                     validation_type="exist",
                     is_valid=is_valid,
-                    expected=_('{} marked').format(k),
+                    expected='{} marked'.format(k),
                     obtained=v,
                     advice=advice,
+                    advice_text=None,
+                    advice_params={},
+                    message_text=i18n._(
+                        "Got {obtained}, expected {component} to be marked"
+                    ),
+                    message_params={
+                        "obtained": v,
+                        "component": k,
+                    },
                     data={k: v},
                     error_level=self.params["aff_components_error_level"]
                 )
@@ -676,8 +685,8 @@ class AffiliationValidation:
         if words:
             for k, v in not_found.items():
                 if v:
-                    advice = _('{}: {} ({}) not found in {}').format(self.info, v, k, self.original)
-                    advice_i18n = _('{info}: {value} ({key}) not found in {original}')
+                    advice = '{}: {} ({}) not found in {}'.format(self.info, v, k, self.original)
+                    advice_i18n = i18n._('{info}: {value} ({key}) not found in {original}')
                     params = {
                         "info": self.info,
                         "value": v,
@@ -685,8 +694,8 @@ class AffiliationValidation:
                         "original": self.original
                     }
                 else:
-                    advice = _('{}: {} was not marked. Check {} is found in {}').format(self.info, k, k, self.original)
-                    advice_i18n = _('{info}: {key} was not marked. Check {key} is found in {original}')
+                    advice = '{}: {} was not marked. Check {} is found in {}'.format(self.info, k, k, self.original)
+                    advice_i18n = i18n._('{info}: {key} was not marked. Check whether {key} appears in {original}')
                     params = {
                         "info": self.info,
                         "key": k,
@@ -694,6 +703,21 @@ class AffiliationValidation:
                     }
 
                 is_valid = False
+                if v:
+                    message_text = i18n._(
+                        "Got {obtained}, expected {component} to be marked"
+                    )
+                    message_params = {
+                        "obtained": v,
+                        "component": k,
+                    }
+                else:
+                    message_text = i18n._(
+                        "No value was found for {component}; "
+                        "expected {component} to be marked"
+                    )
+                    message_params = {"component": k}
+
                 yield build_response(
                     title="original",
                     parent=self.affiliation,
@@ -701,13 +725,15 @@ class AffiliationValidation:
                     sub_item='@content-type="original"',
                     validation_type="exist",
                     is_valid=is_valid,
-                    expected=_('{} marked').format(k),
+                    expected='{} marked'.format(k),
                     obtained=v,
                     advice=advice,
                     data={k: v, "original": self.original},
                     error_level=self.params["aff_components_error_level"],
                     advice_text=advice_i18n,
-                    advice_params=params
+                    advice_params=params,
+                    message_text=message_text,
+                    message_params=message_params,
                 )
 
     def validate(self):

--- a/packtools/sps/validation/alternatives.py
+++ b/packtools/sps/validation/alternatives.py
@@ -1,6 +1,6 @@
 from itertools import chain
-from gettext import gettext as _
 
+from packtools.sps import i18n
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.exceptions import ValidationAlternativesException
 from packtools.sps.validation.models import fig, formula, tablewrap
@@ -56,12 +56,12 @@ class AlternativeValidation:
             is_valid=is_valid,
             expected=self.expected_elements,
             obtained=self.obtained_elements,
-            advice=_('Add {} as sub-elements of {}/alternatives').format(
+            advice='Add {} as sub-elements of {}/alternatives'.format(
                 self.expected_elements, self.parent_element
             ),
             data=self.alternative_data,
             error_level=error_level,
-            advice_text=_('Add {expected} as sub-elements of {parent}/alternatives'),
+            advice_text=i18n._('Add {expected} as sub-elements of {parent}/alternatives'),
             advice_params={
                 "expected": str(self.expected_elements),
                 "parent": self.parent_element
@@ -110,14 +110,12 @@ class AlternativeValidation:
                 sub_item="alternatives/graphic",
                 validation_type="format",
                 is_valid=is_valid,
-                expected=_(".svg format"),
+                expected=".svg format",
                 obtained=obtained,
-                advice=None if is_valid else _(
-                    'Use SVG format for graphic in {}/alternatives. Got: {}'
-                ).format(self.parent_element, obtained),
+                advice=None if is_valid else 'Use SVG format for graphic in {}/alternatives. Got: {}'.format(self.parent_element, obtained),
                 data=self.alternative_data,
                 error_level=error_level,
-                advice_text=None if is_valid else _('Use SVG format for graphic in {parent}/alternatives. Got: {obtained}'),
+                advice_text=None if is_valid else i18n._('Use SVG format for graphic in {parent}/alternatives. Got: {obtained}'),
                 advice_params={
                     "parent": self.parent_element,
                     "obtained": obtained
@@ -149,16 +147,14 @@ class AlternativeValidation:
             sub_item="alternatives/graphic",
             validation_type="exist",
             is_valid=is_valid,
-            expected=_("no <alt-text> in alternatives/graphic"),
-            obtained=_("no <alt-text> found") if is_valid else _("<alt-text> found: {}").format(alt_text),
-            advice=None if is_valid else _(
-                'Remove <alt-text> from graphic in {}/alternatives. '
+            expected="no <alt-text> in alternatives/graphic",
+            obtained="no <alt-text> found" if is_valid else "<alt-text> found: {}".format(alt_text),
+            advice=None if is_valid else 'Remove <alt-text> from graphic in {}/alternatives. '
                 'Alternative images do not require alt-text because the coded version '
-                '(table/formula) is already accessible.'
-            ).format(self.parent_element),
+                '(table/formula) is already accessible.'.format(self.parent_element),
             data=self.alternative_data,
             error_level=error_level,
-            advice_text=None if is_valid else _(
+            advice_text=None if is_valid else i18n._(
                 'Remove <alt-text> from graphic in {parent}/alternatives. '
                 'Alternative images do not require alt-text because the coded version '
                 '({coded_version}) is already accessible.'
@@ -195,16 +191,14 @@ class AlternativeValidation:
             sub_item="alternatives/graphic",
             validation_type="exist",
             is_valid=is_valid,
-            expected=_("no <long-desc> in alternatives/graphic"),
-            obtained=_("no <long-desc> found") if is_valid else _("<long-desc> found"),
-            advice=None if is_valid else _(
-                'Remove <long-desc> from graphic in {}/alternatives. '
+            expected="no <long-desc> in alternatives/graphic",
+            obtained="no <long-desc> found" if is_valid else "<long-desc> found",
+            advice=None if is_valid else 'Remove <long-desc> from graphic in {}/alternatives. '
                 'Alternative images do not require long-desc because the coded version '
-                '(table/formula) is already accessible.'
-            ).format(self.parent_element),
+                '(table/formula) is already accessible.'.format(self.parent_element),
             data=self.alternative_data,
             error_level=error_level,
-            advice_text=None if is_valid else _(
+            advice_text=None if is_valid else i18n._(
                 'Remove <long-desc> from graphic in {parent}/alternatives. '
                 'Alternative images do not require long-desc because the coded version '
                 '({coded_version}) is already accessible.'
@@ -279,14 +273,12 @@ class AlternativeValidation:
                 sub_item="alternatives",
                 validation_type="exist",
                 is_valid=is_valid,
-                expected=_("both {} and {}").format(coded_version, image_version),
-                obtained=_("found: {}, missing: {}").format(elements, missing),
-                advice=_(
-                    'Add both coded version ({}) and image ({}) to {}/alternatives'
-                ).format(coded_version, image_version, self.parent_element),
+                expected="both {} and {}".format(coded_version, image_version),
+                obtained="found: {}, missing: {}".format(elements, missing),
+                advice='Add both coded version ({}) and image ({}) to {}/alternatives'.format(coded_version, image_version, self.parent_element),
                 data=self.alternative_data,
                 error_level=error_level,
-                advice_text=_('Add both coded version ({coded}) and image ({image}) to {parent}/alternatives'),
+                advice_text=i18n._('Add both coded version ({coded}) and image ({image}) to {parent}/alternatives'),
                 advice_params={
                     "coded": coded_version,
                     "image": image_version,

--- a/packtools/sps/validation/app_group.py
+++ b/packtools/sps/validation/app_group.py
@@ -1,5 +1,6 @@
 from packtools.sps.validation.models.app_group import XmlAppGroup
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class AppValidation:
@@ -48,8 +49,10 @@ class AppValidation:
                 advice="Consider adding an <app> element to include additional content such as appendices.",
                 data=None,
                 error_level=self.params["app_existence_error_level"],
-                advice_text="Consider adding an <app> element to include additional content such as appendices.",
-                advice_params={}
+                advice_text=i18n._("Consider adding an <app> element to include additional content such as appendices."),
+                advice_params={},
+                message_text=i18n._("No <app> element was found"),
+                message_params={},
             )
         else:
             for app in self.apps:
@@ -94,7 +97,7 @@ class AppValidation:
                 advice='Add @id attribute to <app>. Example: <app id="app1">',
                 data=app,
                 error_level=self.params["app_id_error_level"],
-                advice_text='Add @id attribute to <app>. Example: <app id="app1">',
+                advice_text=i18n._('Add @id attribute to <app>. Example: <app id="app1">'),
                 advice_params=None
             )
 
@@ -126,8 +129,8 @@ class AppValidation:
                        f'Example: <app id="{app_id_or_example_fix}"><label>Appendix 1</label></app>',
                 data=app,
                 error_level=self.params["app_label_error_level"],
-                advice_text='Add <label> element to <app id="{app_id_or_placeholder}">. '
-                           'Example: <app id="{app_id_or_example_fix}"><label>Appendix 1</label></app>',
+                advice_text=i18n._('Add <label> element to <app id="{app_id_or_placeholder}">. '
+                           'Example: <app id="{app_id_or_example_fix}"><label>Appendix 1</label></app>'),
                 advice_params={
                     "app_id_or_placeholder": app_id_or_placeholder,
                     "app_id_or_example_fix": app_id_or_example_fix
@@ -181,8 +184,8 @@ class AppValidation:
                            f'Example: <back><app-group><app id="{app_id}">...</app></app-group></back>',
                     data={"app_id": app_id},
                     error_level=self.params["app_group_wrapper_error_level"],
-                    advice_text='Wrap <app id="{app_id}"> with <app-group>. '
-                               'Example: <back><app-group><app id="{app_id}">...</app></app-group></back>',
+                    advice_text=i18n._('Wrap <app id="{app_id}"> with <app-group>. '
+                               'Example: <back><app-group><app id="{app_id}">...</app></app-group></back>'),
                     advice_params={
                         "app_id": app_id
                     }
@@ -218,8 +221,13 @@ class AppValidation:
                 advice=f'Merge all {len(app_groups)} <app-group> elements into a single <app-group>.',
                 data={"count": len(app_groups)},
                 error_level=self.params["app_group_occurrence_error_level"],
-                advice_text='Merge all {count} <app-group> elements into a single <app-group>.',
+                advice_text=i18n._('Merge all {count} <app-group> elements into a single <app-group>.'),
                 advice_params={
                     "count": len(app_groups)
-                }
+                },
+                message_text=i18n._(
+                    "Found {count} <app-group> elements in <back>; "
+                    "expected at most one"
+                ),
+                message_params={"count": len(app_groups)},
             )

--- a/packtools/sps/validation/article_abstract.py
+++ b/packtools/sps/validation/article_abstract.py
@@ -1,9 +1,8 @@
 from packtools.sps.validation.models.abstract import XMLAbstracts
 from packtools.sps.validation.utils import build_response
-import gettext
+from packtools.sps import i18n
 
 # Configuração de internacionalização
-_ = gettext.gettext
 
 
 class AbstractValidation:
@@ -179,7 +178,7 @@ class AbstractValidation:
 
         if abstract_type:
             advice = f'Replace {abstract_type} in {xml} by a valid value: {expected_abstract_type_list}'
-            advice_text = _('Replace {value} in {element} by a valid value: {valid_values}')
+            advice_text = i18n._('Replace {value} in {element} by a valid value: {valid_values}')
             advice_params = {
                 "value": abstract_type,
                 "element": xml,
@@ -187,7 +186,7 @@ class AbstractValidation:
             }
         else:
             advice = f'Add abstract type in {xml}. Valid values: {expected_abstract_type_list}'
-            advice_text = _('Add abstract type in {element}. Valid values: {valid_values}')
+            advice_text = i18n._('Add abstract type in {element}. Valid values: {valid_values}')
             advice_params = {
                 "element": xml,
                 "valid_values": str(expected_abstract_type_list)
@@ -236,7 +235,7 @@ class AbstractValidation:
             expected="graphic",
             obtained=graphic,
             advice='Mark graphic in <abstract abstract-type="graphical">',
-            advice_text=_('Mark {element} in {container}'),
+            advice_text=i18n._('Mark {element} in {container}'),
             advice_params={
                 "element": "graphic",
                 "container": '<abstract abstract-type="graphical">'
@@ -270,7 +269,7 @@ class AbstractValidation:
             expected=f"<kwd-group xml:lang='{lang}'>",
             obtained=kwds,
             advice=f'Add <kwd-group xml:lang="{lang}"> as sibling of {xml}',
-            advice_text=_('Add {element} as sibling of {container}'),
+            advice_text=i18n._('Add {element} as sibling of {container}'),
             advice_params={
                 "element": f'<kwd-group xml:lang="{lang}">',
                 "container": xml
@@ -308,7 +307,7 @@ class AbstractValidation:
                 expected=None,
                 obtained=kwds,
                 advice=f'Remove <kwd-group xml:lang="{lang}"> which is associated with {xml} by language',
-                advice_text=_('Remove {element} which is associated with {container} by language'),
+                advice_text=i18n._('Remove {element} which is associated with {container} by language'),
                 advice_params={
                     "element": f'<kwd-group xml:lang="{lang}">',
                     "container": xml
@@ -348,7 +347,7 @@ class AbstractValidation:
             expected="title",
             obtained=title,
             advice="Mark abstract title with <title> in <abstract>",
-            advice_text=_("Mark abstract title with {element} in {container}"),
+            advice_text=i18n._("Mark abstract title with {element} in {container}"),
             advice_params={
                 "element": "<title>",
                 "container": "<abstract>"
@@ -378,7 +377,7 @@ class AbstractValidation:
             expected=None,
             obtained=list_items,
             advice='Replace <list> inside <abstract abstract-type="key-points"> by <p>',
-            advice_text=_('Replace {wrong_element} inside {container} by {correct_element}'),
+            advice_text=i18n._('Replace {wrong_element} inside {container} by {correct_element}'),
             advice_params={
                 "wrong_element": "<list>",
                 "container": '<abstract abstract-type="key-points">',
@@ -412,7 +411,7 @@ class AbstractValidation:
             expected="more than one p",
             obtained=p_list,
             advice='Provide more than one <p> in <abstract abstract-type="key-points">',
-            advice_text=_('Provide more than one {element} in {container}'),
+            advice_text=i18n._('Provide more than one {element} in {container}'),
             advice_params={
                 "element": "<p>",
                 "container": '<abstract abstract-type="key-points">'
@@ -525,14 +524,14 @@ class StandardAbstractsValidation(AbstractsValidationBase):
             is_valid = bool(data)
             error_level = self.params["article_type_requires_abstract_error_level"]
             advice = f"Mark abstract which is required for {self.article_type}"
-            advice_text = "Mark abstract which is required for {article_type}"
+            advice_text = i18n._("Mark abstract which is required for {article_type}")
             advice_params = {"article_type": self.article_type}
         elif self.article_type in self.params["article_type_unexpects"]:
             expected = f"Abstract is unexpected"
             is_valid = not bool(data)
             error_level = self.params["article_type_unexpects_abstract_error_level"]
             advice = f"Abstract is not expected for {self.article_type}"
-            advice_text = "Abstract is not expected for {article_type}"
+            advice_text = i18n._("Abstract is not expected for {article_type}")
             advice_params = {"article_type": self.article_type}
         elif self.article_type in self.params["article_type_neutral"]:
             is_valid = True

--- a/packtools/sps/validation/article_and_subarticles.py
+++ b/packtools/sps/validation/article_and_subarticles.py
@@ -8,6 +8,7 @@ from packtools.sps.validation.exceptions import (
 )
 from packtools.sps.validation.similarity_utils import most_similar, similarity
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class ArticleLangValidation:
@@ -93,14 +94,14 @@ class ArticleLangValidation:
             if article_lang:
                 xml = f'<{parent}{parent_id} xml:lang="{article_lang}">'
                 advice = f'Replace {article_lang} in {xml} with one of {language_codes_list}'
-                advice_text = 'Replace {lang} in {xml} with one of {lang_list}'
+                advice_text = i18n._('Replace {lang} in {xml} with one of {lang_list}')
                 advice_params = {"lang": article_lang, "xml": xml, "lang_list": str(language_codes_list)}
             else:
                 xml = f'<{parent}{parent_id}>'
                 xml2 = f'<{parent}{parent_id} xml:lang="VALUE">'
 
                 advice = f'Add xml:lang="VALUE" in {xml}: {xml2} and replace VALUE with one of {language_codes_list}'
-                advice_text = 'Add xml:lang="VALUE" in {xml}: {xml2} and replace VALUE with one of {lang_list}'
+                advice_text = i18n._('Add xml:lang="VALUE" in {xml}: {xml2} and replace VALUE with one of {lang_list}')
                 advice_params = {"xml": xml, "xml2": xml2, "lang_list": str(language_codes_list)}
             yield build_response(
                     title=f"{name} language",
@@ -171,7 +172,14 @@ class ArticleTypeValidation:
             name = article_id or parent
             xml = f'<{parent} article-type=""/>'
             advice = None if valid else f'Complete {name} article-type {xml} with valid value {article_type_list}'
-            advice_text = None if valid else 'Complete {name} article-type {xml} with valid value {type_list}'
+            advice_text = (
+                None
+                if valid
+                else i18n._(
+                    "Complete {name} article-type {xml} with valid value"
+                    " {type_list}"
+                )
+            )
             advice_params = {} if valid else {"name": name, "xml": xml, "type_list": str(article_type_list)}
             yield build_response(
                     title=f"{name} article-type",
@@ -251,7 +259,7 @@ class ArticleTypeValidation:
                     f"Check {xml_article_type} and {xml_subject}. Other values for article-type seems to be more suitable: {choices}. "
                 )
                 advice_text = (
-                    "Check {xml_article_type} and {xml_subject}. Other values for article-type seems to be more suitable: {choices}. "
+                    i18n._("Check {xml_article_type} and {xml_subject}. Other values for article-type seems to be more suitable: {choices}. ")
                 )
                 advice_params = {
                     "xml_article_type": xml_article_type,
@@ -326,6 +334,15 @@ class ArticleIdValidation:
             expected=expected_value,
             obtained=order,
             advice=f'Fix the table of contents article order {order} in <article-id pub-id-type="other">{order}</article-id>. It must be {expected_value}',
+            advice_text=(
+                i18n._("Fix the table of contents article order {order} in "
+                '<article-id pub-id-type="other">{order}</article-id>. '
+                "It must be {expected}")
+            ),
+            advice_params={
+                "order": order,
+                "expected": expected_value,
+            },
             data=self.article_ids.data,
             error_level=self.params["id_other_error_level"],
         )
@@ -371,13 +388,13 @@ class JATSAndDTDVersionValidation:
         advice_params = {}
         if not versions:
             advice = f'Complete SPS version <article specific-use=""/> with valid value: {list(versions.keys())}',
-            advice_text = 'Complete SPS version <article specific-use=""/> with valid value: {versions}'
+            advice_text = i18n._('Complete SPS version <article specific-use=""/> with valid value: {versions}')
             advice_params = {"versions": str(list(versions.keys()))}
 
         elif jats_version not in expected_jats_versions:
             xml = f'<article specific-use="" dtd-version=""/>'
             advice = f'Complete SPS (specific-use="") and JATS (dtd-version="") versions in {xml} with compatible values: {versions}'
-            advice_text = 'Complete SPS (specific-use="") and JATS (dtd-version="") versions in {xml} with compatible values: {versions}'
+            advice_text = i18n._('Complete SPS (specific-use="") and JATS (dtd-version="") versions in {xml} with compatible values: {versions}')
             advice_params = {"xml": xml, "versions": str(versions)}
 
         expected = expected_jats_versions or versions

--- a/packtools/sps/validation/article_contribs.py
+++ b/packtools/sps/validation/article_contribs.py
@@ -2,6 +2,7 @@ import re
 
 from packtools.sps.models.article_contribs import TextContribs, XMLContribs
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 def _callable_extern_validate_default(orcid, data):
@@ -26,6 +27,10 @@ class ContribValidation:
         if parent_id := self.data.get("parent_id"):
             return f'{self.contrib_name} (sub-article {parent_id}) :'
         return f'{self.contrib_name} :'
+
+    @property
+    def i18n_info(self):
+        return self.info.removesuffix(" :")
 
     def _get_default_params(self):
         return {
@@ -68,10 +73,10 @@ class ContribValidation:
             valid_values_str = ", ".join(valid_values)
             advice = f'{self.info} Add @contrib-type attribute to <contrib>. Valid values: {valid_values_str}'
             advice_text = (
-                '{info} Add @contrib-type attribute to <contrib>. Valid values: {values}'
+                i18n._('{info}: Add @contrib-type attribute to <contrib>. Valid values: {values}')
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
                 "values": ", ".join(valid_values),
             }
 
@@ -99,10 +104,10 @@ class ContribValidation:
             valid_values_str = " or ".join(valid_values)
             advice = f'{self.info} @contrib-type="{contrib_type}" is invalid. Use: {valid_values_str}'
             advice_text = (
-                '{info} @contrib-type="{obtained}" is invalid. Use: {expected}'
+                i18n._('{info}: @contrib-type="{obtained}" is invalid. Use: {expected}')
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
                 "obtained": contrib_type,
                 "expected": " or ".join(valid_values),
             }
@@ -129,10 +134,10 @@ class ContribValidation:
             if not is_author:
                 advice = f'{self.info} @contrib-type must be "author" for this document type (except reviewer reports)'
                 advice_text = (
-                    '{info} @contrib-type must be "author" for this document type (except reviewer reports)'
+                    i18n._('{info}: @contrib-type must be "author" for this document type (except reviewer reports)')
                 )
                 advice_params = {
-                    "info": self.info,
+                    "info": self.i18n_info,
                 }
 
                 yield build_response(
@@ -161,10 +166,10 @@ class ContribValidation:
 
             advice = f"{self.info} Mark the contrib role. Consult SPS documentation for detailed instructions"
             advice_text = (
-                "{info} Mark the contrib role. Consult SPS documentation for detailed instructions"
+                i18n._("{info}: Mark the contrib role. Consult SPS documentation for detailed instructions")
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
             }
 
             yield build_response(
@@ -222,10 +227,10 @@ class ContribValidation:
         if _orcid and ("http://" in _orcid or "https://" in _orcid or "orcid.org" in _orcid):
             advice = f'{self.info} Do not use URLs. Extract only the alphanumeric identifier from {_orcid}'
             advice_text = (
-                "{info} Do not use URLs. Extract only the alphanumeric identifier from {orcid}"
+                i18n._("{info}: Do not use URLs. Extract only the alphanumeric identifier from {orcid}")
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
                 "orcid": _orcid,
             }
 
@@ -253,7 +258,7 @@ class ContribValidation:
         if _orcid:
             advice = f'Fix ORCID format <contrib-id contrib-id-type="orcid">{_orcid}</contrib-id>'
             advice_text = (
-                'Fix ORCID format <contrib-id contrib-id-type="orcid">{orcid}</contrib-id>'
+                i18n._('Fix ORCID format <contrib-id contrib-id-type="orcid">{orcid}</contrib-id>')
             )
             advice_params = {
                 "orcid": _orcid,
@@ -261,10 +266,10 @@ class ContribValidation:
         else:
             advice = f'{self.info} Add ORCID <contrib-id contrib-id-type="orcid"></contrib-id> in <contrib>'
             advice_text = (
-                '{info} Add ORCID <contrib-id contrib-id-type="orcid"></contrib-id> in <contrib>'
+                i18n._('{info}: Add ORCID <contrib-id contrib-id-type="orcid"></contrib-id> in <contrib>')
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
             }
 
         yield build_response(
@@ -281,6 +286,19 @@ class ContribValidation:
             error_level=error_level,
             advice_text=advice_text,
             advice_params=advice_params,
+            message_text=(
+                i18n._("ORCID {orcid} is valid")
+                if is_valid
+                else (
+                    i18n._(
+                        "ORCID {orcid} is invalid; expected format "
+                        "XXXX-XXXX-XXXX-XXXX"
+                    )
+                    if _orcid
+                    else i18n._("A valid ORCID is required")
+                )
+            ),
+            message_params={"orcid": _orcid} if _orcid else {},
         )
 
     def validate_orcid_is_registered(self):
@@ -316,10 +334,10 @@ class ContribValidation:
 
         advice = f'{self.info} Unable to automatically check the {orcid}. Check it manually'
         advice_text = (
-            '{info} Unable to automatically check the {orcid}. Check it manually'
+            i18n._('{info}: Unable to automatically check the {orcid}. Check it manually')
         )
         advice_params = {
-            "info": self.info,
+            "info": self.i18n_info,
             "orcid": orcid,
         }
 
@@ -355,10 +373,10 @@ class ContribValidation:
 
         advice = f'{self.info} Add <xref ref-type="aff" rid=""> in <contrib>'
         advice_text = (
-            '{info} Add <xref ref-type="aff" rid=""> in <contrib>'
+            i18n._('{info}: Add <xref ref-type="aff" rid=""> in <contrib>')
         )
         advice_params = {
-            "info": self.info,
+            "info": self.i18n_info,
         }
 
         yield build_response(
@@ -384,10 +402,10 @@ class ContribValidation:
 
         advice = f"{self.info} Mark contributor name with <name> in <contrib>"
         advice_text = (
-            "{info} Mark contributor name with <name> in <contrib>"
+            i18n._("{info}: Mark contributor name with <name> in <contrib>")
         )
         advice_params = {
-            "info": self.info,
+            "info": self.i18n_info,
         }
 
         yield build_response(
@@ -413,10 +431,10 @@ class ContribValidation:
 
         advice = f"{self.info} Mark institutional contributor with <collab> in <contrib>"
         advice_text = (
-            "{info} Mark institutional contributor with <collab> in <contrib>"
+            i18n._("{info}: Mark institutional contributor with <collab> in <contrib>")
         )
         advice_params = {
-            "info": self.info,
+            "info": self.i18n_info,
         }
 
         yield build_response(
@@ -449,20 +467,20 @@ class ContribValidation:
             value = self.contrib.get("contrib_name") or self.contrib.get("anonymous")
             advice = f"{self.info} Mark contributor with <name> and anonymous contributor with <anonymous/> in <contrib>"
             advice_text = (
-                "{info} Mark contributor with <name> and anonymous contributor with <anonymous/> in <contrib>"
+                i18n._("{info}: Mark contributor with <name> and anonymous contributor with <anonymous/> in <contrib>")
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
             }
         else:
             expected = ["name", "collab"]
             value = self.contrib.get("contrib_name") or self.contrib.get("collab")
             advice = f"{self.info} Mark contributor with <name> and institutional contributor with <collab> in <contrib>"
             advice_text = (
-                "{info} Mark contributor with <name> and institutional contributor with <collab> in <contrib>"
+                i18n._("{info}: Mark contributor with <name> and institutional contributor with <collab> in <contrib>")
             )
             advice_params = {
-                "info": self.info,
+                "info": self.i18n_info,
             }
 
         yield build_response(
@@ -522,7 +540,7 @@ class XMLContribsValidation:
         questions = "; ".join(questions)
 
         advice = f"ORCID must be unique. {questions}"
-        advice_text = ("ORCID must be unique. {questions}")
+        advice_text = (i18n._("ORCID must be unique. {questions}"))
         advice_params = {
             "questions": questions,
         }
@@ -614,7 +632,7 @@ class CollabListValidation:
             if expected_type == "collab-list":
                 advice = f'Add person authors, members of {self.text_contribs.collab}, with <contrib><name>...</name></contrib> in <contrib-group content-type="collab-list"></contrib-group>'
                 advice_text = (
-                    'Add person authors, members of {collab}, with <contrib><name>...</name></contrib> in <contrib-group content-type="collab-list"></contrib-group>'
+                    i18n._('Add person authors, members of {collab}, with <contrib><name>...</name></contrib> in <contrib-group content-type="collab-list"></contrib-group>')
                 )
                 advice_params = {
                     "collab": self.text_contribs.collab,
@@ -623,7 +641,7 @@ class CollabListValidation:
                 type_value = contrib_group_data["type"]
                 advice = f'Remove content-type="{type_value}" from <contrib-group content-type="{type_value}">'
                 advice_text = (
-                    'Remove content-type="{type}" from <contrib-group content-type="{type}">'
+                    i18n._('Remove content-type="{type}" from <contrib-group content-type="{type}">')
                 )
                 advice_params = {
                     "type": type_value,
@@ -690,7 +708,7 @@ class CollabGroupValidation:
                 if not contrib_data.get("contrib_name"):
                     advice = "All members of collaboration group must have name <name> in <contrib-group content-type='collab-list'>"
                     advice_text = (
-                        "All members of collaboration group must have name <name> in <contrib-group content-type='collab-list'>"
+                        i18n._("All members of collaboration group must have name <name> in <contrib-group content-type='collab-list'>")
                     )
                     advice_params = {}
 
@@ -726,7 +744,7 @@ class CollabGroupValidation:
                 if not has_affiliation:
                     advice = "All members of collaboration group must have complete affiliation <xref ref-type='aff'> (described in PDF)"
                     advice_text = (
-                        "All members of collaboration group must have complete affiliation <xref ref-type='aff'> (described in PDF)"
+                        i18n._("All members of collaboration group must have complete affiliation <xref ref-type='aff'> (described in PDF)")
                     )
                     advice_params = {}
 
@@ -754,8 +772,8 @@ class CollabGroupValidation:
                         "Without ORCID identification, authors cannot assign DOI as their work in curriculum databases"
                     )
                     advice_text = (
-                        "All members of collaboration group MUST have ORCID (described in PDF). "
-                        "Without ORCID identification, authors cannot assign DOI as their work in curriculum databases"
+                        i18n._("All members of collaboration group MUST have ORCID (described in PDF). "
+                        "Without ORCID identification, authors cannot assign DOI as their work in curriculum databases")
                     )
                     advice_params = {}
 
@@ -849,8 +867,8 @@ class DocumentCreditConsistencyValidation:
                 "All roles for a contributor must use the same taxonomy."
             )
             advice_text = (
-                "Do not mix CRediT taxonomy with other taxonomies in the same contributor. "
-                "All roles for a contributor must use the same taxonomy."
+                i18n._("Do not mix CRediT taxonomy with other taxonomies in the same contributor. "
+                "All roles for a contributor must use the same taxonomy.")
             )
             advice_params = {}
 
@@ -880,9 +898,9 @@ class DocumentCreditConsistencyValidation:
                 "SciELO Rule: 'tudo ou nada' (all or nothing)."
             )
             advice_text = (
-                "CRediT taxonomy must be used consistently: either ALL contributors use CRediT "
+                i18n._("CRediT taxonomy must be used consistently: either ALL contributors use CRediT "
                 "or NONE use it. Do not mix taxonomies in the document. "
-                "SciELO Rule: 'tudo ou nada' (all or nothing)."
+                "SciELO Rule: 'tudo ou nada' (all or nothing).")
             )
             advice_params = {}
 
@@ -986,8 +1004,8 @@ class SubArticleCollabIDValidation:
                     f"If article uses id='collab', sub-article should use id='collab1'"
                 )
                 advice_text = (
-                    "Sub-article {sub_id} uses same @id as main article: {collisions}. "
-                    "If article uses id='collab', sub-article should use id='collab1'"
+                    i18n._("Sub-article {sub_id} uses same @id as main article: {collisions}. "
+                    "If article uses id='collab', sub-article should use id='collab1'")
                 )
                 advice_params = {
                     "sub_id": sub_article_id,
@@ -1021,8 +1039,8 @@ class SubArticleCollabIDValidation:
                     f"If article uses rid='collab', sub-article should use rid='collab1'"
                 )
                 advice_text = (
-                    "Sub-article {sub_id} uses same @rid as main article: {collisions}. "
-                    "If article uses rid='collab', sub-article should use rid='collab1'"
+                    i18n._("Sub-article {sub_id} uses same @rid as main article: {collisions}. "
+                    "If article uses rid='collab', sub-article should use rid='collab1'")
                 )
                 advice_params = {
                     "sub_id": sub_article_id,
@@ -1076,6 +1094,10 @@ class ContribRoleValidation:
         if parent_id := self.contrib.get("parent_id"):
             return f'{contrib_name} (sub-article {parent_id}) :'
         return f'{contrib_name} :'
+
+    @property
+    def i18n_info(self):
+        return self.info.removesuffix(" :")
 
     def _get_default_params(self):
         return {
@@ -1147,22 +1169,22 @@ class ContribRoleValidation:
         if not valid_uri:
             if expected_uri and uri:
                 advice = f'{self.info} replace <role content-type="{uri}"> by <role content-type="{expected_uri}">'
-                advice_text = ('{info} replace <role content-type="{uri}"> by <role content-type="{expected_uri}">')
-                advice_params = {"info": self.info, "uri": uri, "expected_uri": expected_uri}
+                advice_text = (i18n._('{info}: replace <role content-type="{uri}"> by <role content-type="{expected_uri}">'))
+                advice_params = {"info": self.i18n_info, "uri": uri, "expected_uri": expected_uri}
             elif expected_uri:
                 advice = f'{self.info} replace <role>{text}</role> by <role content-type="{expected_uri}">{text}</role>'
-                advice_text = ('{info} replace <role>{text}</role> by <role content-type="{expected_uri}">{text}</role>')
-                advice_params = {"info": self.info, "text": text, "expected_uri": expected_uri}
+                advice_text = (i18n._('{info}: replace <role>{text}</role> by <role content-type="{expected_uri}">{text}</role>'))
+                advice_params = {"info": self.i18n_info, "text": text, "expected_uri": expected_uri}
             elif uri:
                 expected_uris = list(credit_taxonomy_by_uri.keys())
                 advice = f'{self.info} check if <role content-type="{uri}">{text}</role> has corresponding CRediT URI: {expected_uris}'
-                advice_text = ('{info} check if <role content-type="{uri}">{text}</role> has corresponding CRediT URI')
-                advice_params = {"info": self.info, "uri": uri, "text": text}
+                advice_text = (i18n._('{info}: check if <role content-type="{uri}">{text}</role> has corresponding CRediT URI'))
+                advice_params = {"info": self.i18n_info, "uri": uri, "text": text}
             elif text:
                 expected_uris = list(credit_taxonomy_by_uri.keys())
                 advice = f'{self.info} check if <role>{text}</role> has corresponding CRediT URI: {expected_uris}'
-                advice_text = ('{info} check if <role>{text}</role> has corresponding CRediT URI')
-                advice_params = {"info": self.info, "text": text}
+                advice_text = (i18n._('{info}: check if <role>{text}</role> has corresponding CRediT URI'))
+                advice_params = {"info": self.i18n_info, "text": text}
 
         yield build_response(
             title="CRediT taxonomy URI",
@@ -1187,22 +1209,22 @@ class ContribRoleValidation:
                 content_type = ''
             if expected_term and text:
                 advice = f'{self.info} replace <role{content_type}>{text}</role> by <role{content_type}>{expected_term}</role>'
-                advice_text = ('{info} replace <role{content_type}>{text}</role> by <role{content_type}>{expected_term}</role>')
-                advice_params = {"info": self.info, "content_type": content_type, "text": text, "expected_term": expected_term}
+                advice_text = (i18n._('{info}: replace <role{content_type}>{text}</role> by <role{content_type}>{expected_term}</role>'))
+                advice_params = {"info": self.i18n_info, "content_type": content_type, "text": text, "expected_term": expected_term}
             elif expected_term:
                 advice = f'{self.info} replace <role{content_type}></role> by <role{content_type}>{expected_term}</role>'
-                advice_text = ('{info} replace <role{content_type}></role> by <role{content_type}>{expected_term}</role>')
-                advice_params = {"info": self.info, "content_type": content_type, "expected_term": expected_term}
+                advice_text = (i18n._('{info}: replace <role{content_type}></role> by <role{content_type}>{expected_term}</role>'))
+                advice_params = {"info": self.i18n_info, "content_type": content_type, "expected_term": expected_term}
             elif text:
                 expected_terms = self.params["credit_taxonomy_by_terms"]
                 advice = f'{self.info} check if <role{content_type}>{text}</role> has corresponding CRediT term: {expected_terms}'
-                advice_text = ('{info} check if <role{content_type}>{text}</role> has corresponding CRediT term')
-                advice_params = {"info": self.info, "content_type": content_type, "text": text}
+                advice_text = (i18n._('{info}: check if <role{content_type}>{text}</role> has corresponding CRediT term'))
+                advice_params = {"info": self.i18n_info, "content_type": content_type, "text": text}
             else:
                 expected_terms = self.params["credit_taxonomy_by_terms"]
                 advice = f'{self.info} check if <role{content_type}>{text}</role> has corresponding CRediT term: {expected_terms}'
-                advice_text = ('{info} check if <role{content_type}>{text}</role> has corresponding CRediT term')
-                advice_params = {"info": self.info, "content_type": content_type, "text": text}
+                advice_text = (i18n._('{info}: check if <role{content_type}>{text}</role> has corresponding CRediT term'))
+                advice_params = {"info": self.i18n_info, "content_type": content_type, "text": text}
 
         yield build_response(
             title="CRediT taxonomy term",
@@ -1241,8 +1263,8 @@ class ContribRoleValidation:
             if is_reviewer_report:
                 # Para reviewer-report, ausência é ERRO
                 advice = f'{self.info} add <role specific-use="[reviewer|editor]"> for reviewer report'
-                advice_text = '{info} add <role specific-use=""> with {expected}'
-                advice_params = {"info": self.info, "expected": " or ".join(expected)}
+                advice_text = i18n._('{info}: add <role specific-use=""> with {expected}')
+                advice_params = {"info": self.i18n_info, "expected": " or ".join(expected)}
 
                 yield build_response(
                     title="contributor role type (reviewer report)",
@@ -1268,8 +1290,8 @@ class ContribRoleValidation:
         if not valid:
             expected_str = " or ".join(expected)
             advice = f'{self.info} replace <role specific-use="{specific_use}"> with {expected_str}'
-            advice_text = '{info} replace <role specific-use="{specific_use}"> with {expected}'
-            advice_params = {"info": self.info, "specific_use": specific_use, "expected": expected_str}
+            advice_text = i18n._('{info}: replace <role specific-use="{specific_use}"> with {expected}')
+            advice_params = {"info": self.i18n_info, "specific_use": specific_use, "expected": expected_str}
 
             yield build_response(
                 title="contributor role type value",
@@ -1286,4 +1308,3 @@ class ContribRoleValidation:
                 advice_text=advice_text,
                 advice_params=advice_params,
             )
-

--- a/packtools/sps/validation/article_data_availability.py
+++ b/packtools/sps/validation/article_data_availability.py
@@ -1,6 +1,7 @@
 from packtools.sps.validation.models.article_data_availability import DataAvailability
 from packtools.sps.validation.exceptions import ValidationDataAvailabilityException
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class DataAvailabilityValidation:
@@ -118,6 +119,11 @@ class DataAvailabilityValidation:
                     expected=specific_use_list,
                     obtained=got_value,
                     advice=f"""Complete  specific-use="" in {xml} with valid value: {valid_values}""",
+                    advice_text=i18n._('Complete  specific-use="" in {xml} with valid value: {valid_values}'),
+                    advice_params={
+                        "xml": xml,
+                        "valid_values": valid_values,
+                    },
                     data=item,
                     error_level=error_level,
                 )
@@ -158,6 +164,9 @@ class DataAvailabilityValidation:
             else:
                 xml = f"""<{representative_item["parent"]}>"""
 
+            advice_text = None
+            advice_params = {}
+
             # Validate based on the demand level
             if demand in ("required", None):
                 valid = has_data_availability
@@ -169,6 +178,12 @@ class DataAvailabilityValidation:
                         f"""Mark in {xml} the data availability statement in footnote with <fn fn-type="data-availability" specific-use=""> or in text with <sec sec-type="data-availability" specific-use="">. And complete specific-use="" with valid value: {valid_values}"""
                     )
                 )
+                if not valid:
+                    advice_text = i18n._('Mark in {xml} the data availability statement in footnote with <fn fn-type="data-availability" specific-use=""> or in text with <sec sec-type="data-availability" specific-use="">. And complete specific-use="" with valid value: {valid_values}')
+                    advice_params = {
+                        "xml": xml,
+                        "valid_values": valid_values,
+                    }
             elif demand == "optional":
                 valid = True
                 expected = representative_item
@@ -185,6 +200,13 @@ class DataAvailabilityValidation:
                         f"""Remove from {xml} the data availability statement (<{tag} {tag}-type="data-availability">) because it is unexpected for {article_type}"""
                     )
                 )
+                if not valid:
+                    advice_text = i18n._('Remove from {xml} the data availability statement (<{tag} {tag}-type="data-availability">) because it is unexpected for {article_type}')
+                    advice_params = {
+                        "xml": xml,
+                        "tag": tag,
+                        "article_type": article_type,
+                    }
 
             yield build_response(
                 title="data availability statement",
@@ -196,6 +218,8 @@ class DataAvailabilityValidation:
                 expected=expected,
                 obtained=representative_item,
                 advice=advice,
+                advice_text=advice_text,
+                advice_params=advice_params,
                 data=representative_item,
                 error_level=error_level,
             )

--- a/packtools/sps/validation/article_doi.py
+++ b/packtools/sps/validation/article_doi.py
@@ -5,6 +5,7 @@ from packtools.sps.validation.utils import (
     build_response,
     validate_doi_format as validate_doi_format_util,
 )
+from packtools.sps import i18n
 
 
 def _callable_extern_validate_default(doi):
@@ -43,7 +44,7 @@ class ArticleDoiValidation:
                 text = f"<article>"
 
             advice = f'Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>'
-            advice_text = 'Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>'
+            advice_text = i18n._('Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>')
             advice_params = {"text": text}
 
             # Preparar dicionário parent para build_response
@@ -101,7 +102,7 @@ class ArticleDoiValidation:
                 text = f"<article>"
 
             advice = f'Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>'
-            advice_text = 'Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>'
+            advice_text = i18n._('Mark DOI for {text} with <article-id pub-id-type="doi"></article-id>')
             advice_params = {"text": text}
 
             parent = {
@@ -151,7 +152,7 @@ class ArticleDoiValidation:
         diff = [doi for doi, freq in dois.items() if freq > 1]
 
         advice = f"Fix doi to be unique. Found repetition: {diff}"
-        advice_text = "Fix doi to be unique. Found repetition: {diff}"
+        advice_text = i18n._("Fix doi to be unique. Found repetition: {diff}")
         advice_params = {"diff": str(diff)}
 
         parent = {
@@ -210,7 +211,7 @@ class ArticleDoiValidation:
             if not result.get("valid"):
                 if registered := result.get("registered"):
                     advice = f'Check doi (<article-id pub-id-type="doi">{xml_doi}</article-id>) is not registered for {expected}. It is registered for {registered}'
-                    advice_text = 'Check doi (<article-id pub-id-type="doi">{xml_doi}</article-id>) is not registered for {expected}. It is registered for {registered}'
+                    advice_text = i18n._('The DOI (<article-id pub-id-type="doi">{xml_doi}</article-id>) is not registered for {expected}. It is registered for {registered}')
                     advice_params = {
                         "xml_doi": xml_doi,
                         "expected": str(expected),
@@ -219,7 +220,7 @@ class ArticleDoiValidation:
                 else:
                     current_error_level = "WARNING"
                     advice = f"Unable to check if {xml_doi} is registered for {expected}"
-                    advice_text = "Unable to check if {xml_doi} is registered for {expected}"
+                    advice_text = i18n._("Unable to check if {xml_doi} is registered for {expected}")
                     advice_params = {
                         "xml_doi": xml_doi,
                         "expected": str(expected)
@@ -246,6 +247,13 @@ class ArticleDoiValidation:
                 error_level=current_error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "Got {obtained}, expected DOI registered for {metadata}"
+                ),
+                message_params={
+                    "obtained": xml_doi,
+                    "metadata": str(expected),
+                },
             )
 
     def validate_different_doi_in_translation(self, error_level="WARNING"):
@@ -282,7 +290,7 @@ class ArticleDoiValidation:
                 xml = f'<{parent_tag} id="{parent_id}"><article-id pub-id-type="doi">{doi}</article-id>'
 
                 advice = f"Change {doi} in {xml} for a DOI different from {doi_list}"
-                advice_text = "Change {doi} in {xml} for a DOI different from {doi_list}"
+                advice_text = i18n._("Change {doi} in {xml} for a DOI different from {doi_list}")
                 advice_params = {
                     "doi": doi,
                     "xml": xml,

--- a/packtools/sps/validation/article_license.py
+++ b/packtools/sps/validation/article_license.py
@@ -5,6 +5,7 @@ from packtools.sps.validation.exceptions import (
     ValidationLicenseCodeException
 )
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class ArticleLicenseValidation:
@@ -130,8 +131,8 @@ class ArticleLicenseValidation:
                     f"{lang} and standard adopted by the journal"
                 )
                 advice_text = (
-                    "Provide license data that is consistent with the language: "
-                    "{lang} and standard adopted by the journal"
+                    i18n._("Provide license data that is consistent with the language: "
+                    "{lang} and standard adopted by the journal")
                 )
                 advice_params = {"lang": lang}
             else:
@@ -144,10 +145,10 @@ class ArticleLicenseValidation:
                     "</license>"
                 )
                 advice_text = (
-                    "Mark license information with "
+                    i18n._("Mark license information with "
                     '<license license-type="open-access" xlink:href={link} '
                     "xml:lang={lang}>"
-                    "<license-p>{license_p}</license-p></license>"
+                    "<license-p>{license_p}</license-p></license>")
                 )
                 advice_params = expected_license_p
 
@@ -248,7 +249,7 @@ class ArticleLicenseValidation:
                 advice=f'add <permissions><license xlink:href="http://creativecommons.org/licenses/VALUE/4.0/"> and replace VALUE with {expected_code}',
                 data=licenses,
                 error_level=error_level,
-                advice_text='add <permissions><license xlink:href="http://creativecommons.org/licenses/VALUE/4.0/"> and replace VALUE with {code}',
+                advice_text=i18n._('add <permissions><license xlink:href="http://creativecommons.org/licenses/VALUE/4.0/"> and replace VALUE with {code}'),
                 advice_params={"code": expected_code},
             )
 

--- a/packtools/sps/validation/article_toc_sections.py
+++ b/packtools/sps/validation/article_toc_sections.py
@@ -1,6 +1,7 @@
 from packtools.sps.validation.models.article_toc_sections import ArticleTocSections
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.similarity_utils import how_similar
+from packtools.sps import i18n
 
 
 class XMLTocSectionsValidation:
@@ -86,8 +87,11 @@ class SubjectValidation:
         # Há seções excedentes (heading)
         if subj_group_type:
             advice = f'Remove <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable'
+            advice_text = i18n._('Remove <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable')
         else:
             advice = f'Remove <subject-group><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable'
+            advice_text = i18n._('Remove <subject-group><subject>{subject}</subject></subject-group> because it is unexpected, only one subject-group is acceptable')
+
         return build_response(
             title="unexpected subject-group",
             parent=self.data,
@@ -98,6 +102,8 @@ class SubjectValidation:
             expected=None,
             obtained=self.data,
             advice=advice,
+            advice_text=advice_text,
+            advice_params={"subject": subject},
             data=self.data,
             error_level=self.params["unexpected_subj_group_error_level"],
         )
@@ -112,10 +118,20 @@ class SubjectValidation:
         valid = subj_group_type == "heading"
         if subj_group_type and subject:
             advice = f'Replace <subject-group subj-group-type="{subj_group_type}"><subject>{subject}</subject></subject-group> by <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>'
+            advice_text = i18n._('Replace <subject-group subj-group-type="{subj_group_type}"><subject>{subject}</subject></subject-group> by <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>')
+            advice_params = {
+                "subj_group_type": subj_group_type,
+                "subject": subject,
+            }
         elif subject:
             advice = f'Replace <subject-group><subject>{subject}</subject></subject-group> by <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>'
+            advice_text = i18n._('Replace <subject-group><subject>{subject}</subject></subject-group> by <subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>')
+            advice_params = {"subject": subject}
         else:
             advice = f'Mark table of contents section with  <subject-group subj-group-type="heading"><subject>table of contents section</subject></subject-group>'
+            advice_text = i18n._('Mark table of contents section with  <subject-group subj-group-type="heading"><subject>table of contents section</subject></subject-group>')
+            advice_params = {}
+
         return build_response(
             title="table of contents section",
             parent=self.data,
@@ -126,6 +142,8 @@ class SubjectValidation:
             expected="heading",
             obtained=subj_group_type,
             advice=advice,
+            advice_text=advice_text,
+            advice_params=advice_params,
             data=self.data,
             error_level=self.subj_group_type_error_level,
         )
@@ -142,6 +160,7 @@ class SubjectValidation:
         # É desincentivado a usar subject-group/subject-group
         valid = not subsections
         advice = f'Write section and subsection in one subject: <subject-group subj-group-type="heading"><subject>{subject}: {subsection_text}</subject></subject-group>. Remove <subject-group><subject>{subsection_text}</subject></subject-group>'
+
         return build_response(
             title="table of contents section with subsection",
             parent=self.data,
@@ -152,6 +171,16 @@ class SubjectValidation:
             expected=[],
             obtained=subsections,
             advice=advice,
+            advice_text=(
+                i18n._("Write section and subsection in one subject: "
+                '<subject-group subj-group-type="heading"><subject>'
+                "{subject}: {subsection}</subject></subject-group>. Remove "
+                "<subject-group><subject>{subsection}</subject></subject-group>")
+            ),
+            advice_params={
+                "subject": subject,
+                "subsection": subsection_text,
+            },
             data=self.data,
             error_level=self.subsection_error_level,
         )
@@ -184,12 +213,24 @@ class SubjectValidation:
                     expected_toc_sections or self.expected_toc_sections
                 )
                 advice = f"{subject} is not registered as a table of contents section. Valid values: {self.expected_toc_sections}"
+                advice_text = i18n._("{subject} is not registered as a table of contents section. Valid values: {valid_values}")
+                advice_params = {
+                    "subject": subject,
+                    "valid_values": self.expected_toc_sections,
+                }
             else:
                 error_level = "WARNING"
                 advice = f'Unable to check if {subject} (<subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>) is a valid table of contents section because the journal ({journal}) sections were not informed'
+                advice_text = i18n._('Unable to check whether {subject} (<subject-group subj-group-type="heading"><subject>{subject}</subject></subject-group>) is a valid table of contents section because no sections were provided for the journal {journal}')
+                advice_params = {
+                    "subject": subject,
+                    "journal": journal,
+                }
         else:
             validation_type = "exist"
             advice = 'Mark table of contents section with <subject-group subj-group-type="heading"><subject></subject></subject-group>'
+            advice_text = i18n._('Mark table of contents section with <subject-group subj-group-type="heading"><subject></subject></subject-group>')
+            advice_params = {}
 
         return build_response(
             title="table of contents section",
@@ -201,6 +242,17 @@ class SubjectValidation:
             expected=expected,
             obtained=subject,
             advice=advice,
+            message_text=(
+                i18n._(
+                    "Got {subject}, but the registered table of contents "
+                    "sections could not be checked"
+                )
+                if subject and not self.expected_toc_sections
+                else None
+            ),
+            message_params={"subject": subject},
+            advice_text=advice_text,
+            advice_params=advice_params,
             data=self.data,
             error_level=error_level,
         )
@@ -235,6 +287,15 @@ class SubjectValidation:
             expected=msg,
             obtained=article_title,
             advice=msg,
+            advice_text=(
+                i18n._("The article title ({article_title}) must represent its "
+                "contents and must be different from the section title "
+                "({section_title}) to get a better ranking in search results")
+            ),
+            advice_params={
+                "article_title": article_title,
+                "section_title": section_title,
+            },
             data=data,
             error_level=self.article_title_and_toc_section_are_similar_error_level,
         )

--- a/packtools/sps/validation/article_xref.py
+++ b/packtools/sps/validation/article_xref.py
@@ -1,5 +1,6 @@
 from packtools.sps.validation.models.article_xref import XMLCrossReference
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 # Allowed values for @ref-type per SPS 1.10
@@ -110,7 +111,7 @@ class ArticleXrefValidation:
                 advice=f'Provide a valid @rid attribute for <xref>',
                 data=xref_data,
                 error_level=error_level,
-                advice_text='Provide a valid @rid attribute for <xref>',
+                advice_text=i18n._('Provide a valid @rid attribute for <xref>'),
                 advice_params={},
             )
 
@@ -139,7 +140,7 @@ class ArticleXrefValidation:
                 advice=f'Provide a valid @ref-type attribute for <xref>',
                 data=xref_data,
                 error_level=error_level,
-                advice_text='Provide a valid @ref-type attribute for <xref>',
+                advice_text=i18n._('Provide a valid @ref-type attribute for <xref>'),
                 advice_params={},
             )
 
@@ -171,7 +172,7 @@ class ArticleXrefValidation:
                 advice=f'Replace "{ref_type}" with one of the allowed values: {ref_type_list}',
                 data=xref_data,
                 error_level=error_level,
-                advice_text='Replace "{ref_type}" with one of the allowed values: {ref_type_list}',
+                advice_text=i18n._('Replace "{ref_type}" with one of the allowed values: {ref_type_list}'),
                 advice_params={"ref_type": ref_type, "ref_type_list": str(ref_type_list)},
             )
 
@@ -201,8 +202,8 @@ class ArticleXrefValidation:
             advice='Add at least one <xref ref-type="bibr"> to the document (SciELO Brasil criterion)',
             data={"bibr_count": bibr_count},
             error_level=error_level,
-            advice_text='Add at least one <xref ref-type="bibr"> to the document (SciELO Brasil criterion)',
-            advice_params={"bibr_count": str(bibr_count)},
+            advice_text=i18n._('Add at least one <xref ref-type="bibr"> to the document (SciELO Brasil criterion)'),
+            advice_params={},
         )
 
     def validate_rid_has_corresponding_id(self):
@@ -234,7 +235,7 @@ class ArticleXrefValidation:
                 advice=f'@rid="{rid}" in <xref> has no corresponding @id in the document',
                 data=xref_data,
                 error_level=error_level,
-                advice_text='@rid="{rid}" in <xref> has no corresponding @id in the document',
+                advice_text=i18n._('@rid="{rid}" in <xref> has no corresponding @id in the document'),
                 advice_params={"rid": rid},
             )
 
@@ -273,7 +274,7 @@ class ArticleXrefValidation:
                 advice=f'Add <xref ref-type="sec" rid="{sec_id}"> to reference the transcript section',
                 data={"transcript_sec_id": sec_id},
                 error_level=error_level,
-                advice_text='Add <xref ref-type="sec" rid="{sec_id}"> to reference the transcript section',
+                advice_text=i18n._('Add <xref ref-type="sec" rid="{sec_id}"> to reference the transcript section'),
                 advice_params={"sec_id": sec_id},
             )
 
@@ -310,7 +311,7 @@ class ArticleXrefValidation:
                 advice=f'For @ref-type="aff" without text content, use self-closing: <xref ref-type="aff" rid="{rid}"/>',
                 data=xref_data,
                 error_level=error_level,
-                advice_text='For @ref-type="aff" without text content, use self-closing: <xref ref-type="aff" rid="{rid}"/>',
+                advice_text=i18n._('For @ref-type="aff" without text content, use self-closing: <xref ref-type="aff" rid="{rid}"/>'),
                 advice_params={"rid": rid},
             )
 
@@ -353,7 +354,7 @@ class ArticleXrefValidation:
                         "missing_elems": self.missing_elems,
                     },
                     error_level=self.params["xref_rid_error_level"],
-                    advice_text='Found {tag_and_attribs}, but not found the corresponding {elem_xml}',
+                    advice_text=i18n._('Found {tag_and_attribs}, but not found the corresponding {elem_xml}'),
                     advice_params={
                         "tag_and_attribs": xref.get("tag_and_attribs"),
                         "elem_xml": xref.get("elem_xml"),
@@ -393,8 +394,8 @@ class ArticleXrefValidation:
                             f'Mark {label}, mention to {tag_and_attribs}, with {xref_xml}'
                         )
                         advice_text = (
-                            'Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
-                            'Mark {label}, mention to {tag_and_attribs}, with {xref_xml}'
+                            i18n._('Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
+                            'Mark {label}, mention to {tag_and_attribs}, with {xref_xml}')
                         )
                         advice_params = {
                             "tag_and_attribs": tag_and_attribs,
@@ -406,7 +407,7 @@ class ArticleXrefValidation:
                             f'Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
                         )
                         advice_text = (
-                            'Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
+                            i18n._('Found {tag_and_attribs}, but no corresponding {xref_xml} was found. ')
                         )
                         advice_params = {
                             "tag_and_attribs": tag_and_attribs,
@@ -489,8 +490,8 @@ class ArticleXrefValidation:
                         "missing_elems": self.missing_elems,
                     },
                     error_level=error_level,
-                    advice_text='Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
-                    'Mark the {tag_and_attribs} cross-references using {xref_xml}',
+                    advice_text=i18n._('Found {tag_and_attribs}, but no corresponding {xref_xml} was found. '
+                    'Mark the {tag_and_attribs} cross-references using {xref_xml}'),
                     advice_params={
                         "tag_and_attribs": tag_and_attribs,
                         "xref_xml": xref_xml,

--- a/packtools/sps/validation/author_notes.py
+++ b/packtools/sps/validation/author_notes.py
@@ -3,6 +3,7 @@ from packtools.sps.models.article_and_subarticles import ArticleAndSubArticles
 
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.basefn import BaseFnValidation
+from packtools.sps import i18n
 
 
 class AuthorNotesFnValidation(BaseFnValidation):
@@ -18,7 +19,7 @@ class AuthorNotesFnValidation(BaseFnValidation):
         
         if not is_valid:
             advice = 'Add mandatory @fn-type attribute to <fn> in <author-notes>. Valid values for author notes: abbr, coi-statement, corresp'
-            advice_text = 'Add mandatory @fn-type attribute to <fn> in <author-notes>. Valid values for author notes: {values}'
+            advice_text = i18n._('Add mandatory @fn-type attribute to <fn> in <author-notes>. Valid values for author notes: {values}')
             advice_params = {"values": "abbr, coi-statement, corresp"}
             
             return build_response(
@@ -76,7 +77,7 @@ class AuthorNotesFnValidation(BaseFnValidation):
         
         if not is_valid:
             advice = f'@fn-type="{fn_type}" is not valid for <fn> in <author-notes>. Use one of: {", ".join(allowed_values)}'
-            advice_text = '@fn-type="{fn_type}" is not valid for <fn> in <author-notes>. Use one of: {values}'
+            advice_text = i18n._('@fn-type="{fn_type}" is not valid for <fn> in <author-notes>. Use one of: {values}')
             advice_params = {
                 "fn_type": fn_type,
                 "values": ", ".join(allowed_values)
@@ -108,7 +109,7 @@ class AuthorNotesFnValidation(BaseFnValidation):
         
         if fn_type == "corresp":
             advice = 'For corresponding author information, use <corresp> element instead of <fn fn-type="corresp">'
-            advice_text = 'For corresponding author information, use <corresp> element instead of <fn fn-type="corresp">'
+            advice_text = i18n._('For corresponding author information, use <corresp> element instead of <fn fn-type="corresp">')
             advice_params = {}
             
             return build_response(
@@ -139,6 +140,8 @@ class AuthorNotesFnValidation(BaseFnValidation):
                 expected="bio",
                 obtained=self.fn_data.get("fn_type"),
                 advice='<fn fn-type="current-aff"> is deprecated. Use <fn fn-type="bio"> instead.',
+                advice_text=i18n._('<fn fn-type="current-aff"> is deprecated. Use <fn fn-type="bio"> instead.'),
+                advice_params={},
                 data=self.fn_data,
                 error_level=self.rules["current-aff_error_level"],
             )
@@ -157,6 +160,10 @@ class AuthorNotesFnValidation(BaseFnValidation):
                 advice='<fn fn-type="con"> is deprecated. '
                        'Use <role content-type="http://credit.niso.org/contributor-roles/CONTRIBUTION/"> '
                        'inside <contrib> instead. Replace CONTRIBUTION with the author\'s contribution type.',
+                advice_text=i18n._('<fn fn-type="con"> is deprecated. '
+                            'Use <role content-type="http://credit.niso.org/contributor-roles/CONTRIBUTION/"> '
+                            'inside <contrib> instead. Replace CONTRIBUTION with the author\'s contribution type.'),
+                advice_params={},
                 data=self.fn_data,
                 error_level=self.rules["con_error_level"],
             )
@@ -233,7 +240,7 @@ class XMLAuthorNotesValidation:
         
         if article_author_notes_count > 1:
             advice = f'<author-notes> element should appear at most once in the article. Found {article_author_notes_count} occurrences.'
-            advice_text = '<author-notes> element should appear at most once in the article. Found {count} occurrences.'
+            advice_text = i18n._('<author-notes> element should appear at most once in the article. Found {count} occurrences.')
             advice_params = {"count": str(article_author_notes_count)}
             
             yield build_response(
@@ -259,7 +266,7 @@ class XMLAuthorNotesValidation:
             
             if sub_author_notes_count > 1:
                 advice = f'<author-notes> element should appear at most once in sub-article (id={sub_article_id}). Found {sub_author_notes_count} occurrences.'
-                advice_text = '<author-notes> element should appear at most once in sub-article (id={id}). Found {count} occurrences.'
+                advice_text = i18n._('<author-notes> element should appear at most once in sub-article (id={id}). Found {count} occurrences.')
                 advice_params = {
                     "id": sub_article_id,
                     "count": str(sub_author_notes_count)
@@ -347,6 +354,8 @@ class CorrespValidation:
             expected="corresp/label",
             obtained="corresp/label" if is_valid else None,
             advice=f"Mark corresp label with <corresp><label>",
+            advice_text=i18n._("Mark corresp label with <corresp><label>"),
+            advice_params={},
             data=self.corresp_data,
             error_level=self.rules["corresp_label_error_level"],
         )
@@ -367,6 +376,8 @@ class CorrespValidation:
             expected="corresp/label" if not is_valid else None,
             obtained="corresp/title" if not is_valid else None,
             advice=f"Replace <corresp><title> with <corresp><label>",
+            advice_text=i18n._("Replace <corresp><title> with <corresp><label>"),
+            advice_params={},
             data=self.corresp_data,
             error_level=self.rules["corresp_title_error_level"],
         )
@@ -387,6 +398,8 @@ class CorrespValidation:
             expected="corresp/label" if not is_valid else None,
             obtained="corresp/bold" if not is_valid else None,
             advice=f"Replace <corresp><bold> with <corresp><label>",
+            advice_text=i18n._("Replace <corresp><bold> with <corresp><label>"),
+            advice_params={},
             data=self.corresp_data,
             error_level=self.rules["corresp_bold_error_level"],
         )

--- a/packtools/sps/validation/basefn.py
+++ b/packtools/sps/validation/basefn.py
@@ -1,4 +1,5 @@
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class BaseFnValidation:
@@ -40,6 +41,8 @@ class BaseFnValidation:
             expected="fn/label",
             obtained="fn/label" if is_valid else None,
             advice=f"Mark footnote label with <fn><label>",
+            advice_text=i18n._("Mark footnote label with <fn><label>"),
+            advice_params={},
             data=self.fn_data,
             error_level=self.rules["fn_label_error_level"],
         )
@@ -60,6 +63,8 @@ class BaseFnValidation:
             expected="fn/label" if not is_valid else None,
             obtained="fn/title" if not is_valid else None,
             advice=f"Replace <fn><title> with <fn><label>",
+            advice_text=i18n._("Replace <fn><title> with <fn><label>"),
+            advice_params={},
             data=self.fn_data,
             error_level=self.rules["fn_title_error_level"],
         )
@@ -80,6 +85,8 @@ class BaseFnValidation:
             expected="fn/label" if not is_valid else None,
             obtained="fn/bold" if not is_valid else None,
             advice=f"Replace <fn><bold> with <fn><label>",
+            advice_text=i18n._("Replace <fn><bold> with <fn><label>"),
+            advice_params={},
             data=self.fn_data,
             error_level=self.rules["fn_bold_error_level"],
         )
@@ -105,6 +112,8 @@ class BaseFnValidation:
             expected=expected,
             obtained=fn_type,
             advice=f'Complete fn-type="" in <fn fn-type=""> with a valid values: {expected}',
+            advice_text=i18n._('Complete fn-type="" in <fn fn-type=""> with a valid values: {expected}'),
+            advice_params={"expected": expected},
             data=self.fn_data,
             error_level=self.rules["fn_type_error_level"],
         )
@@ -131,6 +140,8 @@ class BaseFnValidation:
                 expected=expected_fn_type,
                 obtained=obtained_fn_type,
                 advice='Use <fn fn-type="conflict"> for JATS < 1.3 and <fn fn-type="coi-statement"> for JATS ≥ 1.3.',
+                advice_text=i18n._('Use <fn fn-type="conflict"> for JATS < 1.3 and <fn fn-type="coi-statement"> for JATS ≥ 1.3.'),
+                advice_params={},
                 data=self.fn_data,
                 error_level=self.rules["conflict_error_level"],
             )

--- a/packtools/sps/validation/dates.py
+++ b/packtools/sps/validation/dates.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 
 from packtools.sps.models.dates import FulltextDates
 from packtools.sps.validation.utils import build_response, get_future_date
+from packtools.sps import i18n
 
 
 def is_subsequence_in_order(subsequence, main_sequence):
@@ -77,6 +78,13 @@ class DateValidation:
             expected=f"{number}-digits {label}",
             obtained=self.date_data.get(label),
             advice=f'Complete <{self.tag} date-type="{self.date_type}"><{label}> with {number}-digits',
+            advice_text=i18n._('Complete <{tag} date-type="{date_type}"><{label}> with {number}-digits'),
+            advice_params={
+                "tag": self.tag,
+                "date_type": self.date_type,
+                "label": label,
+                "number": number,
+            },
             data=self.date_data,
             error_level=self.params[f"{label}_format_error_level"],
         )
@@ -106,6 +114,12 @@ class DateValidation:
             expected="max one year in the future",
             obtained=year,
             advice=advice,
+            advice_text=i18n._('Complete <{tag} date-type="{date_type}"><year> with an year previous or equal to {limit_year}'),
+            advice_params={
+                "tag": self.tag,
+                "date_type": self.date_type,
+                "limit_year": limit_year,
+            },
             data=self.date_data,
             error_level=self.params["year_value_error_level"],
         )
@@ -137,6 +151,12 @@ class DateValidation:
                 expected="valid date",
                 obtained=self.date_data,
                 advice=f'<date date-type="{self.date_type}"> ({parts}) is invalid: {e}',
+                advice_text=i18n._('<date date-type="{date_type}"> ({parts}) is invalid: {error}'),
+                advice_params={
+                    "date_type": self.date_type,
+                    "parts": parts,
+                    "error": e,
+                },
                 data=self.date_data,
                 error_level=self.params["value_error_level"],
             )
@@ -172,6 +192,13 @@ class DateValidation:
                 expected="valid date",
                 obtained=formatted_date,
                 advice=advice,
+                advice_text=i18n._('<date date-type="{date_type}"> ({formatted_date}) must be previous to {max_date_label} ({max_date})'),
+                advice_params={
+                    "date_type": date_type,
+                    "formatted_date": formatted_date,
+                    "max_date_label": max_date_label,
+                    "max_date": max_date,
+                },
                 data=self.date_data,
                 error_level=self.params["limit_error_level"],
             )
@@ -187,6 +214,11 @@ class DateValidation:
                 expected="a date with year, month (2-digits) and day (2-digits)",
                 obtained=self.date_data,
                 advice=advice,
+                advice_text=i18n._('<date date-type="{date_type}"> ({parts}) must be a date with year, month (2-digits) and day (2-digits)'),
+                advice_params={
+                    "date_type": date_type,
+                    "parts": parts,
+                },
                 data=self.date_data,
                 error_level=self.params["format_error_level"],
             )
@@ -332,6 +364,8 @@ class FulltextDatesValidation:
             expected='<pub-date date-type="pub">',
             obtained='<pub-date date-type="pub">' if is_valid else None,
             advice='Add <pub-date publication-format="electronic" date-type="pub"> with <day>, <month> and <year>',
+            advice_text=i18n._('Add <pub-date publication-format="electronic" date-type="pub"> with <day>, <month> and <year>'),
+            advice_params={},
             data=None,
             error_level=self.params["pub_date_presence_error_level"],
         )
@@ -353,6 +387,8 @@ class FulltextDatesValidation:
             expected='<pub-date date-type="collection">',
             obtained='<pub-date date-type="collection">' if is_valid else None,
             advice='Add <pub-date publication-format="electronic" date-type="collection"> with <year>',
+            advice_text=i18n._('Add <pub-date publication-format="electronic" date-type="collection"> with <year>'),
+            advice_params={},
             data=None,
             error_level=self.params["collection_date_presence_error_level"],
         )
@@ -372,6 +408,8 @@ class FulltextDatesValidation:
                 expected="electronic",
                 obtained=pub_format,
                 advice=f'Set @publication-format="electronic" in <pub-date date-type="{date_obj.type}">',
+                advice_text=i18n._('Set @publication-format="electronic" in <pub-date date-type="{date_type}">'),
+                advice_params={"date_type": date_obj.type},
                 data=date_obj.data,
                 error_level=self.params["publication_format_error_level"],
             )
@@ -393,6 +431,8 @@ class FulltextDatesValidation:
                 expected=f"<{element}> in pub-date[@date-type='pub']",
                 obtained=article_date.get(element),
                 advice=f'Add <{element}> to <pub-date date-type="pub">',
+                advice_text=i18n._('Add <{element}> to <pub-date date-type="pub">'),
+                advice_params={"element": element},
                 data=article_date,
                 error_level=self.params["pub_date_required_elements_error_level"],
             )
@@ -413,6 +453,8 @@ class FulltextDatesValidation:
             expected="<year> in pub-date[@date-type='collection']",
             obtained=collection_date.get("year"),
             advice='Add <year> to <pub-date date-type="collection">',
+            advice_text=i18n._('Add <year> to <pub-date date-type="collection">'),
+            advice_params={},
             data=collection_date,
             error_level=self.params["collection_date_year_error_level"],
         )
@@ -434,6 +476,8 @@ class FulltextDatesValidation:
             expected="no <day> in pub-date[@date-type='collection']",
             obtained=f"<day>{collection_date.get('day')}</day>" if has_day else None,
             advice='Remove <day> from <pub-date date-type="collection">',
+            advice_text=i18n._('Remove <day> from <pub-date date-type="collection">'),
+            advice_params={},
             data=collection_date,
             error_level=self.params["collection_date_day_error_level"],
         )
@@ -454,6 +498,8 @@ class FulltextDatesValidation:
                 expected=f"at most 1 pub-date[@date-type='{date_type}']",
                 obtained=f"{count} pub-date[@date-type='{date_type}']",
                 advice=f'Ensure there is at most one <pub-date date-type="{date_type}">',
+                advice_text=i18n._('Ensure there is at most one <pub-date date-type="{date_type}">'),
+                advice_params={"date_type": date_type},
                 data=None,
                 error_level=self.params["pub_date_uniqueness_error_level"],
             )
@@ -480,6 +526,8 @@ class FulltextDatesValidation:
                     expected="a value between 00 and 31",
                     obtained=day,
                     advice=f'Fix <day> value in <pub-date date-type="{date_type}">. Must be between 00 and 31',
+                    advice_text=i18n._('Fix <day> value in <pub-date date-type="{date_type}">. Must be between 00 and 31'),
+                    advice_params={"date_type": date_type},
                     data=date_data,
                     error_level=self.params["day_value_error_level"],
                 )
@@ -499,6 +547,8 @@ class FulltextDatesValidation:
                     expected="a value between 00 and 12",
                     obtained=month,
                     advice=f'Fix <month> value in <pub-date date-type="{date_type}">. Must be between 00 and 12',
+                    advice_text=i18n._('Fix <month> value in <pub-date date-type="{date_type}">. Must be between 00 and 12'),
+                    advice_params={"date_type": date_type},
                     data=date_data,
                     error_level=self.params["month_value_error_level"],
                 )
@@ -579,6 +629,11 @@ class FulltextDatesValidation:
             expected=self.expected_events,
             obtained=self.date_types_ordered_by_date,
             advice=f"History dates found: {self.date_types_ordered_by_date}. Exclude unexpected dates: {self.unexpected_events}",
+            advice_text=i18n._("History dates found: {date_types}. Exclude unexpected dates: {unexpected_events}"),
+            advice_params={
+                "date_types": self.date_types_ordered_by_date,
+                "unexpected_events": self.unexpected_events,
+            },
             data=history_dates,
             error_level=self.params["unexpected_events_error_level"],
         )
@@ -593,6 +648,11 @@ class FulltextDatesValidation:
             expected=self.expected_events,
             obtained=self.date_types_ordered_by_date,
             advice=f"History dates found: {self.date_types_ordered_by_date}. Add missing dates: {self.missing_events}",
+            advice_text=i18n._("History dates found: {date_types}. Add missing dates: {missing_events}"),
+            advice_params={
+                "date_types": self.date_types_ordered_by_date,
+                "missing_events": self.missing_events,
+            },
             data=history_dates,
             error_level=self.params["missing_events_error_level"],
         )
@@ -614,6 +674,11 @@ class FulltextDatesValidation:
             expected=expected,
             obtained=self.date_types_ordered_by_date,
             advice=f"History dates ({self.date_types_ordered_by_date}) must be in chronological order: {expected}",
+            advice_text=i18n._("History dates ({date_types}) must be in chronological order: {expected}"),
+            advice_params={
+                "date_types": self.date_types_ordered_by_date,
+                "expected": expected,
+            },
             data=self.history_dates,
             error_level=self.params["history_order_error_level"],
         )

--- a/packtools/sps/validation/ext_link.py
+++ b/packtools/sps/validation/ext_link.py
@@ -11,12 +11,11 @@ Implements validations for external link elements to ensure:
 Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJNOIqzBNSgA/edit?tab=t.0#heading=h.n2z5yrri2aba
 """
 import re
-import gettext
 
+from packtools.sps import i18n
 from packtools.sps.models.ext_link import ArticleExtLinks
 from packtools.sps.validation.utils import build_response
 
-_ = gettext.gettext
 
 
 class ExtLinkValidation:
@@ -97,7 +96,7 @@ class ExtLinkValidation:
 
             is_valid = bool(ext_link_type)
 
-            advice_text = _(
+            advice_text = i18n._(
                 'Add @ext-link-type attribute to <ext-link> with text "{text}".'
                 " Valid values: {allowed_values}"
             )
@@ -122,11 +121,18 @@ class ExtLinkValidation:
                 is_valid=is_valid,
                 expected="@ext-link-type attribute present",
                 obtained=ext_link_type,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @ext-link-type attribute to <ext-link> with text "{text}".'
+                " Valid values: {allowed_values}").format(**advice_params),
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=(
+                    i18n._("The @ext-link-type attribute is present")
+                    if is_valid
+                    else i18n._("The @ext-link-type attribute is required")
+                ),
+                message_params={},
             )
 
     def validate_xlink_href_presence(self, error_level=None):
@@ -153,7 +159,7 @@ class ExtLinkValidation:
 
             is_valid = bool(xlink_href)
 
-            advice_text = _(
+            advice_text = i18n._(
                 'Add @xlink:href attribute to <ext-link> with text "{text}"'
             )
             advice_params = {"text": text}
@@ -174,11 +180,17 @@ class ExtLinkValidation:
                 is_valid=is_valid,
                 expected="@xlink:href attribute present",
                 obtained=xlink_href,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @xlink:href attribute to <ext-link> with text "{text}"').format(**advice_params),
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=(
+                    i18n._("The @xlink:href attribute is present")
+                    if is_valid
+                    else i18n._("The @xlink:href attribute is required")
+                ),
+                message_params={},
             )
 
     def validate_xlink_href_format(self, error_level=None):
@@ -208,7 +220,7 @@ class ExtLinkValidation:
 
             is_valid = bool(re.match(r'^https?://', xlink_href, re.IGNORECASE))
 
-            advice_text = _(
+            advice_text = i18n._(
                 'URL in @xlink:href="{xlink_href}" must start with http:// or https://'
             )
             advice_params = {"xlink_href": xlink_href}
@@ -229,11 +241,15 @@ class ExtLinkValidation:
                 is_valid=is_valid,
                 expected="URL starting with http:// or https://",
                 obtained=xlink_href,
-                advice=advice_text.format(**advice_params),
+                advice=('URL in @xlink:href="{xlink_href}" must start with http:// or https://').format(**advice_params),
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "URL {url} must start with http:// or https://"
+                ),
+                message_params={"url": xlink_href},
             )
 
     def validate_ext_link_type_value(self, error_level=None):
@@ -263,7 +279,7 @@ class ExtLinkValidation:
 
             is_valid = ext_link_type in self.ALLOWED_EXT_LINK_TYPES
 
-            advice_text = _(
+            advice_text = i18n._(
                 'Replace @ext-link-type="{ext_link_type}" with one of: {allowed_values}'
             )
             advice_params = {
@@ -287,7 +303,7 @@ class ExtLinkValidation:
                 is_valid=is_valid,
                 expected=", ".join(self.ALLOWED_EXT_LINK_TYPES),
                 obtained=ext_link_type,
-                advice=advice_text.format(**advice_params),
+                advice=('Replace @ext-link-type="{ext_link_type}" with one of: {allowed_values}').format(**advice_params),
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
@@ -326,7 +342,7 @@ class ExtLinkValidation:
             if not is_generic:
                 continue
 
-            advice_text = _(
+            advice_text = i18n._(
                 'Replace generic text "{text}" in <ext-link> with descriptive text,'
                 " or add @xlink:title attribute"
             )
@@ -348,7 +364,8 @@ class ExtLinkValidation:
                 is_valid=False,
                 expected="descriptive text (not generic)",
                 obtained=text,
-                advice=advice_text.format(**advice_params),
+                advice=('Replace generic text "{text}" in <ext-link> with descriptive text,'
+                " or add @xlink:title attribute").format(**advice_params),
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
@@ -401,12 +418,20 @@ class ExtLinkValidation:
             # English words ("generic", "URL") into translated messages,
             # which was the original i18n bug (Copilot observation).
             if is_generic:
-                advice_text = _(
+                advice = (
+                    'Add @xlink:title attribute to <ext-link> with generic text'
+                    ' "{text}" to describe the link destination'
+                ).format(text=text)
+                advice_text = i18n._(
                     'Add @xlink:title attribute to <ext-link> with generic text'
                     ' "{text}" to describe the link destination'
                 )
             else:
-                advice_text = _(
+                advice = (
+                    'Add @xlink:title attribute to <ext-link> where the text is'
+                    ' the URL "{text}" to describe the link destination'
+                ).format(text=text)
+                advice_text = i18n._(
                     'Add @xlink:title attribute to <ext-link> where the text is'
                     ' the URL "{text}" to describe the link destination'
                 )
@@ -429,9 +454,14 @@ class ExtLinkValidation:
                 is_valid=False,
                 expected="@xlink:title attribute when text is generic or URL",
                 obtained=xlink_title,
-                advice=advice_text.format(**advice_params),
+                advice=advice,
                 data=ext_link,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "The @xlink:title attribute is required when the link "
+                    "text is generic or a URL"
+                ),
+                message_params={},
             )

--- a/packtools/sps/validation/fig.py
+++ b/packtools/sps/validation/fig.py
@@ -1,6 +1,6 @@
+from packtools.sps import i18n
 from packtools.sps.validation.models.fig import ArticleFigs
 from packtools.sps.validation.utils import build_response
-from gettext import gettext as _
 
 
 class ArticleFigValidation:
@@ -26,10 +26,10 @@ class ArticleFigValidation:
                 is_valid=False,
                 expected="<fig>",
                 obtained=None,
-                advice=_('article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct').format(article_type=self.article_type),
+                advice='article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct'.format(article_type=self.article_type),
                 data=None,
                 error_level=self.rules.get("absent_error_level", "WARNING"),
-                advice_text=_('article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct'),
+                advice_text=i18n._('article-type={article_type} requires <fig>. Found 0. Identify the fig or check if article-type is correct'),
                 advice_params={"article_type": self.article_type},
             )
 
@@ -105,10 +105,10 @@ class FigValidation:
             is_valid=is_valid,
             expected="@id attribute",
             obtained=obtained,
-            advice=_('Add @id attribute to <fig>. Example: <fig id="f01">. The @id attribute is mandatory.'),
+            advice='Add @id attribute to <fig>. Example: <fig id="f01">. The @id attribute is mandatory.',
             data=self.data,
             error_level=self.rules["id_error_level"],
-            advice_text=_('Add @id attribute to <fig>. Example: <fig id="f01">. The @id attribute is mandatory.'),
+            advice_text=i18n._('Add @id attribute to <fig>. Example: <fig id="f01">. The @id attribute is mandatory.'),
             advice_params={},
         )
 
@@ -124,10 +124,10 @@ class FigValidation:
             is_valid=has_graphic,
             expected="<graphic> element",
             obtained="<graphic>" if has_graphic else None,
-            advice=_('Add <graphic> element inside <fig>. Example: <graphic xlink:href="image.jpg"/>. Every <fig> must contain at least one <graphic> element.'),
+            advice='Add <graphic> element inside <fig>. Example: <graphic xlink:href="image.jpg"/>. Every <fig> must contain at least one <graphic> element.',
             data=self.data,
             error_level=self.rules["graphic_error_level"],
-            advice_text=_('Add <graphic> element inside <fig>. Example: <graphic xlink:href="image.jpg"/>. Every <fig> must contain at least one <graphic> element.'),
+            advice_text=i18n._('Add <graphic> element inside <fig>. Example: <graphic xlink:href="image.jpg"/>. Every <fig> must contain at least one <graphic> element.'),
             advice_params={},
         )
 
@@ -149,10 +149,10 @@ class FigValidation:
             is_valid=is_valid,
             expected="@xlink:href attribute in <graphic>",
             obtained=href,
-            advice=_('Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href="image.jpg"/>. The @xlink:href attribute is mandatory in <graphic>.'),
+            advice='Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href="image.jpg"/>. The @xlink:href attribute is mandatory in <graphic>.',
             data=self.data,
             error_level=self.rules["xlink_href_error_level"],
-            advice_text=_('Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href="image.jpg"/>. The @xlink:href attribute is mandatory in <graphic>.'),
+            advice_text=i18n._('Add @xlink:href attribute to <graphic>. Example: <graphic xlink:href="image.jpg"/>. The @xlink:href attribute is mandatory in <graphic>.'),
             advice_params={},
         )
 
@@ -185,8 +185,8 @@ class FigValidation:
             # SVG is only valid when the <graphic> is a direct child of <alternatives>
             is_valid = is_in_alternatives
             if not is_valid:
-                advice = _('SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>.').format(allowed_formats=", ".join(allowed_extensions))
-                advice_text = _('SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>.')
+                advice = 'SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>.'.format(allowed_formats=", ".join(allowed_extensions))
+                advice_text = i18n._('SVG files are only allowed inside <alternatives>. Either use a different format ({allowed_formats}) or wrap the graphic in <alternatives>.')
                 advice_params = {"allowed_formats": ", ".join(allowed_extensions)}
             else:
                 advice = None
@@ -195,12 +195,12 @@ class FigValidation:
         else:
             is_valid = file_extension in allowed_extensions if file_extension else False
             if file_extension and not is_valid:
-                advice = _('File extension "{file_extension}" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>.').format(file_extension=file_extension, allowed_formats=", ".join(allowed_extensions))
-                advice_text = _('File extension "{file_extension}" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>.')
+                advice = 'File extension "{file_extension}" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>.'.format(file_extension=file_extension, allowed_formats=", ".join(allowed_extensions))
+                advice_text = i18n._('File extension "{file_extension}" is not allowed. Use one of: {allowed_formats}. If using SVG, it must be inside <alternatives>.')
                 advice_params = {"file_extension": file_extension, "allowed_formats": ", ".join(allowed_extensions)}
             elif not file_extension:
-                advice = _('File "{graphic_href}" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>.').format(graphic_href=graphic_href, allowed_formats=", ".join(allowed_extensions))
-                advice_text = _('File "{graphic_href}" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>.')
+                advice = 'File "{graphic_href}" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>.'.format(graphic_href=graphic_href, allowed_formats=", ".join(allowed_extensions))
+                advice_text = i18n._('File "{graphic_href}" must have a valid extension. Allowed: {allowed_formats}. SVG is only allowed inside <alternatives>.')
                 advice_params = {"graphic_href": graphic_href, "allowed_formats": ", ".join(allowed_extensions)}
             else:
                 advice = None
@@ -238,10 +238,10 @@ class FigValidation:
             is_valid=is_valid,
             expected=f'one of {allowed_types}',
             obtained=fig_type,
-            advice=_('Invalid @fig-type value "{fig_type}". Use one of: {allowed_types}.').format(fig_type=fig_type, allowed_types=", ".join(allowed_types)),
+            advice='Invalid @fig-type value "{fig_type}". Use one of: {allowed_types}.'.format(fig_type=fig_type, allowed_types=", ".join(allowed_types)),
             data=self.data,
             error_level=self.rules["fig_type_error_level"],
-            advice_text=_('Invalid @fig-type value "{fig_type}". Use one of: {allowed_types}.'),
+            advice_text=i18n._('Invalid @fig-type value "{fig_type}". Use one of: {allowed_types}.'),
             advice_params={"fig_type": fig_type, "allowed_types": ", ".join(allowed_types)},
         )
 
@@ -259,10 +259,10 @@ class FigValidation:
             is_valid=is_valid,
             expected="@xml:lang attribute",
             obtained=xml_lang,
-            advice=_('When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang="en">.'),
+            advice='When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang="en">.',
             data=self.data,
             error_level=self.rules["xml_lang_in_fig_group_error_level"],
-            advice_text=_('When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang="en">.'),
+            advice_text=i18n._('When <fig> is inside <fig-group>, the @xml:lang attribute is mandatory. Add xml:lang attribute to <fig>. Example: <fig xml:lang="en">.'),
             advice_params={},
         )
 
@@ -271,6 +271,13 @@ class FigValidation:
         alt_text = self.data.get("graphic_alt_text")
         long_desc = self.data.get("graphic_long_desc")
         has_accessibility = bool(alt_text or long_desc)
+        if has_accessibility:
+            message_text = i18n._("Accessibility description is present")
+        else:
+            message_text = i18n._(
+                "No accessibility description was found; "
+                "expected <alt-text> or <long-desc>"
+            )
 
         return build_response(
             title="accessibility",
@@ -281,11 +288,13 @@ class FigValidation:
             is_valid=has_accessibility,
             expected="<alt-text> or <long-desc>",
             obtained="present" if has_accessibility else None,
-            advice=_('For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href="image.jpg"><alt-text>Brief description</alt-text></graphic>.'),
+            advice='For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href="image.jpg"><alt-text>Brief description</alt-text></graphic>.',
             data=self.data,
             error_level=self.rules["accessibility_error_level"],
-            advice_text=_('For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href="image.jpg"><alt-text>Brief description</alt-text></graphic>.'),
+            advice_text=i18n._('For accessibility, add <alt-text> or <long-desc> inside <graphic>. Example: <graphic xlink:href="image.jpg"><alt-text>Brief description</alt-text></graphic>.'),
             advice_params={},
+            message_text=message_text,
+            message_params={},
         )
 
     def validate_alt_text_length(self):
@@ -304,9 +313,9 @@ class FigValidation:
             is_valid=is_valid,
             expected=f"≤ {max_length} characters",
             obtained=f"{current_length} characters",
-            advice=_('The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description.').format(current_length=current_length, max_length=max_length),
+            advice='The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description.'.format(current_length=current_length, max_length=max_length),
             data=self.data,
             error_level=self.rules["alt_text_length_error_level"],
-            advice_text=_('The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description.'),
+            advice_text=i18n._('The <alt-text> content has {current_length} characters, exceeding the recommended maximum of {max_length}. Please shorten the description.'),
             advice_params={"current_length": current_length, "max_length": max_length},
         )

--- a/packtools/sps/validation/fn.py
+++ b/packtools/sps/validation/fn.py
@@ -1,6 +1,7 @@
 from packtools.sps.validation.models.fn import XMLFns
 from packtools.sps.validation.basefn import BaseFnValidation
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class FnValidation(BaseFnValidation):
@@ -21,7 +22,7 @@ class FnValidation(BaseFnValidation):
         
         if not is_valid:
             advice = 'Add mandatory @fn-type attribute to <fn> in <fn-group>'
-            advice_text = 'Add mandatory @fn-type attribute to <fn> in <fn-group>'
+            advice_text = i18n._('Add mandatory @fn-type attribute to <fn> in <fn-group>')
             advice_params = {}
             
             return build_response(
@@ -136,7 +137,7 @@ class XMLFnGroupValidation:
         
         if article_fn_group_count > 1:
             advice = f'<fn-group> element should appear at most once in the article. Found {article_fn_group_count} occurrences.'
-            advice_text = '<fn-group> element should appear at most once in the article. Found {count} occurrences.'
+            advice_text = i18n._('<fn-group> element should appear at most once in the article. Found {count} occurrences.')
             advice_params = {"count": str(article_fn_group_count)}
             
             yield build_response(
@@ -162,7 +163,7 @@ class XMLFnGroupValidation:
             
             if sub_fn_group_count > 1:
                 advice = f'<fn-group> element should appear at most once in sub-article (id={sub_article_id}). Found {sub_fn_group_count} occurrences.'
-                advice_text = '<fn-group> element should appear at most once in sub-article (id={id}). Found {count} occurrences.'
+                advice_text = i18n._('<fn-group> element should appear at most once in sub-article (id={id}). Found {count} occurrences.')
                 advice_params = {
                     "id": sub_article_id,
                     "count": str(sub_fn_group_count)
@@ -212,6 +213,8 @@ class XMLFnGroupValidation:
             expected='<fn fn-type="edited-by">',
             obtained='<fn fn-type="edited-by">' if is_valid else None,
             advice='Make the responsible editor with <fn fn-type="edited-by">',
+            advice_text=i18n._('Make the responsible editor with <fn fn-type="edited-by">'),
+            advice_params={},
             data=list(self.xml_article.fn_edited_by),
             error_level=self.rules["fn_type_error_level"]
         )

--- a/packtools/sps/validation/formula.py
+++ b/packtools/sps/validation/formula.py
@@ -1,6 +1,6 @@
 import logging
-from gettext import gettext as _
 
+from packtools.sps import i18n
 from packtools.sps.validation.models.formula import ArticleFormulas
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.xml_validator_rules import get_group_rules
@@ -45,10 +45,10 @@ class ArticleDispFormulaValidation:
                 is_valid=False,
                 expected="disp-formula",
                 obtained=None,
-                advice=_('No <disp-formula> found in XML'),
+                advice='No <disp-formula> found in XML',
                 data=None,
                 error_level=self.rules["absent_error_level"],
-                advice_text=_('No <disp-formula> found in XML'),
+                advice_text=i18n._('No <disp-formula> found in XML'),
                 advice_params={},
             )
         else:
@@ -126,10 +126,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected="@id",
             obtained=formula_id,
-            advice=_('Add the formula ID with id="" in <disp-formula>: <disp-formula id="">. Consult SPS documentation for more detail.'),
+            advice='Add the formula ID with id="" in <disp-formula>: <disp-formula id="">. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["id_error_level"],
-            advice_text=_('Add the formula ID with id="" in <disp-formula>: <disp-formula id="">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Add the formula ID with id="" in <disp-formula>: <disp-formula id="">. Consult SPS documentation for more detail.'),
             advice_params={},
         )
 
@@ -147,7 +147,7 @@ class DispFormulaValidation:
             return None
 
         is_valid = formula_id.startswith("e")
-        expected = _("id starting with 'e'")
+        expected = "id starting with 'e'"
 
         return build_response(
             title="@id prefix",
@@ -158,10 +158,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected=expected,
             obtained=formula_id,
-            advice=_('The @id of <disp-formula> must start with prefix "e". Change {id} to e{id} in <disp-formula id="{id}">. Consult SPS documentation for more detail.').format(id=formula_id),
+            advice='The @id of <disp-formula> must start with prefix "e". Change {id} to e{id} in <disp-formula id="{id}">. Consult SPS documentation for more detail.'.format(id=formula_id),
             data=self.data,
             error_level=self.rules["id_prefix_error_level"],
-            advice_text=_('The @id of <disp-formula> must start with prefix "e". Change {id} to e{id} in <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('The @id of <disp-formula> must start with prefix "e". Change {id} to e{id} in <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
             advice_params={"id": formula_id},
         )
 
@@ -186,10 +186,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected="label",
             obtained=label,
-            advice=_('Mark each label with <label> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.').format(id=item_id),
+            advice='Mark each label with <label> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'.format(id=item_id),
             data=self.data,
             error_level=self.rules["label_error_level"],
-            advice_text=_('Mark each label with <label> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Mark each label with <label> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
             advice_params={"id": item_id},
         )
 
@@ -209,7 +209,7 @@ class DispFormulaValidation:
             count += 1
             found.append("tex-math")
 
-        obtained = " and ".join(found) if found else _("not found codification formula")
+        obtained = " and ".join(found) if found else "not found codification formula"
 
         alternatives = self.data.get("alternative_elements") or []
         is_valid = (count == 1) or (count == len(alternatives) and count > 1)
@@ -223,10 +223,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected="mml:math or tex-math",
             obtained=obtained,
-            advice=_('Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.').format(id=item_id),
+            advice='Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'.format(id=item_id),
             data=self.data,
             error_level=self.rules["codification_error_level"],
-            advice_text=_('Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Mark each formula codification with <mml:math> or <tex-math> inside <disp-formula id="{id}">. Consult SPS documentation for more detail.'),
             advice_params={"id": item_id},
         )
 
@@ -254,10 +254,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected="@id in mml:math",
             obtained=mml_math_id,
-            advice=_('Add the @id attribute in <mml:math> inside <disp-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.').format(formula_id=item_id),
+            advice='Add the @id attribute in <mml:math> inside <disp-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'.format(formula_id=item_id),
             data=self.data,
             error_level=self.rules["mml_math_id_error_level"],
-            advice_text=_('Add the @id attribute in <mml:math> inside <disp-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Add the @id attribute in <mml:math> inside <disp-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'),
             advice_params={"formula_id": item_id},
         )
 
@@ -274,7 +274,7 @@ class DispFormulaValidation:
 
         mml_math_id = self.data.get("mml_math_id")
         is_valid = mml_math_id.startswith("m")
-        expected = _("id starting with 'm'")
+        expected = "id starting with 'm'"
         item_id = self.data.get("id")
 
         return build_response(
@@ -286,10 +286,10 @@ class DispFormulaValidation:
             is_valid=is_valid,
             expected=expected,
             obtained=mml_math_id,
-            advice=_('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <disp-formula id="{formula_id}">. Consult SPS documentation for more detail.').format(mml_id=mml_math_id, formula_id=item_id),
+            advice='The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <disp-formula id="{formula_id}">. Consult SPS documentation for more detail.'.format(mml_id=mml_math_id, formula_id=item_id),
             data=self.data,
             error_level=self.rules["mml_math_id_prefix_error_level"],
-            advice_text=_('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <disp-formula id="{formula_id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <disp-formula id="{formula_id}">. Consult SPS documentation for more detail.'),
             advice_params={"mml_id": mml_math_id, "formula_id": item_id},
         )
 
@@ -314,7 +314,7 @@ class DispFormulaValidation:
                 validation_type="exist",
                 is_valid=True,
                 expected="mml:math or tex-math",
-                obtained=_("no codification found"),
+                obtained="no codification found",
                 advice=None,
                 data=self.data,
                 error_level=self.rules["mathml_error_level"],
@@ -337,10 +337,10 @@ class DispFormulaValidation:
                 is_valid=is_valid,
                 expected=expected,
                 obtained=obtained,
-                advice=_('For accessibility, consider adding <mml:math> in <disp-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.').format(formula_id=item_id),
+                advice='For accessibility, consider adding <mml:math> in <disp-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'.format(formula_id=item_id),
                 data=self.data,
                 error_level=self.rules["mathml_error_level"],
-                advice_text=_('For accessibility, consider adding <mml:math> in <disp-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'),
+                advice_text=i18n._('For accessibility, consider adding <mml:math> in <disp-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'),
                 advice_params={"formula_id": item_id},
             )
         
@@ -379,22 +379,22 @@ class DispFormulaValidation:
         if mml + tex + len(graphic) > 1 and len(alternatives) == 0:
             expected = "alternatives"
             obtained = None
-            advice = _('Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>')
-            advice_text = _('Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>')
+            advice = 'Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>'
+            advice_text = i18n._('Wrap <tex-math> and <mml:math> with <alternatives> inside <disp-formula>')
             advice_params = {}
             valid = False
         elif mml + tex + len(graphic) == 1 and len(alternatives) > 0:
             expected = None
             obtained = "alternatives"
-            advice = _('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>').format(found=found)
-            advice_text = _('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>')
+            advice = 'Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>'.format(found=found)
+            advice_text = i18n._('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>')
             advice_params = {"found": found}
             valid = False
         elif len(alternatives) == 1:
             expected = None
             obtained = "alternatives"
-            advice = _('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>').format(found=found)
-            advice_text = _('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>')
+            advice = 'Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>'.format(found=found)
+            advice_text = i18n._('Remove the <alternatives> from <disp-formula> and keep <{found}> inside <disp-formula>')
             advice_params = {"found": found}
             valid = False
         else:
@@ -463,10 +463,10 @@ class ArticleInlineFormulaValidation:
                 is_valid=False,
                 expected="inline-formula",
                 obtained=None,
-                advice=_('No <inline-formula> found in XML'),
+                advice='No <inline-formula> found in XML',
                 data=None,
                 error_level=self.rules["absent_error_level"],
-                advice_text=_('No <inline-formula> found in XML'),
+                advice_text=i18n._('No <inline-formula> found in XML'),
                 advice_params={},
             )
         else:
@@ -545,10 +545,10 @@ class InlineFormulaValidation:
             is_valid=is_valid,
             expected="@id",
             obtained=formula_id,
-            advice=_('Add the formula ID with id="" in <inline-formula>: <inline-formula id="">. Consult SPS documentation for more detail.'),
+            advice='Add the formula ID with id="" in <inline-formula>: <inline-formula id="">. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["id_error_level"],
-            advice_text=_('Add the formula ID with id="" in <inline-formula>: <inline-formula id="">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Add the formula ID with id="" in <inline-formula>: <inline-formula id="">. Consult SPS documentation for more detail.'),
             advice_params={},
         )
 
@@ -566,7 +566,7 @@ class InlineFormulaValidation:
             return None
 
         is_valid = formula_id.startswith("e")
-        expected = _("id starting with 'e'")
+        expected = "id starting with 'e'"
 
         return build_response(
             title="@id prefix",
@@ -577,10 +577,10 @@ class InlineFormulaValidation:
             is_valid=is_valid,
             expected=expected,
             obtained=formula_id,
-            advice=_('The @id of <inline-formula> must start with prefix "e". Change {id} to e{id} in <inline-formula id="{id}">. Consult SPS documentation for more detail.').format(id=formula_id),
+            advice='The @id of <inline-formula> must start with prefix "e". Change {id} to e{id} in <inline-formula id="{id}">. Consult SPS documentation for more detail.'.format(id=formula_id),
             data=self.data,
             error_level=self.rules["id_prefix_error_level"],
-            advice_text=_('The @id of <inline-formula> must start with prefix "e". Change {id} to e{id} in <inline-formula id="{id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('The @id of <inline-formula> must start with prefix "e". Change {id} to e{id} in <inline-formula id="{id}">. Consult SPS documentation for more detail.'),
             advice_params={"id": formula_id},
         )
 
@@ -601,7 +601,7 @@ class InlineFormulaValidation:
             count += 1
             found.append("tex-math")
 
-        obtained = " and ".join(found) if found else _("not found codification formula")
+        obtained = " and ".join(found) if found else "not found codification formula"
 
         alternatives = self.data.get("alternative_elements") or []
         is_valid = (count == 1) or ((count == len(alternatives)) and (count > 1))
@@ -615,10 +615,10 @@ class InlineFormulaValidation:
             is_valid=is_valid,
             expected="mml:math or tex-math",
             obtained=obtained,
-            advice=_('Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail.'),
+            advice='Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["codification_error_level"],
-            advice_text=_('Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Mark each formula codification with <mml:math> or <tex-math> inside <inline-formula>. Consult SPS documentation for more detail.'),
             advice_params={},
         )
 
@@ -646,10 +646,10 @@ class InlineFormulaValidation:
             is_valid=is_valid,
             expected="@id in mml:math",
             obtained=mml_math_id,
-            advice=_('Add the @id attribute in <mml:math> inside <inline-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.').format(formula_id=item_id),
+            advice='Add the @id attribute in <mml:math> inside <inline-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'.format(formula_id=item_id),
             data=self.data,
             error_level=self.rules["mml_math_id_error_level"],
-            advice_text=_('Add the @id attribute in <mml:math> inside <inline-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('Add the @id attribute in <mml:math> inside <inline-formula id="{formula_id}">: <mml:math id="">. Consult SPS documentation for more detail.'),
             advice_params={"formula_id": item_id},
         )
 
@@ -666,7 +666,7 @@ class InlineFormulaValidation:
 
         mml_math_id = self.data.get("mml_math_id")
         is_valid = mml_math_id.startswith("m")
-        expected = _("id starting with 'm'")
+        expected = "id starting with 'm'"
         item_id = self.data.get("id")
 
         return build_response(
@@ -678,10 +678,10 @@ class InlineFormulaValidation:
             is_valid=is_valid,
             expected=expected,
             obtained=mml_math_id,
-            advice=_('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <inline-formula id="{formula_id}">. Consult SPS documentation for more detail.').format(mml_id=mml_math_id, formula_id=item_id),
+            advice='The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <inline-formula id="{formula_id}">. Consult SPS documentation for more detail.'.format(mml_id=mml_math_id, formula_id=item_id),
             data=self.data,
             error_level=self.rules["mml_math_id_prefix_error_level"],
-            advice_text=_('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <inline-formula id="{formula_id}">. Consult SPS documentation for more detail.'),
+            advice_text=i18n._('The @id of <mml:math> must start with prefix "m". Change {mml_id} to m{mml_id} in <mml:math id="{mml_id}"> inside <inline-formula id="{formula_id}">. Consult SPS documentation for more detail.'),
             advice_params={"mml_id": mml_math_id, "formula_id": item_id},
         )
 
@@ -706,7 +706,7 @@ class InlineFormulaValidation:
                 validation_type="exist",
                 is_valid=True,
                 expected="mml:math or tex-math",
-                obtained=_("no codification found"),
+                obtained="no codification found",
                 advice=None,
                 data=self.data,
                 error_level=self.rules["mathml_error_level"],
@@ -729,10 +729,10 @@ class InlineFormulaValidation:
                 is_valid=is_valid,
                 expected=expected,
                 obtained=obtained,
-                advice=_('For accessibility, consider adding <mml:math> in <inline-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.').format(formula_id=item_id),
+                advice='For accessibility, consider adding <mml:math> in <inline-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'.format(formula_id=item_id),
                 data=self.data,
                 error_level=self.rules["mathml_error_level"],
-                advice_text=_('For accessibility, consider adding <mml:math> in <inline-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'),
+                advice_text=i18n._('For accessibility, consider adding <mml:math> in <inline-formula id="{formula_id}">. MathML improves accessibility for screen readers. Consult SPS documentation for more detail.'),
                 advice_params={"formula_id": item_id},
             )
         
@@ -771,22 +771,22 @@ class InlineFormulaValidation:
         if mml + tex + len(graphic) > 1 and len(alternatives) == 0:
             expected = "alternatives"
             obtained = None
-            advice = _('Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>')
-            advice_text = _('Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>')
+            advice = 'Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>'
+            advice_text = i18n._('Wrap <tex-math> and <mml:math> with <alternatives> inside <inline-formula>')
             advice_params = {}
             valid = False
         elif mml + tex + len(graphic) == 1 and len(alternatives) > 0:
             expected = None
             obtained = "alternatives"
-            advice = _('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>').format(found=found)
-            advice_text = _('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>')
+            advice = 'Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>'.format(found=found)
+            advice_text = i18n._('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>')
             advice_params = {"found": found}
             valid = False
         elif len(alternatives) == 1:
             expected = None
             obtained = "alternatives"
-            advice = _('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>').format(found=found)
-            advice_text = _('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>')
+            advice = 'Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>'.format(found=found)
+            advice_text = i18n._('Remove the <alternatives> from <inline-formula> and keep <{found}> inside <inline-formula>')
             advice_params = {"found": found}
             valid = False
         else:

--- a/packtools/sps/validation/front_articlemeta_issue.py
+++ b/packtools/sps/validation/front_articlemeta_issue.py
@@ -1,6 +1,8 @@
+import re
+
 from packtools.sps.models.front_articlemeta_issue import ArticleMetaIssue
 from packtools.sps.validation.utils import build_response
-import re
+from packtools.sps import i18n
 
 
 def is_valid_value(value, zero_is_allowed):
@@ -72,6 +74,11 @@ class IssueValidation:
                 expected=result["expected"],
                 obtained=result["got"],
                 advice=f'Replace {result["got"]} in <article-meta><volume> with {result["expected"]}',
+                advice_text=i18n._("Replace {obtained} in <article-meta><volume> with {expected}"),
+                advice_params={
+                    "obtained": result["got"],
+                    "expected": result["expected"],
+                },
                 data=self.article_issue.data,
                 error_level=self.params["volume_format_error_level"],
                 element_name="article-meta",
@@ -101,6 +108,11 @@ class IssueValidation:
                 expected=result["expected"],
                 obtained=result["got"],
                 advice=f'Replace {result["got"]} in <article-meta><issue> with {result["expected"]}',
+                advice_text=i18n._("Replace {obtained} in <article-meta><issue> with {expected}"),
+                advice_params={
+                    "obtained": result["got"],
+                    "expected": result["expected"],
+                },
                 data=self.article_issue.data,
                 error_level=self.params["number_format_error_level"],
                 element_name="article-meta",
@@ -130,6 +142,11 @@ class IssueValidation:
                 expected=result["expected"],
                 obtained=result["got"],
                 advice=f'Replace {result["got"]} in <article-meta><supplement> with {result["expected"]}',
+                advice_text=i18n._("Replace {obtained} in <article-meta><supplement> with {expected}"),
+                advice_params={
+                    "obtained": result["got"],
+                    "expected": result["expected"],
+                },
                 data=self.article_issue.data,
                 error_level=self.params["supplement_format_error_level"],
                 element_name="article-meta",
@@ -189,6 +206,11 @@ class IssueValidation:
                     if not got_valid_format
                     else None
                 ),
+                advice_text=i18n._("Replace {issue} in <article-meta><issue> with one of {expected}"),
+                advice_params={
+                    "issue": self.article_issue.issue,
+                    "expected": expected,
+                },
                 data={"issue": self.article_issue.issue},
                 error_level=self.params["issue_format_error_level"],
             )
@@ -225,6 +247,13 @@ class IssueValidation:
                 expected="Journal issue registered in title manager or scielo manager or core",
                 obtained=issue,
                 advice="Unable to check if issue is registered",
+                message_text=i18n._(
+                    "Got {issue}, but the registered journal issue could not "
+                    "be checked"
+                ),
+                message_params={"issue": issue},
+                advice_text=i18n._("Unable to check if issue is registered"),
+                advice_params={},
                 data=issue,
                 error_level="WARNING",
             )
@@ -239,6 +268,11 @@ class IssueValidation:
             expected=expected_issues,
             obtained=issue,
             advice=f'Replace {issue} in <article-meta> with one of {expected_issues}',
+            advice_text=i18n._("Replace {issue} in <article-meta> with one of {expected_issues}"),
+            advice_params={
+                "issue": issue,
+                "expected_issues": expected_issues,
+            },
             data=issue,
             error_level=self.params["expected_issues_error_level"],
         )
@@ -265,6 +299,8 @@ class IssueValidation:
             expected="at most one <issue> element in <article-meta>",
             obtained=f"{count} <issue> element(s) found",
             advice=f"Remove duplicate <issue> elements from <article-meta>. Found {count} elements, expected at most 1.",
+            advice_text=i18n._("Remove duplicate <issue> elements from <article-meta>. Found {count} elements, expected at most 1."),
+            advice_params={"count": count},
             data={"issue_count": count, "issue_values": [elem.text for elem in issue_elements]},
             error_level=self.params.get("issue_element_uniqueness_error_level", "ERROR"),
         )
@@ -296,6 +332,11 @@ class IssueValidation:
             expected="issue value without punctuation marks",
             obtained=issue_value,
             advice=f"Remove punctuation marks {found_punctuation} from <issue> value '{issue_value}'",
+            advice_text=i18n._("Remove punctuation marks {found_punctuation} from <issue> value '{issue_value}'"),
+            advice_params={
+                "found_punctuation": found_punctuation,
+                "issue_value": issue_value,
+            },
             data={"issue": issue_value, "punctuation_found": found_punctuation},
             error_level=self.params.get("issue_no_punctuation_error_level", "ERROR"),
         )
@@ -325,6 +366,11 @@ class IssueValidation:
             expected="issue value in lowercase only",
             obtained=issue_value,
             advice=f"Convert uppercase letters to lowercase in <issue> value '{issue_value}'. Expected: '{issue_value.lower()}'",
+            advice_text=i18n._("Convert uppercase letters to lowercase in <issue> value '{issue_value}'. Expected: '{expected}'"),
+            advice_params={
+                "issue_value": issue_value,
+                "expected": issue_value.lower(),
+            },
             data={"issue": issue_value, "expected": issue_value.lower()},
             error_level=self.params.get("issue_no_uppercase_error_level", "ERROR"),
         )
@@ -370,6 +416,11 @@ class IssueValidation:
             expected="supplement nomenclature as 'suppl'",
             obtained=issue_value,
             advice=f"Use 'suppl' for supplement nomenclature in <issue> value '{issue_value}'. Invalid terms found: {invalid_patterns}",
+            advice_text=i18n._("Use 'suppl' for supplement nomenclature in <issue> value '{issue_value}'. Invalid terms found: {invalid_patterns}"),
+            advice_params={
+                "issue_value": issue_value,
+                "invalid_patterns": invalid_patterns,
+            },
             data={"issue": issue_value, "invalid_terms": invalid_patterns},
             error_level=self.params.get("issue_supplement_nomenclature_error_level", "ERROR"),
         )
@@ -422,6 +473,11 @@ class IssueValidation:
             expected="special issue nomenclature as 'spe'",
             obtained=issue_value,
             advice=f"Use 'spe' for special issue nomenclature in <issue> value '{issue_value}'. Invalid terms found: {found_invalid}",
+            advice_text=i18n._("Use 'spe' for special issue nomenclature in <issue> value '{issue_value}'. Invalid terms found: {found_invalid}"),
+            advice_params={
+                "issue_value": issue_value,
+                "found_invalid": found_invalid,
+            },
             data={"issue": issue_value, "invalid_terms": found_invalid},
             error_level=self.params.get("issue_special_nomenclature_error_level", "ERROR"),
         )
@@ -449,6 +505,8 @@ class IssueValidation:
             expected="no <supplement> element in <article-meta>",
             obtained=f"{count} <supplement> element(s) found",
             advice="Remove <supplement> element(s) from <article-meta>. Use <issue> element to indicate supplements (e.g., '4 suppl 1').",
+            advice_text=i18n._("Remove <supplement> element(s) from <article-meta>. Use <issue> element to indicate supplements (e.g., '4 suppl 1')."),
+            advice_params={},
             data={"supplement_count": count, "supplement_values": [elem.text for elem in supplement_elements]},
             error_level=self.params.get("no_supplement_element_error_level", "CRITICAL"),
         )
@@ -502,6 +560,11 @@ class IssueValidation:
             expected="numeric values without leading zeros",
             obtained=issue_value,
             advice=f"Remove leading zeros from numeric parts in <issue> value '{issue_value}'. Expected: '{expected_value}'",
+            advice_text=i18n._("Remove leading zeros from numeric parts in <issue> value '{issue_value}'. Expected: '{expected_value}'"),
+            advice_params={
+                "issue_value": issue_value,
+                "expected_value": expected_value,
+            },
             data={"issue": issue_value, "parts_with_leading_zeros": issues_found, "expected": expected_value},
             error_level=self.params.get("issue_no_leading_zeros_error_level", "WARNING"),
         )
@@ -587,6 +650,8 @@ class PaginationValidation:
             expected="elocation id or first and last pages",
             obtained=f"elocation-id: {self.issue.elocation_id}, fpage: {self.issue.fpage}, lpage: {self.issue.lpage}",
             advice="Mark elocation id with <elocation-id> or first page with <fpage> and last page with <lpage>",
+            advice_text=i18n._("Mark elocation id with <elocation-id> or first page with <fpage> and last page with <lpage>"),
+            advice_params={},
             data=self.issue.data,
             error_level=self.params["pagination_error_level"],
         )

--- a/packtools/sps/validation/funding_group.py
+++ b/packtools/sps/validation/funding_group.py
@@ -1,6 +1,7 @@
 from packtools.sps.models.funding_group import FundingGroup
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.similarity_utils import most_similar, similarity
+from packtools.sps import i18n
 
 def _callable_extern_validate_default(award_id):
     raise NotImplementedError
@@ -56,15 +57,24 @@ class FundingGroupValidation:
             if funding_sources and award_ids:
                 valid = True
                 advice = None
+                advice_text = None
+                advice_params = {}
             elif award_ids:
                 valid = False
                 advice = f'Mark the sponsor institution with <funding-source> for <award-id> ({award_ids}). Consult SPS documentation for more detail'
+                advice_text = i18n._("Mark the sponsor institution with <funding-source> for <award-id> ({award_ids}). Consult SPS documentation for more detail")
+                advice_params = {"award_ids": award_ids}
             elif funding_sources:
                 valid = False
                 advice = f'Mark the contract number with <award-id> for <funding-source> ({funding_sources}). Consult SPS documentation for more detail'
+                advice_text = i18n._("Mark the contract number with <award-id> for <funding-source> ({funding_sources}). Consult SPS documentation for more detail")
+                advice_params = {"funding_sources": funding_sources}
             else:
                 valid = False
-                advice = f'Mark the contract number with <award-id> and the funding institution with <funding-source> insider <award-group>. Consult SPS documentation for more detail'
+                advice = 'Mark the contract number with <award-id> and the funding institution with <funding-source> insider <award-group>. Consult SPS documentation for more detail'
+                advice_text = i18n._("Mark the contract number with <award-id> and the funding institution with <funding-source> insider <award-group>. Consult SPS documentation for more detail")
+                advice_params = {}
+
             yield build_response(
                 title="award-id and funding-source",
                 parent=parent,
@@ -75,6 +85,20 @@ class FundingGroupValidation:
                 expected="award-id and funding-source in award-group",
                 obtained=item,
                 advice=advice,
+                advice_text=advice_text,
+                advice_params=advice_params,
+                message_text=(
+                    i18n._(
+                        "<award-group> contains both <award-id> and "
+                        "<funding-source>"
+                    )
+                    if valid
+                    else i18n._(
+                        "<award-group> must contain both <award-id> and "
+                        "<funding-source>"
+                    )
+                ),
+                message_params={},
                 data=item,
                 error_level=self.params["award_id_error_level"],
             )
@@ -101,6 +125,12 @@ class FundingGroupValidation:
                     expected="award-id and funding-source in award-group",
                     obtained=None,
                     advice=f"Found {missing} in {text} ({context}), if {missing} is a contract number, add <award-id>{missing}</award-id> and the corresponding funding institution with <funding-source> inside <award-group>. Consult the SPS documentation for more detail",
+                    advice_text=i18n._("Found {missing} in {text} ({context}), if {missing} is a contract number, add <award-id>{missing}</award-id> and the corresponding funding institution with <funding-source> inside <award-group>. Consult the SPS documentation for more detail"),
+                    advice_params={
+                        "missing": missing,
+                        "text": text,
+                        "context": context,
+                    },
                     data=item,
                     error_level=self.params["award_id_error_level"],
                 )
@@ -174,6 +204,8 @@ class FundingGroupValidation:
             texts = all_texts
             valid = False
             advice = None
+            advice_text = None
+            advice_params = {}
 
             if funding_statement and texts:
                 # Both a <funding-statement> and reference texts exist: compare them.
@@ -187,6 +219,11 @@ class FundingGroupValidation:
                         f"Replace <funding-statement>{funding_statement}</funding-statement>"
                         f" by <funding-statement>{texts[0]}</funding-statement>"
                     )
+                    advice_text = i18n._("Replace <funding-statement>{funding_statement}</funding-statement> by <funding-statement>{reference_text}</funding-statement>")
+                    advice_params = {
+                        "funding_statement": funding_statement,
+                        "reference_text": texts[0],
+                    }
             elif funding_statement and not texts:
                 # <funding-statement> is present but no reference texts (fn/ack) were
                 # found to compare against.  We cannot invalidate the statement, so
@@ -196,18 +233,22 @@ class FundingGroupValidation:
                     "No reference texts (fn/ack elements) were found to compare with"
                     " <funding-statement>. Verify manually that the statement is correct."
                 )
+                advice_text = i18n._("No reference texts (fn/ack elements) were found to compare with <funding-statement>. Verify manually that the statement is correct.")
             elif texts:
                 # Reference texts exist but <funding-statement> is absent.
                 advice = (
                     f"Add <funding-statement>{texts[0]}</funding-statement>"
                     " in <funding-group>. Consult SPS documentation for more detail"
                 )
+                advice_text = i18n._("Add <funding-statement>{reference_text}</funding-statement> in <funding-group>. Consult SPS documentation for more detail")
+                advice_params = {"reference_text": texts[0]}
             else:
                 # Neither <funding-statement> nor reference texts are present.
                 advice = (
                     "Add funding statement with <funding-statement> inside"
                     " <funding-group>. Consult SPS documentation for more detail"
                 )
+                advice_text = i18n._("Add funding statement with <funding-statement> inside <funding-group>. Consult SPS documentation for more detail")
 
             yield build_response(
                 title="funding-statement",
@@ -219,6 +260,8 @@ class FundingGroupValidation:
                 expected="funding-statement",
                 obtained=funding_statement or "None",
                 advice=advice,
+                advice_text=advice_text,
+                advice_params=advice_params,
                 data={"funding_statement": funding_statement, "texts": texts},
                 error_level=self.params["funding_statement_error_level"],
             )
@@ -281,6 +324,8 @@ class FundingGroupValidation:
                 expected="At most one <funding-group> in <article-meta>",
                 obtained=f"{count} <funding-group> element(s) found",
                 advice=advice,
+                advice_text=i18n._("Found {count} <funding-group> elements in <article-meta>. Only one is allowed. Merge them into a single <funding-group>."),
+                advice_params={"count": count},
                 data={"count": count},
                 error_level=error_level,
             )
@@ -346,6 +391,16 @@ class FundingGroupValidation:
                 expected="<funding-statement> present in <funding-group>",
                 obtained=obtained,
                 advice=advice,
+                advice_text=i18n._("Add <funding-statement> element inside <funding-group> (index {index}). It is mandatory according to SPS 1.10."),
+                advice_params={"index": idx + 1},
+                message_text=(
+                    i18n._("<funding-statement> is present in <funding-group>")
+                    if is_valid
+                    else i18n._(
+                        "<funding-statement> is required in <funding-group>"
+                    )
+                ),
+                message_params={},
                 data={"funding_group_index": idx + 1, "has_funding_statement": is_valid},
                 error_level=error_level,
             )
@@ -393,6 +448,8 @@ class FundingGroupValidation:
                 expected="At least one <funding-source> in <award-group>",
                 obtained=f"{len(funding_sources)} <funding-source> element(s) found",
                 advice=advice,
+                advice_text=i18n._("Add at least one <funding-source> element inside this <award-group>. It is mandatory when <award-group> exists."),
+                advice_params={},
                 data=item,
                 error_level=error_level,
             )
@@ -439,6 +496,8 @@ class FundingGroupValidation:
             expected="No <label> elements in <funding-group>",
             obtained=f"{count} <label> element(s) found",
             advice=advice,
+            advice_text=i18n._("Remove {count} <label> element(s) from <funding-group>. <label> is not allowed according to SPS 1.10."),
+            advice_params={"count": count},
             data={
                 "count": count,
                 "labels": [
@@ -493,6 +552,8 @@ class FundingGroupValidation:
             expected="No <title> elements in <funding-group>",
             obtained=f"{count} <title> element(s) found",
             advice=advice,
+            advice_text=i18n._("Remove {count} <title> element(s) from <funding-group>. <title> is not allowed according to SPS 1.10."),
+            advice_params={"count": count},
             data={
                 "count": count,
                 "titles": [
@@ -557,6 +618,11 @@ class FundingGroupValidation:
                 expected="Consistent quantities: 0 awards (support), 1 award (contract), or N awards matching N sources",
                 obtained=f"{num_sources} funding-source(s), {num_awards} award-id(s)",
                 advice=advice,
+                advice_text=i18n._("Inconsistent quantities: {num_sources} <funding-source>(s) but {num_awards} <award-id>(s). When multiple <award-id> elements exist, they should typically match the number of <funding-source> elements, or use separate <award-group> elements."),
+                advice_params={
+                    "num_sources": num_sources,
+                    "num_awards": num_awards,
+                },
                 data=item,
                 error_level=error_level,
             )

--- a/packtools/sps/validation/graphic.py
+++ b/packtools/sps/validation/graphic.py
@@ -2,6 +2,7 @@ import os
 from packtools.sps.validation.visual_resource_base import VisualResourceBaseValidation
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.models.graphic import XmlGraphic
+from packtools.sps import i18n
 
 
 class GraphicValidation(VisualResourceBaseValidation):
@@ -51,6 +52,14 @@ class GraphicValidation(VisualResourceBaseValidation):
             expected="@id attribute",
             obtained=id_value,
             advice=f'Add id="" to {elem}' if not valid else None,
+            advice_text=i18n._('Add id="" to {element}'),
+            advice_params={"element": elem},
+            message_text=(
+                i18n._("The @id attribute is present in <{element}>")
+                if valid
+                else i18n._("The @id attribute is required in <{element}>")
+            ),
+            message_params={"element": tag},
             error_level=self.params["media_attributes_error_level"],
             data=self.data,
         )
@@ -82,6 +91,11 @@ class GraphicValidation(VisualResourceBaseValidation):
                     f'<{self.data.get("tag")}> '
                     f'(valid extensions: jpg, jpeg, png, tif, tiff, svg)'
                 ),
+                advice_text=(
+                    i18n._('Add xlink:href="filename.ext" to <{tag}> '
+                    '(valid extensions: jpg, jpeg, png, tif, tiff, svg)')
+                ),
+                advice_params={"tag": self.data.get("tag")},
                 error_level=self.params["xlink_href_error_level"],
                 data=self.data,
             )
@@ -125,6 +139,16 @@ class GraphicValidation(VisualResourceBaseValidation):
                     f"Either move this <graphic> inside <alternatives> or use a "
                     f"different format (.jpg, .png, .tif)."
                 ) if not is_valid else None,
+                advice_text=(
+                    i18n._("SVG files are only allowed inside <alternatives>. "
+                    "The file '{xlink_href}' is currently in <{parent_tag}>. "
+                    "Either move this <graphic> inside <alternatives> or use a "
+                    "different format (.jpg, .png, .tif).")
+                ),
+                advice_params={
+                    "xlink_href": xlink_href,
+                    "parent_tag": parent_tag,
+                },
                 error_level=self.params.get("svg_error_level", "ERROR"),
                 data=self.data,
             )

--- a/packtools/sps/validation/history.py
+++ b/packtools/sps/validation/history.py
@@ -9,6 +9,7 @@ Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJ
 """
 
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 # Allowed values for @date-type according to SPS 1.10
@@ -225,6 +226,11 @@ class HistoryValidation:
                 expected="at most one <history> element",
                 obtained=f"{history_count} <history> element(s)",
                 advice=advice,
+                advice_text=(
+                    i18n._("Remove duplicate <history> elements. Found {count} "
+                    "occurrences, expected at most 1.")
+                ),
+                advice_params={"count": history_count},
                 data={"history_count": history_count},
                 error_level=self.params["history_uniqueness_error_level"],
             )
@@ -269,6 +275,17 @@ class HistoryValidation:
                     expected="@date-type attribute present",
                     obtained=date_type if has_date_type else "missing",
                     advice=advice,
+                    advice_text=(
+                        i18n._("Add @date-type attribute to <date> element. "
+                        "Date parts: {date_parts}")
+                    ),
+                    advice_params={"date_parts": date_parts},
+                    message_text=(
+                        i18n._("The @date-type attribute is present")
+                        if has_date_type
+                        else i18n._("The @date-type attribute is required")
+                    ),
+                    message_params={},
                     data=date_parts,
                     error_level=self.params["date_type_presence_error_level"],
                 )
@@ -323,6 +340,14 @@ class HistoryValidation:
                     expected=ALLOWED_DATE_TYPES,
                     obtained=date_type,
                     advice=advice,
+                    advice_text=(
+                        i18n._("Change @date-type='{date_type}' to one of the "
+                        "allowed values: {allowed_values}")
+                    ),
+                    advice_params={
+                        "date_type": date_type,
+                        "allowed_values": ", ".join(ALLOWED_DATE_TYPES),
+                    },
                     data=date_parts,
                     error_level=self.params["date_type_value_error_level"],
                 )
@@ -370,6 +395,20 @@ class HistoryValidation:
                         "to <history>"
                     )
 
+                if has_date:
+                    message_text = i18n._(
+                        'The required <date date-type="{date_type}"> is present'
+                    )
+                elif date_required:
+                    message_text = i18n._(
+                        'The required <date date-type="{date_type}"> is missing'
+                    )
+                else:
+                    message_text = i18n._(
+                        '<date date-type="{date_type}"> is not required for '
+                        "article type {article_type}"
+                    )
+
                 yield build_response(
                     title=f"required date: {required_type}",
                     parent=parent,
@@ -384,6 +423,13 @@ class HistoryValidation:
                     ),
                     obtained="present" if has_date else "missing",
                     advice=advice,
+                    advice_text=i18n._('Add <date date-type="{date_type}"> to <history>'),
+                    advice_params={"date_type": required_type},
+                    message_text=message_text,
+                    message_params={
+                        "date_type": required_type,
+                        "article_type": article_type,
+                    },
                     data={
                         "article_type": article_type,
                         "is_exempt": is_exempt,
@@ -459,6 +505,14 @@ class HistoryValidation:
                     expected="complete date with day, month, and year",
                     obtained=f"day={day}, month={month}, year={year}",
                     advice=advice,
+                    advice_text=(
+                        i18n._('Add missing elements to <date date-type="{date_type}">: '
+                        "{missing_parts}")
+                    ),
+                    advice_params={
+                        "date_type": date_type,
+                        "missing_parts": ", ".join(missing_parts),
+                    },
                     data=date_parts,
                     error_level=self.params["complete_date_error_level"],
                 )
@@ -508,6 +562,20 @@ class HistoryValidation:
                     expected="<year> element present",
                     obtained=year if has_year else "missing",
                     advice=advice,
+                    advice_text=i18n._('Add <year> element to <date date-type="{date_type}">'),
+                    advice_params={"date_type": date_type},
+                    message_text=(
+                        i18n._(
+                            "<year> is present in "
+                            '<date date-type="{date_type}">'
+                        )
+                        if has_year
+                        else i18n._(
+                            "<year> is required in "
+                            '<date date-type="{date_type}">'
+                        )
+                    ),
+                    message_params={"date_type": date_type},
                     data=date_parts,
                     error_level=self.params["year_presence_error_level"],
                 )

--- a/packtools/sps/validation/journal_meta.py
+++ b/packtools/sps/validation/journal_meta.py
@@ -9,6 +9,7 @@ from packtools.sps.validation.utils import (
     build_response,
     format_response,
 )
+from packtools.sps import i18n
 
 
 class ISSNValidation:
@@ -91,7 +92,7 @@ class ISSNValidation:
                 advice='Mark {} ISSN with <issn pub-type="{}">{}</issn> inside <journal-meta>'.format(name, tp, issn_expected),
                 data=self.journal_issns.data,
                 error_level=error_level,
-                advice_text='Mark {name} ISSN with <issn pub-type="{tp}">{issn}</issn> inside <journal-meta>',
+                advice_text=i18n._('Mark {name} ISSN with <issn pub-type="{tp}">{issn}</issn> inside <journal-meta>'),
                 advice_params={"name": name, "tp": tp, "issn": issn_expected},
             )
 
@@ -122,7 +123,7 @@ class AcronymValidation:
             advice='Mark journal acronym with <journal-id journal-id-type="publisher-id">{}</journal-id> inside <journal-meta>'.format(expected_value),
             data={'acronym': self.journal_acronym.text},
             error_level=error_level,
-            advice_text='Mark journal acronym with <journal-id journal-id-type="publisher-id">{acronym}</journal-id> inside <journal-meta>',
+            advice_text=i18n._('Mark journal acronym with <journal-id journal-id-type="publisher-id">{acronym}</journal-id> inside <journal-meta>'),
             advice_params={"acronym": expected_value},
         )
 
@@ -156,7 +157,7 @@ class TitleValidation:
                 for item in self.journal_titles.data
             },
             error_level=error_level,
-            advice_text='Mark journal title with <journal-title> inside <journal-title-group>',
+            advice_text=i18n._('Mark journal title with <journal-title> inside <journal-title-group>'),
             advice_params={},
         )
 
@@ -184,7 +185,7 @@ class TitleValidation:
                 for item in self.journal_titles.data
             },
             error_level=error_level,
-            advice_text='Mark abbreviated journal title with <abbrev-journal-title> inside <journal-title-group>',
+            advice_text=i18n._('Mark abbreviated journal title with <abbrev-journal-title> inside <journal-title-group>'),
             advice_params={},
         )
 
@@ -266,7 +267,7 @@ class PublisherNameValidation:
                 advice=f'Mark publisher name with <publisher><publisher-name>{expected}</publisher-name></publisher> inside <journal-meta>',
                 data=None,
                 error_level=error_level,
-                advice_text='Mark publisher name with <publisher><publisher-name>{name}</publisher-name></publisher> inside <journal-meta>',
+                advice_text=i18n._('Mark publisher name with <publisher><publisher-name>{name}</publisher-name></publisher> inside <journal-meta>'),
                 advice_params={"name": expected},
             )
 
@@ -301,7 +302,7 @@ class PublisherNameValidation:
                 advice=advice,
                 data=None,
                 error_level=error_level,
-                advice_text='{action} the following items {in_from} the XML: {items}',
+                advice_text=i18n._('{action} the following items {in_from} the XML: {items}'),
                 advice_params={"action": action[0], "in_from": action[1], "items": diff_str},
             )
 
@@ -374,7 +375,7 @@ class JournalIdValidation:
             advice=f'Mark an nlm-ta value with <journal-id journal-id-type="nlm-ta">{expected_value}</journal-id> inside <journal-meta>',
             data=None,
             error_level=error_level,
-            advice_text='Mark an nlm-ta value with <journal-id journal-id-type="nlm-ta">{nlm_ta}</journal-id> inside <journal-meta>',
+            advice_text=i18n._('Mark an nlm-ta value with <journal-id journal-id-type="nlm-ta">{nlm_ta}</journal-id> inside <journal-meta>'),
             advice_params={"nlm_ta": expected_value},
         )
 
@@ -448,6 +449,8 @@ class JournalMetaPresenceValidation:
             expected='<journal-meta> element',
             obtained='<journal-meta>' if is_valid else None,
             advice='Add <journal-meta> element inside <front>',
+            advice_text=i18n._('Add <journal-meta> element inside <front>'),
+            advice_params={},
             data=None,
             error_level=error_level,
         )
@@ -485,6 +488,8 @@ class JournalMetaPresenceValidation:
             expected='exactly one <journal-meta> element',
             obtained=obtained,
             advice='Ensure exactly one <journal-meta> element exists inside <front>',
+            advice_text=i18n._('Ensure exactly one <journal-meta> element exists inside <front>'),
+            advice_params={},
             data={'count': count},
             error_level=error_level,
         )
@@ -514,6 +519,8 @@ class JournalMetaPresenceValidation:
             expected='<journal-id journal-id-type="publisher-id"> with non-empty value',
             obtained=publisher_id if is_valid else None,
             advice='Add <journal-id journal-id-type="publisher-id">ACRONYM</journal-id> inside <journal-meta>',
+            advice_text=i18n._('Add <journal-id journal-id-type="publisher-id">ACRONYM</journal-id> inside <journal-meta>'),
+            advice_params={},
             data={'publisher_id': publisher_id} if is_valid else None,
             error_level=error_level,
         )
@@ -543,6 +550,8 @@ class JournalMetaPresenceValidation:
             expected='<journal-title> with non-empty value',
             obtained=journal_title if is_valid else None,
             advice='Add <journal-title>Title</journal-title> inside <journal-title-group>',
+            advice_text=i18n._('Add <journal-title>Title</journal-title> inside <journal-title-group>'),
+            advice_params={},
             data={'journal_title': journal_title} if is_valid else None,
             error_level=error_level,
         )
@@ -572,6 +581,8 @@ class JournalMetaPresenceValidation:
             expected='<abbrev-journal-title abbrev-type="publisher"> with non-empty value',
             obtained=abbrev_title if is_valid else None,
             advice='Add <abbrev-journal-title abbrev-type="publisher">Abbrev. Title</abbrev-journal-title> inside <journal-title-group>',
+            advice_text=i18n._('Add <abbrev-journal-title abbrev-type="publisher">Abbrev. Title</abbrev-journal-title> inside <journal-title-group>'),
+            advice_params={},
             data={'abbrev_title': abbrev_title} if is_valid else None,
             error_level=error_level,
         )
@@ -603,6 +614,8 @@ class JournalMetaPresenceValidation:
             expected='at least one <issn> element',
             obtained=f'{len(issn_list)} ISSN(s) found' if is_valid else 'No ISSN found',
             advice='Add at least one <issn pub-type="epub">XXXX-XXXX</issn> or <issn pub-type="ppub">XXXX-XXXX</issn> inside <journal-meta>',
+            advice_text=i18n._('Add at least one <issn pub-type="epub">XXXX-XXXX</issn> or <issn pub-type="ppub">XXXX-XXXX</issn> inside <journal-meta>'),
+            advice_params={},
             data=issn_data if is_valid else None,
             error_level=error_level,
         )
@@ -632,6 +645,8 @@ class JournalMetaPresenceValidation:
             expected='<publisher-name> with non-empty value',
             obtained=publisher_name if is_valid else None,
             advice='Add <publisher><publisher-name>Publisher Name</publisher-name></publisher> inside <journal-meta>',
+            advice_text=i18n._('Add <publisher><publisher-name>Publisher Name</publisher-name></publisher> inside <journal-meta>'),
+            advice_params={},
             data={'publisher_name': publisher_name} if is_valid else None,
             error_level=error_level,
         )
@@ -679,6 +694,8 @@ class ISSNFormatValidation:
                 expected='ISSN with format XXXX-XXXX (where X can be a digit or letter X)',
                 obtained=issn_value,
                 advice=f'Correct ISSN format to XXXX-XXXX pattern. Current value: {issn_value}',
+                advice_text=i18n._('Correct ISSN format to XXXX-XXXX pattern. Current value: {issn_value}'),
+                advice_params={'issn_value': issn_value},
                 data=issn_data,
                 error_level=error_level,
             )
@@ -723,6 +740,11 @@ class JournalMetaAttributeValidation:
                 expected=allowed_types,
                 obtained=id_type,
                 advice=f'Set @journal-id-type to one of {allowed_types}. Current value: {id_type}',
+                advice_text=i18n._('Set @journal-id-type to one of {allowed_types}. Current value: {id_type}'),
+                advice_params={
+                    'allowed_types': allowed_types,
+                    'id_type': id_type,
+                },
                 data={'journal_id_type': id_type, 'value': id_value},
                 error_level=error_level,
             )
@@ -758,6 +780,11 @@ class JournalMetaAttributeValidation:
                 expected=allowed_types,
                 obtained=pub_type,
                 advice=f'Set @pub-type to one of {allowed_types}. Current value: {pub_type}',
+                advice_text=i18n._('Set @pub-type to one of {allowed_types}. Current value: {pub_type}'),
+                advice_params={
+                    'allowed_types': allowed_types,
+                    'pub_type': pub_type,
+                },
                 data={'pub_type': pub_type, 'value': issn_value},
                 error_level=error_level,
             )
@@ -801,6 +828,8 @@ class JournalMetaAttributeValidation:
             expected='unique pub-type values for each ISSN',
             obtained=obtained,
             advice=f'Remove duplicate ISSN elements with same pub-type. Duplicates: {duplicates}' if duplicates else None,
+            advice_text=i18n._('Remove duplicate ISSN elements with same pub-type. Duplicates: {duplicates}'),
+            advice_params={'duplicates': duplicates},
             data={'type_counts': type_counts, 'duplicates': duplicates},
             error_level=error_level,
         )

--- a/packtools/sps/validation/list.py
+++ b/packtools/sps/validation/list.py
@@ -1,5 +1,6 @@
 from packtools.sps.models.list import ArticleLists
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class ArticleListValidation:
@@ -58,12 +59,15 @@ class ListValidation:
         if list_type is None:
             obtained = None
             advice = "Add list-type attribute to <list> element. Use one of: order, bullet, alpha-lower, alpha-upper, roman-lower, roman-upper, simple"
+            advice_text = i18n._("Add list-type attribute to <list> element. Use one of: {values}")
         elif list_type == "":
             obtained = '""'
             advice = "The @list-type attribute cannot be empty. Use one of: order, bullet, alpha-lower, alpha-upper, roman-lower, roman-upper, simple"
+            advice_text = i18n._("The @list-type attribute cannot be empty. Use one of: {values}")
         else:
             obtained = list_type
             advice = None
+            advice_text = None
 
         yield build_response(
             title="@list-type presence",
@@ -75,6 +79,13 @@ class ListValidation:
             expected="@list-type",
             obtained=obtained,
             advice=advice,
+            advice_text=advice_text,
+            advice_params={
+                "values": (
+                    "order, bullet, alpha-lower, alpha-upper, roman-lower, "
+                    "roman-upper, simple"
+                )
+            },
             data=self.data,
             error_level=self.rules["list_type_presence_error_level"],
         )
@@ -105,6 +116,14 @@ class ListValidation:
                 expected=allowed_list_types,
                 obtained=list_type,
                 advice=advice,
+                advice_text=(
+                    i18n._('Value "{list_type}" is not allowed for @list-type. '
+                    "Use one of: {allowed_types}")
+                ),
+                advice_params={
+                    "list_type": list_type,
+                    "allowed_types": ", ".join(allowed_list_types),
+                },
                 data=self.data,
                 error_level=self.rules["list_type_value_error_level"],
             )
@@ -132,6 +151,14 @@ class ListValidation:
             expected=f"at least {min_items} list-item elements",
             obtained=f"{list_items_count} list-item elements",
             advice=advice,
+            advice_text=(
+                i18n._("<list> must contain at least {min_items} <list-item> "
+                "elements. Found {count}")
+            ),
+            advice_params={
+                "min_items": min_items,
+                "count": list_items_count,
+            },
             data=self.data,
             error_level=self.rules["min_list_items_error_level"],
         )
@@ -158,6 +185,11 @@ class ListValidation:
             expected="no <label> in <list-item>",
             obtained="<label> found in <list-item>" if has_label else "no <label>",
             advice=advice,
+            advice_text=(
+                i18n._("For accessibility, do not use <label> in <list-item>. "
+                "The @list-type attribute generates labels automatically")
+            ),
+            advice_params={},
             data=self.data,
             error_level=self.rules["label_in_list_item_error_level"],
         )
@@ -184,6 +216,11 @@ class ListValidation:
             expected="all list-item elements with content",
             obtained=f"{empty_count} empty list-item(s)" if not is_valid else "all list-items have content",
             advice=advice,
+            advice_text=(
+                i18n._("Found {count} empty <list-item> element(s). Each <list-item> "
+                "should contain at least one child element (typically <p>)")
+            ),
+            advice_params={"count": empty_count},
             data=self.data,
             error_level=self.rules["empty_list_item_error_level"],
         )
@@ -210,6 +247,20 @@ class ListValidation:
             expected="<title> when list has a descriptive heading",
             obtained="<title> present" if has_title else "no <title>",
             advice=advice,
+            advice_text=(
+                i18n._("Consider adding a <title> element if the list has a "
+                "descriptive heading")
+            ),
+            advice_params={},
+            message_text=(
+                i18n._("<title> is present in the list")
+                if has_title
+                else i18n._(
+                    "<title> is recommended when the list has a "
+                    "descriptive heading"
+                )
+            ),
+            message_params={},
             data=self.data,
             error_level=self.rules["missing_title_error_level"],
         )

--- a/packtools/sps/validation/media.py
+++ b/packtools/sps/validation/media.py
@@ -1,6 +1,7 @@
 from packtools.sps.validation.utils import build_response
 from packtools.sps.validation.visual_resource_base import VisualResourceBaseValidation
 from packtools.sps.validation.models.media import XmlMedias
+from packtools.sps import i18n
 
 
 class MediaValidation(VisualResourceBaseValidation):
@@ -28,6 +29,8 @@ class MediaValidation(VisualResourceBaseValidation):
             expected=mime_types_and_subtypes,
             obtained=got,
             advice=f"Use expected values: {mime_types_and_subtypes}",
+            advice_text=i18n._("Use expected values: {expected_values}"),
+            advice_params={"expected_values": mime_types_and_subtypes},
             error_level=self.params["mime_type_error_level"],
             data=self.data,
         )

--- a/packtools/sps/validation/metadata_langs.py
+++ b/packtools/sps/validation/metadata_langs.py
@@ -1,5 +1,6 @@
 from packtools.sps.models import article_and_subarticles, article_titles, article_abstract, kwd_group
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 def _elements_exist(title, abstract, keyword):
@@ -129,6 +130,6 @@ class MetadataLanguagesValidation:
                     advice=f'Mark {missing_element_name} for {lang} language',
                     data=None,
                     error_level=error_level,
-                    advice_text='Mark {element} for {language} language',
+                    advice_text=i18n._('Mark {element} for {language} language'),
                     advice_params={"element": missing_element_name, "language": lang},
                 )

--- a/packtools/sps/validation/peer_review.py
+++ b/packtools/sps/validation/peer_review.py
@@ -5,6 +5,7 @@ from packtools.sps.validation.related_articles import (
     FulltextRelatedArticlesValidation,
 )
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class CustomMetaPeerReviewValidation:
@@ -29,7 +30,9 @@ class CustomMetaPeerReviewValidation:
             is_valid=is_valid,
             expected="meta-name",
             obtained=meta_name,
-            advice=f"Mark peer review name with <custom-meta><meta-name>.",
+            advice="Mark peer review name with <custom-meta><meta-name>.",
+            advice_text=i18n._("Mark peer review name with <custom-meta><meta-name>."),
+            advice_params={},
             data=self.custom_meta,
             error_level=self.params.get("meta_name_error_level"),
             element_name="custom-meta",
@@ -51,6 +54,8 @@ class CustomMetaPeerReviewValidation:
             expected="peer review recommendation",
             obtained=meta_value,
             advice="Mark peer review recommendation value with <custom-meta><meta-value>.",
+            advice_text=i18n._("Mark peer review recommendation value with <custom-meta><meta-value>."),
+            advice_params={},
             data=self.custom_meta,
             error_level=self.params.get("meta_value_error_level"),
             element_name="custom-meta",
@@ -162,6 +167,10 @@ class PeerReviewValidation:
             expected=self.params["article_type_list"],
             obtained=article_type,
             advice=f"Add article_type in <article article-type='VALUE'> and replace VALUE with {self.params['article_type_list']}",
+            advice_text=i18n._("Add article_type in <article article-type='VALUE'> and replace VALUE with {article_types}"),
+            advice_params={
+                "article_types": self.params["article_type_list"],
+            },
             data=self.peer_review.attribs,
             error_level=self.params["article_type_error_level"],
             element_name="article",
@@ -194,6 +203,8 @@ class PeerReviewValidation:
                 expected=item,
                 obtained=obtained,
                 advice=f'Add date-type in <history><date date-type="VALUE"> and replace VALUE with : {item}',
+                advice_text=i18n._('Add date-type in <history><date date-type="VALUE"> and replace VALUE with : {event}'),
+                advice_params={"event": item},
                 data=self.peer_review.history_dates,
                 error_level=self.params["missing_events_error_level"],
                 element_name="history",

--- a/packtools/sps/validation/permissions.py
+++ b/packtools/sps/validation/permissions.py
@@ -11,6 +11,7 @@ Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJ
 import re
 
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 XLINK_HREF = "{http://www.w3.org/1999/xlink}href"
@@ -97,6 +98,8 @@ class PermissionsValidation:
             expected="<permissions> element in <article-meta>",
             obtained="<permissions>" if is_valid else None,
             advice="Add <permissions> element to <article-meta> with a Creative Commons license declaration",
+            advice_text=i18n._("Add <permissions> element to <article-meta> with a Creative Commons license declaration"),
+            advice_params={},
             data={"permissions_count": len(permissions)},
             error_level=error_level,
         )
@@ -121,6 +124,8 @@ class PermissionsValidation:
             expected="exactly 1 <permissions> element",
             obtained=f"{count} <permissions> elements",
             advice="Remove duplicate <permissions> elements. Only one <permissions> should exist in <article-meta>",
+            advice_text=i18n._("Remove duplicate <permissions> elements. Only one <permissions> should exist in <article-meta>"),
+            advice_params={},
             data={"permissions_count": count},
             error_level=error_level,
         )
@@ -146,6 +151,8 @@ class PermissionsValidation:
                 expected="<license> element in <permissions>",
                 obtained="<license>" if is_valid else None,
                 advice="Add <license> element to <permissions> with Creative Commons CC-BY attributes",
+                advice_text=i18n._("Add <license> element to <permissions> with Creative Commons CC-BY attributes"),
+                advice_params={},
                 data={"license_count": len(licenses)},
                 error_level=error_level,
             )
@@ -170,6 +177,8 @@ class PermissionsValidation:
                 expected=expected_type,
                 obtained=obtained_type,
                 advice=f'Set license-type="{expected_type}" in <license> element',
+                advice_text=i18n._('Set license-type="{license_type}" in <license> element'),
+                advice_params={"license_type": expected_type},
                 data={
                     "license_type": obtained_type,
                     "lang": license_node.get(XML_LANG),
@@ -196,6 +205,8 @@ class PermissionsValidation:
                 expected="@xlink:href attribute in <license>",
                 obtained=href,
                 advice="Add xlink:href attribute with a valid Creative Commons CC-BY URL to <license>",
+                advice_text=i18n._("Add xlink:href attribute with a valid Creative Commons CC-BY URL to <license>"),
+                advice_params={},
                 data={
                     "xlink_href": href,
                     "lang": license_node.get(XML_LANG),
@@ -222,6 +233,8 @@ class PermissionsValidation:
                 expected="@xml:lang attribute in <license>",
                 obtained=lang,
                 advice="Add xml:lang attribute to <license> element indicating the language of the license text",
+                advice_text=i18n._("Add xml:lang attribute to <license> element indicating the language of the license text"),
+                advice_params={},
                 data={
                     "xml_lang": lang,
                     "xlink_href": license_node.get(XLINK_HREF),
@@ -248,6 +261,8 @@ class PermissionsValidation:
                 expected="<license-p> element in <license>",
                 obtained="<license-p>" if is_valid else None,
                 advice="Add <license-p> element with the license text to <license>",
+                advice_text=i18n._("Add <license-p> element with the license text to <license>"),
+                advice_params={},
                 data={
                     "has_license_p": is_valid,
                     "lang": license_node.get(XML_LANG),
@@ -281,6 +296,16 @@ class PermissionsValidation:
                 expected=f"a Creative Commons CC-BY URL starting with one of {valid_patterns}",
                 obtained=href,
                 advice=f"Use a valid Creative Commons CC-BY 4.0 URL, e.g. https://creativecommons.org/licenses/by/4.0/",
+                advice_text=i18n._("Use a valid Creative Commons CC-BY 4.0 URL, e.g. https://creativecommons.org/licenses/by/4.0/"),
+                advice_params={},
+                message_text=i18n._(
+                    "URL {url} must start with one of the valid Creative "
+                    "Commons CC-BY prefixes: {valid_prefixes}"
+                ),
+                message_params={
+                    "url": href,
+                    "valid_prefixes": ", ".join(valid_patterns),
+                },
                 data={
                     "xlink_href": href,
                     "lang": license_node.get(XML_LANG),
@@ -327,6 +352,15 @@ class PermissionsValidation:
                 obtained=href,
                 advice=f"For xml:lang=\"{lang}\", use a URL ending with '{expected_deed}', "
                        f"e.g. https://creativecommons.org/licenses/by/4.0/{expected_deed}",
+                advice_text=(
+                    i18n._('For xml:lang="{language}", use a URL ending with '
+                    "'{expected_deed}', e.g. "
+                    "https://creativecommons.org/licenses/by/4.0/{expected_deed}")
+                ),
+                advice_params={
+                    "language": lang,
+                    "expected_deed": expected_deed,
+                },
                 data={
                     "xml_lang": lang,
                     "xlink_href": href,
@@ -363,6 +397,17 @@ class PermissionsValidation:
                     obtained=None,
                     advice=f"Add <copyright-year>{year_match.group(1)}</copyright-year> to <permissions> "
                            f"since the copyright statement mentions the year '{year_match.group(1)}'",
+                    advice_text=(
+                        i18n._("Add <copyright-year>{year}</copyright-year> to "
+                        "<permissions> since the copyright statement mentions "
+                        "the year '{year}'")
+                    ),
+                    advice_params={"year": year_match.group(1)},
+                    message_text=i18n._(
+                        "<copyright-year> is required when "
+                        "<copyright-statement> mentions a year"
+                    ),
+                    message_params={},
                     data={
                         "copyright_statement": statement_text,
                         "mentioned_year": year_match.group(1),

--- a/packtools/sps/validation/preprint.py
+++ b/packtools/sps/validation/preprint.py
@@ -1,3 +1,4 @@
+from packtools.sps import i18n
 from packtools.sps.models.related_articles import RelatedItems
 from packtools.sps.models.dates import ArticleDates
 
@@ -55,17 +56,36 @@ class PreprintValidation:
         if not (has_preprint or has_preprint_date):
             return []
 
-        response, expected_value, got_value, advice = 'OK', has_preprint_date, has_preprint_date, None
+        response = "OK"
+        expected_value = has_preprint_date
+        got_value = has_preprint_date
+        advice = None
+        advice_text = None
 
         if has_preprint and not has_preprint_date:
-            response, expected_value, got_value, advice = \
-                'ERROR', 'The preprint publication date', None, 'Provide the publication date of the preprint'
+            response = "ERROR"
+            expected_value = "The preprint publication date"
+            got_value = None
+            advice = "Provide the publication date of the preprint"
+            advice_text = i18n._(
+                "Provide the publication date of the preprint"
+            )
         elif not has_preprint and has_preprint_date:
-            response, expected_value, got_value, advice = \
-                'ERROR', None, has_preprint_date, 'The article does not reference the preprint, ' \
-                                                  'provide it as in the example: <related-article id="pp1" ' \
-                                                  'related-article-type="preprint" ext-link-type="doi" ' \
-                                                  'xlink:href="10.1590/SciELOPreprints.1174"/>'
+            response = "ERROR"
+            expected_value = None
+            got_value = has_preprint_date
+            advice = (
+                "The article does not reference the preprint, "
+                "provide it as in the example: <related-article id=\"pp1\" "
+                "related-article-type=\"preprint\" ext-link-type=\"doi\" "
+                "xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+            )
+            advice_text = i18n._(
+                "The article does not reference the preprint, "
+                "provide it as in the example: <related-article id=\"pp1\" "
+                "related-article-type=\"preprint\" ext-link-type=\"doi\" "
+                "xlink:href=\"10.1590/SciELOPreprints.1174\"/>"
+            )
 
         return [
             {
@@ -76,6 +96,15 @@ class PreprintValidation:
                 'expected_value': expected_value,
                 'got_value': got_value,
                 'message': f'Got {got_value} expected {expected_value}',
-                'advice': advice
+                "msg_text": i18n._(
+                    "Got {obtained}, expected {expected}"
+                ),
+                "msg_params": {
+                    "obtained": got_value,
+                    "expected": expected_value,
+                },
+                'advice': advice,
+                "adv_text": advice_text,
+                "adv_params": {} if advice else None,
             }
         ]

--- a/packtools/sps/validation/product.py
+++ b/packtools/sps/validation/product.py
@@ -9,12 +9,11 @@ Implements validations for book review product elements to ensure:
 
 Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJNOIqzBNSgA/edit?tab=t.0#heading=h.product
 """
-import gettext
 
+from packtools.sps import i18n
 from packtools.sps.models.product import ArticleProducts
 from packtools.sps.validation.utils import build_response
 
-_ = gettext.gettext
 
 
 class ProductValidation:
@@ -62,11 +61,16 @@ class ProductValidation:
         # Distinguish between absent attribute and present-but-empty attribute
         # to produce a more accurate advice message.
         if product_type is None:
-            advice_text = _(
+            advice = 'Add @product-type="book" attribute to <product>.'
+            advice_text = i18n._(
                 'Add @product-type="book" attribute to <product>.'
             )
         else:
-            advice_text = _(
+            advice = (
+                '@product-type is present but empty.'
+                ' Set the value to "book".'
+            )
+            advice_text = i18n._(
                 '@product-type is present but empty.'
                 ' Set the value to "book".'
             )
@@ -81,11 +85,21 @@ class ProductValidation:
             is_valid=is_valid,
             expected='@product-type attribute present with value "book"',
             obtained=product_type,
-            advice=advice_text,
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
             advice_params=advice_params,
+            message_text=(
+                i18n._(
+                    'The @product-type attribute is present with value "book"'
+                )
+                if is_valid
+                else i18n._(
+                    'The @product-type attribute with value "book" is required'
+                )
+            ),
+            message_params={},
         )
 
     def validate_product_type_value(self):
@@ -112,7 +126,14 @@ class ProductValidation:
 
         is_valid = product_type in expected_values
 
-        advice_text = _(
+        advice = (
+            'Replace @product-type="{product_type}" with one of:'
+            " {allowed_values}."
+        ).format(
+            product_type=product_type,
+            allowed_values=", ".join(expected_values),
+        )
+        advice_text = i18n._(
             'Replace @product-type="{product_type}" with one of: {allowed_values}.'
         )
         advice_params = {
@@ -129,7 +150,7 @@ class ProductValidation:
             is_valid=is_valid,
             expected=", ".join(expected_values),
             obtained=product_type,
-            advice=advice_text.format(**advice_params),
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
@@ -152,7 +173,8 @@ class ProductValidation:
 
         is_valid = source is not None and bool(source.strip())
 
-        advice_text = _(
+        advice = "Add <source> element with the book title inside <product>"
+        advice_text = i18n._(
             "Add <source> element with the book title inside <product>"
         )
         advice_params = {}
@@ -166,7 +188,7 @@ class ProductValidation:
             is_valid=is_valid,
             expected="<source> element with book title",
             obtained=source,
-            advice=advice_text,
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
@@ -190,7 +212,11 @@ class ProductValidation:
 
         is_valid = article_type == "book-review"
 
-        advice_text = _(
+        advice = (
+            '<product> is present but @article-type="{article_type}".'
+            ' For book reviews, use @article-type="book-review" in <article>'
+        ).format(article_type=article_type)
+        advice_text = i18n._(
             '<product> is present but @article-type="{article_type}".'
             ' For book reviews, use @article-type="book-review" in <article>'
         )
@@ -205,7 +231,7 @@ class ProductValidation:
             is_valid=is_valid,
             expected="book-review",
             obtained=article_type,
-            advice=advice_text.format(**advice_params),
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
@@ -227,7 +253,11 @@ class ProductValidation:
         error_level = self.rules.get("author_presence_error_level", "WARNING")
         has_author = self.data.get("has_author", False)
 
-        advice_text = _(
+        advice = (
+            'Add <person-group person-group-type="author"> with the'
+            " author(s) of the reviewed book inside <product>"
+        )
+        advice_text = i18n._(
             "Add <person-group person-group-type=\"author\"> with the"
             " author(s) of the reviewed book inside <product>"
         )
@@ -242,7 +272,7 @@ class ProductValidation:
             is_valid=has_author,
             expected='<person-group person-group-type="author">',
             obtained=str(has_author),
-            advice=advice_text,
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
@@ -263,7 +293,11 @@ class ProductValidation:
         error_level = self.rules.get("publisher_name_presence_error_level", "WARNING")
         has_publisher = self.data.get("has_publisher_name", False)
 
-        advice_text = _(
+        advice = (
+            "Add <publisher-name> element with the publisher name"
+            " inside <product> for bibliographic completeness"
+        )
+        advice_text = i18n._(
             "Add <publisher-name> element with the publisher name"
             " inside <product> for bibliographic completeness"
         )
@@ -278,7 +312,7 @@ class ProductValidation:
             is_valid=has_publisher,
             expected="<publisher-name>",
             obtained=str(has_publisher),
-            advice=advice_text,
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,
@@ -299,7 +333,11 @@ class ProductValidation:
         error_level = self.rules.get("year_presence_error_level", "WARNING")
         has_year = self.data.get("has_year", False)
 
-        advice_text = _(
+        advice = (
+            "Add <year> element with the publication year"
+            " inside <product> for bibliographic completeness"
+        )
+        advice_text = i18n._(
             "Add <year> element with the publication year"
             " inside <product> for bibliographic completeness"
         )
@@ -314,7 +352,7 @@ class ProductValidation:
             is_valid=has_year,
             expected="<year>",
             obtained=str(has_year),
-            advice=advice_text,
+            advice=advice,
             data=self.data,
             error_level=error_level,
             advice_text=advice_text,

--- a/packtools/sps/validation/references.py
+++ b/packtools/sps/validation/references.py
@@ -1,6 +1,7 @@
 from packtools.sps.models.references import XMLReferences
 from packtools.sps.validation.exceptions import ValidationReferencesException
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class ReferenceValidation:
@@ -53,19 +54,33 @@ class ReferenceValidation:
         element_name=None,
         valid=None,
         advice=None,
+        advice_text=None,
+        advice_params=None,
         expected=None,
         error_level=None,
         validation_type=None,
+        message_text=None,
+        message_params=None,
     ):
         value = self.data.get(item_name)
         element_name = element_name or item_name
         advice = advice or f"Mark {label} with <{element_name}>"
+        advice_text = advice_text or i18n._(
+            "Mark {label} with <{element_name}>"
+        )
+        advice_params = advice_params or {
+            "label": label,
+            "element_name": element_name,
+        }
         expected = expected or f"reference {element_name}"
 
         advice = f'{self.info} : {advice}'
+        advice_text = "{info}: " + advice_text
+        advice_params["info"] = self.info
 
         if valid is None:
             valid = bool(value)
+
         yield build_response(
             title=f"reference {element_name}",
             parent=self.data,
@@ -76,6 +91,10 @@ class ReferenceValidation:
             expected=expected,
             obtained=value,
             advice=advice,
+            advice_text=advice_text,
+            advice_params=advice_params,
+            message_text=message_text,
+            message_params=message_params,
             data=self.data,
             error_level=error_level,
         )
@@ -95,20 +114,37 @@ class ReferenceValidation:
             advice = (
                 f"Mark the reference year ({year}) with <year> and it must be previous or equal to {end_year}"
             )
+            advice_text = i18n._("Mark the reference year ({year}) with <year>; it must be earlier than or equal to {end_year}")
+            advice_params = {
+                "year": year,
+                "end_year": end_year,
+            }
             expected = f"reference year ({year}) previous or equal to {end_year}"
         else:
             advice = (
                 f"Mark the reference year with <year> and it must be previous or equal to {end_year}"
             )
+            advice_text = i18n._("Mark the reference year with <year>; it must be earlier than or equal to {end_year}")
+            advice_params = {"end_year": end_year}
             expected = f"reference year previous or equal to {end_year}"
+
         yield from self._validate_item(
             "reference year",
             "year",
             valid=is_valid,
             advice=advice,
+            advice_text=advice_text,
+            advice_params=advice_params,
             expected=expected,
             error_level=self.params["year_error_level"],
-            validation_type="format"
+            validation_type="format",
+            message_text=(
+                i18n._(
+                    "Reference year {year} must be numeric and no later "
+                    "than {end_year}"
+                )
+            ),
+            message_params={"year": year, "end_year": end_year},
         )
 
     def validate_source(self):
@@ -137,7 +173,9 @@ class ReferenceValidation:
                 "all_authors",
                 element_name="person-group//name or person-group//collab",
                 valid=valid,
-                advice=f'Mark reference authors with <name> (person) or <collab> (institutional)',
+                advice='Mark reference authors with <name> (person) or <collab> (institutional)',
+                advice_text=i18n._("Mark reference authors with <name> (person) or <collab> (institutional)"),
+                advice_params={},
                 error_level=self.params["authors_error_level"],
             )
 
@@ -153,9 +191,12 @@ class ReferenceValidation:
         advice = (
             f'Complete publication-type="" in <element-citation publication-type=""> with valid value: {publication_type_list}'
         )
+
         yield from self._validate_item(
-            "reference type",
-            "publication_type", advice=advice,
+            "reference type", "publication_type",
+            advice=advice,
+            advice_text=i18n._('Complete publication-type="" in <element-citation publication-type=""> with valid value: {publication_type_list}'),
+            advice_params={"publication_type_list": publication_type_list},
             valid=valid,
             error_level=error_level, expected=publication_type_list, validation_type="value in list"
         )
@@ -178,6 +219,10 @@ class ReferenceValidation:
                 "expected": f"<comment>{text_before_extlink}{ext_link_xml}</comment>",
                 "obtained": f"<comment></comment>{text_before_extlink}{ext_link_xml}",
                 "advice": f"Wrap {text_before_extlink}{ext_link_xml} with <comment> tag",
+                "advice_text": i18n._(
+                    "{info}: Wrap {text_before_extlink}{ext_link_xml} "
+                    "with <comment> tag"
+                ),
             },
             {
                 "condition": has_comment
@@ -186,18 +231,32 @@ class ReferenceValidation:
                 "expected": ext_link_xml,
                 "obtained": f"<comment></comment>{ext_link_xml}",
                 "advice": f"Analyze and decide to remove <comment> or mark the text between <comment> and {ext_link_tag_with_attrib}",
+                "advice_text": i18n._(
+                    "{info}: Analyze and decide to remove <comment> or "
+                    "mark the text between <comment> and "
+                    "{ext_link_tag_with_attrib}"
+                ),
             },
             {
                 "condition": not has_comment and text_before_extlink,
                 "expected": f"<comment>{text_before_extlink}{ext_link_xml}</comment>",
                 "obtained": f"{text_before_extlink}{ext_link_xml}",
                 "advice": f"Wrap the {text_before_extlink}{ext_link_xml} with <comment> tag",
+                "advice_text": i18n._(
+                    "{info}: Wrap the "
+                    "{text_before_extlink}{ext_link_xml} with <comment> tag"
+                ),
             },
             {
                 "condition": full_comment and not text_between,
                 "expected": ext_link_xml,
                 "obtained": f"<comment>{ext_link_xml}</comment>",
                 "advice": f"Analyze and decide to remove <comment> or mark the text between <comment> and {ext_link_tag_with_attrib}",
+                "advice_text": i18n._(
+                    "{info}: Analyze and decide to remove <comment> or "
+                    "mark the text between <comment> and "
+                    "{ext_link_tag_with_attrib}"
+                ),
             },
         ]
 
@@ -216,6 +275,13 @@ class ReferenceValidation:
                     expected=scenario["expected"],
                     obtained=scenario["obtained"],
                     advice=advice,
+                    advice_text=scenario["advice_text"],
+                    advice_params={
+                        "info": self.info,
+                        "text_before_extlink": text_before_extlink,
+                        "ext_link_xml": ext_link_xml,
+                        "ext_link_tag_with_attrib": ext_link_tag_with_attrib,
+                    },
                     data=self.data,
                     error_level=self.params["comment_error_level"],
                 )
@@ -235,6 +301,8 @@ class ReferenceValidation:
                     expected=allowed_tags,
                     obtained=self.data.get("mixed_citation_sub_tags"),
                     advice=f"remove {remaining_tags} from mixed-citation",
+                    advice_text=i18n._("remove {remaining_tags} from mixed-citation"),
+                    advice_params={"remaining_tags": remaining_tags},
                     data=self.data,
                     error_level=self.params["mixed_citation_sub_tags_error_level"],
                 )
@@ -252,6 +320,8 @@ class ReferenceValidation:
             expected="mixed-citation",
             obtained=None,
             advice=advice,
+            advice_text=i18n._("{info}: mark the full reference with <mixed-citation>"),
+            advice_params={"info": self.info},
             data=self.data,
             error_level=self.params["mixed_citation_error_level"],
         )
@@ -274,6 +344,8 @@ class ReferenceValidation:
                 expected="<part-title>",
                 obtained="<chapter-title>",
                 advice=f'{self.info} : replace <chapter-title> by <part-title>',
+                advice_text=i18n._("{info}: replace <chapter-title> by <part-title>"),
+                advice_params={"info": self.info},
                 data=self.data,
                 error_level=self.params.get("title_tag_by_dtd_version_error_level"),
             )
@@ -292,6 +364,13 @@ class ReferenceValidation:
                 expected=None,
                 obtained=item,
                 advice=f'{self.info} : {item.get("text")} ({item.get("tag")}) not found in <mixed-citation>{self.data.get("mixed_citation")}</mixed-citation>',
+                advice_text=i18n._("{info}: {text} ({tag}) not found in <mixed-citation>{mixed_citation}</mixed-citation>"),
+                advice_params={
+                    "info": self.info,
+                    "text": item.get("text"),
+                    "tag": item.get("tag"),
+                    "mixed_citation": self.data.get("mixed_citation"),
+                },
                 data=self.data,
                 error_level=self.params.get("unmatched_data_error_level"),
             )
@@ -310,6 +389,11 @@ class ReferenceValidation:
                 expected=None,
                 obtained=item,
                 advice=f'{self.info} : "{item}" was not marked, analyze it and mark it with a corresponding tag',
+                advice_text=i18n._('{info}: "{item}" was not marked, analyze it and mark it with a corresponding tag'),
+                advice_params={
+                    "info": self.info,
+                    "item": item,
+                },
                 data=self.data,
                 error_level=self.params.get("not_marked_data_error_level"),
             )
@@ -327,6 +411,8 @@ class ReferenceValidation:
             expected="element-citation",
             obtained="element-citation" if has_ec else None,
             advice=advice,
+            advice_text=i18n._("{info}: mark the structured reference with <element-citation>"),
+            advice_params={"info": self.info},
             data=self.data,
             error_level=self.params.get("element_citation_error_level", "CRITICAL"),
         )
@@ -344,6 +430,8 @@ class ReferenceValidation:
                 expected="at most 1 <ext-link> in <element-citation>",
                 obtained=f"{count} <ext-link> elements",
                 advice=f"{self.info}: remove extra <ext-link> from <element-citation>, keep at most one",
+                advice_text=i18n._("{info}: remove extra <ext-link> from <element-citation>, keep at most one"),
+                advice_params={"info": self.info},
                 data=self.data,
                 error_level=self.params.get("ext_link_count_element_citation_error_level", "ERROR"),
             )
@@ -361,6 +449,8 @@ class ReferenceValidation:
                 expected="at most 1 <ext-link> in <mixed-citation>",
                 obtained=f"{count} <ext-link> elements",
                 advice=f"{self.info}: remove extra <ext-link> from <mixed-citation>, keep at most one",
+                advice_text=i18n._("{info}: remove extra <ext-link> from <mixed-citation>, keep at most one"),
+                advice_params={"info": self.info},
                 data=self.data,
                 error_level=self.params.get("ext_link_count_mixed_citation_error_level", "ERROR"),
             )
@@ -379,6 +469,12 @@ class ReferenceValidation:
                 expected="<lpage> when <fpage> is present",
                 obtained=f"<fpage>{fpage}</fpage> without <lpage>",
                 advice=f"{self.info}: add <lpage> because <fpage> is present",
+                advice_text=i18n._("{info}: add <lpage> because <fpage> is present"),
+                advice_params={"info": self.info},
+                message_text=i18n._(
+                    "<lpage> is required when <fpage> is present"
+                ),
+                message_params={},
                 data=self.data,
                 error_level=self.params.get("lpage_error_level", "ERROR"),
             )
@@ -398,6 +494,8 @@ class ReferenceValidation:
                     expected='<size units="pages">',
                     obtained=f'<size units="{units}">',
                     advice=f'{self.info}: set @units="pages" in <size>',
+                    advice_text=i18n._('{info}: set @units="pages" in <size>'),
+                    advice_params={"info": self.info},
                     data=self.data,
                     error_level=self.params.get("size_units_error_level", "ERROR"),
                 )
@@ -416,6 +514,8 @@ class ReferenceValidation:
                 expected='<date-in-citation content-type="access-date">',
                 obtained=f'<date-in-citation content-type="{content_type}">',
                 advice=f'{self.info}: set @content-type="access-date" in <date-in-citation>',
+                advice_text=i18n._('{info}: set @content-type="access-date" in <date-in-citation>'),
+                advice_params={"info": self.info},
                 data=self.data,
                 error_level=self.params.get("date_in_citation_content_type_error_level", "ERROR"),
             )
@@ -433,6 +533,8 @@ class ReferenceValidation:
                 expected="<surname> in <name>",
                 obtained=name,
                 advice=f"{self.info}: add <surname> to <name> in <person-group>",
+                advice_text=i18n._("{info}: add <surname> to <name> in <person-group>"),
+                advice_params={"info": self.info},
                 data=self.data,
                 error_level=self.params.get("surname_error_level", "ERROR"),
             )
@@ -495,6 +597,8 @@ class ReferencesValidation:
             expected="<ref-list> in <back>",
             obtained="<ref-list>" if is_valid else None,
             advice="Add <ref-list> to <back> with at least one <ref>",
+            advice_text=i18n._("Add <ref-list> to <back> with at least one <ref>"),
+            advice_params={},
             data=self._get_parent_data(),
             error_level=self.params.get("ref_list_presence_error_level", "CRITICAL"),
         )
@@ -515,6 +619,8 @@ class ReferencesValidation:
                 expected="at least one <ref> in <ref-list>",
                 obtained=f"{len(refs)} <ref> elements",
                 advice="Add at least one <ref> to <ref-list>",
+                advice_text=i18n._("Add at least one <ref> to <ref-list>"),
+                advice_params={},
                 data=self._get_parent_data(),
                 error_level=self.params.get("ref_presence_error_level", "CRITICAL"),
             )

--- a/packtools/sps/validation/related_articles.py
+++ b/packtools/sps/validation/related_articles.py
@@ -9,8 +9,8 @@ Implements validations for related article elements to ensure:
 
 Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJNOIqzBNSgA/edit?tab=t.0#heading=h.relatedarticle
 """
-import gettext
 
+from packtools.sps import i18n
 from packtools.sps.models.v2.related_articles import RelatedArticlesByNode
 from packtools.sps.validation.utils import (
     build_response,
@@ -18,7 +18,6 @@ from packtools.sps.validation.utils import (
     validate_doi_format,
 )
 
-_ = gettext.gettext
 
 ALLOWED_RELATED_ARTICLE_TYPES = [
     "corrected-article",
@@ -126,7 +125,7 @@ class RelatedArticleValidation:
         obtained = self.related_article.get("related-article-type")
         is_valid = obtained is not None and obtained.strip() != ""
 
-        advice_text = _(
+        advice_text = i18n._(
             'Add @related-article-type attribute to <related-article>.'
             ' Valid values: {allowed_values}'
         )
@@ -144,11 +143,16 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected="@related-article-type attribute present",
                 obtained=obtained,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @related-article-type attribute to <related-article>.'
+            ' Valid values: {allowed_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "The @related-article-type attribute is required"
+                ),
+                message_params={},
             )
 
     def validate_ext_link_type_presence(self):
@@ -166,7 +170,7 @@ class RelatedArticleValidation:
         obtained = self.related_article.get("ext-link-type")
         is_valid = obtained is not None and obtained.strip() != ""
 
-        advice_text = _(
+        advice_text = i18n._(
             'Add @ext-link-type attribute to <related-article>.'
             ' Valid values: {allowed_values}'
         )
@@ -184,11 +188,16 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected="@ext-link-type attribute present",
                 obtained=obtained,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @ext-link-type attribute to <related-article>.'
+            ' Valid values: {allowed_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "The @ext-link-type attribute is required"
+                ),
+                message_params={},
             )
 
     def validate_related_article_type_value(self):
@@ -210,7 +219,7 @@ class RelatedArticleValidation:
         error_level = self._get_error_level("related_article_type_value")
         is_valid = obtained in ALLOWED_RELATED_ARTICLE_TYPES
 
-        advice_text = _(
+        advice_text = i18n._(
             'Value "{obtained}" is not allowed for @related-article-type.'
             ' Valid values: {allowed_values}'
         )
@@ -229,11 +238,16 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=ALLOWED_RELATED_ARTICLE_TYPES,
                 obtained=obtained,
-                advice=advice_text.format(**advice_params),
+                advice=('Value "{obtained}" is not allowed for @related-article-type.'
+            ' Valid values: {allowed_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=error_level,
                 advice_text=advice_text,
                 advice_params=advice_params,
+                message_text=i18n._(
+                    "The @xlink:href attribute is required"
+                ),
+                message_params={},
             )
 
     def validate_xlink_href_presence(self):
@@ -251,7 +265,7 @@ class RelatedArticleValidation:
         obtained = self.related_article.get("href")
         is_valid = obtained is not None and obtained.strip() != ""
 
-        advice_text = _(
+        advice_text = i18n._(
             'Add @xlink:href attribute to <related-article>.'
             ' Provide a valid DOI or URI.'
         )
@@ -267,7 +281,8 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected="@xlink:href attribute present",
                 obtained=obtained,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @xlink:href attribute to <related-article>.'
+            ' Provide a valid DOI or URI.').format(**advice_params),
                 data=self.related_article,
                 error_level=error_level,
                 advice_text=advice_text,
@@ -293,7 +308,7 @@ class RelatedArticleValidation:
         error_level = self._get_error_level("ext_link_type_value")
         is_valid = obtained in ALLOWED_EXT_LINK_TYPES
 
-        advice_text = _(
+        advice_text = i18n._(
             'Value "{obtained}" is not allowed for @ext-link-type.'
             ' Valid values: {allowed_values}'
         )
@@ -312,7 +327,8 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=ALLOWED_EXT_LINK_TYPES,
                 obtained=obtained,
-                advice=advice_text.format(**advice_params),
+                advice=('Value "{obtained}" is not allowed for @ext-link-type.'
+            ' Valid values: {allowed_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=error_level,
                 advice_text=advice_text,
@@ -344,7 +360,7 @@ class RelatedArticleValidation:
 
         error_level = self._get_error_level("doi_preference")
 
-        advice_text = _(
+        advice_text = i18n._(
             'For @related-article-type="{related_type}", use @ext-link-type="doi".'
             ' Value "uri" is only recommended for: {uri_types}'
         )
@@ -362,7 +378,8 @@ class RelatedArticleValidation:
             is_valid=False,
             expected="doi",
             obtained=ext_link_type,
-            advice=advice_text.format(**advice_params),
+            advice=('For @related-article-type="{related_type}", use @ext-link-type="doi".'
+            ' Value "uri" is only recommended for: {uri_types}').format(**advice_params),
             data=self.related_article,
             error_level=error_level,
             advice_text=advice_text,
@@ -378,7 +395,7 @@ class RelatedArticleValidation:
         obtained_type = self.related_article.get("related-article-type")
 
         if not expected_values:
-            advice_text = _(
+            advice_text = i18n._(
                 'The article-type "{article_type}" does not match the'
                 ' related-article-type "{obtained_type}".'
                 ' Provide one of: {expected_values}'
@@ -397,7 +414,9 @@ class RelatedArticleValidation:
                 is_valid=False,
                 expected=expected_values,
                 obtained=obtained_type,
-                advice=advice_text.format(**advice_params),
+                advice=('The article-type "{article_type}" does not match the'
+                ' related-article-type "{obtained_type}".'
+                ' Provide one of: {expected_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("type"),
                 advice_text=advice_text,
@@ -406,7 +425,7 @@ class RelatedArticleValidation:
 
         is_valid = obtained_type in expected_values
         if not is_valid:
-            advice_text = _(
+            advice_text = i18n._(
                 'The article-type "{article_type}" does not match the'
                 ' related-article-type "{obtained_type}".'
                 ' Provide one of: {expected_values}'
@@ -425,7 +444,9 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=expected_values,
                 obtained=obtained_type,
-                advice=advice_text.format(**advice_params),
+                advice=('The article-type "{article_type}" does not match the'
+                ' related-article-type "{obtained_type}".'
+                ' Provide one of: {expected_values}').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("type"),
                 advice_text=advice_text,
@@ -438,7 +459,7 @@ class RelatedArticleValidation:
         is_valid = ext_link_type in self.valid_ext_link_types
 
         if not is_valid:
-            advice_text = _(
+            advice_text = i18n._(
                 'The @ext-link-type should be one of {allowed_values}'
                 ' for related article with id="{related_id}"'
             )
@@ -455,7 +476,8 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=self.valid_ext_link_types,
                 obtained=ext_link_type,
-                advice=advice_text.format(**advice_params),
+                advice=('The @ext-link-type should be one of {allowed_values}'
+                ' for related article with id="{related_id}"').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("ext_link_type"),
                 advice_text=advice_text,
@@ -470,7 +492,7 @@ class RelatedArticleValidation:
 
         link = self.related_article.get("href")
         if not link:
-            advice_text = _(
+            advice_text = i18n._(
                 'Provide a valid {link_type} for <related-article'
                 ' id="{related_id}" />'
             )
@@ -487,7 +509,8 @@ class RelatedArticleValidation:
                 is_valid=False,
                 expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
                 obtained=link,
-                advice=advice_text.format(**advice_params),
+                advice=('Provide a valid {link_type} for <related-article'
+                ' id="{related_id}" />').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("uri"),
                 advice_text=advice_text,
@@ -498,7 +521,7 @@ class RelatedArticleValidation:
         expected = "A valid URI format (e.g., http://example.com)"
 
         if not is_valid:
-            advice_text = _(
+            advice_text = i18n._(
                 'Invalid {link_type} format for link: {link}'
             )
             advice_params = {
@@ -514,7 +537,7 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=expected,
                 obtained=link,
-                advice=advice_text.format(**advice_params),
+                advice=('Invalid {link_type} format for link: {link}').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("uri_format"),
                 advice_text=advice_text,
@@ -529,7 +552,7 @@ class RelatedArticleValidation:
 
         link = self.related_article.get("href")
         if not link:
-            advice_text = _(
+            advice_text = i18n._(
                 'Provide a valid {link_type} for <related-article'
                 ' id="{related_id}" />'
             )
@@ -546,7 +569,8 @@ class RelatedArticleValidation:
                 is_valid=False,
                 expected=f'A valid {ext_link_type.upper() if ext_link_type else "link"}',
                 obtained=link,
-                advice=advice_text.format(**advice_params),
+                advice=('Provide a valid {link_type} for <related-article'
+                ' id="{related_id}" />').format(**advice_params),
                 data=self.related_article,
                 error_level=self.params.get("doi_error_level"),
                 advice_text=advice_text,
@@ -558,7 +582,7 @@ class RelatedArticleValidation:
         expected = "A valid DOI"
 
         if not is_valid:
-            advice_text = _(
+            advice_text = i18n._(
                 'Invalid {link_type} format for link: {link}'
             )
             advice_params = {
@@ -574,7 +598,7 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected=expected,
                 obtained=link,
-                advice=advice_text.format(**advice_params),
+                advice=('Invalid {link_type} format for link: {link}').format(**advice_params),
                 data=self.related_article,
                 error_level=self.params.get("doi_format_error_level"),
                 advice_text=advice_text,
@@ -596,7 +620,7 @@ class RelatedArticleValidation:
         is_valid = related_id is not None and related_id.strip() != ""
 
         if not is_valid:
-            advice_text = _(
+            advice_text = i18n._(
                 'Add @id attribute to <related-article>.'
                 ' The @id must be a non-empty unique identifier.'
             )
@@ -610,7 +634,8 @@ class RelatedArticleValidation:
                 is_valid=is_valid,
                 expected="A non-empty ID",
                 obtained=related_id,
-                advice=advice_text.format(**advice_params),
+                advice=('Add @id attribute to <related-article>.'
+                ' The @id must be a non-empty unique identifier.').format(**advice_params),
                 data=self.related_article,
                 error_level=self._get_error_level("id"),
                 advice_text=advice_text,
@@ -647,7 +672,7 @@ class RelatedArticleValidation:
             return
 
         if list(order) != list(expected_order):
-            advice_text = _(
+            advice_text = i18n._(
                 'Set related-article attributes in this order: {expected_order}'
             )
             advice_params = {
@@ -662,7 +687,7 @@ class RelatedArticleValidation:
                 is_valid=False,
                 expected=expected_order,
                 obtained=list(order),
-                advice=advice_text.format(**advice_params),
+                advice=('Set related-article attributes in this order: {expected_order}').format(**advice_params),
                 data=self.related_article,
                 error_level=self.params.get("attrib_order_error_level", "INFO"),
                 advice_text=advice_text,
@@ -811,7 +836,7 @@ class FulltextRelatedArticlesValidation:
                 "lang": self.node.get("{http://www.w3.org/XML/1998/namespace}lang"),
                 "article_type": self._article_type,
             }
-            advice_text = _(
+            advice_text = i18n._(
                 'Article type "{article_type}" requires related articles'
                 ' of types: {missing_types}'
             )
@@ -828,7 +853,8 @@ class FulltextRelatedArticlesValidation:
                 is_valid=False,
                 expected=self.required_types,
                 obtained=list(found_types),
-                advice=advice_text.format(**advice_params),
+                advice=('Article type "{article_type}" requires related articles'
+                ' of types: {missing_types}').format(**advice_params),
                 data={
                     "article_type": self._article_type,
                     "missing_types": list(missing_types),

--- a/packtools/sps/validation/response.py
+++ b/packtools/sps/validation/response.py
@@ -9,6 +9,7 @@ Reference: https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJ
 """
 
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 XML_LANG = "{http://www.w3.org/XML/1998/namespace}lang"
@@ -132,6 +133,8 @@ class ResponseValidation:
                 expected="reply",
                 obtained=response_type,
                 advice='Add @response-type="reply" to <response>.',
+                advice_text=i18n._('Add @response-type="reply" to <response>.'),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
             )
@@ -158,6 +161,8 @@ class ResponseValidation:
                 expected="reply",
                 obtained=response_type,
                 advice='Replace @response-type with "reply" in <response>.',
+                advice_text=i18n._('Replace @response-type with "reply" in <response>.'),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
                 element_name="response",
@@ -186,6 +191,8 @@ class ResponseValidation:
                 expected="a valid xml:lang value",
                 obtained=xml_lang,
                 advice="Add @xml:lang to <response>.",
+                advice_text=i18n._("Add @xml:lang to <response>."),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
             )
@@ -212,6 +219,8 @@ class ResponseValidation:
                 expected="a unique id value",
                 obtained=response_id,
                 advice="Add @id to <response>.",
+                advice_text=i18n._("Add @id to <response>."),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
             )
@@ -252,6 +261,8 @@ class ResponseValidation:
                 expected="a unique @id for each <response>",
                 obtained=response_id,
                 advice=f'Replace duplicate @id="{response_id}" with a unique value in <response>.',
+                advice_text=i18n._('Replace duplicate @id="{response_id}" with a unique value in <response>.'),
+                advice_params={"response_id": response_id},
                 data=response_id,
                 error_level=error_level,
                 element_name="response",
@@ -279,6 +290,8 @@ class ResponseValidation:
                 expected="<front-stub> element",
                 obtained="front-stub" if is_valid else None,
                 advice="Add <front-stub> with response metadata inside <response>.",
+                advice_text=i18n._("Add <front-stub> with response metadata inside <response>."),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
             )
@@ -304,6 +317,8 @@ class ResponseValidation:
                 expected="<body> element",
                 obtained="body" if is_valid else None,
                 advice="Add <body> with response content inside <response>.",
+                advice_text=i18n._("Add <body> with response content inside <response>."),
+                advice_params={},
                 data=ctx.get("id"),
                 error_level=error_level,
             )

--- a/packtools/sps/validation/sec.py
+++ b/packtools/sps/validation/sec.py
@@ -2,6 +2,7 @@ import re
 
 from packtools.sps.models.sec import ArticleSecs, VALID_SEC_TYPES, NON_COMBINABLE_SEC_TYPES
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class SecValidation:
@@ -40,6 +41,8 @@ class SecValidation:
             expected="<title> element in <sec>",
             obtained=self.data.get("title"),
             advice="Add <title> element to <sec> for accessibility",
+            advice_text=i18n._("Add <title> element to <sec> for accessibility"),
+            advice_params={},
             data=self.data,
             error_level=self.params.get("title_error_level", "CRITICAL"),
         )
@@ -75,6 +78,11 @@ class SecValidation:
             expected=str(valid_sec_types),
             obtained=sec_type,
             advice=f'Replace @sec-type="{sec_type}" with a valid value: {valid_sec_types}',
+            advice_text=i18n._('Replace @sec-type="{sec_type}" with a valid value: {valid_types}'),
+            advice_params={
+                "sec_type": sec_type,
+                "valid_types": valid_sec_types,
+            },
             data=self.data,
             error_level=self.params.get("sec_type_value_error_level", "ERROR"),
         )
@@ -98,6 +106,8 @@ class SecValidation:
             expected='@id attribute in <sec sec-type="transcript">',
             obtained=sec_id,
             advice='Add @id attribute to <sec sec-type="transcript">',
+            advice_text=i18n._('Add @id attribute to <sec sec-type="transcript">'),
+            advice_params={},
             data=self.data,
             error_level=self.params.get("transcript_id_error_level", "ERROR"),
         )
@@ -128,6 +138,8 @@ class SecValidation:
             expected='Combined sec-types separated by pipe "|" (e.g., "materials|methods")',
             obtained=sec_type,
             advice=f'Use pipe "|" as separator in @sec-type="{sec_type}" (e.g., "materials|methods")',
+            advice_text=i18n._('Use pipe "|" as separator in @sec-type="{sec_type}" (e.g., "materials|methods")'),
+            advice_params={"sec_type": sec_type},
             data=self.data,
             error_level=self.params.get("combined_format_error_level", "WARNING"),
         )
@@ -162,6 +174,11 @@ class SecValidation:
             expected=f"Types {non_combinable} must not be combined with other types",
             obtained=sec_type,
             advice=f'Do not combine "{found_non_combinable[0]}" with other types in @sec-type="{sec_type}"',
+            advice_text=i18n._('Do not combine "{non_combinable}" with other types in @sec-type="{sec_type}"'),
+            advice_params={
+                "non_combinable": found_non_combinable[0],
+                "sec_type": sec_type,
+            },
             data=self.data,
             error_level=self.params.get("non_combinable_error_level", "WARNING"),
         )
@@ -181,6 +198,12 @@ class SecValidation:
             expected="At least one <p> element in <sec>",
             obtained=f"{paragraph_count} paragraphs",
             advice="Add at least one <p> element to <sec>",
+            advice_text=i18n._("Add at least one <p> element to <sec>"),
+            advice_params={},
+            message_text=i18n._(
+                "Found {count} paragraphs in <sec>; expected at least one <p>"
+            ),
+            message_params={"count": paragraph_count},
             data=self.data,
             error_level=self.params.get("content_error_level", "WARNING"),
         )
@@ -265,11 +288,24 @@ class XMLSecValidation:
                 if has_data_availability
                 else "missing"
             ),
+            message_text=i18n._(
+                "Data availability statement is missing; expected "
+                '<sec sec-type="data-availability"> in <body> or <back>, '
+                'or <fn fn-type="data-availability">'
+            ),
+            message_params={},
             advice=(
                 f'Add <sec sec-type="data-availability" specific-use="..."> to <body> or <back>, '
                 f'or <fn fn-type="data-availability"> '
                 f'(required for article-type="{article_type}")'
             ),
+            advice_text=(
+                i18n._('Add <sec sec-type="data-availability" specific-use="..."> '
+                "to <body> or <back>, or "
+                '<fn fn-type="data-availability"> '
+                '(required for article-type="{article_type}")')
+            ),
+            advice_params={"article_type": article_type},
             data=parent,
             error_level=self.params.get("data_availability_error_level", "ERROR"),
         )

--- a/packtools/sps/validation/supplementary_material.py
+++ b/packtools/sps/validation/supplementary_material.py
@@ -5,6 +5,7 @@ from packtools.sps.validation.graphic import GraphicValidation
 from packtools.sps.validation.media import MediaValidation
 from packtools.sps.validation.utils import build_response
 from packtools.sps.utils.xml_utils import tostring
+from packtools.sps import i18n
 
 
 class SupplementaryMaterialValidation:
@@ -45,6 +46,8 @@ class SupplementaryMaterialValidation:
                 expected="<sec sec-type='supplementary-material'>",
                 obtained=self.data.get("parent_tag"),
                 advice=f'In <sec sec-type="{sec_type}"><supplementary-material> replace "{sec_type}" with "supplementary-material".',
+                advice_text=i18n._('In <sec sec-type="{sec_type}"><supplementary-material> replace "{sec_type}" with "supplementary-material".'),
+                advice_params={"sec_type": sec_type},
                 error_level=self.params["sec_type_error_level"],
                 data=self.data,
             )
@@ -65,6 +68,8 @@ class SupplementaryMaterialValidation:
             expected="<label> in <supplementary-material>",
             obtained=label,
             advice="Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail.",
+            advice_text=i18n._("Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail."),
+            advice_params={},
             error_level=self.params["label_error_level"],
             data=self.data,
         )
@@ -84,6 +89,8 @@ class SupplementaryMaterialValidation:
             expected="Outside <app-group> and <app>",
             obtained=self.data.get("parent_tag"),
             advice="Do not use <supplementary-material> inside <app-group> or <app>.",
+            advice_text=i18n._("Do not use <supplementary-material> inside <app-group> or <app>."),
+            advice_params={},
             error_level=self.params["app_group_error_level"],
             data=self.data,
         )
@@ -115,6 +122,12 @@ class XmlSupplementaryMaterialValidation:
             expected="No <inline-supplementary-material>",
             obtained=obtained,
             advice="The use of <inline-supplementary-material> is prohibited.",
+            advice_text=i18n._("The use of <inline-supplementary-material> is prohibited."),
+            advice_params={},
+            message_text=i18n._(
+                "The <inline-supplementary-material> element is not allowed"
+            ),
+            message_params={},
             error_level=self.params["inline_error_level"],
             data={},
         )
@@ -163,6 +176,13 @@ class XmlSupplementaryMaterialValidation:
             expected="Last section of <body> or inside <back>",
             obtained=parent_tag,
             advice="The supplementary materials section must be at the end of <body> or inside <back>.",
+            advice_text=i18n._("The supplementary materials section must be at the end of <body> or inside <back>."),
+            advice_params={},
+            message_text=i18n._(
+                "The supplementary materials section must be the last "
+                "section of <body> or be inside <back>"
+            ),
+            message_params={},
             error_level=self.params["position_error_level"],
             data={},
         )

--- a/packtools/sps/validation/tablewrap.py
+++ b/packtools/sps/validation/tablewrap.py
@@ -1,5 +1,6 @@
 from packtools.sps.validation.models.tablewrap import ArticleTableWrappers
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class ArticleTableWrapValidation:
@@ -49,7 +50,7 @@ class ArticleTableWrapValidation:
                 advice=f'({self.article_type}) No <table-wrap> found in XML',
                 data=None,
                 error_level=self.rules["absent_error_level"],
-                advice_text='({article_type}) No <table-wrap> found in XML',
+                advice_text=i18n._('({article_type}) No <table-wrap> found in XML'),
                 advice_params={"article_type": self.article_type},
             )
         else:
@@ -134,7 +135,7 @@ class TableWrapValidation:
             advice='Add the table ID with id="" in <table-wrap>: <table-wrap id="">. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["id_error_level"],
-            advice_text='Add the table ID with id="" in <table-wrap>: <table-wrap id="">. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Add the table ID with id="" in <table-wrap>: <table-wrap id="">. Consult SPS documentation for more detail.'),
             advice_params={},
         )
 
@@ -185,8 +186,12 @@ class TableWrapValidation:
             advice=advice,
             data=self.data,
             error_level=self.rules["label_or_caption_error_level"],
-            advice_text='Add <label> or <caption> with <title> inside {xml}. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Add <label> or <caption> with <title> inside {xml}. Consult SPS documentation for more detail.'),
             advice_params={"xml": self.xml},
+            message_text=i18n._(
+                "Expected <label> or <caption> with <title> inside <table-wrap>"
+            ),
+            message_params={},
         )
 
     def validate_table(self):
@@ -215,7 +220,7 @@ class TableWrapValidation:
             advice=f'Wrap each table with <table> inside {self.xml}. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["table_error_level"],
-            advice_text='Wrap each table with <table> inside {xml}. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Wrap each table with <table> inside {xml}. Consult SPS documentation for more detail.'),
             advice_params={"xml": self.xml},
         )
 
@@ -234,14 +239,14 @@ class TableWrapValidation:
             expected = "alternatives"
             obtained = None
             advice = f'Wrap <table> and <graphic> with <alternatives> inside {self.xml} '
-            advice_text = 'Wrap <table> and <graphic> with <alternatives> inside {xml} '
+            advice_text = i18n._('Wrap <table> and <graphic> with <alternatives> inside {xml} ')
             advice_params = {"xml": self.xml}
             valid = False
         elif graphic + table == 1 and len(alternatives) > 0:
             expected = None
             obtained = "alternatives"
             advice = f'Remove the <alternatives> from {self.xml}.'
-            advice_text = 'Remove the <alternatives> from {xml}.'
+            advice_text = i18n._('Remove the <alternatives> from {xml}.')
             advice_params = {"xml": self.xml}
             valid = False
         else:
@@ -302,7 +307,7 @@ class TableWrapValidation:
             advice=f'Remove <tr> as a direct child of <table> in {self.xml}. Use <thead> or <tbody> to wrap <tr> elements.',
             data=self.data,
             error_level=self.rules["tr_in_table_error_level"],
-            advice_text='Remove <tr> as a direct child of <table> in {xml}. Use <thead> or <tbody> to wrap <tr> elements.',
+            advice_text=i18n._('Remove <tr> as a direct child of <table> in {xml}. Use <thead> or <tbody> to wrap <tr> elements.'),
             advice_params={"xml": self.xml},
         )
 
@@ -334,7 +339,7 @@ class TableWrapValidation:
             advice=f'Move <th> elements to be inside <thead> in {self.xml}. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["th_in_thead_error_level"],
-            advice_text='Move <th> elements to be inside <thead> in {xml}. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Move <th> elements to be inside <thead> in {xml}. Consult SPS documentation for more detail.'),
             advice_params={"xml": self.xml},
         )
 
@@ -366,7 +371,7 @@ class TableWrapValidation:
             advice=f'Move <td> elements to be inside <tbody> in {self.xml}. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["td_in_tbody_error_level"],
-            advice_text='Move <td> elements to be inside <tbody> in {xml}. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Move <td> elements to be inside <tbody> in {xml}. Consult SPS documentation for more detail.'),
             advice_params={"xml": self.xml},
         )
 
@@ -398,6 +403,6 @@ class TableWrapValidation:
             advice=f'Add <tbody> inside <table> in {self.xml}. Consult SPS documentation for more detail.',
             data=self.data,
             error_level=self.rules["tbody_error_level"],
-            advice_text='Add <tbody> inside <table> in {xml}. Consult SPS documentation for more detail.',
+            advice_text=i18n._('Add <tbody> inside <table> in {xml}. Consult SPS documentation for more detail.'),
             advice_params={"xml": self.xml},
         )

--- a/packtools/sps/validation/utils.py
+++ b/packtools/sps/validation/utils.py
@@ -1,13 +1,44 @@
 import urllib.parse
 import re
-import gettext
 from datetime import date, timedelta
 
+from packtools.sps import i18n
 from packtools.sps.libs.requester import fetch_data
 from packtools.sps.validation.similarity_utils import most_similar, similarity, how_similar
 
-# Configuração de internacionalização
-_ = gettext.gettext
+
+def _normalize_message_value(value):
+    if isinstance(value, str):
+        preserve_leading_space = value.startswith(" ")
+        preserve_trailing_space = value.endswith(" ")
+        value = (
+            value.replace("\\n", " ")
+            .replace("\\r", " ")
+            .replace("\\t", " ")
+        )
+        value = re.sub(r"[\x00-\x1f\x7f]+", " ", value)
+        value = " ".join(value.split())
+
+        if value and preserve_leading_space:
+            value = f" {value}"
+        if value and preserve_trailing_space:
+            value = f"{value} "
+
+        return value
+
+    if isinstance(value, dict):
+        return {
+            key: _normalize_message_value(item)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [_normalize_message_value(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(_normalize_message_value(item) for item in value)
+
+    return value
 
 
 def format_response(
@@ -29,10 +60,19 @@ def format_response(
     sub_element_name=None,
     attribute_name=None,
     xml=None,
+    message_text=None,
+    message_params=None,
+    advice_text=None,
+    advice_params=None,
 ):
+    message_expected = (
+        expected.removeprefix("one of ")
+        if isinstance(expected, str)
+        else expected
+    )
     if validation_type == "value in list" and "one of " not in expected:
         expected = f"one of {expected}"
-    
+
     advice = format_advice(
         title,
         validation_type,
@@ -50,6 +90,29 @@ def format_response(
     )
 
     message = f"Got {obtained}, expected {expected}"
+    if message_text:
+        localized_message = message_text
+    elif validation_type == "value in list":
+        localized_message = i18n._(
+            "Got {obtained}, expected one of {expected}"
+        )
+    else:
+        localized_message = i18n._(
+            "Got {obtained}, expected {expected}"
+        )
+    localized_message_params = (
+        _normalize_message_value(message_params or {})
+        if message_text
+        else {
+            "obtained": _normalize_message_value(obtained),
+            "expected": _normalize_message_value(message_expected),
+        }
+    )
+    localized_advice = (
+        advice_text
+        if advice_text
+        else i18n._(advice) if advice else None
+    )
 
     return {
         "title": title,
@@ -64,11 +127,17 @@ def format_response(
         "expected_value": obtained if is_valid else expected,
         "got_value": obtained,
         "message": message,
-        "msg_text": _("Got {obtained}, expected {expected}"),
-        "msg_params": {"obtained": obtained, "expected": expected},
+        "msg_text": localized_message,
+        "msg_params": localized_message_params,
         "advice": None if is_valid else advice,
-        "adv_text": None if is_valid else advice,  # Por enquanto, será melhorado no build_response
-        "adv_params": None if is_valid else {},
+        "adv_text": (
+            localized_advice if not is_valid else None
+        ),
+        "adv_params": (
+            None
+            if is_valid
+            else _normalize_message_value(advice_params or {})
+        ),
         "data": data,
     }
 
@@ -89,28 +158,18 @@ def build_response(
     sub_element_name=None,
     attribute_name=None,
     xml=None,
+    message_text=None,
+    message_params=None,
     advice_text=None,
     advice_params=None,
 ):
-    """
-    Constrói um dicionário de resposta para validações.
-
-    NOVO: Adicionado suporte para internacionalização com:
-    - msg_text e msg_params: para a mensagem principal
-    - adv_text e adv_params: para o conselho (advice)
-
-    Args:
-        advice_text: Template de mensagem internacionalizada usando _()
-        advice_params: Dicionário com parâmetros para o template
-    """
+    message_expected = (
+        expected.removeprefix("one of ")
+        if isinstance(expected, str)
+        else expected
+    )
     if validation_type == "value in list" and "one of " not in expected:
         expected = f"one of {expected}"
-
-    # if not attribute_name:
-    #     if sub_item and '@' == sub_item[0]:
-    #         attribute_name = sub_item[1:]
-    # if not element_name:
-    #     element_name = item
 
     advice = format_advice(
         title,
@@ -125,10 +184,33 @@ def build_response(
         attribute_name,
         xml,
         item,
-        sub_item
+        sub_item,
     )
 
     message = f"Got {obtained}, expected {expected}"
+    if message_text:
+        localized_message = message_text
+    elif validation_type == "value in list":
+        localized_message = i18n._(
+            "Got {obtained}, expected one of {expected}"
+        )
+    else:
+        localized_message = i18n._(
+            "Got {obtained}, expected {expected}"
+        )
+    localized_message_params = (
+        _normalize_message_value(message_params or {})
+        if message_text
+        else {
+            "obtained": str(_normalize_message_value(obtained)),
+            "expected": str(_normalize_message_value(message_expected)),
+        }
+    )
+    localized_advice = (
+        advice_text
+        if advice_text
+        else i18n._(advice) if advice else None
+    )
 
     return {
         "title": title,
@@ -143,11 +225,17 @@ def build_response(
         "expected_value": expected,
         "got_value": obtained,
         "message": message,
-        "msg_text": _("Got {obtained}, expected {expected}"),
-        "msg_params": {"obtained": str(obtained), "expected": str(expected)},
+        "msg_text": localized_message,
+        "msg_params": localized_message_params,
         "advice": None if is_valid else advice,
-        "adv_text": None if is_valid else advice_text,
-        "adv_params": None if is_valid else (advice_params or {}),
+        "adv_text": (
+            localized_advice if not is_valid else None
+        ),
+        "adv_params": (
+            None
+            if is_valid
+            else _normalize_message_value(advice_params or {})
+        ),
         "data": data,
     }
 
@@ -276,16 +364,7 @@ def format_advice(
     sub_item,
 ):
     if is_valid:
-        return ''
-
-    # if not attribute_name:
-    #     if sub_item:
-    #         if '@' == sub_item[0]:
-    #             attribute_name = sub_item[1:]
-    #         else:
-    #             sub_element_name = sub_item
-    # if not element_name:
-    #     element_name = item
+        return ""
 
     if element_name or sub_element_name or attribute_name or xml:
         if validation_type == "value in list" and "one of " not in expected:
@@ -294,38 +373,52 @@ def format_advice(
         if validation_type == "exist":
             marked = ""
             verb = "Mark"
+
             if attribute_name:
                 verb = "Add "
                 marked = f' {attribute_name}="VALUE"'
+
             if sub_element_name:
                 marked = f"<{sub_element_name}{marked}>"
+
             if element_name:
                 marked = f"<{element_name}{marked}>"
+
             advice = f"{verb} {title} with {marked}"
 
         elif validation_type == "value in list":
-
             if obtained:
                 incorrect = ""
+
                 if attribute_name:
                     incorrect = f' {attribute_name}="{obtained}"'
+
                 if sub_element_name:
                     incorrect = f"<{sub_element_name}{incorrect}>"
+
                 if element_name:
                     incorrect = f"<{element_name}{incorrect}>"
+
                 advice = f"Replace {obtained} in {incorrect} with {expected}"
             else:
                 incomplete = ""
+
                 if attribute_name:
                     attribute = f' {attribute_name}="VALUE"'
+
                 if sub_element_name:
                     incomplete = f"<{sub_element_name}{incomplete}>"
+
                 if element_name:
                     incomplete = f"<{element_name}{incomplete}>"
-                advice = f"Add {attribute} in {incomplete} and replace VALUE with {expected}"
+
+                advice = (
+                    f"Add {attribute} in {incomplete} "
+                    f"and replace VALUE with {expected}"
+                )
 
     return advice
-    
+
 
 def get_future_date(from_date, days):
     if isinstance(from_date, str):

--- a/packtools/sps/validation/visual_resource_base.py
+++ b/packtools/sps/validation/visual_resource_base.py
@@ -1,6 +1,7 @@
 import os
 
 from packtools.sps.validation.utils import build_response
+from packtools.sps import i18n
 
 
 class VisualResourceBaseValidation:
@@ -38,6 +39,8 @@ class VisualResourceBaseValidation:
             expected=expected,
             obtained=self.data.get("id"),
             advice=f'Add id="" to {xml}',
+            advice_text=i18n._('Add id="" to {element}'),
+            advice_params={"element": xml},
             error_level=self.params["media_attributes_error_level"],
             data=self.data,
         )
@@ -62,7 +65,13 @@ class VisualResourceBaseValidation:
             expected="File name with extension",
             obtained=obtained,
             advice=f'In @xlink:href, provide a valid file name with its extension in {self.params["valid_extension"]}.',
+            advice_text=(
+                i18n._("In @xlink:href, provide a valid file name with its extension "
+                "in {valid_extensions}.")
+            ),
+            advice_params={
+                "valid_extensions": self.params["valid_extension"],
+            },
             error_level=self.params["xlink_href_error_level"],
             data=self.data,
         )
-

--- a/packtools/sps/validation/xml_structure.py
+++ b/packtools/sps/validation/xml_structure.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 
 from packtools import XMLValidator, etree, XML
 from packtools.domain import SchematronValidator, PyValidator
-from gettext import gettext as _
+from packtools.sps import i18n
 
 
 IS_PACKTOOLS_INSTALLED = False
@@ -85,21 +85,39 @@ class StructureValidator:
         except KeyError:
             yield {
                 "result": "error",
-                "message": _('Unknown {}: {}').format(
+                "message": 'Unknown {}: {}'.format(
                     'PUBLIC ID',
                     self.xml_with_pre.public_id,
-                )
+                ),
+                "msg_text": i18n._("Unknown {identifier}: {value}"),
+                "msg_params": {
+                    "identifier": "PUBLIC ID",
+                    "value": self.xml_with_pre.public_id,
+                },
+                "adv_text": None,
+                "adv_params": None,
             }
             return
 
         if self.xml_with_pre.sps_version not in dtd_version["sps_versions"]:
             yield {
                 "result": "error",
-                "message": _('Unmatched {}: {}. Expected one of {}').format(
+                "message": 'Unmatched {}: {}. Expected one of {}'.format(
                     'sps version',
                     self.xml_with_pre.sps_version,
                     dtd_version["sps_versions"],
-                )
+                ),
+                "msg_text": i18n._(
+                    "Unmatched {identifier}: {value}. "
+                    "Expected one of {expected}"
+                ),
+                "msg_params": {
+                    "identifier": "sps version",
+                    "value": self.xml_with_pre.sps_version,
+                    "expected": dtd_version["sps_versions"],
+                },
+                "adv_text": None,
+                "adv_params": None,
             }
 
         try:
@@ -107,20 +125,41 @@ class StructureValidator:
             if system_id not in dtd_version['url']:
                 yield {
                     "result": "error",
-                    "message": _('Unmatched {}: {}. Expected {}').format(
+                    "message": 'Unmatched {}: {}. Expected {}'.format(
                         'SYSTEM ID',
                         self.xml_with_pre.system_id,
                         dtd_version['url'],
-                    )
+                    ),
+                    "msg_text": i18n._(
+                        "Unmatched {identifier}: {value}. "
+                        "Expected {expected}"
+                    ),
+                    "msg_params": {
+                        "identifier": "SYSTEM ID",
+                        "value": self.xml_with_pre.system_id,
+                        "expected": dtd_version["url"],
+                    },
+                    "adv_text": None,
+                    "adv_params": None,
                 }
         except (AttributeError, ValueError, TypeError, IndexError):
             yield {
                 "result": "error",
-                "message": _('Unmatched {}: {}. Expected {}').format(
+                "message": 'Unmatched {}: {}. Expected {}'.format(
                     'SYSTEM ID',
                     self.xml_with_pre.system_id,
                     dtd_version['url'],
-                )
+                ),
+                "msg_text": i18n._(
+                    "Unmatched {identifier}: {value}. Expected {expected}"
+                ),
+                "msg_params": {
+                    "identifier": "SYSTEM ID",
+                    "value": self.xml_with_pre.system_id,
+                    "expected": dtd_version["url"],
+                },
+                "adv_text": None,
+                "adv_params": None,
             }
 
     def annotate_errors(self):

--- a/tests/sps/test_i18n.py
+++ b/tests/sps/test_i18n.py
@@ -1,0 +1,664 @@
+import ast
+import gettext
+import re
+import unittest
+from contextvars import Context
+from pathlib import Path
+from unittest.mock import patch
+
+from babel.messages.pofile import read_po
+from lxml import etree
+
+from packtools.sps import i18n
+from packtools.sps.validation.journal_meta import (
+    ISSNFormatValidation,
+    JournalMetaPresenceValidation,
+)
+from packtools.sps.validation.product import ProductValidation
+from packtools.sps.validation.utils import build_response, format_response
+
+
+class PrefixTranslations(gettext.NullTranslations):
+    def __init__(self, prefix):
+        super().__init__()
+        self.prefix = prefix
+
+    def gettext(self, message):
+        return f"{self.prefix}:{message}"
+
+
+class I18nTest(unittest.TestCase):
+    def test_catalogs_preserve_xml_tags_and_attribute_names(self):
+        token_patterns = {
+            "tags": re.compile(r"</?([A-Za-z_][\w:.-]*)"),
+            "attributes": re.compile(
+                r"(?<![\w:-])([A-Za-z_][\w:.-]*)\s*="
+            ),
+            "at_attributes": re.compile(
+                r"@([A-Za-z_](?:[\w:.-]*[\w:-])?)"
+            ),
+        }
+        mismatches = []
+
+        for locale in ("pt_BR", "es"):
+            po_path = (
+                i18n.LOCALE_DIR
+                / locale
+                / "LC_MESSAGES"
+                / f"{i18n.DOMAIN}.po"
+            )
+            with po_path.open(encoding="utf-8") as stream:
+                catalog = read_po(stream)
+
+            for message in catalog:
+                if (
+                    not message.id
+                    or not message.string
+                    or not isinstance(message.id, str)
+                    or not isinstance(message.string, str)
+                ):
+                    continue
+
+                for token_type, pattern in token_patterns.items():
+                    source_tokens = sorted(pattern.findall(message.id))
+                    translated_tokens = sorted(
+                        pattern.findall(message.string)
+                    )
+                    if source_tokens != translated_tokens:
+                        mismatches.append(
+                            (
+                                locale,
+                                token_type,
+                                message.id,
+                                source_tokens,
+                                translated_tokens,
+                            )
+                        )
+
+        self.assertEqual([], mismatches)
+
+    def test_validation_result_dicts_include_i18n_contract(self):
+        validation_dir = (
+            Path(__file__).resolve().parents[2]
+            / "packtools"
+            / "sps"
+            / "validation"
+        )
+        required_fields = {
+            "msg_text",
+            "msg_params",
+            "adv_text",
+            "adv_params",
+        }
+        incomplete = []
+
+        for path in validation_dir.glob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Dict):
+                    continue
+
+                keys = {
+                    key.value
+                    for key in node.keys
+                    if isinstance(key, ast.Constant)
+                    and isinstance(key.value, str)
+                }
+                if "message" not in keys:
+                    continue
+
+                missing = required_fields - keys
+                if missing:
+                    incomplete.append(
+                        f"{path.name}:{node.lineno}: "
+                        f"{', '.join(sorted(missing))}"
+                    )
+
+        self.assertEqual([], incomplete)
+
+    def test_uses_null_translation_before_locale_is_set(self):
+        translated = Context().run(
+            i18n._,
+            "Got {obtained}, expected {expected}",
+        )
+
+        self.assertEqual("Got {obtained}, expected {expected}", translated)
+
+    def test_set_locale_loads_expected_domain_and_directory(self):
+        translation = PrefixTranslations("pt_BR")
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ) as load_translation:
+            context = Context()
+            context.run(i18n.set_locale, "pt_BR")
+
+            self.assertEqual(
+                "pt_BR:Message",
+                context.run(i18n._, "Message"),
+            )
+
+        load_translation.assert_called_once_with(
+            i18n.DOMAIN,
+            localedir=str(i18n.LOCALE_DIR),
+            languages=["pt_BR"],
+            fallback=True,
+        )
+
+    def test_set_locale_defaults_to_english_with_catalog_fallback(self):
+        context = Context()
+
+        context.run(i18n.set_locale)
+
+        self.assertEqual("Message", context.run(i18n._, "Message"))
+
+    def test_locales_are_isolated_between_contexts(self):
+        translations = {
+            "pt_BR": PrefixTranslations("pt_BR"),
+            "es": PrefixTranslations("es"),
+        }
+
+        def load_translation(domain, localedir, languages, fallback):
+            return translations[languages[0]]
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            side_effect=load_translation,
+        ):
+            portuguese_context = Context()
+            spanish_context = Context()
+            portuguese_context.run(i18n.set_locale, "pt_BR")
+            spanish_context.run(i18n.set_locale, "es")
+
+            self.assertEqual(
+                "pt_BR:Message",
+                portuguese_context.run(i18n._, "Message"),
+            )
+            self.assertEqual(
+                "es:Message",
+                spanish_context.run(i18n._, "Message"),
+            )
+
+    def test_build_response_uses_active_translation(self):
+        translation = PrefixTranslations("pt_BR")
+        context = Context()
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("pt_BR")
+                return build_response(
+                    title="article title",
+                    parent={
+                        "parent": "article",
+                        "parent_id": None,
+                        "parent_article_type": "research-article",
+                        "parent_lang": "pt",
+                    },
+                    item="article-title",
+                    sub_item=None,
+                    validation_type="value",
+                    is_valid=False,
+                    expected="present",
+                    obtained="missing",
+                    advice="Mark article title for pt language",
+                    data=None,
+                    error_level="ERROR",
+                    advice_text=i18n._(
+                        "Mark {element} for {language} language"
+                    ),
+                    advice_params={
+                        "element": "article title",
+                        "language": "pt",
+                    },
+                )
+
+            result = context.run(validate)
+
+        self.assertEqual(
+            "Got missing, expected present",
+            result["message"],
+        )
+        self.assertEqual(
+            "pt_BR:Got {obtained}, expected {expected}",
+            result["msg_text"],
+        )
+        self.assertEqual(
+            "Mark article title for pt language",
+            result["advice"],
+        )
+        self.assertEqual(
+            "pt_BR:Mark {element} for {language} language",
+            result["adv_text"],
+        )
+
+    def test_value_in_list_uses_localized_fallback_without_legacy_prefix(self):
+        translation = PrefixTranslations("pt_BR")
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("pt_BR")
+                return build_response(
+                    title="article type",
+                    parent={"parent": "article"},
+                    item="article",
+                    sub_item="@article-type",
+                    validation_type="value in list",
+                    is_valid=False,
+                    expected=["research-article", "review-article"],
+                    obtained="translation",
+                    advice="Use a valid article type",
+                    data=None,
+                    error_level="CRITICAL",
+                )
+
+            result = Context().run(validate)
+
+        self.assertEqual(
+            "one of ['research-article', 'review-article']",
+            result["expected_value"],
+        )
+        self.assertEqual(
+            "Got translation, expected one of "
+            "['research-article', 'review-article']",
+            result["message"],
+        )
+        self.assertEqual(
+            "pt_BR:Got {obtained}, expected one of {expected}",
+            result["msg_text"],
+        )
+        self.assertEqual(
+            {
+                "obtained": "translation",
+                "expected": "['research-article', 'review-article']",
+            },
+            result["msg_params"],
+        )
+
+    def test_format_response_uses_explicit_advice_template(self):
+        translation = PrefixTranslations("es")
+        context = Context()
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("es")
+                return format_response(
+                    title="journal meta presence",
+                    parent="article",
+                    parent_id=None,
+                    parent_article_type="research-article",
+                    parent_lang="pt",
+                    item="journal-meta",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=False,
+                    expected="present",
+                    obtained=None,
+                    advice="Add <journal-meta> inside <front>",
+                    data=None,
+                    error_level="ERROR",
+                    advice_text=i18n._(
+                        "Add <{element}> inside <{parent}>"
+                    ),
+                    advice_params={
+                        "element": "journal-meta",
+                        "parent": "front",
+                    },
+                )
+
+            result = context.run(validate)
+
+        self.assertEqual(
+            "Add <journal-meta> inside <front>",
+            result["advice"],
+        )
+        self.assertEqual(
+            "es:Add <{element}> inside <{parent}>",
+            result["adv_text"],
+        )
+        self.assertEqual(
+            {
+                "element": "journal-meta",
+                "parent": "front",
+            },
+            result["adv_params"],
+        )
+
+    def test_explicit_message_template_is_not_translated_twice(self):
+        translation = PrefixTranslations("pt_BR")
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("pt_BR")
+                translated = i18n._(
+                    "The required <date date-type=\"{date_type}\"> is missing"
+                )
+                return build_response(
+                    title="history date",
+                    parent={"parent": "article"},
+                    item="date",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=False,
+                    expected='<date date-type="accepted"> present',
+                    obtained="missing",
+                    advice="Add the date",
+                    data=None,
+                    error_level="ERROR",
+                    message_text=translated,
+                    message_params={"date_type": "accepted"},
+                )
+
+            result = Context().run(validate)
+
+        self.assertEqual(
+            'pt_BR:The required <date date-type="{date_type}"> is missing',
+            result["msg_text"],
+        )
+        self.assertEqual({"date_type": "accepted"}, result["msg_params"])
+        self.assertNotIn("pt_BR:pt_BR:", result["msg_text"])
+        self.assertEqual(
+            'Got missing, expected <date date-type="accepted"> present',
+            result["message"],
+        )
+
+    def test_empty_message_template_uses_central_fallback(self):
+        translation = PrefixTranslations("es")
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("es")
+                return format_response(
+                    title="title",
+                    parent="article",
+                    parent_id=None,
+                    parent_article_type=None,
+                    parent_lang=None,
+                    item="item",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=False,
+                    expected="present",
+                    obtained="missing",
+                    advice=None,
+                    data=None,
+                    error_level="ERROR",
+                    message_text="",
+                    message_params={"unused": "value"},
+                )
+
+            result = Context().run(validate)
+
+        self.assertEqual(
+            "es:Got {obtained}, expected {expected}",
+            result["msg_text"],
+        )
+        self.assertEqual(
+            {"obtained": "missing", "expected": "present"},
+            result["msg_params"],
+        )
+
+    def test_explicit_message_without_params_uses_empty_params(self):
+        result = build_response(
+            title="title",
+            parent={"parent": "article"},
+            item="item",
+            sub_item=None,
+            validation_type="exist",
+            is_valid=False,
+            expected="present",
+            obtained="missing",
+            advice=None,
+            data=None,
+            error_level="ERROR",
+            message_text="Required element is missing",
+        )
+
+        self.assertEqual("Required element is missing", result["msg_text"])
+        self.assertEqual({}, result["msg_params"])
+
+    def test_invalid_response_with_advice_uses_it_as_adv_text_fallback(self):
+        result = format_response(
+            title="article title",
+            parent="article",
+            parent_id=None,
+            parent_article_type="research-article",
+            parent_lang="pt",
+            item="article-title",
+            sub_item=None,
+            validation_type="exist",
+            is_valid=False,
+            expected="present",
+            obtained=None,
+            advice=None,
+            data=None,
+            error_level="ERROR",
+            element_name="article-title",
+        )
+
+        self.assertEqual(
+            "Mark article title with <article-title>",
+            result["advice"],
+        )
+        self.assertEqual(result["advice"], result["adv_text"])
+        self.assertEqual({}, result["adv_params"])
+
+    def test_invalid_build_response_with_advice_uses_fallback(self):
+        translation = PrefixTranslations("pt_BR")
+
+        with patch(
+            "packtools.sps.i18n.gettext.translation",
+            return_value=translation,
+        ):
+            def validate():
+                i18n.set_locale("pt_BR")
+                return build_response(
+                    title="history date",
+                    parent={
+                        "parent": "article",
+                        "parent_id": None,
+                        "parent_article_type": "research-article",
+                        "parent_lang": "pt",
+                    },
+                    item="date",
+                    sub_item=None,
+                    validation_type="exist",
+                    is_valid=False,
+                    expected="present",
+                    obtained=None,
+                    advice="Add <date> to <history>",
+                    data=None,
+                    error_level="ERROR",
+                )
+
+            result = Context().run(validate)
+
+        self.assertEqual("Add <date> to <history>", result["advice"])
+        self.assertEqual(
+            "pt_BR:Add <date> to <history>",
+            result["adv_text"],
+        )
+        self.assertEqual({}, result["adv_params"])
+
+    def test_portuguese_catalog_translates_validator_templates(self):
+        xmltree = etree.fromstring("<article><front/></article>")
+
+        def validate():
+            i18n.set_locale("pt_BR")
+
+            return next(
+                JournalMetaPresenceValidation(
+                    xmltree
+                ).validate_journal_meta_presence()
+            )
+
+        result = Context().run(validate)
+
+        self.assertEqual(
+            "Obtido {obtained}, esperado {expected}",
+            result["msg_text"],
+        )
+        self.assertEqual(
+            "Adicione o elemento <journal-meta> dentro de <front>",
+            result["adv_text"],
+        )
+
+    def test_spanish_catalog_translates_parameterized_validator_template(self):
+        xmltree = etree.fromstring(
+            """
+            <article>
+                <front>
+                    <journal-meta>
+                        <issn pub-type="epub">invalid</issn>
+                    </journal-meta>
+                </front>
+            </article>
+            """
+        )
+
+        def validate():
+            i18n.set_locale("es")
+
+            return next(
+                ISSNFormatValidation(xmltree).validate_issn_format()
+            )
+
+        result = Context().run(validate)
+
+        self.assertEqual(
+            "Se obtuvo {obtained}, se esperaba {expected}",
+            result["msg_text"],
+        )
+        self.assertEqual(
+            "Corrija el formato del ISSN al patrón XXXX-XXXX. Valor actual: {issn_value}",
+            result["adv_text"],
+        )
+        self.assertEqual(
+            {"issn_value": "invalid"},
+            result["adv_params"],
+        )
+        self.assertEqual(
+            "Correct ISSN format to XXXX-XXXX pattern. Current value: invalid",
+            result["advice"],
+        )
+
+    def test_product_and_parameterized_advice_contract_in_supported_locales(self):
+        product_data = {
+            "product_type": None,
+            "parent": "article",
+            "parent_id": None,
+            "parent_article_type": "book-review",
+            "parent_lang": "en",
+        }
+        issn_xml = etree.fromstring(
+            """
+            <article>
+                <front>
+                    <journal-meta>
+                        <issn pub-type="epub">invalid</issn>
+                    </journal-meta>
+                </front>
+            </article>
+            """
+        )
+        expectations = {
+            "pt_BR": {
+                "product": 'Adicione o atributo @product-type="book" a <product>.',
+                "issn": (
+                    "Corrija o formato do ISSN para o padrão XXXX-XXXX."
+                    " Valor atual: {issn_value}"
+                ),
+            },
+            "es": {
+                "product": 'Agregue el atributo @product-type="book" a <product>.',
+                "issn": (
+                    "Corrija el formato del ISSN al patrón XXXX-XXXX."
+                    " Valor actual: {issn_value}"
+                ),
+            },
+        }
+
+        for locale, translated in expectations.items():
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    product = ProductValidation(
+                        product_data,
+                        {"product_type_presence_error_level": "CRITICAL"},
+                    ).validate_product_type_presence()
+                    issn = next(
+                        ISSNFormatValidation(issn_xml).validate_issn_format()
+                    )
+                    return product, issn
+
+                product, issn = Context().run(validate)
+
+                self.assertEqual(
+                    'Add @product-type="book" attribute to <product>.',
+                    product["advice"],
+                )
+                self.assertEqual(translated["product"], product["adv_text"])
+                self.assertEqual({}, product["adv_params"])
+                self.assertEqual(
+                    "Correct ISSN format to XXXX-XXXX pattern."
+                    " Current value: invalid",
+                    issn["advice"],
+                )
+                self.assertEqual(translated["issn"], issn["adv_text"])
+                self.assertEqual(
+                    {"issn_value": "invalid"},
+                    issn["adv_params"],
+                )
+
+    def test_message_params_preserve_controlled_values_in_all_locales(self):
+        for locale in ("pt_BR", "es"):
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    return build_response(
+                        title="CRediT taxonomy term",
+                        parent={"parent": "article"},
+                        item="role",
+                        sub_item=None,
+                        validation_type="exist",
+                        is_valid=False,
+                        expected="contributor role",
+                        obtained="study design",
+                        advice="Check the contributor role",
+                        data=None,
+                        error_level="CRITICAL",
+                    )
+
+                result = Context().run(validate)
+                rendered = result["msg_text"].format(
+                    **result["msg_params"]
+                )
+
+                self.assertEqual(
+                    {
+                        "obtained": "study design",
+                        "expected": "contributor role",
+                    },
+                    result["msg_params"],
+                )
+                self.assertIn("study design", rendered)
+                self.assertIn("contributor role", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_accessibility_data.py
+++ b/tests/sps/validation/test_accessibility_data.py
@@ -93,6 +93,14 @@ class TestAccessibilityDataValidation(unittest.TestCase):
         self.assertEqual(len(alt_text_results), 1)
         self.assertIn(alt_text_results[0]["response"], ["WARNING", "ERROR", "CRITICAL"])
         self.assertEqual(alt_text_results[0]["response"], "WARNING")
+        self.assertEqual(
+            "Got {obtained}, expected up to {max_length} characters",
+            alt_text_results[0]["msg_text"],
+        )
+        self.assertEqual(
+            {"obtained": None, "max_length": 120},
+            alt_text_results[0]["msg_params"],
+        )
 
     # ========== TESTES: <alt-text> LOCALIZAÇÃO (NOVA VALIDAÇÃO) ==========
 

--- a/tests/sps/validation/test_article_and_subarticles.py
+++ b/tests/sps/validation/test_article_and_subarticles.py
@@ -567,6 +567,10 @@ class TestArticleIdValidation(unittest.TestCase):
         self.assertIn("a numerical value from 1 to 99999", result['expected_value'])
         self.assertIsNotNone(result['advice'])
         self.assertIn("Fix the table of contents article order", result['advice'])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_article_id_other_with_zero_id(self):
         """Testa validação com um ID inválido (zero)"""

--- a/tests/sps/validation/test_article_contribs.py
+++ b/tests/sps/validation/test_article_contribs.py
@@ -186,6 +186,12 @@ class TestContribValidation(unittest.TestCase):
         
         self.assertEqual(responses, expected_responses)
         self.assertEqual(advices, expected_advices)
+        self.assertEqual("Smith, John", errors[0]["adv_params"]["info"])
+        self.assertEqual(
+            "Smith, John: Unable to automatically check the "
+            "0000-0002-1234-5678. Check it manually",
+            errors[0]["adv_text"].format(**errors[0]["adv_params"]),
+        )
 
     def test_validate_affiliations_success(self):
         """Test validate_affiliations with valid affiliation"""
@@ -237,6 +243,20 @@ class TestContribRoleValidation(unittest.TestCase):
         responses = [error['response'] for error in errors]
         expected_responses = ['ERROR', 'ERROR']
         self.assertEqual(responses, expected_responses)
+
+        term_error = next(
+            error
+            for error in errors
+            if error["title"] == "CRediT taxonomy term"
+        )
+        rendered_advice = term_error["adv_text"].format(
+            **term_error["adv_params"]
+        )
+        self.assertIn(
+            '<role content-type="invalid-uri">',
+            rendered_advice,
+        )
+        self.assertNotIn("<rolecontent-type=", rendered_advice)
 
     def test_validate_role_specific_use_success(self):
         """Test validate_role_specific_use with valid role"""

--- a/tests/sps/validation/test_article_data_availability.py
+++ b/tests/sps/validation/test_article_data_availability.py
@@ -186,6 +186,10 @@ class DataAvailabilityValidationTest(unittest.TestCase):
             mode_validation["expected_value"],
         )
         self.assertIn("Complete  specific-use=", mode_validation["advice"])
+        self.assertEqual(
+            mode_validation["adv_text"].format(**mode_validation["adv_params"]),
+            mode_validation["advice"],
+        )
 
     def test_validate_data_availability_without_data_availability(self):
         self.maxDiff = None
@@ -217,6 +221,10 @@ class DataAvailabilityValidationTest(unittest.TestCase):
         self.assertEqual("ERROR", exist_validation["response"])
         self.assertIsNone(exist_validation["got_value"].get("tag"))
         self.assertIn("Mark in <article>", exist_validation["advice"])
+        self.assertEqual(
+            exist_validation["adv_text"].format(**exist_validation["adv_params"]),
+            exist_validation["advice"],
+        )
 
     def test_validate_data_availability_article_type_optional(self):
         self.maxDiff = None
@@ -282,6 +290,10 @@ class DataAvailabilityValidationTest(unittest.TestCase):
         self.assertEqual("data availability statement", exist_validation["title"])
         self.assertEqual("ERROR", exist_validation["response"])
         self.assertIn("Remove from <article>", exist_validation["advice"])
+        self.assertEqual(
+            exist_validation["adv_text"].format(**exist_validation["adv_params"]),
+            exist_validation["advice"],
+        )
 
         # Check the mode validation
         mode_validation = validations[1]

--- a/tests/sps/validation/test_article_doi.py
+++ b/tests/sps/validation/test_article_doi.py
@@ -170,6 +170,25 @@ class TestArticleDoiValidation(unittest.TestCase):
 
         # Should have results (validation executed)
         self.assertEqual(len(results), 2)  # Main article + translation
+        for result in results:
+            self.assertEqual(
+                "Got {obtained}, expected DOI registered for {metadata}",
+                result["msg_text"],
+            )
+            self.assertTrue(result["advice"].startswith("Check doi ("))
+            self.assertEqual(
+                "The DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) "
+                "is not registered for {expected}. It is registered for {registered}",
+                result["adv_text"],
+            )
+            self.assertEqual(
+                result["got_value"],
+                result["msg_params"]["obtained"],
+            )
+            self.assertIn(
+                "article title",
+                result["msg_params"]["metadata"],
+            )
 
     @patch("packtools.sps.validation.utils.check_doi_is_registered")
     def test_validate_doi_registered_skip(self, mock_check_doi):

--- a/tests/sps/validation/test_article_toc_sections.py
+++ b/tests/sps/validation/test_article_toc_sections.py
@@ -103,6 +103,10 @@ class ArticleTocSectionsTest(TestCase):
             result['advice'],
             'Replace <subject-group subj-group-type="wrong-type"><subject>Health Sciences</subject></subject-group> by <subject-group subj-group-type="heading"><subject>Health Sciences</subject></subject-group>'
         )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_article_title_similarity(self):
         self.maxDiff = None
@@ -139,6 +143,10 @@ class ArticleTocSectionsTest(TestCase):
         self.assertEqual(
             result['advice'],
             'The article title (Health Sciences) must represent its contents and must be different from the section title (Health Sciences) to get a better ranking in search results'
+        )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
         )
 
     def test_validate_full_process(self):
@@ -237,6 +245,10 @@ class ArticleTocSectionsErrorTest(TestCase):
         self.assertEqual(
             result['advice'], 
             'Incorrect Section is not registered as a table of contents section. Valid values: {\'en\': [\'Health Sciences\', \'Biology\']}'
+        )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
         )
 
     def test_validate_missing_subj_group_type(self):
@@ -360,6 +372,14 @@ class ArticleTocSectionsErrorTest(TestCase):
         self.assertEqual(result["response"], "WARNING")
         self.assertEqual(result['advice'], 'Unable to check if Health Sciences (<subject-group subj-group-type="heading"><subject>Health Sciences</subject></subject-group>) is a valid table of contents section because the journal (Braz Journal ...) sections were not informed'
         )
+        self.assertEqual(
+            "Unable to check whether Health Sciences "
+            "(<subject-group subj-group-type=\"heading\"><subject>Health "
+            "Sciences</subject></subject-group>) is a valid table of contents "
+            "section because no sections were provided for the journal "
+            "Braz Journal ...",
+            result["adv_text"].format(**result["adv_params"]),
+        )
 
         # validade_article_title_is_different_from_section_title
         result = results[3]
@@ -413,6 +433,10 @@ class ArticleTocSectionsErrorTest(TestCase):
         self.assertEqual(result['response'], 'CRITICAL')
         self.assertEqual(result['got_value'], ['Public Health'])
         self.assertEqual(result['advice'], 'Write section and subsection in one subject: <subject-group subj-group-type="heading"><subject>Health Sciences: Public Health</subject></subject-group>. Remove <subject-group><subject>Public Health</subject></subject-group>')
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_all_validation_types_with_errors(self):
         """Testa múltiplos tipos de erro em uma única validação"""
@@ -494,6 +518,10 @@ class TestUnexpectedItemValidation(unittest.TestCase):
         self.assertEqual(
             result['response'],
             'CRITICAL'
+        )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
         )
 
 

--- a/tests/sps/validation/test_author_notes.py
+++ b/tests/sps/validation/test_author_notes.py
@@ -1,6 +1,11 @@
 import unittest
+
 from lxml import etree
-from packtools.sps.validation.author_notes import XMLAuthorNotesValidation
+
+from packtools.sps.validation.author_notes import (
+    CorrespValidation,
+    XMLAuthorNotesValidation,
+)
 
 
 class TestAuthorNotesFnValidation(unittest.TestCase):
@@ -75,6 +80,12 @@ class TestAuthorNotesFnValidation(unittest.TestCase):
         self.assertEqual(len(current_aff_deprecation), 1)
         self.assertEqual(current_aff_deprecation[0]["validation_type"], "unexpected")
         self.assertEqual(current_aff_deprecation[0]["response"], "CRITICAL")
+        self.assertEqual(
+            current_aff_deprecation[0]["adv_text"].format(
+                **current_aff_deprecation[0]["adv_params"]
+            ),
+            current_aff_deprecation[0]["advice"],
+        )
 
     def test_validate_contribution_attrib_type_deprecation(self):
         xml_tree = etree.fromstring('''
@@ -112,6 +123,12 @@ class TestAuthorNotesFnValidation(unittest.TestCase):
         self.assertEqual(len(con_deprecation), 1)
         self.assertEqual(con_deprecation[0]["validation_type"], "unexpected")
         self.assertEqual(con_deprecation[0]["response"], "CRITICAL")
+        self.assertEqual(
+            con_deprecation[0]["adv_text"].format(
+                **con_deprecation[0]["adv_params"]
+            ),
+            con_deprecation[0]["advice"],
+        )
 
     def test_validate_corresp_label_presence(self):
         xml_tree = etree.fromstring('''
@@ -134,6 +151,10 @@ class TestAuthorNotesFnValidation(unittest.TestCase):
         self.assertEqual(len(obtained), 1)
         self.assertEqual(obtained[0]["response"], "WARNING")
         self.assertIn("corresp label", obtained[0]["advice"])
+        self.assertEqual(
+            obtained[0]["adv_text"].format(**obtained[0]["adv_params"]),
+            obtained[0]["advice"],
+        )
 
     def test_validate_corresp_title_unexpected(self):
         xml_tree = etree.fromstring('''
@@ -157,6 +178,23 @@ class TestAuthorNotesFnValidation(unittest.TestCase):
         self.assertEqual(len(obtained), 1)
         self.assertEqual(obtained[0]["response"], "CRITICAL")
         self.assertIn("Replace <corresp><title> with <corresp><label>", obtained[0]["advice"])
+        self.assertEqual(
+            obtained[0]["adv_text"].format(**obtained[0]["adv_params"]),
+            obtained[0]["advice"],
+        )
+
+    def test_validate_corresp_bold_i18n(self):
+        validator = CorrespValidation(
+            {"corresp_bold": "Correspondence"},
+            self.rules,
+        )
+
+        result = validator.validate_bold()
+
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_fn_type_attribute_expected_value(self):
         xml_tree = etree.fromstring('''

--- a/tests/sps/validation/test_fn.py
+++ b/tests/sps/validation/test_fn.py
@@ -1,5 +1,9 @@
 import unittest
+from unittest.mock import Mock
+
 from lxml import etree
+
+from packtools.sps.validation.basefn import BaseFnValidation
 from packtools.sps.validation.fn import XMLFnGroupValidation, FnValidation
 
 
@@ -54,6 +58,37 @@ class TestFnValidation(unittest.TestCase):
         self.assertEqual(results[4]["response"], "OK")
         self.assertIsNone(results[4]["advice"])
 
+    def test_base_fn_invalid_advices_i18n(self):
+        validator = BaseFnValidation(
+            {
+                "fn_label": None,
+                "fn_title": "Title",
+                "fn_bold": "Label",
+                "fn_type": "invalid",
+            },
+            self.rules,
+            1.3,
+        )
+        conflict_validator = BaseFnValidation(
+            {"fn_type": "conflict"},
+            self.rules,
+            1.3,
+        )
+
+        results = [
+            validator.validate_label(),
+            validator.validate_title(),
+            validator.validate_bold(),
+            validator.validate_type(),
+            conflict_validator.validate_conflict(),
+        ]
+
+        for result in results:
+            self.assertEqual(
+                result["adv_text"].format(**result["adv_params"]),
+                result["advice"],
+            )
+
     def test_validate_group(self):
         xml_tree = etree.fromstring('''
             <article>
@@ -81,6 +116,18 @@ class TestFnValidation(unittest.TestCase):
         # Check that edited-by validation exists (may be OK or CRITICAL depending on presence)
         edited_by = [r for r in results if r["title"] == "edited-by"]
         self.assertEqual(len(edited_by), 1)
+
+    def test_validate_edited_by_i18n(self):
+        xml_tree = etree.fromstring("<article/>")
+        validator = XMLFnGroupValidation(xml_tree, self.rules)
+        validator.xml_article = Mock(fn_edited_by=[])
+
+        result = list(validator.validate_edited_by())[0]
+
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_sub_article(self):
         xml_tree = etree.fromstring('''

--- a/tests/sps/validation/test_front_articlemeta_issue.py
+++ b/tests/sps/validation/test_front_articlemeta_issue.py
@@ -692,8 +692,11 @@ class IssueTest(TestCase):
             "msg_text": "Got {obtained}, expected {expected}",
             "msg_params": {"obtained": "*2", "expected": "alphanumeric value"},
             "advice": "Replace *2 in <article-meta><supplement> with alphanumeric value",
-            "adv_text": None,
-            "adv_params": {},
+            "adv_text": "Replace {obtained} in <article-meta><supplement> with {expected}",
+            "adv_params": {
+                "obtained": "*2",
+                "expected": "alphanumeric value",
+            },
             "data": {"number": "4", "suppl": "*2", "volume": "56"},
         }
 

--- a/tests/sps/validation/test_graphic.py
+++ b/tests/sps/validation/test_graphic.py
@@ -72,6 +72,10 @@ class TestGraphicValidation(unittest.TestCase):
         self.assertIsNone(result["got_value"])
         self.assertIn("Add id=", result["advice"])
         self.assertEqual(result["expected_value"], "@id attribute")
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_inline_graphic_with_id_passes(self):
         """Test that <inline-graphic> with @id attribute passes validation."""
@@ -141,6 +145,10 @@ class TestGraphicValidation(unittest.TestCase):
         self.assertEqual(result["response"], "ERROR")
         self.assertIsNone(result["got_value"])
         self.assertIsNotNone(result["advice"])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_inline_graphic_missing_xlink_href_fails(self):
         """Test that <inline-graphic> without @xlink:href returns ERROR gracefully."""
@@ -358,6 +366,10 @@ class TestGraphicValidation(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["response"], "ERROR")
         self.assertIn("alternatives", results[0]["advice"].lower())
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
 
     def test_non_svg_not_in_alternatives_passes(self):
         """Test that non-.svg file NOT in <alternatives> passes validation."""

--- a/tests/sps/validation/test_history.py
+++ b/tests/sps/validation/test_history.py
@@ -101,6 +101,10 @@ class TestHistoryUniqueness(TestCase):
         self.assertEqual(results[0]["response"], "ERROR")
         self.assertIn("duplicate", results[0]["advice"].lower())
         self.assertIn("2", results[0]["got_value"])
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
     
     def test_no_history_element(self):
         """Test that no <history> element is valid."""
@@ -174,6 +178,10 @@ class TestDateTypePresence(TestCase):
         self.assertEqual(results[0]["response"], "CRITICAL")
         self.assertEqual(results[0]["got_value"], "missing")
         self.assertIn("Add @date-type", results[0]["advice"])
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
     
     def test_date_with_empty_date_type(self):
         """Test that <date> with empty @date-type is invalid."""
@@ -289,6 +297,10 @@ class TestDateTypeValues(TestCase):
         self.assertEqual(results[0]["response"], "CRITICAL")
         self.assertEqual(results[0]["got_value"], "invalid-type")
         self.assertIn("allowed values", results[0]["advice"])
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
     
     def test_multiple_dates_mixed_validity(self):
         """Test validation with both valid and invalid date types."""
@@ -382,6 +394,10 @@ class TestRequiredDates(TestCase):
         self.assertNotEqual(received_result["response"], "OK")
         self.assertEqual(received_result["response"], "CRITICAL")
         self.assertIn("Add <date date-type=\"received\">", received_result["advice"])
+        self.assertEqual(
+            received_result["adv_text"].format(**received_result["adv_params"]),
+            received_result["advice"],
+        )
         # accepted should be valid
         accepted_result = next(r for r in results if "accepted" in r["title"])
         self.assertEqual(accepted_result["response"], "OK")
@@ -519,6 +535,10 @@ class TestCompleteDateForCriticalTypes(TestCase):
         self.assertNotEqual(results[0]["response"], "OK")
         self.assertEqual(results[0]["response"], "CRITICAL")
         self.assertIn("day", results[0]["advice"])
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
     
     def test_accepted_missing_month(self):
         """Test that accepted date without month is invalid."""
@@ -710,6 +730,10 @@ class TestYearPresence(TestCase):
         self.assertEqual(results[0]["response"], "CRITICAL")
         self.assertEqual(results[0]["got_value"], "missing")
         self.assertIn("Add <year>", results[0]["advice"])
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
     
     def test_date_with_empty_year(self):
         """Test that date with empty year is invalid."""

--- a/tests/sps/validation/test_i18n_message_rendering.py
+++ b/tests/sps/validation/test_i18n_message_rendering.py
@@ -1,0 +1,437 @@
+import unittest
+from contextvars import Context
+
+from lxml import etree
+
+from packtools.sps import i18n
+from packtools.sps.validation.aff import AffiliationValidation
+from packtools.sps.validation.ext_link import ExtLinkValidation
+from packtools.sps.validation.fig import FigValidation
+from packtools.sps.validation.references import ReferenceValidation
+from packtools.sps.validation.sec import XMLSecValidation
+from packtools.sps.validation.supplementary_material import (
+    XmlSupplementaryMaterialValidation,
+)
+
+
+def render_message(result):
+    return result["msg_text"].format(**result["msg_params"])
+
+
+class I18nMessageRenderingTest(unittest.TestCase):
+    def test_editorial_translations_from_multilingual_csv(self):
+        cases = [
+            (
+                "Unable to check if issue is registered",
+                {},
+                "Não é possível verificar se o fascículo está cadastrado",
+                "No se puede comprobar si el fascículo está registrado",
+            ),
+            (
+                "The DOI (<article-id pub-id-type=\"doi\">{xml_doi}</article-id>) "
+                "is not registered for {expected}. It is registered for {registered}",
+                {
+                    "xml_doi": "10.1234/example",
+                    "expected": "article A",
+                    "registered": "article B",
+                },
+                "O DOI (<article-id pub-id-type=\"doi\">10.1234/example"
+                "</article-id>) não está registrado para article A. Ele está "
+                "registrado para article B",
+                "El DOI (<article-id pub-id-type=\"doi\">10.1234/example"
+                "</article-id>) no está registrado para article A. Está "
+                "registrado para article B",
+            ),
+            (
+                "Unable to check whether {subject} (<subject-group "
+                "subj-group-type=\"heading\"><subject>{subject}</subject>"
+                "</subject-group>) is a valid table of contents section "
+                "because no sections were provided for the journal {journal}",
+                {"subject": "Article", "journal": "Biota Neotropica"},
+                "Não foi possível verificar se Article (<subject-group "
+                "subj-group-type=\"heading\"><subject>Article</subject>"
+                "</subject-group>) é uma seção de sumário válida porque não "
+                "foram informadas seções para o periódico Biota Neotropica",
+                "No se puede comprobar si Article (<subject-group "
+                "subj-group-type=\"heading\"><subject>Article</subject>"
+                "</subject-group>) es una sección válida de la tabla de "
+                "contenido porque no se informaron secciones para la revista "
+                "Biota Neotropica",
+            ),
+            (
+                "{info}: {key} was not marked. Check whether {key} appears "
+                "in {original}",
+                {
+                    "info": "(article - aff2)",
+                    "key": "orgdiv1",
+                    "original": "Universidade, Brasil.",
+                },
+                "(article - aff2): orgdiv1 não foi marcado. Verifique se "
+                "orgdiv1 aparece em Universidade, Brasil.",
+                "(article - aff2): orgdiv1 no fue marcado. Compruebe si "
+                "orgdiv1 aparece en Universidade, Brasil.",
+            ),
+            (
+                "Mark the reference year ({year}) with <year>; it must be "
+                "earlier than or equal to {end_year}",
+                {"year": "2013a", "end_year": "2026"},
+                "Marque o ano da referência (2013a) com <year>; ele deve ser "
+                "anterior ou igual a 2026",
+                "Marque el año de la referencia (2013a) con <year>; debe ser "
+                "anterior o igual a 2026",
+            ),
+            (
+                "Got {obtained}, expected one of {expected}",
+                {
+                    "obtained": "translation",
+                    "expected": "['research-article', 'review-article']",
+                },
+                "Obtido translation, esperado um dos seguintes valores: "
+                "['research-article', 'review-article']",
+                "Se obtuvo translation, se esperaba uno de los siguientes "
+                "valores: ['research-article', 'review-article']",
+            ),
+            (
+                "Missing <alt-text>. Provide a concise textual description "
+                "of the visual element content.",
+                {},
+                "Falta o elemento <alt-text>. Forneça uma descrição textual "
+                "concisa do conteúdo do elemento visual.",
+                "Falta <alt-text>. Proporcione una descripción textual "
+                "concisa del contenido del elemento visual.",
+            ),
+            (
+                'Complete  specific-use="" in {xml} with valid value: '
+                "{valid_values}",
+                {
+                    "xml": "<article>",
+                    "valid_values": ["data-available"],
+                },
+                'Preencha specific-use="" em <article> com um valor válido: '
+                "['data-available']",
+                'Complete specific-use="" en <article> con un valor válido: '
+                "['data-available']",
+            ),
+        ]
+
+        for template, params, portuguese, spanish in cases:
+            for locale, expected in (
+                ("pt_BR", portuguese),
+                ("es", spanish),
+            ):
+                with self.subTest(locale=locale, template=template):
+                    def translate():
+                        i18n.set_locale(locale)
+                        return i18n._(template).format(**params)
+
+                    self.assertEqual(expected, Context().run(translate))
+
+    def test_default_reference_advice_is_localized(self):
+        reference_data = {
+            "ref_id": "B1",
+            "publication_type": "journal",
+            "source": None,
+            "parent": "article",
+        }
+        params = {
+            "publication_type_requires": {"journal": ["source"]},
+            "source_error_level": "ERROR",
+        }
+        expected = {
+            "pt_BR": "B1 (journal): Marque reference source com <source>",
+            "es": "B1 (journal): Marque reference source con <source>",
+        }
+
+        for locale, translated_advice in expected.items():
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    return next(
+                        ReferenceValidation(
+                            reference_data,
+                            params,
+                        ).validate_source()
+                    )
+
+                result = Context().run(validate)
+
+                self.assertEqual(
+                    "B1 (journal) : Mark reference source with <source>",
+                    result["advice"],
+                )
+                self.assertEqual(
+                    translated_advice,
+                    result["adv_text"].format(**result["adv_params"]),
+                )
+
+    def test_missing_data_availability_message_is_localized(self):
+        xmltree = etree.fromstring(
+            """
+            <article article-type="research-article" xml:lang="en">
+              <body>
+                <sec sec-type="methods">
+                  <title>Methods</title>
+                  <p>Content.</p>
+                </sec>
+              </body>
+            </article>
+            """
+        )
+        params = {
+            "data_availability_required_article_types": [
+                "research-article",
+            ],
+            "data_availability_error_level": "ERROR",
+        }
+        expected = {
+            "pt_BR": (
+                "A declaração de disponibilidade de dados está ausente; "
+                'esperava-se <sec sec-type="data-availability"> em <body> '
+                'ou <back>, ou <fn fn-type="data-availability">'
+            ),
+            "es": (
+                "Falta la declaración de disponibilidad de datos; se "
+                'esperaba <sec sec-type="data-availability"> en <body> o '
+                '<back>, o <fn fn-type="data-availability">'
+            ),
+        }
+
+        for locale, translated_message in expected.items():
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    return next(
+                        XMLSecValidation(
+                            xmltree,
+                            params,
+                        ).validate_data_availability_presence()
+                    )
+
+                result = Context().run(validate)
+
+                self.assertEqual("missing", result["got_value"])
+                self.assertEqual(
+                    "Got missing, expected <sec "
+                    'sec-type="data-availability"> in <body> or <back>, '
+                    'or <fn fn-type="data-availability">',
+                    result["message"],
+                )
+                self.assertEqual(
+                    translated_message,
+                    render_message(result),
+                )
+
+    def test_fallback_normalizes_nested_display_values_only(self):
+        from packtools.sps.validation.utils import build_response
+
+        obtained = {
+            "funding-source": [
+                "Institute affiliated\\n\\twith the Ministry",
+            ],
+            "award-id": [],
+        }
+        result = build_response(
+            title="funding",
+            parent={"parent": "article"},
+            item="funding-group",
+            sub_item=None,
+            validation_type="exist",
+            is_valid=False,
+            expected="award-id and funding-source in award-group",
+            obtained=obtained,
+            advice="Review funding",
+            advice_text="Review {funding}",
+            advice_params={"funding": obtained},
+            data=obtained,
+            error_level="ERROR",
+        )
+
+        self.assertNotIn("\\n", result["msg_params"]["obtained"])
+        self.assertNotIn("\\t", result["msg_params"]["obtained"])
+        self.assertEqual(
+            "Institute affiliated with the Ministry",
+            result["adv_params"]["funding"]["funding-source"][0],
+        )
+        self.assertEqual(
+            "Institute affiliated\\n\\twith the Ministry",
+            result["got_value"]["funding-source"][0],
+        )
+
+    def test_affiliation_keeps_legacy_values_and_localizes_prose(self):
+        raw_orgname = "Universidade Federal Rural da \n\t Amazônia"
+        affiliation = {
+            "parent": "article",
+            "original": raw_orgname,
+            "orgname": raw_orgname,
+        }
+        expected_messages = {
+            "pt_BR": (
+                "Obtido Universidade Federal Rural da Amazônia, "
+                "esperado que orgname esteja marcado"
+            ),
+            "es": (
+                "Se obtuvo Universidade Federal Rural da Amazônia, "
+                "se esperaba que orgname estuviera marcado"
+            ),
+        }
+
+        for locale, expected_message in expected_messages.items():
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    return next(
+                        AffiliationValidation(
+                            affiliation,
+                            {"country_codes_list": ["BR"]},
+                        ).validate_aff_components()
+                    )
+
+                result = Context().run(validate)
+
+                self.assertEqual("orgname marked", result["expected_value"])
+                self.assertEqual(raw_orgname, result["got_value"])
+                self.assertEqual(
+                    {
+                        "obtained": "Universidade Federal Rural da Amazônia",
+                        "component": "orgname",
+                    },
+                    result["msg_params"],
+                )
+                self.assertEqual(expected_message, render_message(result))
+
+    def test_missing_affiliation_component_does_not_render_none(self):
+        affiliation = {
+            "parent": "article",
+            "original": "Universidade Federal Rural da Amazônia",
+            "orgdiv1": None,
+        }
+
+        def validate():
+            i18n.set_locale("pt_BR")
+            return next(
+                result
+                for result in AffiliationValidation(
+                    affiliation,
+                    {"country_codes_list": ["BR"]},
+                ).validate_aff_components()
+                if result["expected_value"] == "orgdiv1 marked"
+            )
+
+        result = Context().run(validate)
+
+        self.assertIsNone(result["got_value"])
+        self.assertNotIn("None", render_message(result))
+        self.assertEqual(
+            "Nenhum valor foi encontrado para orgdiv1; "
+            "esperado que orgdiv1 esteja marcado",
+            render_message(result),
+        )
+
+    def test_observed_messages_are_localized_and_keep_technical_tokens(self):
+        expectations = {
+            "pt_BR": {
+                "fig": (
+                    "Nenhuma descrição de acessibilidade foi encontrada; "
+                    "esperado <alt-text> ou <long-desc>"
+                ),
+                "url": "O URL ftp://example.org/file deve começar com http:// ou https://",
+                "title": (
+                    "O atributo @xlink:title é obrigatório quando o texto "
+                    "do link é genérico ou um URL"
+                ),
+                "inline": (
+                    "O elemento <inline-supplementary-material> não é permitido"
+                ),
+            },
+            "es": {
+                "fig": (
+                    "No se encontró ninguna descripción de accesibilidad; "
+                    "se esperaba <alt-text> o <long-desc>"
+                ),
+                "url": (
+                    "La URL ftp://example.org/file debe comenzar con "
+                    "http:// o https://"
+                ),
+                "title": (
+                    "El atributo @xlink:title es obligatorio cuando el texto "
+                    "del enlace es genérico o una URL"
+                ),
+                "inline": (
+                    "El elemento <inline-supplementary-material> no está permitido"
+                ),
+            },
+        }
+        ext_link_xml = etree.fromstring(
+            """
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+              <body>
+                <p>
+                  <ext-link ext-link-type="uri"
+                            xlink:href="ftp://example.org/file">Leia mais</ext-link>
+                </p>
+              </body>
+            </article>
+            """
+        )
+        inline_xml = etree.fromstring(
+            """
+            <article>
+              <body>
+                <inline-supplementary-material>Figure S1</inline-supplementary-material>
+              </body>
+            </article>
+            """
+        )
+
+        for locale, expected in expectations.items():
+            with self.subTest(locale=locale):
+                def validate():
+                    i18n.set_locale(locale)
+                    ext_link_validator = ExtLinkValidation(ext_link_xml)
+                    return {
+                        "fig": FigValidation(
+                            {
+                                "parent": "article",
+                                "graphic_alt_text": None,
+                                "graphic_long_desc": None,
+                            },
+                            {"accessibility_error_level": "WARNING"},
+                        ).validate_accessibility(),
+                        "url": next(
+                            ext_link_validator.validate_xlink_href_format()
+                        ),
+                        "title": next(
+                            ext_link_validator.validate_xlink_title_when_generic()
+                        ),
+                        "inline": XmlSupplementaryMaterialValidation(
+                            inline_xml,
+                            {"inline_error_level": "CRITICAL"},
+                        ).validate_prohibited_inline(),
+                    }
+
+                results = Context().run(validate)
+
+                for key, result in results.items():
+                    self.assertEqual(expected[key], render_message(result))
+                    self.assertNotIn("None", render_message(result))
+
+                self.assertEqual(
+                    "<alt-text> or <long-desc>",
+                    results["fig"]["expected_value"],
+                )
+                self.assertEqual(
+                    "URL starting with http:// or https://",
+                    results["url"]["expected_value"],
+                )
+                self.assertEqual(
+                    "@xlink:title attribute when text is generic or URL",
+                    results["title"]["expected_value"],
+                )
+                self.assertEqual(
+                    "No <inline-supplementary-material>",
+                    results["inline"]["expected_value"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/validation/test_journal_meta.py
+++ b/tests/sps/validation/test_journal_meta.py
@@ -1,8 +1,17 @@
 from unittest import TestCase
 from lxml import etree
 
-from packtools.sps.validation.journal_meta import ISSNValidation, AcronymValidation, TitleValidation, \
-    PublisherNameValidation, JournalMetaValidation, JournalIdValidation
+from packtools.sps.validation.journal_meta import (
+    AcronymValidation,
+    ISSNFormatValidation,
+    ISSNValidation,
+    JournalIdValidation,
+    JournalMetaAttributeValidation,
+    JournalMetaPresenceValidation,
+    JournalMetaValidation,
+    PublisherNameValidation,
+    TitleValidation,
+)
 
 
 class ISSNTest(TestCase):
@@ -1534,3 +1543,67 @@ class JournalMetaAttributeTest(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['response'], 'WARNING')
         self.assertIn('epub', results[0]['data']['duplicates'])
+
+
+class JournalMetaI18nTest(TestCase):
+    def assert_i18n_advice(self, result):
+        self.assertIsNotNone(result["adv_text"])
+        self.assertIsInstance(result["adv_params"], dict)
+        self.assertEqual(
+            result["advice"],
+            result["adv_text"].format(**result["adv_params"]),
+        )
+
+    def test_static_advices_have_templates(self):
+        xmltree = etree.fromstring(
+            """
+            <article article-type="research-article" xml:lang="en">
+                <front/>
+            </article>
+            """
+        )
+        validation = JournalMetaPresenceValidation(xmltree)
+        results = [
+            *validation.validate_journal_meta_presence(),
+            *validation.validate_journal_meta_uniqueness(),
+            *validation.validate_publisher_id_presence(),
+            *validation.validate_journal_title_presence(),
+            *validation.validate_abbrev_journal_title_presence(),
+            *validation.validate_issn_presence(),
+            *validation.validate_publisher_name_presence(),
+        ]
+
+        self.assertEqual(7, len(results))
+
+        for result in results:
+            with self.subTest(title=result["title"]):
+                self.assert_i18n_advice(result)
+
+    def test_dynamic_advices_have_templates(self):
+        xmltree = etree.fromstring(
+            """
+            <article article-type="research-article" xml:lang="en">
+                <front>
+                    <journal-meta>
+                        <journal-id journal-id-type="invalid-type">test</journal-id>
+                        <issn pub-type="online">invalid</issn>
+                        <issn pub-type="online">invalid</issn>
+                    </journal-meta>
+                </front>
+            </article>
+            """
+        )
+        format_validation = ISSNFormatValidation(xmltree)
+        attribute_validation = JournalMetaAttributeValidation(xmltree)
+        results = [
+            *format_validation.validate_issn_format(),
+            *attribute_validation.validate_journal_id_type_values(),
+            *attribute_validation.validate_issn_pub_type_values(),
+            *attribute_validation.validate_issn_type_uniqueness(),
+        ]
+
+        self.assertEqual(6, len(results))
+
+        for result in results:
+            with self.subTest(title=result["title"]):
+                self.assert_i18n_advice(result)

--- a/tests/sps/validation/test_list.py
+++ b/tests/sps/validation/test_list.py
@@ -82,6 +82,12 @@ class ListValidationTest(unittest.TestCase):
         self.assertEqual(list_type_validation["response"], "CRITICAL")
         self.assertIsNone(list_type_validation["got_value"])
         self.assertIn("Add list-type attribute", list_type_validation["advice"])
+        self.assertEqual(
+            list_type_validation["adv_text"].format(
+                **list_type_validation["adv_params"]
+            ),
+            list_type_validation["advice"],
+        )
 
     def test_list_validation_empty_list_type(self):
         """Test list with empty @list-type attribute (CRITICAL error)"""
@@ -154,6 +160,12 @@ class ListValidationTest(unittest.TestCase):
         self.assertEqual(list_type_value_validation["response"], "ERROR")
         self.assertEqual(list_type_value_validation["got_value"], "numbered")
         self.assertIn('"numbered" is not allowed', list_type_value_validation["advice"])
+        self.assertEqual(
+            list_type_value_validation["adv_text"].format(
+                **list_type_value_validation["adv_params"]
+            ),
+            list_type_value_validation["advice"],
+        )
 
     def test_list_validation_only_one_list_item(self):
         """Test list with only one <list-item> (ERROR)"""
@@ -185,6 +197,12 @@ class ListValidationTest(unittest.TestCase):
         ][0]
         self.assertEqual(min_items_validation["response"], "ERROR")
         self.assertIn("at least 2", min_items_validation["advice"])
+        self.assertEqual(
+            min_items_validation["adv_text"].format(
+                **min_items_validation["adv_params"]
+            ),
+            min_items_validation["advice"],
+        )
 
     def test_list_validation_with_label_in_list_item(self):
         """Test list with <label> in <list-item> (WARNING)"""
@@ -221,6 +239,10 @@ class ListValidationTest(unittest.TestCase):
         ][0]
         self.assertEqual(label_validation["response"], "WARNING")
         self.assertIn("For accessibility", label_validation["advice"])
+        self.assertEqual(
+            label_validation["adv_text"].format(**label_validation["adv_params"]),
+            label_validation["advice"],
+        )
 
     def test_list_validation_empty_list_items(self):
         """Test list with empty <list-item> elements (WARNING)"""
@@ -254,6 +276,12 @@ class ListValidationTest(unittest.TestCase):
         ][0]
         self.assertEqual(empty_items_validation["response"], "WARNING")
         self.assertIn("empty <list-item>", empty_items_validation["advice"])
+        self.assertEqual(
+            empty_items_validation["adv_text"].format(
+                **empty_items_validation["adv_params"]
+            ),
+            empty_items_validation["advice"],
+        )
 
     def test_list_validation_all_list_types(self):
         """Test that all valid list-type values are accepted"""
@@ -380,6 +408,10 @@ class ListValidationTest(unittest.TestCase):
         ][0]
         # This is a recommendation, so it should pass but have advice
         self.assertEqual(title_validation["response"], "INFO")
+        self.assertEqual(
+            title_validation["adv_text"].format(**title_validation["adv_params"]),
+            title_validation["advice"],
+        )
         # Since it's just a recommendation with INFO level, it should still pass
 
     def test_list_validation_with_title_present(self):

--- a/tests/sps/validation/test_media.py
+++ b/tests/sps/validation/test_media.py
@@ -65,6 +65,10 @@ class MediaValidationTest(unittest.TestCase):
         result = validator.validate_mime_type_and_subtype()
         self.assertEqual(result["response"], "CRITICAL")
         self.assertIsNotNone(result["advice"])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_mime_type_and_subtype_success(self):
         """Passes when mime-type/mime-subtype combination is valid."""

--- a/tests/sps/validation/test_peer_review.py
+++ b/tests/sps/validation/test_peer_review.py
@@ -463,6 +463,11 @@ class TestInvalidPeerReview(BasePeerReviewTest):
         """Test article type validation with invalid type"""
         errors = list(self.validator.validate_article_type())
         self.assertEqual(1, len(errors))
+        self.assertEqual(
+            errors[0]["adv_text"].format(**errors[0]["adv_params"]),
+            "Add article_type in <article article-type='VALUE'> and replace "
+            "VALUE with ['reviewer-report']",
+        )
 
     def test_invalid_contributor_type(self):
         """Test contributor validation with invalid type"""
@@ -473,6 +478,11 @@ class TestInvalidPeerReview(BasePeerReviewTest):
         """Test history dates validation with missing dates"""
         errors = list(self.validator.validate_history_dates())
         self.assertEqual(1, len(errors))
+        self.assertEqual(
+            errors[0]["adv_text"].format(**errors[0]["adv_params"]),
+            'Add date-type in <history><date date-type="VALUE"> and replace '
+            "VALUE with : reviewer-report-received",
+        )
 
 
 class TestCustomMetaValidation(BasePeerReviewTest):
@@ -506,6 +516,15 @@ class TestCustomMetaValidation(BasePeerReviewTest):
         )
         errors = list(validator.validate_custom_meta())
         self.assertTrue(any(e["response"] == "CRITICAL" for e in errors))
+        result = next(
+            error
+            for error in errors
+            if error["title"] == "Review recommendation name"
+        )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            "Mark peer review name with <custom-meta><meta-name>.",
+        )
 
     def test_missing_meta_value(self):
         """Test validation with missing meta-value"""
@@ -521,6 +540,16 @@ class TestCustomMetaValidation(BasePeerReviewTest):
         )
         errors = list(validator.validate_custom_meta())
         self.assertTrue(any(e["response"] == "CRITICAL" for e in errors))
+        result = next(
+            error
+            for error in errors
+            if error["title"] == "Review recommendation value"
+        )
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            "Mark peer review recommendation value with "
+            "<custom-meta><meta-value>.",
+        )
 
 
 class TestRelatedArticlesValidation(BasePeerReviewTest):

--- a/tests/sps/validation/test_preprint.py
+++ b/tests/sps/validation/test_preprint.py
@@ -70,7 +70,14 @@ class PreprintValidationTest(unittest.TestCase):
                 'expected_value': 'The preprint publication date',
                 'got_value': None,
                 'message': 'Got None expected The preprint publication date',
-                'advice': 'Provide the publication date of the preprint'
+                'msg_text': 'Got {obtained}, expected {expected}',
+                'msg_params': {
+                    'obtained': None,
+                    'expected': 'The preprint publication date',
+                },
+                'advice': 'Provide the publication date of the preprint',
+                'adv_text': 'Provide the publication date of the preprint',
+                'adv_params': {},
 
             }
         ]
@@ -108,9 +115,18 @@ class PreprintValidationTest(unittest.TestCase):
                 'expected_value': None,
                 'got_value': '2002-10-18',
                 'message': 'Got 2002-10-18 expected None',
+                'msg_text': 'Got {obtained}, expected {expected}',
+                'msg_params': {
+                    'obtained': '2002-10-18',
+                    'expected': None,
+                },
                 'advice': 'The article does not reference the preprint, provide it as in the example: '
                           '<related-article id="pp1" related-article-type="preprint" ext-link-type="doi" '
-                          'xlink:href="10.1590/SciELOPreprints.1174"/>'
+                          'xlink:href="10.1590/SciELOPreprints.1174"/>',
+                'adv_text': 'The article does not reference the preprint, provide it as in the example: '
+                            '<related-article id="pp1" related-article-type="preprint" ext-link-type="doi" '
+                            'xlink:href="10.1590/SciELOPreprints.1174"/>',
+                'adv_params': {},
 
             }
         ]

--- a/tests/sps/validation/test_references.py
+++ b/tests/sps/validation/test_references.py
@@ -65,6 +65,11 @@ class ReferenceValidationTest(TestCase):
         self.assertEqual("2015", result["got_value"])
         self.assertEqual("reference year (2015) previous or equal to 2014", result["expected_value"])
         self.assertEqual("B1 (journal) : Mark the reference year (2015) with <year> and it must be previous or equal to 2014", result["advice"])
+        self.assertEqual(
+            "B1 (journal): Mark the reference year (2015) with <year>; "
+            "it must be earlier than or equal to 2014",
+            result["adv_text"].format(**result["adv_params"]),
+        )
 
     def test_validate_year_fail_invalid_year(self):
         reference_data = self.reference_data.copy()
@@ -80,6 +85,11 @@ class ReferenceValidationTest(TestCase):
         self.assertEqual("201a", result["got_value"])
         self.assertEqual("reference year (201a) previous or equal to 2014", result["expected_value"])
         self.assertEqual("B1 (journal) : Mark the reference year (201a) with <year> and it must be previous or equal to 2014", result["advice"])
+        self.assertEqual(
+            "B1 (journal): Mark the reference year (201a) with <year>; "
+            "it must be earlier than or equal to 2014",
+            result["adv_text"].format(**result["adv_params"]),
+        )
 
     # Testes para validate_source
     def test_validate_source_fail_missing(self):

--- a/tests/sps/validation/test_response.py
+++ b/tests/sps/validation/test_response.py
@@ -674,3 +674,42 @@ class TestCustomErrorLevels(TestCase):
 
         for r in results:
             self.assertEqual(r["response"], "CRITICAL")
+
+
+class TestResponseI18n(TestCase):
+
+    def test_invalid_advices(self):
+        xml = """
+        <article article-type="letter" xml:lang="en">
+            <response response-type="wrong"/>
+            <response response-type="reply" xml:lang="en" id="S1">
+                <front-stub/>
+                <body/>
+            </response>
+            <response xml:lang="en" id="S1">
+                <front-stub/>
+                <body/>
+            </response>
+        </article>
+        """
+        results = list(ResponseValidation(etree.fromstring(xml)).validate())
+        invalid = [result for result in results if result["response"] != "OK"]
+
+        self.assertEqual(
+            {result["title"] for result in invalid},
+            {
+                "response @response-type presence",
+                "response @response-type value",
+                "response @xml:lang presence",
+                "response @id presence",
+                "response @id uniqueness",
+                "response front-stub presence",
+                "response body presence",
+            },
+        )
+
+        for result in invalid:
+            self.assertEqual(
+                result["adv_text"].format(**result["adv_params"]),
+                result["advice"],
+            )

--- a/tests/sps/validation/test_sec.py
+++ b/tests/sps/validation/test_sec.py
@@ -79,6 +79,10 @@ class TestSecValidationTitle(unittest.TestCase):
         result = validator.validate_title()
         self.assertEqual(result["response"], "CRITICAL")
         self.assertIn("Add <title>", result["advice"])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
 
 class TestSecValidationSecTypeValue(unittest.TestCase):
@@ -138,6 +142,10 @@ class TestSecValidationSecTypeValue(unittest.TestCase):
         result = validator.validate_sec_type_value()
         self.assertEqual(result["response"], "ERROR")
         self.assertEqual(result["got_value"], "invalid-type")
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_no_sec_type_returns_none(self):
         xml = """
@@ -231,6 +239,10 @@ class TestSecValidationTranscriptId(unittest.TestCase):
         result = validator.validate_transcript_id()
         self.assertEqual(result["response"], "ERROR")
         self.assertIn("Add @id", result["advice"])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_non_transcript_returns_none(self):
         xml = """
@@ -306,6 +318,10 @@ class TestSecValidationCombinedFormat(unittest.TestCase):
         validator = SecValidation(secs[0], self.params)
         result = validator.validate_combined_format()
         self.assertEqual(result["response"], "WARNING")
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_comma_separator_fails(self):
         xml = """
@@ -381,6 +397,10 @@ class TestSecValidationNonCombinable(unittest.TestCase):
         validator = SecValidation(secs[0], self.params)
         result = validator.validate_non_combinable()
         self.assertEqual(result["response"], "WARNING")
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_combined_data_availability_fails(self):
         xml = """
@@ -490,6 +510,10 @@ class TestSecValidationContent(unittest.TestCase):
         result = validator.validate_content()
         self.assertEqual(result["response"], "WARNING")
         self.assertIn("Add at least one <p>", result["advice"])
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
 
 class TestXMLSecValidationDataAvailability(unittest.TestCase):
@@ -561,6 +585,10 @@ class TestXMLSecValidationDataAvailability(unittest.TestCase):
                    if r is not None]
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["response"], "ERROR")
+        self.assertEqual(
+            results[0]["adv_text"].format(**results[0]["adv_params"]),
+            results[0]["advice"],
+        )
 
     def test_editorial_no_data_availability_check(self):
         xml = """

--- a/tests/sps/validation/test_supplementary_material.py
+++ b/tests/sps/validation/test_supplementary_material.py
@@ -83,6 +83,10 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             results["advice"],
             'In <sec sec-type="None"><supplementary-material> replace "None" with "supplementary-material".',
         )
+        self.assertEqual(
+            results["adv_text"].format(**results["adv_params"]),
+            results["advice"],
+        )
 
     def test_validate_label(self):
         """Fails when supplementary material lacks an label element."""
@@ -106,6 +110,10 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(
             results["advice"],
             "Add label in <supplementary-material>: <supplementary-material><label>. Consult SPS documentation for more detail.",
+        )
+        self.assertEqual(
+            results["adv_text"].format(**results["adv_params"]),
+            results["advice"],
         )
 
     def test_validate_position_failure(self):
@@ -138,6 +146,10 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             results["advice"],
             "The supplementary materials section must be at the end of <body> or inside <back>.",
         )
+        self.assertEqual(
+            results["adv_text"].format(**results["adv_params"]),
+            results["advice"],
+        )
 
     def test_validate_supplementary_material_not_in_app_group(self):
         """Verifies that <supplementary-material> does not occur inside <app-group> or <app>."""
@@ -166,6 +178,10 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
             results["advice"],
             "Do not use <supplementary-material> inside <app-group> or <app>.",
         )
+        self.assertEqual(
+            results["adv_text"].format(**results["adv_params"]),
+            results["advice"],
+        )
 
     def test_validate_prohibited_inline_supplementary_material(self):
         """Verifies that <inline-supplementary-material> is not used."""
@@ -187,6 +203,10 @@ class TestSupplementaryMaterialValidation(unittest.TestCase):
         self.assertEqual(
             results["advice"],
             "The use of <inline-supplementary-material> is prohibited.",
+        )
+        self.assertEqual(
+            results["adv_text"].format(**results["adv_params"]),
+            results["advice"],
         )
 
     def test_validate_full_workflow(self):

--- a/tests/sps/validation/test_visual_resource_base.py
+++ b/tests/sps/validation/test_visual_resource_base.py
@@ -17,6 +17,10 @@ class TestVisualResourceBaseValidation(unittest.TestCase):
         self.assertEqual(result["response"], self.params["media_attributes_error_level"])
         self.assertIsNone(result["got_value"])
         self.assertEqual(result["advice"], 'Add id="" to <media></media>')
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_id_present_on_non_inline(self):
         data = {"tag": "media", "xml": "<media></media>", "id": "media1"}
@@ -45,6 +49,10 @@ class TestVisualResourceBaseValidation(unittest.TestCase):
         result = validator.validate_xlink_href()
         self.assertEqual(result["response"], "WARNING")
         self.assertEqual(result["expected_value"], "File name with extension")
+        self.assertEqual(
+            result["adv_text"].format(**result["adv_params"]),
+            result["advice"],
+        )
 
     def test_validate_integration_yields_only_id_and_xlink_href(self):
         data = {


### PR DESCRIPTION
# Internacionaliza as mensagens das validações SPS

## O que esse PR faz?

Este PR implementa a internacionalização das mensagens produzidas por `packtools.sps.validation`, conforme a issue #1257. As validações passam a produzir textos de mensagem e recomendação em português do Brasil, espanhol ou inglês, mantendo:

- campos legados em inglês;
- códigos, nomes de campos, elementos, atributos e demais valores técnicos estáveis;
- valores obtidos diretamente do XML sem tradução;
- textos parametrizados, com valores dinâmicos separados em `msg_params` e `adv_params`;
- isolamento do idioma por contexto de execução.

O PR também adiciona e empacota os catálogos `pt_BR` e `es`, usando o `gettext` da biblioteca padrão durante a execução. O Babel é utilizado como ferramenta opcional para extrair, atualizar e compilar os catálogos.


## Onde a revisão poderia começar?

A revisão pode começar pelos seguintes arquivos:

1. `packtools/sps/i18n.py` — seleção e isolamento do idioma;
2. `packtools/sps/validation/utils.py` — contrato das mensagens e recomendações;
3. `packtools/sps/validation/references.py` e `packtools/sps/validation/sec.py` — exemplos de uso em validadores;
4. `tests/sps/test_i18n.py` — integridade dos catálogos e seleção do idioma;
5. `tests/sps/validation/test_i18n_message_rendering.py` — cenários integrados de renderização.

## Como este poderia ser testado manualmente?

Crie um ambiente virtual limpo e instale a branch do PR em modo editável.

No Linux ou macOS:

```bash
python -m venv .venv
source .venv/bin/activate
python -m pip install --upgrade pip
python -m pip install -e .
```

No Windows, usando PowerShell:

```powershell
python -m venv .venv
.\.venv\Scripts\Activate.ps1
python -m pip install --upgrade pip
python -m pip install -e .
```

O pacote SPS pode ser informado diretamente em formato ZIP, sem extração manual. Salve o código abaixo, por exemplo, como `validar_pacote.py`:

```python
import csv
import json
from pathlib import Path

from lxml import etree

from packtools.sps import i18n
from packtools.sps.models.packages import explore_source
from packtools.sps.validation.xml_validator import get_validation_results


IDIOMA = "pt_BR"  # use também "en" e "es"
ARQUIVO_ZIP = Path("/caminho/para/pacote.zip")
ARQUIVO_CSV = Path(f"validacao-packtools-{IDIOMA}.csv")


def renderizar(template, parametros):
    if not template:
        return ""
    return template.format(**(parametros or {}))


def preparar_valor(valor):
    if isinstance(valor, (dict, list, tuple)):
        return json.dumps(valor, ensure_ascii=False)
    return valor


i18n.set_locale(IDIOMA)

resultados = []

for pacote in explore_source(str(ARQUIVO_ZIP)).values():
    xmltree = etree.fromstring(pacote.xml_content)

    for resultado in get_validation_results(xmltree, {}):
        resultado = dict(resultado)
        resultado["package"] = pacote.name
        resultado["localized_message"] = renderizar(
            resultado.get("msg_text"),
            resultado.get("msg_params"),
        )
        resultado["localized_advice"] = renderizar(
            resultado.get("adv_text"),
            resultado.get("adv_params"),
        )
        resultados.append(resultado)

colunas = sorted(
    {chave for resultado in resultados for chave in resultado}
)

with ARQUIVO_CSV.open(
    "w",
    encoding="utf-8-sig",
    newline="",
) as arquivo:
    writer = csv.DictWriter(
        arquivo,
        fieldnames=colunas,
        extrasaction="ignore",
    )
    writer.writeheader()

    for resultado in resultados:
        writer.writerow(
            {
                chave: preparar_valor(valor)
                for chave, valor in resultado.items()
            }
        )

print(
    f"{len(resultados)} resultados gravados em "
    f"{ARQUIVO_CSV.resolve()}"
)
```

Altere `ARQUIVO_ZIP` para o pacote desejado e execute:

```bash
python validar_pacote.py
```

Repita a execução alterando `IDIOMA` para `pt_BR`, `en` e `es`. Recomenda-se usar estes três pacotes, disponíveis no Google Drive compartilhado previamente com a equipe:

1. `rbent-2025-0077/1806-9665-rbent-rpass-02-70-2.zip`;
2. `rbef-2025-0423/1806-1117-rbef-rpass-06-48.zip`;
3. `jvatitd-2026-0029/1678-9199-jvatitd-rpass-32-0326.zip`.

Verifique que:

- `msg_text` e `adv_text` acompanham o idioma selecionado;
- `message` e `advice` permanecem em inglês;
- `msg_params` e `adv_params` preservam os valores reais e os tokens técnicos;
- elementos, atributos, identificadores, URLs e códigos não são traduzidos;
- a quantidade de resultados, os grupos e os níveis de erro não mudam entre os idiomas.

As colunas `localized_message` e `localized_advice` são produzidas somente pelo script para facilitar a leitura. Elas renderizam os templates `msg_text` e `adv_text` com seus respectivos parâmetros e não alteram o contrato público do `packtools`.

A suíte automatizada pode ser executada com:

```bash
python -m unittest discover \
  -s tests/sps/validation \
  -p "test_*.py" \
  -v

python -m unittest tests/sps/test_i18n.py -v
```

Resultados obtidos durante o desenvolvimento:

- suíte `tests/sps/validation`: 1.112 testes aprovados e 3 ignorados;
- suíte `tests/sps/test_i18n.py`: 18 testes aprovados.

## Algum cenário de contexto que queira dar?

Antes desta mudança, parte da prosa apresentada ao usuário permanecia em inglês mesmo quando a validação era executada em outro idioma. Além disso, havia usos inconsistentes de `gettext`, possibilidade de tradução dupla e respostas inválidas com campos localizados incompletos.

A solução mantém duas representações:

- os campos legados, preservados para compatibilidade;
- os campos `msg_text`, `msg_params`, `adv_text` e `adv_params`, destinados à apresentação localizada.

Durante os testes com 30 pacotes reais, executados em três idiomas, foram gerados e analisados 90 CSVs. Nesse processo foram identificadas validações preexistentes com semântica questionável, como resultados que apresentam `None` como valor esperado ou obtido. Esses casos não foram alterados porque pertencem à semântica individual das validações, e não à internacionalização. Devem ser tratados separadamente para evitar mudanças de comportamento neste PR.

Também foi observada uma variação preexistente na ordem de alguns resultados. Por isso, comparações entre execuções devem considerar o conjunto dos resultados e não somente sua posição no CSV.

O formato do CSV não faz parte do contrato do `packtools`; o exemplo acima existe apenas para facilitar a inspeção manual das validações do XML. Ele não executa nem reproduz validações adicionais de aplicações consumidoras, como verificações próprias de assets ou renditions.

## Screenshots
N/A

## Quais são os tickets relevantes?
#1257

## Referências

- [Python — gettext](https://docs.python.org/3/library/gettext.html)
- [Babel — Message Catalogs](https://babel.pocoo.org/en/latest/messages.html)

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

- [ ] Sim
- [x] Não

As validações continuam processando os mesmos dados do XML, sem armazenar, transmitir ou expor novas informações.

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

- [x] Sim — adiciona o Babel às dependências opcionais para manutenção dos catálogos. A tradução em tempo de execução utiliza o `gettext` da biblioteca padrão.
  - [ ] Verificado e aprovado no SBOM/Trivy
  - [x] Pendente de verificação pelo pipeline
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

- [ ] Sim — link do job:
- [x] Não aplicável neste momento — a execução será confirmada pelo pipeline do PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**

- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
