### PR TITLE
Explicita defeitos em datas de publicação (`pub-date`) em XMLWithPre e melhora sua atualização no XML

### DIFF
--- a/packtools/sps/pid_provider/models/dates.py
+++ b/packtools/sps/pid_provider/models/dates.py
@@ -1,3 +1,5 @@
+import logging
+
 from datetime import date
 from functools import lru_cache, cached_property
 
@@ -114,12 +116,15 @@ class ArticleDates:
             return Date(nodes[0]).data
         except IndexError:
             return None
-        except Exception:
-            return None
 
     @property
     def article_date_isoformat(self):
-        return format_date(**self.article_date)
+        try:
+            return format_date(**self.article_date)
+        except TypeError:
+            raise XMLWithPreArticlePublicationDateError(
+                f"Unable to get ArticleDates.article_date_isoformat for {self.article_date}"
+            )
 
     @property
     def article_year(self):
@@ -144,8 +149,6 @@ class ArticleDates:
             )
             return Date(nodes[0]).data
         except IndexError:
-            return None
-        except Exception:
             return None
 
     @property

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -47,9 +47,6 @@ class GetXMLItemsError(Exception): ...
 class GetXMLWithPreFromZipFileError(Exception): ...
 
 
-class XMLWithPreArticlePublicationDateError(Exception): ...
-
-
 def get_xml_items(xml_sps_file_path, filenames=None, capture_errors=None):
     """
     Get XML items from XML file or Zip file
@@ -1099,33 +1096,38 @@ class XMLWithPre:
         # href, ext-link-type, related-article-type
         return self.issns.get("epub")
 
-    @cached_property
+    @property
     def _article_dates(self):
         return ArticleDates(self.xmltree)
 
     def get_complete_publication_date(self, default_month=6, default_day=15):
         try:
             xml = self._article_dates
-        except Exception as e:
-            logging.exception(e)
-            return None
-        try:
             return xml.article_date_isoformat
         except Exception as e:
+            pass
+        try:
+            year = month = day = None
             data = xml.article_date
+            if data:
+                year = data.get("year")
+                month = data.get("month")
+                day = data.get("day")
             return date(
-                int(data["year"]),
-                int(data.get("month") or default_month),
-                int(data.get("day") or default_day),
+                int(year or self.pub_year),
+                int(month or default_month),
+                int(day or default_day),
             ).isoformat()
-        return self.article_publication_date
+        except (TypeError, KeyError):
+            raise XMLWithPreArticlePublicationDateError(
+                f"Unable to get complete publication date from {data}"
+            )
 
     @property
     def article_publication_date(self):
         try:
             return self._article_dates.article_date_isoformat
         except Exception as e:
-            logging.exception(e)
             return self.pub_year
 
     @article_publication_date.setter

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -1179,13 +1179,62 @@ class XMLWithPre:
                 "article-id",
             )
             articlemeta_node = self.xmltree.find(".//article-meta")
+            added = False
             for sibling_name in pub_date_preceding_siblings:
                 try:
                     articlemeta_node.find(sibling_name).addnext(node)
+                    added = True
                     break
                 except AttributeError:
                     continue
-
+            if not added:
+                pub_date_following_siblings = (
+                    "volume",
+                    "volume-id",
+                    "volume-series",
+                    "issue",
+                    "issue-id",
+                    "issue-title",
+                    "issue-title-group",
+                    "issue-sponsor",
+                    "issue-part",
+                    "volume-issue-group",
+                    "isbn",
+                    "supplement",
+                    "fpage",
+                    "lpage",
+                    "page-range",
+                    "elocation-id",
+                    "email",
+                    "ext-link",
+                    "uri",
+                    "product",
+                    "supplementary-material",
+                    "history",
+                    "pub-history",
+                    "permissions",
+                    "self-uri",
+                    "related-article",
+                    "related-object",
+                    "abstract",
+                    "trans-abstract",
+                    "kwd-group",
+                    "funding-group",
+                    "support-group",
+                    "conference",
+                    "counts",
+                    "custom-meta-group",
+                )
+                articlemeta_node = self.xmltree.find(".//article-meta")
+                for sibling_name in pub_date_following_siblings:
+                    try:
+                        articlemeta_node.find(sibling_name).addprevious(node)
+                        added = True
+                        break
+                    except AttributeError:
+                        continue
+            if not added:
+                articlemeta_node.append(node)
         previous = None
         for name, val in zip(("day", "month", "year"), reversed(formatted.split("-"))):
             elem = node.find(name)

--- a/tests/sps/pid_provider/test_models_dates.py
+++ b/tests/sps/pid_provider/test_models_dates.py
@@ -1,0 +1,141 @@
+import unittest
+from lxml import etree
+
+from packtools.sps.pid_provider.models.dates import format_date, Date, ArticleDates, XMLWithPreArticlePublicationDateError
+
+
+class TestFormatDate(unittest.TestCase):
+
+    def test_format_date_sucesso(self):
+        self.assertEqual(format_date(year="2022", month="4", day="5"), "2022-04-05")
+        self.assertEqual(format_date(year=2022, month=12, day=20), "2022-12-20")
+
+    def test_format_date_invalida_gera_excecao(self):
+        # Fevereiro não tem dia 30
+        with self.assertRaises(XMLWithPreArticlePublicationDateError) as cm:
+            format_date(year="2022", month="02", day="30")
+        
+        self.assertIn("Unable to format_date", str(cm.exception))
+
+    def test_format_date_tipos_invalidos_gera_excecao(self):
+        with self.assertRaises(XMLWithPreArticlePublicationDateError):
+            format_date(year=None, month="04", day="20")
+
+
+class TestDateClass(unittest.TestCase):
+
+    def test_date_com_date_type_explicito(self):
+        node = etree.fromstring('<pub-date date-type="pub"><year>2022</year><day>01</day></pub-date>')
+        d = Date(node)
+        self.assertEqual(d.date_type, "pub")
+        self.assertEqual(d.data, {"year": "2022", "day": "01", "type": "pub"})
+
+    def test_date_inferir_pub_por_presenca_de_day(self):
+        node = etree.fromstring('<pub-date><year>2022</year><day>10</day></pub-date>')
+        d = Date(node)
+        self.assertEqual(d.date_type, "pub")
+
+    def test_date_inferir_collection_sem_day(self):
+        node = etree.fromstring('<pub-date><year>2022</year></pub-date>')
+        d = Date(node)
+        self.assertEqual(d.date_type, "collection")
+
+    def test_date_isoformat(self):
+        node = etree.fromstring('<pub-date date-type="pub"><year>2022</year><month>4</month><day>20</day></pub-date>')
+        d = Date(node)
+        self.assertEqual(d.isoformat, "2022-04-20")
+
+
+class TestArticleDatesClass(unittest.TestCase):
+
+    def setUp(self):
+        self.xml_str = """<article>
+        <front>
+            <article-meta>
+              <pub-date publication-format="electronic" date-type="pub">
+                <day>20</day>
+                <month>04</month>
+                <year>2022</year>
+              </pub-date>
+              <pub-date publication-format="electronic" date-type="collection">
+                <year>2003</year>
+              </pub-date>
+              <history>
+                <date date-type="received">
+                  <day>18</day>
+                  <month>10</month>
+                  <year>2002</year>
+                </date>
+                <date date-type="accepted">
+                  <day>20</day>
+                  <month>12</month>
+                  <year>2002</year>
+                </date>
+              </history>
+            </article-meta>
+          </front>
+        </article>
+        """
+        self.sample_xml = etree.fromstring(self.xml_str.encode('utf-8'))
+
+    def test_article_date_e_epub_date(self):
+        dates = ArticleDates(self.sample_xml)
+        expected = {'year': '2022', 'month': '04', 'day': '20', 'type': 'pub'}
+        
+        self.assertEqual(dates.article_date, expected)
+        self.assertEqual(dates.epub_date, expected)
+        self.assertEqual(dates.article_year, "2022")
+
+    def test_article_date_isoformat_sucesso(self):
+        dates = ArticleDates(self.sample_xml)
+        self.assertEqual(dates.article_date_isoformat, "2022-04-20")
+
+    def test_article_date_isoformat_falha_levanta_excecao(self):
+        # XML sem parâmetros necessários (day/month) para montar o isoformat
+        xml = etree.fromstring('<article><front><pub-date date-type="pub"><year>2022</year></pub-date></front></article>')
+        dates = ArticleDates(xml)
+        
+        with self.assertRaises(XMLWithPreArticlePublicationDateError):
+            _ = dates.article_date_isoformat
+
+    def test_collection_date_e_collection_year(self):
+        dates = ArticleDates(self.sample_xml)
+        expected = {'year': '2003', 'type': 'collection'}
+        
+        self.assertEqual(dates.collection_date, expected)
+        self.assertEqual(dates.collection_year, "2003")
+
+    def test_pub_dates_lista_todas_as_datas(self):
+        dates = ArticleDates(self.sample_xml)
+        result = dates.pub_dates
+        
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], {'year': '2022', 'month': '04', 'day': '20', 'type': 'pub'})
+        self.assertEqual(result[1], {'year': '2003', 'type': 'collection'})
+
+    def test_xml_sem_datas(self):
+        xml_vazio = etree.fromstring('<article><front></front></article>')
+        dates = ArticleDates(xml_vazio)
+
+        self.assertIsNone(dates.article_date)
+        self.assertIsNone(dates.article_year)
+        self.assertIsNone(dates.collection_date)
+        self.assertIsNone(dates.collection_year)
+        self.assertEqual(dates.pub_dates, [])
+
+    def test_xml_com_pub_type_alternativo(self):
+        # Valida se as rotas de XPath com pub-type="epub" funcionam
+        xml_alt = etree.fromstring('''
+        <article>
+            <front>
+                <pub-date pub-type="epub"><year>2021</year><month>01</month><day>15</day></pub-date>
+            </front>
+        </article>
+        ''')
+        dates = ArticleDates(xml_alt)
+        self.assertEqual(dates.article_year, "2021")
+        self.assertEqual(dates.article_date_isoformat, "2021-01-15")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sps/pid_provider/test_models_dates.py
+++ b/tests/sps/pid_provider/test_models_dates.py
@@ -1,7 +1,20 @@
+import os
 import unittest
+from datetime import date
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest import TestCase
+from zipfile import ZipFile, ZIP_DEFLATED
+
 from lxml import etree
 
-from packtools.sps.pid_provider.models.dates import format_date, Date, ArticleDates, XMLWithPreArticlePublicationDateError
+from packtools.sps.pid_provider.models.dates import (
+    format_date, Date, ArticleDates, XMLWithPreArticlePublicationDateError
+)
+from packtools.sps.pid_provider.xml_sps_lib import (
+    GetXMLItemsError,
+    XMLWithPre,
+    get_xml_items,
+)
 
 
 class TestFormatDate(unittest.TestCase):
@@ -137,5 +150,147 @@ class TestArticleDatesClass(unittest.TestCase):
         self.assertEqual(dates.article_date_isoformat, "2021-01-15")
 
 
-if __name__ == '__main__':
+class TestGetXmlItems(TestCase):
+    """Testes para a função get_xml_items."""
+
+    def test_get_xml_items_single_xml_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
+
+        with NamedTemporaryFile(suffix=".xml", mode="w", encoding="utf-8", delete=False) as tmp:
+            tmp.write(xml_content)
+            tmp_path = tmp.name
+
+        try:
+            items = get_xml_items(tmp_path)
+            self.assertEqual(len(items), 1)
+            self.assertIn("xml_with_pre", items[0])
+            self.assertEqual(items[0]["filename"], os.path.basename(tmp_path))
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_get_xml_items_invalid_extension_raises_error(self):
+        with NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tmp:
+            tmp.write("invalid")
+            tmp_path = tmp.name
+
+        try:
+            # Sem capture_errors deve lançar GetXMLItemsError
+            with self.assertRaises(GetXMLItemsError):
+                get_xml_items(tmp_path, capture_errors=False)
+
+            # Com capture_errors deve retornar uma lista com dict contendo a chave 'error'
+            result = get_xml_items(tmp_path, capture_errors=True)
+            self.assertIn("error", result[0])
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_get_xml_items_zip_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
+
+        with TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, "package.zip")
+            with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
+                zf.writestr("article1.xml", xml_content)
+
+            items = list(get_xml_items(zip_path))
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]["filename"], "article1.xml")
+            self.assertIn("xml_with_pre", items[0])
+
+
+class TestPublicationDates(TestCase):
+    """Testes para get_complete_publication_date e article_publication_date."""
+
+    def test_get_complete_publication_date_isoformat_success(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+          <front>
+            <article-meta>
+              <pub-date date-type="pub" publication-format="electronic">
+                <day>15</day>
+                <month>08</month>
+                <year>2023</year>
+              </pub-date>
+            </article-meta>
+          </front>
+        </article>"""
+
+        xml_obj = next(XMLWithPre.create(xml_content=xml_content))
+        self.assertEqual(xml_obj.get_complete_publication_date(), "2023-08-15")
+
+    def test_get_complete_publication_date_fallback_to_defaults(self):
+        # Quando faltam mês e dia no dicionário de datas, usa default_month e default_day
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+          <front>
+            <article-meta>
+              <pub-date date-type="collection">
+                <year>2022</year>
+              </pub-date>
+            </article-meta>
+          </front>
+        </article>"""
+
+        xml_obj = next(XMLWithPre.create(xml_content=xml_content))
+        # Mês padrão (6) e Dia padrão (15)
+        self.assertEqual(
+            xml_obj.get_complete_publication_date(default_month=6, default_day=15),
+            "2022-06-15",
+        )
+
+    def test_get_complete_publication_date_missing_year_raises_exception(self):
+        # Sem data ou sem chave de ano válida deve lançar XMLWithPreArticlePublicationDateError
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+          <front>
+            <article-meta>
+            </article-meta>
+          </front>
+        </article>"""
+
+        xml_obj = next(XMLWithPre.create(xml_content=xml_content))
+        with self.assertRaises(XMLWithPreArticlePublicationDateError):
+            xml_obj.get_complete_publication_date()
+
+    def test_article_publication_date_isoformat_success(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+          <front>
+            <article-meta>
+              <pub-date date-type="pub">
+                <day>01</day>
+                <month>12</month>
+                <year>2021</year>
+              </pub-date>
+            </article-meta>
+          </front>
+        </article>"""
+
+        xml_obj = next(XMLWithPre.create(xml_content=xml_content))
+        self.assertEqual(xml_obj.article_publication_date, "2021-12-01")
+
+    def test_article_publication_date_fallback_to_pub_year(self):
+        # Caso ocorra erro ao tentar extrair a data completa em ISO, faz o fallback para pub_year
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+          <front>
+            <article-meta>
+              <pub-date date-type="collection">
+                <year>2020</year>
+              </pub-date>
+            </article-meta>
+          </front>
+        </article>"""
+
+        xml_obj = next(XMLWithPre.create(xml_content=xml_content))
+        self.assertEqual(xml_obj.article_publication_date, "2020")
+
+
+if __name__ == "__main__":
+    import unittest
+
     unittest.main()

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -1,7 +1,12 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch
+
 from lxml import etree
+
 from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
+from packtools.sps.pid_provider.models.dates import (
+    XMLWithPreArticlePublicationDateError,
+)
 
 
 class XMLWithPreTestMixin:
@@ -690,6 +695,182 @@ class TestV2List(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.v2_list, original)
 
 
+
+
+class TestArticlePublicationDateSetter(TestCase):
+    """Suíte de testes para a propriedade setter article_publication_date em XMLWithPre."""
+
+    def _get_xml_with_pre(self, xml_content):
+        return next(XMLWithPre.create(xml_content=xml_content))
+
+    def test_setter_with_valid_string_format(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date date-type="pub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+        
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2023-08-15"
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertEqual(node.findtext("year"), "2023")
+        self.assertEqual(node.findtext("month"), "08")
+        self.assertEqual(node.findtext("day"), "15")
+
+    def test_setter_with_valid_dict_format(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date date-type="pub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = {"year": "2022", "month": "05", "day": "10"}
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertEqual(node.findtext("year"), "2022")
+        self.assertEqual(node.findtext("month"), "05")
+        self.assertEqual(node.findtext("day"), "10")
+
+    def test_setter_converts_epub_ppub_and_creates_new_pub_date(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date pub-type="epub-ppub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2024-03-20"
+
+        # Verifica se o nó antigo trocou pub-type para collection
+        collection_node = xml_obj.xmltree.find(".//pub-date[@pub-type='collection']")
+        self.assertIsNotNone(collection_node)
+
+        # Verifica se o novo nó foi criado com pub-type="epub" (por causa da presenca de @pub-type)
+        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
+        self.assertIsNotNone(new_node)
+        self.assertEqual(new_node.findtext("year"), "2024")
+        self.assertEqual(new_node.findtext("month"), "03")
+        self.assertEqual(new_node.findtext("day"), "20")
+
+    def test_setter_creates_new_node_recent_pattern_when_none_exists(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <article-id pub-id-type="publisher-id">S0101-0101</article-id>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2023-11-05"
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertIsNotNone(node)
+        self.assertEqual(node.get("date-type"), "pub")
+        self.assertEqual(node.get("publication-format"), "electronic")
+        self.assertEqual(node.findtext("year"), "2023")
+        self.assertEqual(node.findtext("month"), "11")
+        self.assertEqual(node.findtext("day"), "05")
+
+    def test_setter_creates_new_node_legacy_pattern_when_pub_type_present(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date pub-type="ppub">
+                        <year>2010</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2021-07-01"
+
+        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
+        self.assertIsNotNone(new_node)
+        self.assertEqual(new_node.findtext("year"), "2021")
+
+    def test_setter_inserts_node_before_following_siblings_if_no_preceding(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <volume>10</volume>
+                    <issue>2</issue>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2022-09-15"
+
+        article_meta = xml_obj.xmltree.find(".//article-meta")
+        children = [child.tag for child in article_meta]
+        self.assertEqual(children[0], "pub-date")
+        self.assertEqual(children[1], "volume")
+
+    def test_setter_appends_node_if_no_preceding_or_following_siblings_match(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2020-01-01"
+
+        article_meta = xml_obj.xmltree.find(".//article-meta")
+        self.assertEqual(len(article_meta), 1)
+        self.assertEqual(article_meta[0].tag, "pub-date")
+
+    def test_setter_raises_exception_on_invalid_string(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><article-meta></article-meta></front></article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+
+        invalid_values = [
+            "2023-13-01",  # mês inválido
+            "invalid-date",  # string arbitrária
+            "2023-01",  # sem o dia
+            None,
+            12345,
+        ]
+
+        for val in invalid_values:
+            with self.subTest(val=val):
+                with self.assertRaises(XMLWithPreArticlePublicationDateError):
+                    xml_obj.article_publication_date = val
+
+
 if __name__ == "__main__":
     import unittest
+
     unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

O objetivo principal deste PR é **interromper a supressão silenciosa de erros** durante o processamento de datas de publicação (`pub-date`). Anteriormente, quando ocorriam falhas por ausência ou invalidade de campos como `year`, `month` ou `day`, a exceção era engolida (`except Exception: return None`), mascarando problemas de dados no XML.

As alterações realizadas incluem:
- **Tratamento Explicito de Exceções**: A remoção de blocos que engoliam erros em `ArticleDates` e `XMLWithPre`, passando a lançar a exceção esperada `XMLWithPreArticlePublicationDateError`.
- **Ajuste de Propriedades**: A alteração de `_article_dates` para `@property` dinâmico, garantindo que o objeto leia os dados atualizados da árvore.
- **Resiliência Estrutural no Setter (Ajuste Secundário)**: Para garantir a integridade dos testes em cenários de borda onde a estrutura do `<article-meta>` é minimalista (sem os elementos irmãos anteriores padrão), adicionou-se a busca por elementos posteriores (*following siblings*) e fallback com `append`.
- **Nova Cobertura de Testes**: Inclusão de suítes de testes dedicadas para validar o lançamento correto das exceções e os fluxos do setter.

## Onde a revisão poderia começar?

1. `packtools/sps/pid_provider/models/dates.py`: Remoção do `except Exception` genérico e lançamento explícito de `XMLWithPreArticlePublicationDateError`.
2. `packtools/sps/pid_provider/xml_sps_lib.py`: Alteração em `get_complete_publication_date`, remoção do log silencioso em `article_publication_date` e suporte a *following siblings* no setter.
3. `tests/sps/pid_provider/test_models_dates.py` e `tests/sps/pid_provider/test_xml_sps_lib.py`: Novos testes unitários.

## Como este poderia ser testado manualmente?

Execute os testes automatizados para verificar que falhas de datas parciais/inválidas agora lançam exceções adequadamente:

```bash
python -m unittest tests/sps/pid_provider/test_models_dates.py
python -m unittest tests/sps/pid_provider/test_xml_sps_lib.py

```

## Algum cenário de contexto que queira dar?

O problema crítico era a perda de visibilidade sobre XMLs com datas incompletas ou corrompidas, já que o código silenciava o erro. Ao tornar o lançamento de exceção explícito, alguns casos raros de borda nos testes (estruturas de `<article-meta>` extremamente enxutas) começaram a falhar ao tentar reinserir o nó `<pub-date>`, exigindo a inclusão da busca por *following siblings* como suporte secundário.

## Screenshots

N/A

## Quais são os tickets relevantes?

#1263 

## Referências

* Especificação de publicação SciELO Publishing Schema (SPS)

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

* [ ] Sim
* [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

* [ ] Sim
* [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

* [ ] Sim
* [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

* [x] Sim — validado no pipeline do CI
* [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

* [ ] Sim
* [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**

* [ ] Sim
* [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

* [x] Não, nenhum segredo foi commitado
* [ ] Sim (bloquear merge e corrigir antes de prosseguir)
