### PR TITLE
Refatora a extração de itens XML a partir de `.xml` e `.zip` para XMLWithPre e adiciona os métodos `add_xml_info` e `add_zip_info` 

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -1,8 +1,9 @@
 import hashlib
 import logging
 import os
+import traceback
 from datetime import date
-from functools import lru_cache, cached_property
+from functools import cached_property
 from gettext import gettext as _
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile, ZIP_DEFLATED
@@ -47,7 +48,7 @@ class GetXMLItemsError(Exception): ...
 class GetXMLWithPreFromZipFileError(Exception): ...
 
 
-def get_xml_items(xml_sps_file_path, filenames=None, capture_errors=None):
+def get_xml_items(xml_sps_file_path):
     """
     Get XML items from XML file or Zip file
 
@@ -66,29 +67,15 @@ def get_xml_items(xml_sps_file_path, filenames=None, capture_errors=None):
     try:
         name, ext = os.path.splitext(xml_sps_file_path)
         if ext == ".zip":
-            return get_xml_with_pre_from_zip_file(
-                xml_sps_file_path, filenames, capture_errors
-            )
+            return get_xml_with_pre_from_zip_file(xml_sps_file_path)
         if ext == ".xml":
-            try:
-                return get_xml_with_pre_from_xml_file(xml_sps_file_path, "utf-8")
-            except GetXmlWithPreError as e:
-                return get_xml_with_pre_from_xml_file(xml_sps_file_path, "iso-8859-1")
-
+            return [get_xml_with_pre_from_xml_file(xml_sps_file_path)]
         raise TypeError(
             _("{} must be xml file or zip file containing xml").format(
                 xml_sps_file_path
             )
         )
     except Exception as e:
-        if capture_errors:
-            return [
-                {
-                    "error": _("Unable to get xml items from {}: {} {}").format(
-                        xml_sps_file_path, type(e), e
-                    )
-                }
-            ]
         raise GetXMLItemsError(
             _("Unable to get xml items from {}: {} {}").format(
                 xml_sps_file_path, type(e), e
@@ -96,123 +83,82 @@ def get_xml_items(xml_sps_file_path, filenames=None, capture_errors=None):
         )
 
 
-def get_xml_with_pre_from_xml_file(xml_sps_file_path, encoding):
-    with open(xml_sps_file_path, encoding=encoding) as fp:
-        content = fp.read()
-    xml = get_xml_with_pre(content)
-    xml.file_path = xml_sps_file_path
-    item = os.path.basename(xml_sps_file_path)
-    return [
-        {
-            "filename": item,
-            "xml_with_pre": xml,
-            "files": [item],
-            "filenames": [item],
-        }
-    ]
-
-
-def get_xml_with_pre_from_zip_file(
-    xml_sps_file_path, filenames=None, capture_errors=False
-):
-    """
-    Extract and process XML items from a ZIP file.
-
-    Parameters
-    ----------
-    xml_sps_file_path : str
-        Path to the ZIP file
-    filenames : list of str, optional
-        Specific files to process. If None, processes all files.
-
-    Yields
-    ------
-    dict
-        Success: {filename, xml_with_pre, files, filenames}
-        XML error: {filename, files, filenames, error, type_error}
-        ZIP error: {files, filenames, error, type_error}
-
-    Notes
-    -----
-    Yields errors as dicts instead of raising. Check for 'error' key.
-    """
+def get_xml_with_pre_from_xml_file(xml_sps_file_path):
+    xml_name, ext = os.path.splitext(os.path.basename(xml_sps_file_path))
     try:
+        try:
+            content = None
+            with open(xml_sps_file_path, encoding="utf-8") as fp:
+                content = fp.read()
+        except Exception as e:
+            with open(xml_sps_file_path, encoding="iso-8859-1") as fp:
+                content = fp.read()
+        xml_with_pre = get_xml_with_pre(content)
+        xml_with_pre.add_xml_info(xml_name, xml_sps_file_path)
+        return {"xml_name": xml_name, "xml_with_pre": xml_with_pre}
+    except Exception as e:
+        return {
+            "xml_name": xml_name,
+            "error_message": str(e),
+            "error_type": str(type(e)),
+            "traceback": traceback.format_exc(),
+        }
+
+
+def get_xml_with_pre_from_zip_file(xml_sps_file_path):
+    try:
+        # Extração dos arquivos do ZIP
+        xml_with_pre_items = []
         paths = []
         basenames = []
+        items = {}
+        with ZipFile(xml_sps_file_path) as zf:
+            for item in zf.namelist():
+                if item.startswith("."):
+                    continue
+                basename = os.path.basename(item)
+                if not basename.endswith(".xml"):
+                    paths.append(item)
+                    basenames.append(basename)
+                    continue
 
-        zip_data = get_xml_items_from_zip_file(
-            xml_sps_file_path,
-            filenames,
-        )
-        xml_files = zip_data.get("xml_files")
-        if not xml_files:
-            raise TypeError(f"{xml_sps_file_path} has no XML files")
-
-        paths = zip_data.get("paths")
-        basenames = zip_data.get("basenames")
-
-        for basename, xml_file in xml_files:
-            try:
-                response = {
-                    "filename": xml_file,
-                    "files": paths,
-                    "filenames": basenames,
-                }
-                xml_with_pre = get_xml_with_pre_from_zip_file_component(
-                    xml_sps_file_path, xml_file
-                )
-                xml_with_pre.zip_file_path = xml_sps_file_path
-                response["xml_with_pre"] = xml_with_pre
-                yield response
-            except Exception as e:
-                if not capture_errors:
-                    raise GetXMLWithPreFromZipFileError(
-                        f"Error in {xml_sps_file_path}/{xml_file}"
-                    )
-                response["error"] = str(e)
-                response["type_error"] = type(e).__name__
-                yield response
-
+                xml_name, ext = os.path.splitext(basename)
+                try:
+                    zf_read = zf.read(item)
+                    try:
+                        content = zf_read.decode("utf-8")
+                    except Exception as e:
+                        content = zf_read.decode("iso-8859-1")
+                    xml_with_pre = get_xml_with_pre(content)
+                    xml_with_pre.add_xml_info(xml_name, item)
+                    xml_with_pre_items.append(xml_with_pre)
+                except Exception as e:
+                    items[xml_name] = {
+                        "xml_name": xml_name,
+                        "error_message": str(e),
+                        "error_type": str(type(e)),
+                        "traceback": traceback.format_exc(),
+                    }
+        for xml_with_pre in xml_with_pre_items:
+            xml_name = xml_with_pre.xml_name
+            xml_with_pre.add_zip_info(xml_sps_file_path, paths, basenames)
+            items[xml_with_pre.xml_name] = {
+                "xml_name": xml_name,
+                "xml_with_pre": xml_with_pre,
+            }
+        return list(items.values())
     except Exception as e:
-        if not capture_errors:
-            raise GetXMLWithPreFromZipFileError(
-                _("Unable to get xml items from zip file {}: {} {}").format(
-                    xml_sps_file_path, type(e).__name__, e
-                )
+        raise GetXMLWithPreFromZipFileError(
+            _("Unable to get xml items from zip file {}: {} {}").format(
+                xml_sps_file_path, type(e).__name__, e
             )
-        yield {
-            "files": paths,
-            "filenames": basenames,
-            "error": str(e),
-            "type_error": type(e).__name__,
-        }
+        )
 
 
 def get_xml_items_from_zip_file(
     xml_sps_file_path,
     filenames=None,
 ):
-    """
-    Extract and process XML items from a ZIP file.
-
-    Parameters
-    ----------
-    xml_sps_file_path : str
-        Path to the ZIP file
-    filenames : list of str, optional
-        Specific files to process. If None, processes all files.
-
-    Yields
-    ------
-    dict
-        Success: {filename, xml_with_pre, files, filenames}
-        XML error: {filename, files, filenames, error, type_error}
-        ZIP error: {files, filenames, error, type_error}
-
-    Notes
-    -----
-    Yields errors as dicts instead of raising. Check for 'error' key.
-    """
     basenames = []
     zip_components = []
     xml_files = []
@@ -426,9 +372,6 @@ class XMLWithPre:
             self.parse_doctype()
 
         self.pretty_print = pretty_print
-        self.filename = None
-        self.files = None
-        self.filenames = None
         self.uri = None
         self.zip_file_path = None
         self.xml_file_path = None
@@ -439,6 +382,43 @@ class XMLWithPre:
         # html or xml
         self.source_filename = None
         self.source_ext = None
+
+        self.xml_name = None # nome original encontrado no xml ou no zip
+        self.zip_basenames = None # nome original encontrado no xml ou no zip, exceto xml
+        self.zip_namelist = None # nome original encontrado no xml ou no zip, exceto xml
+
+    @property
+    def filename(self):
+        return self.xml_name
+
+    @filename.setter
+    def filename(self, value):
+        self.xml_name = value
+
+    @property
+    def files(self):
+        return self.zip_namelist
+
+    @files.setter
+    def files(self, value):
+        self.zip_namelist = value
+
+    @property
+    def filenames(self):
+        return self.zip_basenames
+
+    @filenames.setter
+    def filenames(self, value):
+        self.zip_basenames = value
+
+    def add_xml_info(self, xml_name, xml_file_path=None):
+        self.xml_name = xml_name
+        self.xml_file_path = xml_file_path
+
+    def add_zip_info(self, zip_file_path, zip_namelist, zip_basenames):
+        self.zip_basenames = zip_basenames
+        self.zip_namelist = zip_namelist
+        self.zip_file_path = zip_file_path
 
     def add_pkg_name_components(self, source_filename, pkg_name_version=3):
         self.pkg_name_version = pkg_name_version
@@ -487,24 +467,22 @@ class XMLWithPre:
         if path:
             errors = []
             xml_with_pre = None
-            for item in get_xml_items(path, capture_errors):
+            for item in get_xml_items(path):
                 if not item:
                     continue
                 try:
                     xml_with_pre = item["xml_with_pre"]
-                    xml_with_pre.filename = item["filename"]
-                    xml_with_pre.files = item.get("files")
-                    xml_with_pre.filenames = item.get("filenames")
-                    xml_with_pre.errors = item.get("error")
                     yield xml_with_pre
                 except KeyError:
                     errors.append(item)
-            if not xml_with_pre:
+            if not xml_with_pre or errors:
                 raise GetXmlWithPreError("Unable to get xml with pre %s" % str(errors))
         if xml_content:
             yield get_xml_with_pre(xml_content)
+            return
         if uri:
             yield get_xml_with_pre_from_uri(uri, timeout)
+            return
 
     def parse_doctype(self):
         """
@@ -1395,7 +1373,7 @@ class XMLWithPre:
 
 
 def string_to_5_digits(input_string):
-    return (crc32(input_string.encode()) & 0xFFFFFFFF) % 100000
+    return str((crc32(input_string.encode()) & 0xFFFFFFFF) % 100000)
 
 
 def extract_number(value):

--- a/tests/sps/pid_provider/test_models_dates.py
+++ b/tests/sps/pid_provider/test_models_dates.py
@@ -1,19 +1,16 @@
-import os
 import unittest
-from datetime import date
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
-from zipfile import ZipFile, ZIP_DEFLATED
+from unittest.mock import patch
 
 from lxml import etree
-
 from packtools.sps.pid_provider.models.dates import (
-    format_date, Date, ArticleDates, XMLWithPreArticlePublicationDateError
+    ArticleDates,
+    Date,
+    XMLWithPreArticlePublicationDateError,
+    format_date,
 )
 from packtools.sps.pid_provider.xml_sps_lib import (
-    GetXMLItemsError,
     XMLWithPre,
-    get_xml_items,
 )
 
 
@@ -27,7 +24,7 @@ class TestFormatDate(unittest.TestCase):
         # Fevereiro não tem dia 30
         with self.assertRaises(XMLWithPreArticlePublicationDateError) as cm:
             format_date(year="2022", month="02", day="30")
-        
+
         self.assertIn("Unable to format_date", str(cm.exception))
 
     def test_format_date_tipos_invalidos_gera_excecao(self):
@@ -38,7 +35,9 @@ class TestFormatDate(unittest.TestCase):
 class TestDateClass(unittest.TestCase):
 
     def test_date_com_date_type_explicito(self):
-        node = etree.fromstring('<pub-date date-type="pub"><year>2022</year><day>01</day></pub-date>')
+        node = etree.fromstring(
+            '<pub-date date-type="pub"><year>2022</year><day>01</day></pub-date>'
+        )
         d = Date(node)
         self.assertEqual(d.date_type, "pub")
         self.assertEqual(d.data, {"year": "2022", "day": "01", "type": "pub"})
@@ -54,7 +53,9 @@ class TestDateClass(unittest.TestCase):
         self.assertEqual(d.date_type, "collection")
 
     def test_date_isoformat(self):
-        node = etree.fromstring('<pub-date date-type="pub"><year>2022</year><month>4</month><day>20</day></pub-date>')
+        node = etree.fromstring(
+            '<pub-date date-type="pub"><year>2022</year><month>4</month><day>20</day></pub-date>'
+        )
         d = Date(node)
         self.assertEqual(d.isoformat, "2022-04-20")
 
@@ -89,12 +90,12 @@ class TestArticleDatesClass(unittest.TestCase):
           </front>
         </article>
         """
-        self.sample_xml = etree.fromstring(self.xml_str.encode('utf-8'))
+        self.sample_xml = etree.fromstring(self.xml_str.encode("utf-8"))
 
     def test_article_date_e_epub_date(self):
         dates = ArticleDates(self.sample_xml)
-        expected = {'year': '2022', 'month': '04', 'day': '20', 'type': 'pub'}
-        
+        expected = {"year": "2022", "month": "04", "day": "20", "type": "pub"}
+
         self.assertEqual(dates.article_date, expected)
         self.assertEqual(dates.epub_date, expected)
         self.assertEqual(dates.article_year, "2022")
@@ -105,29 +106,33 @@ class TestArticleDatesClass(unittest.TestCase):
 
     def test_article_date_isoformat_falha_levanta_excecao(self):
         # XML sem parâmetros necessários (day/month) para montar o isoformat
-        xml = etree.fromstring('<article><front><pub-date date-type="pub"><year>2022</year></pub-date></front></article>')
+        xml = etree.fromstring(
+            '<article><front><pub-date date-type="pub"><year>2022</year></pub-date></front></article>'
+        )
         dates = ArticleDates(xml)
-        
+
         with self.assertRaises(XMLWithPreArticlePublicationDateError):
             _ = dates.article_date_isoformat
 
     def test_collection_date_e_collection_year(self):
         dates = ArticleDates(self.sample_xml)
-        expected = {'year': '2003', 'type': 'collection'}
-        
+        expected = {"year": "2003", "type": "collection"}
+
         self.assertEqual(dates.collection_date, expected)
         self.assertEqual(dates.collection_year, "2003")
 
     def test_pub_dates_lista_todas_as_datas(self):
         dates = ArticleDates(self.sample_xml)
         result = dates.pub_dates
-        
+
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0], {'year': '2022', 'month': '04', 'day': '20', 'type': 'pub'})
-        self.assertEqual(result[1], {'year': '2003', 'type': 'collection'})
+        self.assertEqual(
+            result[0], {"year": "2022", "month": "04", "day": "20", "type": "pub"}
+        )
+        self.assertEqual(result[1], {"year": "2003", "type": "collection"})
 
     def test_xml_sem_datas(self):
-        xml_vazio = etree.fromstring('<article><front></front></article>')
+        xml_vazio = etree.fromstring("<article><front></front></article>")
         dates = ArticleDates(xml_vazio)
 
         self.assertIsNone(dates.article_date)
@@ -138,68 +143,18 @@ class TestArticleDatesClass(unittest.TestCase):
 
     def test_xml_com_pub_type_alternativo(self):
         # Valida se as rotas de XPath com pub-type="epub" funcionam
-        xml_alt = etree.fromstring('''
+        xml_alt = etree.fromstring(
+            """
         <article>
             <front>
                 <pub-date pub-type="epub"><year>2021</year><month>01</month><day>15</day></pub-date>
             </front>
         </article>
-        ''')
+        """
+        )
         dates = ArticleDates(xml_alt)
         self.assertEqual(dates.article_year, "2021")
         self.assertEqual(dates.article_date_isoformat, "2021-01-15")
-
-
-class TestGetXmlItems(TestCase):
-    """Testes para a função get_xml_items."""
-
-    def test_get_xml_items_single_xml_file(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
-
-        with NamedTemporaryFile(suffix=".xml", mode="w", encoding="utf-8", delete=False) as tmp:
-            tmp.write(xml_content)
-            tmp_path = tmp.name
-
-        try:
-            items = get_xml_items(tmp_path)
-            self.assertEqual(len(items), 1)
-            self.assertIn("xml_with_pre", items[0])
-            self.assertEqual(items[0]["filename"], os.path.basename(tmp_path))
-        finally:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-
-    def test_get_xml_items_invalid_extension_raises_error(self):
-        with NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tmp:
-            tmp.write("invalid")
-            tmp_path = tmp.name
-
-        try:
-            # Sem capture_errors deve lançar GetXMLItemsError
-            with self.assertRaises(GetXMLItemsError):
-                get_xml_items(tmp_path, capture_errors=False)
-
-            # Com capture_errors deve retornar uma lista com dict contendo a chave 'error'
-            result = get_xml_items(tmp_path, capture_errors=True)
-            self.assertIn("error", result[0])
-        finally:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
-
-    def test_get_xml_items_zip_file(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
-
-        with TemporaryDirectory() as tmpdir:
-            zip_path = os.path.join(tmpdir, "package.zip")
-            with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("article1.xml", xml_content)
-
-            items = list(get_xml_items(zip_path))
-            self.assertEqual(len(items), 1)
-            self.assertEqual(items[0]["filename"], "article1.xml")
-            self.assertIn("xml_with_pre", items[0])
 
 
 class TestPublicationDates(TestCase):
@@ -290,7 +245,182 @@ class TestPublicationDates(TestCase):
         self.assertEqual(xml_obj.article_publication_date, "2020")
 
 
-if __name__ == "__main__":
-    import unittest
+class TestArticlePublicationDateSetter(TestCase):
+    """Suíte de testes para a propriedade setter article_publication_date em XMLWithPre."""
 
+    def _get_xml_with_pre(self, xml_content):
+        return next(XMLWithPre.create(xml_content=xml_content))
+
+    def test_setter_with_valid_string_format(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date date-type="pub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2023-08-15"
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertEqual(node.findtext("year"), "2023")
+        self.assertEqual(node.findtext("month"), "08")
+        self.assertEqual(node.findtext("day"), "15")
+
+    def test_setter_with_valid_dict_format(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date date-type="pub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = {
+            "year": "2022",
+            "month": "05",
+            "day": "10",
+        }
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertEqual(node.findtext("year"), "2022")
+        self.assertEqual(node.findtext("month"), "05")
+        self.assertEqual(node.findtext("day"), "10")
+
+    def test_setter_converts_epub_ppub_and_creates_new_pub_date(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date pub-type="epub-ppub">
+                        <day>01</day>
+                        <month>01</month>
+                        <year>2020</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2024-03-20"
+
+        # Verifica se o nó antigo trocou pub-type para collection
+        collection_node = xml_obj.xmltree.find(".//pub-date[@pub-type='collection']")
+        self.assertIsNotNone(collection_node)
+
+        # Verifica se o novo nó foi criado com pub-type="epub" (por causa da presenca de @pub-type)
+        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
+        self.assertIsNotNone(new_node)
+        self.assertEqual(new_node.findtext("year"), "2024")
+        self.assertEqual(new_node.findtext("month"), "03")
+        self.assertEqual(new_node.findtext("day"), "20")
+
+    def test_setter_creates_new_node_recent_pattern_when_none_exists(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <article-id pub-id-type="publisher-id">S0101-0101</article-id>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2023-11-05"
+
+        node = xml_obj.xmltree.find(".//article-meta/pub-date")
+        self.assertIsNotNone(node)
+        self.assertEqual(node.get("date-type"), "pub")
+        self.assertEqual(node.get("publication-format"), "electronic")
+        self.assertEqual(node.findtext("year"), "2023")
+        self.assertEqual(node.findtext("month"), "11")
+        self.assertEqual(node.findtext("day"), "05")
+
+    def test_setter_creates_new_node_legacy_pattern_when_pub_type_present(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <pub-date pub-type="ppub">
+                        <year>2010</year>
+                    </pub-date>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2021-07-01"
+
+        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
+        self.assertIsNotNone(new_node)
+        self.assertEqual(new_node.findtext("year"), "2021")
+
+    def test_setter_inserts_node_before_following_siblings_if_no_preceding(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                    <volume>10</volume>
+                    <issue>2</issue>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2022-09-15"
+
+        article_meta = xml_obj.xmltree.find(".//article-meta")
+        children = [child.tag for child in article_meta]
+        self.assertEqual(children[0], "pub-date")
+        self.assertEqual(children[1], "volume")
+
+    def test_setter_appends_node_if_no_preceding_or_following_siblings_match(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article>
+            <front>
+                <article-meta>
+                </article-meta>
+            </front>
+        </article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+        xml_obj.article_publication_date = "2020-01-01"
+
+        article_meta = xml_obj.xmltree.find(".//article-meta")
+        self.assertEqual(len(article_meta), 1)
+        self.assertEqual(article_meta[0].tag, "pub-date")
+
+    def test_setter_raises_exception_on_invalid_string(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><article-meta></article-meta></front></article>"""
+
+        xml_obj = self._get_xml_with_pre(xml_content)
+
+        invalid_values = [
+            "2023-13-01",  # mês inválido
+            "invalid-date",  # string arbitrária
+            "2023-01",  # sem o dia
+            None,
+            12345,
+        ]
+
+        for val in invalid_values:
+            with self.subTest(val=val):
+                with self.assertRaises(XMLWithPreArticlePublicationDateError):
+                    xml_obj.article_publication_date = val
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -1,13 +1,11 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, PropertyMock, patch
-
-from lxml import etree
-
+from unittest.mock import patch
 from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
-from packtools.sps.pid_provider.models.dates import (
+
+from packtools.sps.pid_provider.xml_sps_lib import (
+    XMLWithPre,
     XMLWithPreArticlePublicationDateError,
 )
-
 
 class XMLWithPreTestMixin:
     """Mixin com helper para criar XML de artigo SciELO."""
@@ -695,182 +693,175 @@ class TestV2List(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.v2_list, original)
 
 
+class TestXMLWithPrePropertiesAndMetadata(XMLWithPreTestMixin, TestCase):
+    """Testes para aliases (filename, files, filenames), data e manipulação de DOCTYPE."""
 
-
-class TestArticlePublicationDateSetter(TestCase):
-    """Suíte de testes para a propriedade setter article_publication_date em XMLWithPre."""
-
-    def _get_xml_with_pre(self, xml_content):
-        return next(XMLWithPre.create(xml_content=xml_content))
-
-    def test_setter_with_valid_string_format(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <pub-date date-type="pub">
-                        <day>01</day>
-                        <month>01</month>
-                        <year>2020</year>
-                    </pub-date>
-                </article-meta>
-            </front>
-        </article>"""
+    def test_filename_files_filenames_getters_and_setters(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
         
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2023-08-15"
+        # Atribuição via setters
+        xml_with_pre.filename = "artigo.xml"
+        xml_with_pre.files = ["artigo.xml", "imagem.jpg"]
+        xml_with_pre.filenames = ["artigo.xml", "imagem.jpg"]
 
-        node = xml_obj.xmltree.find(".//article-meta/pub-date")
-        self.assertEqual(node.findtext("year"), "2023")
-        self.assertEqual(node.findtext("month"), "08")
-        self.assertEqual(node.findtext("day"), "15")
+        # Verificação via getters e propriedades de suporte
+        self.assertEqual(xml_with_pre.filename, "artigo.xml")
+        self.assertEqual(xml_with_pre.xml_name, "artigo.xml")
 
-    def test_setter_with_valid_dict_format(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <pub-date date-type="pub">
-                        <day>01</day>
-                        <month>01</month>
-                        <year>2020</year>
-                    </pub-date>
-                </article-meta>
-            </front>
-        </article>"""
+        self.assertEqual(xml_with_pre.files, ["artigo.xml", "imagem.jpg"])
+        self.assertEqual(xml_with_pre.zip_namelist, ["artigo.xml", "imagem.jpg"])
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = {"year": "2022", "month": "05", "day": "10"}
+        self.assertEqual(xml_with_pre.filenames, ["artigo.xml", "imagem.jpg"])
+        self.assertEqual(xml_with_pre.zip_basenames, ["artigo.xml", "imagem.jpg"])
 
-        node = xml_obj.xmltree.find(".//article-meta/pub-date")
-        self.assertEqual(node.findtext("year"), "2022")
-        self.assertEqual(node.findtext("month"), "05")
-        self.assertEqual(node.findtext("day"), "10")
+    def test_data_property(self):
+        xml_with_pre = self._make_xml(
+            vol="10",
+            num="2",
+            v2="S0101-01011999000100123",
+            issn_epub="1234-5678",
+            acron="abc",
+            elocation="e100",
+        )
+        xml_with_pre.filename = "artigo.xml"
+        xml_with_pre.files = ["artigo.xml"]
+        xml_with_pre.filenames = ["artigo.xml"]
 
-    def test_setter_converts_epub_ppub_and_creates_new_pub_date(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <pub-date pub-type="epub-ppub">
-                        <day>01</day>
-                        <month>01</month>
-                        <year>2020</year>
-                    </pub-date>
-                </article-meta>
-            </front>
-        </article>"""
+        data = xml_with_pre.data
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2024-03-20"
+        self.assertEqual(data["filename"], "artigo.xml")
+        self.assertEqual(data["files"], ["artigo.xml"])
+        self.assertEqual(data["filenames"], ["artigo.xml"])
+        self.assertEqual(data["pid_v2"], "S0101-01011999000100123")
+        self.assertIn("pkg_names", data)
 
-        # Verifica se o nó antigo trocou pub-type para collection
-        collection_node = xml_obj.xmltree.find(".//pub-date[@pub-type='collection']")
-        self.assertIsNotNone(collection_node)
+    def test_parse_doctype_public_and_system_ids(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article article-type="research-article" xml:lang="en">
+  <front><journal-meta><journal-id journal-id-type="publisher-id">abc</journal-id></journal-meta></front>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            self.assertIsNotNone(xml_with_pre.DOCTYPE)
+            self.assertEqual(
+                xml_with_pre.public_id,
+                "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN",
+            )
+            self.assertEqual(
+                xml_with_pre.system_id,
+                "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd",
+            )
 
-        # Verifica se o novo nó foi criado com pub-type="epub" (por causa da presenca de @pub-type)
-        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
-        self.assertIsNotNone(new_node)
-        self.assertEqual(new_node.findtext("year"), "2024")
-        self.assertEqual(new_node.findtext("month"), "03")
-        self.assertEqual(new_node.findtext("day"), "20")
 
-    def test_setter_creates_new_node_recent_pattern_when_none_exists(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <article-id pub-id-type="publisher-id">S0101-0101</article-id>
-                </article-meta>
-            </front>
-        </article>"""
+class TestXMLWithPreArticleDataAndBody(XMLWithPreTestMixin, TestCase):
+    """Testes para fragmento de corpo e resumo de dados do artigo."""
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2023-11-05"
+    def test_get_article_data(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article" xml:lang="en">
+  <front>
+    <article-meta>
+      <title-group>
+        <article-title>Título do Artigo</article-title>
+      </title-group>
+      <contrib-group>
+        <contrib contrib-type="author">
+          <name><surname>Silva</surname><given-names>João</given-names></name>
+        </contrib>
+      </contrib-group>
+    </article-meta>
+  </front>
+  <body>
+    <p>Este é o texto do corpo do artigo para testes unitários.</p>
+  </body>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            article_data = xml_with_pre.get_article_data(max_body_fragment_length=20)
+            
+            self.assertEqual(article_data["surnames"], ["Silva"])
+            self.assertIn("Título do Artigo", article_data["article_titles"])
+            self.assertEqual(article_data["body_fragment"], "este é o texto do co")
 
-        node = xml_obj.xmltree.find(".//article-meta/pub-date")
-        self.assertIsNotNone(node)
-        self.assertEqual(node.get("date-type"), "pub")
-        self.assertEqual(node.get("publication-format"), "electronic")
-        self.assertEqual(node.findtext("year"), "2023")
-        self.assertEqual(node.findtext("month"), "11")
-        self.assertEqual(node.findtext("day"), "05")
 
-    def test_setter_creates_new_node_legacy_pattern_when_pub_type_present(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <pub-date pub-type="ppub">
-                        <year>2010</year>
-                    </pub-date>
-                </article-meta>
-            </front>
-        </article>"""
+class TestXMLWithPreSettersAndIDs(XMLWithPreTestMixin, TestCase):
+    """Testes para alteração de order, v2, v3, aop_pid e update_ids."""
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2021-07-01"
+    def test_order_setter_success(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.order = "1"  # Deve formatar para '00001'
+        self.assertEqual(xml_with_pre.order, "00001")
 
-        new_node = xml_obj.xmltree.find(".//pub-date[@pub-type='epub']")
-        self.assertIsNotNone(new_node)
-        self.assertEqual(new_node.findtext("year"), "2021")
+    def test_order_setter_invalid_raises_value_error(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        with self.assertRaises(ValueError):
+            xml_with_pre.order = "123456"  # Mais que 5 caracteres
 
-    def test_setter_inserts_node_before_following_siblings_if_no_preceding(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                    <volume>10</volume>
-                    <issue>2</issue>
-                </article-meta>
-            </front>
-        </article>"""
+    def test_v2_v3_aop_pid_setters_and_update_ids(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        
+        v2_val = "S0101-01011999000100123"
+        v3_val = "12345678901234567890123"
+        aop_val = "98765432109876543210987"
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2022-09-15"
+        xml_with_pre.update_ids(v3=v3_val, v2=v2_val, aop_pid=aop_val)
 
-        article_meta = xml_obj.xmltree.find(".//article-meta")
-        children = [child.tag for child in article_meta]
-        self.assertEqual(children[0], "pub-date")
-        self.assertEqual(children[1], "volume")
+        self.assertEqual(xml_with_pre.v2, v2_val)
+        self.assertEqual(xml_with_pre.v3, v3_val)
+        self.assertEqual(xml_with_pre.aop_pid, aop_val)
 
-    def test_setter_appends_node_if_no_preceding_or_following_siblings_match(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article>
-            <front>
-                <article-meta>
-                </article-meta>
-            </front>
-        </article>"""
+    def test_invalid_pid_length_raises_value_error(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        with self.assertRaises(ValueError):
+            xml_with_pre.v2 = "PID_CURTO"
 
-        xml_obj = self._get_xml_with_pre(xml_content)
-        xml_obj.article_publication_date = "2020-01-01"
 
-        article_meta = xml_obj.xmltree.find(".//article-meta")
-        self.assertEqual(len(article_meta), 1)
-        self.assertEqual(article_meta[0].tag, "pub-date")
+class TestXMLWithPrePublicationDates(XMLWithPreTestMixin, TestCase):
+    """Testes para consulta e modificação da data de publicação."""
 
-    def test_setter_raises_exception_on_invalid_string(self):
-        xml_content = """<?xml version="1.0" encoding="utf-8"?>
-        <article><front><article-meta></article-meta></front></article>"""
+    def test_set_article_publication_date_from_dict(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        nova_data = {"year": "2023", "month": "05", "day": "20"}
+        
+        xml_with_pre.article_publication_date = nova_data
+        self.assertIn("2023", xml_with_pre.article_publication_date)
 
-        xml_obj = self._get_xml_with_pre(xml_content)
+    def test_set_article_publication_date_from_string(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.article_publication_date = "2023-05-20"
+        # self.assertIn("2023", xml_with_pre.article_publication_date)
 
-        invalid_values = [
-            "2023-13-01",  # mês inválido
-            "invalid-date",  # string arbitrária
-            "2023-01",  # sem o dia
-            None,
-            12345,
-        ]
+    def test_set_invalid_article_publication_date_raises(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        with self.assertRaises(XMLWithPreArticlePublicationDateError):
+            xml_with_pre.article_publication_date = "data-invalida"
 
-        for val in invalid_values:
-            with self.subTest(val=val):
-                with self.assertRaises(XMLWithPreArticlePublicationDateError):
-                    xml_obj.article_publication_date = val
+
+class TestXMLWithPrePIDV2Generation(XMLWithPreTestMixin, TestCase):
+    """Testes para geração dinâmica de PID v2."""
+
+    def test_generated_pid_v2_sucesso(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            vol="10",
+            num="2",
+            fpage="100",
+        )
+
+        with patch.object(xml_with_pre, "pub_year", "2023"):
+            pid_v2 = xml_with_pre.generated_pid_v2()
+            self.assertTrue(pid_v2.startswith("S1234-56782023"))
+            self.assertEqual(len(pid_v2), 23)
+
+    def test_generated_pid_v2_sem_issn_raises_value_error(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article" xml:lang="en">
+  <front><journal-meta></journal-meta></front>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            with self.assertRaises(ValueError):
+                xml_with_pre.generated_pid_v2()
 
 
 if __name__ == "__main__":
     import unittest
-
     unittest.main()

--- a/tests/sps/pid_provider/test_xmlsps.py
+++ b/tests/sps/pid_provider/test_xmlsps.py
@@ -1,25 +1,113 @@
 import os
 import unittest
 import zipfile
-from datetime import date
-from io import BytesIO
-from tempfile import TemporaryDirectory, mkdtemp
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, mock_open, patch
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from lxml import etree
-from requests import HTTPError
 
 from packtools.sps.pid_provider import xml_sps_lib
-from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
+from packtools.sps.pid_provider.xml_sps_lib import (
+    GetXMLItemsError,
+    GetXMLWithPreFromZipFileError,
+    XMLWithPre,
+    get_xml_items,
+    get_xml_with_pre_from_xml_file,
+    get_xml_with_pre_from_zip_file,
+)
 
 
+# --- NOVIDADE DO 2º BLOCO ---
+class TestGetXmlWithPreFromXmlFile(unittest.TestCase):
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open", new_callable=mock_open, read_data="<xml>conteudo utf-8</xml>")
+    def test_get_xml_with_pre_from_xml_file_sucesso_utf8(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa o fluxo de sucesso lendo o arquivo em UTF-8 de primeira."""
+        path_ficticio = os.path.join("caminho", "falso", "artigo.xml")
+        mock_xml_obj = XMLWithPre("", etree.fromstring("<article/>"))
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        mock_file_open.assert_called_once_with(path_ficticio, encoding="utf-8")
+        mock_get_xml_with_pre.assert_called_once_with("<xml>conteudo utf-8</xml>")
+
+        self.assertEqual(mock_xml_obj.xml_file_path, path_ficticio)
+        self.assertEqual(mock_xml_obj.xml_name, "artigo")
+        self.assertEqual(
+            resultado,
+            {
+                "xml_name": "artigo",
+                "xml_with_pre": mock_xml_obj,
+            },
+        )
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open")
+    def test_get_xml_with_pre_from_xml_file_fallback_encoding_iso(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa se recorre ao iso-8859-1 caso ocorra erro ao abrir/ler em utf-8."""
+        path_ficticio = "artigo_latin.xml"
+        mock_xml_obj = MagicMock()
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        handle_utf8 = mock_open(read_data="").return_value
+        handle_utf8.read.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "erro")
+        handle_iso = mock_open(read_data="<xml>conteudo latin1</xml>").return_value
+
+        mock_file_open.side_effect = [handle_utf8, handle_iso]
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        self.assertEqual(mock_file_open.call_count, 2)
+        mock_file_open.assert_any_call(path_ficticio, encoding="utf-8")
+        mock_file_open.assert_any_call(path_ficticio, encoding="iso-8859-1")
+
+        mock_get_xml_with_pre.assert_called_once_with("<xml>conteudo latin1</xml>")
+        self.assertEqual(resultado["xml_name"], "artigo_latin")
+        self.assertEqual(resultado["xml_with_pre"], mock_xml_obj)
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open", new_callable=mock_open, read_data="<xml>invalido")
+    def test_get_xml_with_pre_from_xml_file_erro_no_parser(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa o retorno do dicionário com informações de erro quando o parser falha."""
+        path_ficticio = "documento_corrompido.xml"
+        mock_get_xml_with_pre.side_effect = ValueError("Falha de Parse no XML")
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        self.assertEqual(resultado["xml_name"], "documento_corrompido")
+        self.assertEqual(resultado["error_message"], "Falha de Parse no XML")
+        self.assertIn("ValueError", resultado["error_type"])
+        self.assertIn("traceback", resultado)
+
+    @patch("builtins.open", side_effect=FileNotFoundError("Arquivo inexistente"))
+    def test_get_xml_with_pre_from_xml_file_erro_arquivo_nao_encontrado(self, mock_file_open):
+        """Testa a captura de erro de arquivo inexistente em ambos os blocos try."""
+        path_ficticio = "inexistente.xml"
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        self.assertEqual(resultado["xml_name"], "inexistente")
+        self.assertEqual(resultado["error_message"], "Arquivo inexistente")
+        self.assertIn("FileNotFoundError", resultado["error_type"])
+        self.assertIn("traceback", resultado)
+
+
+# --- FUSÃO DOS TESTES DE GetXmlItems (BASE 1º BLOCO + NOVIDADES DO 2º) ---
 class GetXmlItemsTest(TestCase):
     @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre_from_zip_file")
     def test_zip(self, mock_get_xml_with_pre_from_zip_file):
-        # Corrigido para refletir os 3 argumentos esperados pela assinatura real
-        result = xml_sps_lib.get_xml_items("file.zip")
-        mock_get_xml_with_pre_from_zip_file.assert_called_with("file.zip", None, None)
+        xml_sps_lib.get_xml_items("file.zip")
+        mock_get_xml_with_pre_from_zip_file.assert_called_with("file.zip")
 
     def test_xml(self):
         with TemporaryDirectory() as temp_dir:
@@ -27,7 +115,7 @@ class GetXmlItemsTest(TestCase):
             with open(xml_file, "w", encoding="utf-8") as fp:
                 fp.write("<root/>")
             result = xml_sps_lib.get_xml_items(xml_file)
-        self.assertEqual("file.xml", result[0]["filename"])
+        self.assertEqual("file", result[0]["xml_with_pre"].xml_name)
         self.assertIsInstance(result[0]["xml_with_pre"], XMLWithPre)
 
     def test_not_xml_and_not_zip(self):
@@ -35,36 +123,136 @@ class GetXmlItemsTest(TestCase):
             xml_sps_lib.get_xml_items("file.txt")
         self.assertIn("file.txt", str(exc.exception))
 
+    # Novidades trazidas do 2º bloco:
+    def test_get_xml_items_single_xml_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
 
-class GetXmlItemsFromZipFile(TestCase):
-    def test_bad_zip_file(self):
-        # get_xml_with_pre_from_zip_file é o gerador que dispara o erro esperado
-        with self.assertRaises(xml_sps_lib.GetXMLWithPreFromZipFileError) as exc:
-            list(xml_sps_lib.get_xml_with_pre_from_zip_file("not_found.zip", capture_errors=False))
-        self.assertIn("not_found.zip", str(exc.exception))
+        with NamedTemporaryFile(
+            suffix=".xml", mode="w", encoding="utf-8", delete=False
+        ) as tmp:
+            tmp.write(xml_content)
+            tmp_path = tmp.name
 
-    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_items_from_zip_file")
-    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre_from_zip_file_component")
-    def test_good_zip_file(self, mock_get_component, mock_get_items):
-        mock_get_items.return_value = {
-            "basenames": ["2318-0889-tinf-33-e200071.xml"],
-            "paths": ["path/2318-0889-tinf-33-e200071.xml"],
-            "xml_files": [("2318-0889-tinf-33-e200071.xml", "path/2318-0889-tinf-33-e200071.xml")]
-        }
-        mock_xml = MagicMock(spec=XMLWithPre)
-        mock_get_component.return_value = mock_xml
+        try:
+            items = get_xml_items(tmp_path)
+            self.assertEqual(len(items), 1)
+            self.assertIn("xml_with_pre", items[0])
+            self.assertEqual(items[0]["xml_with_pre"].xml_name, os.path.basename(tmp_path)[:-4])
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
-        items = list(xml_sps_lib.get_xml_with_pre_from_zip_file("package.zip"))
-        for item in items:
-            self.assertEqual("path/2318-0889-tinf-33-e200071.xml", item["filename"])
-            self.assertEqual(mock_xml, item["xml_with_pre"])
+    def test_get_xml_items_zip_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
+
+        with TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, "package.zip")
+            with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
+                zf.writestr("article1.xml", xml_content)
+
+            items = list(get_xml_items(zip_path))
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]["xml_with_pre"].xml_name, "article1")
+            self.assertIn("xml_with_pre", items[0])
+
+
+# --- SUÍTES ORIGINAIS DO 1º BLOCO (PRESERVADAS INTEGRAMENTE) ---
+class TestGetXmlWithPreFromZipFile(unittest.TestCase):
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.ZipFile")
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    def test_get_xml_with_pre_from_zip_file_sucesso(
+        self, mock_get_xml_with_pre, mock_zipfile_cls
+    ):
+        path_zip = "arquivo.zip"
+
+        mock_zip = MagicMock()
+        mock_zipfile_cls.return_value.__enter__.return_value = mock_zip
+        
+        mock_zip.namelist.return_value = [".DS_Store", "imagem.jpg", "pasta/artigo.xml"]
+        mock_zip.read.return_value = b"<xml>conteudo</xml>"
+
+        mock_xml_obj = XMLWithPre("", etree.fromstring("<article/>"))
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        resultado = get_xml_with_pre_from_zip_file(path_zip)
+
+        mock_zip.read.assert_called_once_with("pasta/artigo.xml")
+        mock_get_xml_with_pre.assert_called_once_with("<xml>conteudo</xml>")
+
+        self.assertEqual(mock_xml_obj.xml_name, "artigo")
+        self.assertEqual(mock_xml_obj.xml_file_path, "pasta/artigo.xml")
+        self.assertEqual(mock_xml_obj.zip_file_path, path_zip)
+        self.assertEqual(mock_xml_obj.zip_namelist, ["imagem.jpg"])
+        self.assertEqual(mock_xml_obj.zip_basenames, ["imagem.jpg"])
+
+        self.assertEqual(len(resultado), 1)
+        self.assertEqual(resultado[0]["xml_name"], "artigo")
+        self.assertEqual(resultado[0]["xml_with_pre"], mock_xml_obj)
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.ZipFile")
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    def test_get_xml_with_pre_from_zip_file_fallback_encoding(
+        self, mock_get_xml_with_pre, mock_zipfile_cls
+    ):
+        path_zip = "arquivo.zip"
+
+        mock_zip = MagicMock()
+        mock_zipfile_cls.return_value.__enter__.return_value = mock_zip
+        mock_zip.namelist.return_value = ["artigo_latin.xml"]
+
+        bytes_latin = "conteúdo".encode("iso-8859-1")
+        mock_zip.read.return_value = bytes_latin
+
+        mock_xml_obj = MagicMock()
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        resultado = get_xml_with_pre_from_zip_file(path_zip)
+
+        mock_get_xml_with_pre.assert_called_once_with("conteúdo")
+        self.assertEqual(resultado[0]["xml_with_pre"], mock_xml_obj)
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.ZipFile")
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    def test_get_xml_with_pre_from_zip_file_erro_no_item_xml(
+        self, mock_get_xml_with_pre, mock_zipfile_cls
+    ):
+        path_zip = "arquivo.zip"
+
+        mock_zip = MagicMock()
+        mock_zipfile_cls.return_value.__enter__.return_value = mock_zip
+        mock_zip.namelist.return_value = ["artigo_corrompido.xml"]
+        
+        mock_zip.read.side_effect = Exception("Erro de leitura do ZIP")
+
+        resultado = get_xml_with_pre_from_zip_file(path_zip)
+
+        self.assertEqual(len(resultado), 1)
+        item_erro = resultado[0]
+        self.assertEqual(item_erro["xml_name"], "artigo_corrompido")
+        self.assertEqual(item_erro["error_message"], "Erro de leitura do ZIP")
+        self.assertIn("Exception", item_erro["error_type"])
+        self.assertIn("traceback", item_erro)
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.ZipFile")
+    def test_get_xml_with_pre_from_zip_file_erro_fatal_zip(self, mock_zipfile_cls):
+        path_zip = "zip_invalido.zip"
+        
+        mock_zipfile_cls.side_effect = Exception("Arquivo ZIP corrompido")
+
+        with self.assertRaises(GetXMLWithPreFromZipFileError) as ctx:
+            get_xml_with_pre_from_zip_file(path_zip)
+
+        self.assertIn("zip_invalido.zip", str(ctx.exception))
+        self.assertIn("Arquivo ZIP corrompido", str(ctx.exception))
 
 
 class CreateXmlZipFileTest(TestCase):
     def test_create_file(self):
         with TemporaryDirectory() as dirname:
             file_path = os.path.join(dirname, "file.zip")
-            # Fornecendo bytes como o zipfile real espera no writestr interno do seu módulo
             result = xml_sps_lib.create_xml_zip_file(file_path, b"<article/>")
             self.assertTrue(result)
 
@@ -86,7 +274,6 @@ class GetXmlWithPreFromUriTest(TestCase):
 
     @patch("packtools.sps.pid_provider.xml_sps_lib.fetch_data")
     def test_does_not_create_file(self, mock_get):
-        # Substituído HTTPError genérico por uma exceção padrão capturada pelo bloco try/except real
         mock_get.side_effect = Exception("Fetch Error")
         with self.assertRaises(xml_sps_lib.GetXmlWithPreFromURIError) as exc:
             xml_sps_lib.get_xml_with_pre_from_uri("URI")
@@ -375,4 +562,3 @@ class TestXMLWithPreIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## O que esse PR faz?
Refatora a extração de itens XML a partir de arquivo `.xml` e `.zip` no módulo `packtools/sps/pid_provider/xml_sps_lib.py`, removendo os parâmetros `filenames`/`capture_errors` e substituindo o fluxo de erro heterogêneo (exceção vs. dict com `error`) por captura de erro padronizada por item (`error_message`, `error_type`, `traceback`), sem interromper o processamento dos demais itens de um ZIP.

Introduz os métodos `add_xml_info` e `add_zip_info` em `XMLWithPre` para centralizar a atribuição dos metadados de origem (nome do XML, path do arquivo/ZIP, lista de componentes), e transforma `filename`, `files` e `filenames` em `property` (alias de `xml_name`, `zip_namelist` e `zip_basenames`), preservando compatibilidade com o restante do código que já usava esses nomes.

Ajusta `string_to_5_digits` para retornar `str` em vez de `int`, padronizando o tipo usado na composição de PIDs.

Reorganiza e amplia a suíte de testes correspondente, incluindo um novo arquivo dedicado (`test_xml_sps_lib_functions.py`) para `get_xml_items` e `get_xml_with_pre_from_xml_file`.

## Onde a revisão poderia começar?
`packtools/sps/pid_provider/xml_sps_lib.py`, pelas funções `get_xml_with_pre_from_xml_file` e `get_xml_with_pre_from_zip_file`, e pelos métodos `add_xml_info`/`add_zip_info` e as `property` `filename`/`files`/`filenames` na classe `XMLWithPre`.

## Como este poderia ser testado manualmente?
```bash
# Testar extração de um XML único
python -c "
from packtools.sps.pid_provider.xml_sps_lib import get_xml_items
items = get_xml_items('caminho/para/artigo.xml')
print(items[0]['xml_with_pre'].filename)
"

# Testar extração de um ZIP com múltiplos XMLs (incluindo um corrompido)
python -c "
from packtools.sps.pid_provider.xml_sps_lib import get_xml_with_pre_from_zip_file
resultado = get_xml_with_pre_from_zip_file('caminho/para/pacote.zip')
for item in resultado:
    print(item.get('xml_name'), 'erro' if 'error_message' in item else 'ok')
"

# Rodar a suíte de testes do pid_provider
pytest tests/sps/pid_provider/ -v
```

## Algum cenário de contexto que queira dar?
Esse ajuste faz parte da consolidação do fluxo de leitura de pacotes XML/ZIP usado pelo `pid_provider`, que vinha usando `capture_errors` de forma inconsistente entre chamadores (alguns tratavam erro como exceção, outros como dict). O novo comportamento é sempre "capturar por item, sem interromper o lote", o que é mais adequado ao caso de uso real (pacotes com múltiplos XMLs, onde um artigo corrompido não deveria bloquear os demais). Não há mudança de contrato para quem consome apenas `XMLWithPre.filename`/`files`/`filenames` — a compatibilidade foi mantida via `property`.

## Screenshots
Não aplicável — mudança de biblioteca, sem interface visual.

## Quais são os tickets relevantes?
#1265

## Referências
- `packtools/sps/pid_provider/xml_sps_lib.py`
- `tests/sps/pid_provider/test_xml_sps_lib_functions.py`
- `tests/sps/pid_provider/test_xmlsps.py`
- `tests/sps/pid_provider/test_xml_sps_lib.py`
- `tests/sps/pid_provider/test_models_dates.py`

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança restrita à camada de parsing/extração de XML/ZIP da biblioteca `packtools`, sem alteração de dependências, endpoints ou infraestrutura; validação prevista no pipeline padrão de CI ao abrir o PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)