### PR TITLE
Bump version from 4.16.8 to 4.16.9

### DIFF
--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '4.16.8'
+__version__ = '4.16.9'


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza `version.py` de `4.16.8` para `4.16.9`, preparando a próxima release. Desde a tag `4.16.8` (commit #1253), a `master` acumulou correções sem bump de versão, entre elas:

- #1261 — restaura a chave `"text"` em `Abstract.data`
- #1262 — explicita defeitos em datas de publicação (`pub-date`) em `XMLWithPre`

#### Onde a revisão poderia começar?

`version.py` (linha única alterada).

#### Como este poderia ser testado manualmente?

Após o merge, confirmar que `packtools.__version__ == "4.16.9"` e criar a tag `4.16.9` apontando para o commit de merge.

#### Algum cenário de contexto que queira dar?

Optei por PATCH (4.16.9) em vez de MINOR, já que as mudanças pendentes desde a última tag são majoritariamente correções de bug; a leva de commits de i18n (#1257) já havia sido incluída antes da tag 4.16.8.

#### Quais são tickets relevantes?

Refs: #1261, #1262

### Referências

N/A