### PR TITLE
introduz uma nova estratégia determinística de geração de `sps_pkg_name`

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -911,7 +911,10 @@ class PackageNamingMixin:
             variations.add(self.submitted_filename)
 
         for issn in self.available_issns:
-            variations.add(self.build_sps_pkg_name(issn=issn))
+            try:
+                variations.add(self.build_sps_pkg_name(issn=issn))
+            except ValueError:
+                pass
 
         variations.update(self.deprecated_sps_pkg_name_list)
 
@@ -922,13 +925,18 @@ class PackageNamingMixin:
 
         if provided_sps_pkg_name := self.provided_sps_pkg_name:
             variations.add(provided_sps_pkg_name)
-
+        if self.xml_name:
+            variations.add(self.xml_name)
         return variations
 
     @property
     def built_sps_pkg_name(self) -> str:
         """Retorna o nome do pacote SPS construído com base nas regras atuais."""
         return self._built_sps_pkg_name
+
+    @built_sps_pkg_name.setter
+    def built_sps_pkg_name(self, value):
+        self._built_sps_pkg_name = value
 
     @property
     def provided_sps_pkg_name(self) -> str:
@@ -943,29 +951,37 @@ class PackageNamingMixin:
         # não sanitizar, pois pode ser nome legado
         self._provided_sps_pkg_name = value
 
-    @property
-    def sps_pkg_name(self):
+    def set_sps_pkg_data(self):
+        if self._sps_pkg_name_origin and self._sps_pkg_name:
+            return
         if name := self.provided_sps_pkg_name:
-            return name
+            self._sps_pkg_name_origin = "provided_sps_pkg_name"
+            self._sps_pkg_name = name
+            return
         if name := self.built_sps_pkg_name:
-            return name
+            self._sps_pkg_name_origin = "built_sps_pkg_name"
+            self._sps_pkg_name = name
+            return
+        if name := self.xml_name:
+            self._sps_pkg_name_origin = "xml_name"
+            self._sps_pkg_name = name
+            return
         # comportamento defensivo em caso de não ajuste no upload / core
         # versão mais compatível com o guia sps 1.10
-        return self.deprecated_sps_pkg_name_version_2
+        self._sps_pkg_name_origin = "deprecated_sps_pkg_name_version_2"
+        self._sps_pkg_name = self.deprecated_sps_pkg_name_version_2
+
+    @property
+    def sps_pkg_name(self):
+        if not self._sps_pkg_name_origin or not self._sps_pkg_name:
+            self.set_sps_pkg_data()
+        return self._sps_pkg_name
 
     @property
     def sps_pkg_name_origin(self):
-        if name := self.provided_sps_pkg_name:
-            return "provided_sps_pkg_name"
-        if name := self.built_sps_pkg_name:
-            return "built_sps_pkg_name"
-        # comportamento defensivo em caso de não ajuste no upload / core
-        # versão mais compatível com o guia sps 1.10
-        return "deprecated_sps_pkg_name_version_2"
-
-    @sps_pkg_name.setter
-    def sps_pkg_name(self, value):
-        self.provided_sps_pkg_name = value
+        if not self._sps_pkg_name_origin or not self._sps_pkg_name:
+            self.set_sps_pkg_data()
+        return self._sps_pkg_name_origin
 
     @property
     def pkg_names_dict(self) -> dict:
@@ -1630,6 +1646,8 @@ class XMLWithPre(
         self._provided_sps_pkg_name = None
         self._built_sps_pkg_name = None
         self.is_html_source = None
+        self._sps_pkg_name_origin = None
+        self._sps_pkg_name = None
 
     def __str__(self):
         return self.xml_name or self.submitted_filename or self.zip_file_path or self.uri or "<XMLWithPre>"
@@ -1653,14 +1671,7 @@ class XMLWithPre(
                     continue
                 try:
                     xml_with_pre = item["xml_with_pre"]
-                    if xml_native_name:
-                        xml_with_pre.provided_sps_pkg_name = xml_native_name
-                    if xml_native_name or html_name:
-                        xml_with_pre.submitted_filename = xml_native_name or html_name
-                    if built_name:
-                        xml_with_pre._built_sps_pkg_name = built_name
-                    if not xml_native_name and not built_name:
-                        xml_with_pre._built_sps_pkg_name = xml_with_pre.build_sps_pkg_name()
+                    xml_with_pre.add_pkg_name(xml_native_name=xml_native_name, html_name=html_name, built_name=built_name)
                     yield xml_with_pre
                 except (KeyError, ValueError) as e:
                     errors.append(item)
@@ -1672,6 +1683,15 @@ class XMLWithPre(
         if uri:
             yield get_xml_with_pre_from_uri(uri, timeout)
             return
+
+    def add_pkg_name(self, xml_native_name=None, html_name=None, built_name=None):
+        if xml_native_name:
+            self.provided_sps_pkg_name = xml_native_name
+            self.submitted_filename = xml_native_name + ".xml"
+        elif html_name:
+            self.submitted_filename = html_name + ".html"
+        if built_name:
+            self._built_sps_pkg_name = built_name
 
     def tostring(self, pretty_print=False):
         return self.xmlpre + etree.tostring(

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -405,11 +405,10 @@ class PackagingAndFilesMixin:
     # --------------------------------------------------------------------------
     @property
     def filename(self):
-        return self.xml_name
-
-    @filename.setter
-    def filename(self, value):
-        self.xml_name = value
+        if self.zip_file_path:
+            return self.xml_file_path
+        if self.xml_name:
+            return f"{self.xml_name}.xml"
 
     @property
     def files(self):

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -354,37 +354,51 @@ def fix_number(value):
         return value
 
 
-class XMLWithPre:
-    """
-    Preserva o texto anterior ao elemento `root`
-    """
+# ==============================================================================
+# 1. PARSER DE DOCTYPE
+# ==============================================================================
+class DOCTYPEParserMixin:
+    """Gerencia o parsing e extração de informações do DOCTYPE."""
 
-    def __init__(self, xmlpre, xmltree, pretty_print=True):
-        self.xmltree = xmltree
-        self.xmlpre = xmlpre or ""
+    def parse_doctype(self):
+        """
+        Extrai informações do DOCTYPE de forma pythônica.
+        Atualiza self.DOCTYPE, self.public_id e self.system_id.
+        """
+        if not getattr(self, "xmlpre", None) or "<!DOCTYPE" not in self.xmlpre:
+            return
+        try:
+            start = self.xmlpre.index("<!DOCTYPE")
+            end = self.xmlpre.index(">", start) + 1
+            self.DOCTYPE = self.xmlpre[start:end]
 
-        # Parse DOCTYPE uma única vez durante init
-        self.DOCTYPE = None
-        self.public_id = None
-        self.system_id = None
-        if self.xmlpre and "<!DOCTYPE" in self.xmlpre:
-            self.parse_doctype()
+            parts = self.DOCTYPE.split('"')
 
-        self.pretty_print = pretty_print
-        self.uri = None
-        self.zip_file_path = None
-        self.xml_file_path = None
-        self.relative_system_id = None
-        self._sps_version = None
-        self.errors = None
-        self.pkg_name_version = None
+            if "PUBLIC" in self.DOCTYPE and len(parts) >= 4:
+                self.public_id = parts[1]
+                self.system_id = (
+                    parts[3] if parts[3].startswith(("http://", "https://")) else None
+                )
+                return
 
-        self.xml_name = None # nome original encontrado no xml ou no zip
-        self.zip_basenames = None # nome original encontrado no xml ou no zip, exceto xml
-        self.zip_namelist = None # nome original encontrado no xml ou no zip, exceto xml
-        self.submitted_filename = None
-        self.submitted_ext = None
+            if "SYSTEM" in self.DOCTYPE and len(parts) >= 2:
+                self.system_id = (
+                    parts[1] if parts[1].startswith(("http://", "https://")) else None
+                )
 
+        except (ValueError, IndexError):
+            return
+
+
+# ==============================================================================
+# 2. GESTÃO DE ARQUIVOS, ZIPS E COMPONENTES
+# ==============================================================================
+class PackagingAndFilesMixin:
+    """Propriedades e métodos relacionados a arquivos, zips, assets e renditions."""
+
+    # --------------------------------------------------------------------------
+    # Aliases e Setters/Getters para Retrocompatibilidade
+    # --------------------------------------------------------------------------
     @property
     def filename(self):
         return self.xml_name
@@ -425,6 +439,9 @@ class XMLWithPre:
     def source_ext(self, value):
         self.submitted_ext = value
 
+    # --------------------------------------------------------------------------
+    # Métodos Mutadores de Informações do Pacote
+    # --------------------------------------------------------------------------
     def add_xml_info(self, xml_name, xml_file_path=None):
         self.xml_name = xml_name
         self.xml_file_path = xml_file_path
@@ -438,111 +455,6 @@ class XMLWithPre:
         self.pkg_name_version = pkg_name_version
         self.submitted_filename, self.submitted_ext = os.path.splitext(source_filename)
 
-    @property
-    def data(self):
-        return dict(
-            sps_pkg_name=self.sps_pkg_name,
-            pid_v3=self.v3,
-            pid_v2=self.v2,
-            aop_pid=self.aop_pid,
-            submitted_filename=self.submitted_filename,
-            submitted_ext=self.submitted_ext,
-            xml_name=self.xml_name,
-            zip_namelist=self.zip_namelist,
-            zip_basenames=self.zip_basenames,
-            filename=self.filename,
-            files=self.files,
-            filenames=self.filenames,
-            pkg_names=self.deprecated_sps_pkg_name_list,
-        )
-    
-    def get_article_data(self, max_body_fragment_length=300):
-        try:
-            persons = self.authors.get("person") or []
-            surnames = [p.get("surname") for p in persons if p.get("surname")]
-        except Exception:
-            surnames = []
-        return {
-            "surnames": surnames,
-            "collab": self.collab,
-            "links": self.links,
-            "article_titles": self.article_titles_texts,
-            "partial_body": self.partial_body,
-            "body_fragment": self.get_body_fragment(max_body_fragment_length),
-        }
-
-    @classmethod
-    def create(
-        cls, path=None, uri=None, xml_content=None, capture_errors=False, timeout=30
-    ):
-        """
-        Returns instance of XMLWithPre
-
-        path : str
-            zip or XML file
-        uri : str
-            XML file URI
-        """
-        if path:
-            errors = []
-            xml_with_pre = None
-            for item in get_xml_items(path):
-                if not item:
-                    continue
-                try:
-                    xml_with_pre = item["xml_with_pre"]
-                    yield xml_with_pre
-                except KeyError:
-                    errors.append(item)
-            if not xml_with_pre or errors:
-                raise GetXmlWithPreError("Unable to get xml with pre %s" % str(errors))
-        if xml_content:
-            yield get_xml_with_pre(xml_content)
-            return
-        if uri:
-            yield get_xml_with_pre_from_uri(uri, timeout)
-            return
-
-    def parse_doctype(self):
-        """
-        Extrai informações do DOCTYPE de forma pythônica.
-
-        Returns:
-            DoctypeInfo com doctype, public_id e system_id
-        """
-        if not self.xmlpre or "<!DOCTYPE" not in self.xmlpre:
-            return
-        try:
-            # Extrai DOCTYPE
-            start = self.xmlpre.index("<!DOCTYPE")
-            end = self.xmlpre.index(">", start) + 1
-            self.DOCTYPE = self.xmlpre[start:end]
-
-            # Parse dos IDs usando split
-            parts = self.DOCTYPE.split('"')
-
-            if "PUBLIC" in self.DOCTYPE and len(parts) >= 4:
-                self.public_id = parts[1]
-                self.system_id = (
-                    parts[3] if parts[3].startswith(("http://", "https://")) else None
-                )
-                return
-
-            if "SYSTEM" in self.DOCTYPE and len(parts) >= 2:
-                self.system_id = (
-                    parts[1] if parts[1].startswith(("http://", "https://")) else None
-                )
-
-        except (ValueError, IndexError):
-            return
-
-    @cached_property
-    def sps_version(self):
-        try:
-            return self.xmltree.find(".").get("specific-use")
-        except (AttributeError, TypeError, ValueError):
-            return None
-
     def get_zip_content(self, xml_filename, pretty_print=False):
         zip_content = None
         with TemporaryDirectory() as tmpdirname:
@@ -553,750 +465,9 @@ class XMLWithPre:
                 zip_content = fp.read()
         return zip_content
 
-    @cached_property
-    def sps_pkg_name_suffix(self):
-        if self.elocation_id:
-            return self.elocation_id
-        if self.sps_pkg_name_fpage:
-            return self.sps_pkg_name_fpage
-        if self.main_doi:
-            doi = self.main_doi
-            if "/" in doi:
-                doi = doi[doi.rfind("/") + 1 :]
-            return doi.replace(".", "-")
-
-    @cached_property
-    def sps_pkg_name_fpage(self):
-        fpage = fix_number(self.fpage)
-        if not fpage:
-            return None
-        seq = self.fpage_seq
-        if not seq:
-            if self.lpage == fpage:
-                seq = self.v2 and self.v2[-5:]
-        if seq:
-            return f"{fpage}_{seq}"
-        return fpage
-
-    @cached_property
-    def deprecated_sps_pkg_name_fpage(self):
-        fpage = fix_number(self.fpage)
-        if not fpage:
-            return None
-        seq = self.fpage_seq or ""
-        return f"{fpage}{seq}"
-
-    @cached_property
-    def alternative_sps_pkg_name_suffix(self):
-        return self.order or self.filename
-
-    @cached_property
-    def journal_acron(self):
-        return Acronym(self.xmltree).text
-
-    def get_pkg_name_prefix(self, suppl):
-        parts = [
-            self.journal_issn_electronic or self.journal_issn_print,
-            self.journal_acron,
-            self.volume,
-            self.number and self.number.zfill(2),
-            suppl,
-        ]
-        return "-".join([part for part in parts if part])
-
-    def get_pkg_name_suffix(self):
-        parts = [
-            self.elocation_id,
-            self.fpage,
-            self.fpage_seq,
-            self.lpage,
-            self.order or self.v2 and self.v2[-5:],
-            self.source_filename,
-        ]
-        if not parts:
-            raise ValueError("Unable to get pkg name suffix. No valid parts found.")
-        return "_".join([part for part in parts if part])
-
-    @cached_property
-    def sps_pkg_name(self):
-        if self.source_ext == ".xml":
-            return self.source_filename
-
-        parts = [
-            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
-            self.get_pkg_name_suffix(),
-        ]
-        return "-".join([part for part in parts if part])
-
-    @cached_property
-    def deprecated_sps_pkg_name_version_2(self):
-        """Problema com o sufixo - número de páginas se repete por erro humano, então usar mais dados para desambiguar"""
-        parts = [
-            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
-            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
-        ]
-        return "-".join([part for part in parts if part])
-
-    @cached_property
-    def deprecated_sps_pkg_name(self):
-        """Tinha defeito na parte referente ao suppl, ausente o 's' antes do número do suplemento"""
-        parts = [
-            self.get_pkg_name_prefix(suppl=self.deprecated_sps_pkg_name_suppl),
-            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
-        ]
-        return "-".join([part for part in parts if part])
-
-    @cached_property
-    def deprecated_sps_pkg_name_list(self):
-        return [
-            self.deprecated_sps_pkg_name,
-            self.deprecated_sps_pkg_name_version_2,
-        ]
-
-    @property
-    def deprecated_sps_pkg_name_suppl(self):
-        suppl = self.suppl
-        if not suppl:
-            return None
-        try:
-            if int(suppl) == 0:
-                return "suppl"
-        except (TypeError, ValueError):
-            pass
-        return suppl
-
-    @property
-    def sps_pkg_name_suppl(self):
-        suppl = self.deprecated_sps_pkg_name_suppl
-        if not suppl or suppl == "suppl":
-            return suppl
-        return f"s{suppl}"
-
-    @cached_property
-    def article_id_parent(self):
-        """
-        Retorna o nó pai dos elementos article-id (v2, v3, aop_pid)
-        """
-        try:
-            return self.xmltree.xpath(".//article-meta")[0]
-        except IndexError:
-            node = self.xmltree.find(".")
-            front = node.find("front")
-            if front is None:
-                front = etree.Element("front")
-                node.append(front)
-            parent = etree.Element("article-meta")
-            front.append(parent)
-            return parent
-
-    def tostring(self, pretty_print=False):
-        return self.xmlpre + etree.tostring(
-            self.xmltree,
-            encoding="utf-8",
-            pretty_print=pretty_print,
-        ).decode("utf-8")
-
-    def update_ids(self, v3, v2, aop_pid):
-        """
-        Atualiza todos os elementos article-id (v2, v3, aop_pid)
-        """
-        self.article_ids.v3 = v3
-        self.article_ids.v2 = v2
-        if aop_pid:
-            self.article_ids.aop_pid = aop_pid
-
-    @cached_property
-    def related_items(self):
-        return RelatedItems(self.xmltree).related_articles
-
-    @cached_property
-    def links(self):
-        # Ha casos de related-article sem href
-        # <related-article id="pr03" related-article-type="press-release" specific-use="processing-only"/>
-        return [item["href"] for item in self.related_items if item.get("href")]
-
-    @property
-    def article_ids(self):
-        return ArticleIds(self.xmltree)
-
-    @property
-    def v3(self):
-        return self.article_ids.v3
-
-    @property
-    def v2(self):
-        return self.article_ids.v2
-
-    @property
-    def aop_pid(self):
-        return self.article_ids.aop_pid
-
-    @property
-    def order(self):
-        return self.article_ids.other
-
-    @order.setter
-    def order(self, value):
-        try:
-            new_value = str(int(value)).zfill(5)
-        except (TypeError, ValueError, AttributeError):
-            new_value = None
-
-        if not new_value or len(new_value) > 5:
-            raise ValueError(
-                "can't set attribute XMLWithPre.order. "
-                "Expected value must a 5 characters digit. Got: %s" % value
-            )
-        try:
-            node = self.xmltree.xpath('.//article-id[@pub-id-type="other"]')[0]
-        except IndexError:
-            node = etree.Element("article-id")
-            node.set("pub-id-type", "other")
-            parent = self.article_id_parent
-            parent.insert(1, node)
-        node.text = new_value
-
-    @v2.setter
-    def v2(self, value):
-        value = value and value.strip()
-        if not value or len(value) != 23:
-            raise ValueError(
-                "can't set attribute XMLWithPre.v2. "
-                "Expected value must have 23 characters. Got: %s" % value
-            )
-        try:
-            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v2"]')[0]
-        except IndexError:
-            node = etree.Element("article-id")
-            node.set("pub-id-type", "publisher-id")
-            node.set("specific-use", "scielo-v2")
-            parent = self.article_id_parent
-            parent.insert(1, node)
-        node.text = value
-
-    @v3.setter
-    def v3(self, value):
-        value = value and value.strip()
-        if not value or len(value) != 23:
-            raise ValueError(
-                "can't set attribute XMLWithPre.v3. "
-                "Expected value must have 23 characters. Got: %s" % value
-            )
-        try:
-            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v3"]')[0]
-        except IndexError:
-            node = etree.Element("article-id")
-            node.set("pub-id-type", "publisher-id")
-            node.set("specific-use", "scielo-v3")
-            parent = self.article_id_parent
-            parent.insert(1, node)
-        node.text = value
-
-    @aop_pid.setter
-    def aop_pid(self, value):
-        value = value and value.strip()
-        if not value or len(value) != 23:
-            raise ValueError(
-                "can't set attribute XMLWithPre.aop_pid. "
-                "Expected value must have 23 characters. Got: %s" % value
-            )
-        try:
-            node = self.xmltree.xpath(
-                './/article-id[@specific-use="previous-pid" and '
-                '@pub-id-type="publisher-id"]'
-            )[0]
-        except IndexError:
-            node = etree.Element("article-id")
-            node.set("pub-id-type", "publisher-id")
-            node.set("specific-use", "previous-pid")
-            parent = self.article_id_parent
-            parent.insert(1, node)
-        node.text = value
-
-    @property
-    def v2_list(self):
-        """
-        Retorna TODOS os PID v2 (article-id[@specific-use="scielo-v2"])
-        presentes no XML, com ou sem `assigning-authority`, como uma
-        lista de dicts:
-
-            [
-                {"assigning-authority": "scielo-scl", "pid": "S0103-65642009000300003"},
-                {"assigning-authority": "scielo-psi", "pid": "S1678-51772009000300003"},
-            ]
-
-        Cenário: um mesmo artigo pode ter mais de um PID v2 quando
-        publicado em mais de uma coleção SciELO, cada um identificado
-        pelo atributo `assigning-authority`:
-
-        <article-id pub-id-type="publisher-id" specific-use="scielo-v2"
-                    assigning-authority="scielo-scl">S0103-65642009000300003</article-id>
-        <article-id pub-id-type="publisher-id" specific-use="scielo-v2"
-                    assigning-authority="scielo-psi">S1678-51772009000300003</article-id>
-
-        Compatibilidade retroativa: XML "clássico", com apenas 1
-        article-id scielo-v2 e sem o atributo `assigning-authority`
-        (formato original, anterior ao suporte a múltiplas coleções),
-        continua funcionando normalmente — é retornado como um único
-        item da lista com "assigning-authority" igual a None. O
-        getter/setter simples `v2` (primeiro nó encontrado) não é
-        afetado por esta propriedade.
-
-        Returns
-        -------
-        list of dict
-        """
-        items = []
-        for node in self.xmltree.xpath('.//article-id[@specific-use="scielo-v2"]'):
-            items.append(
-                {
-                    "assigning-authority": node.get("assigning-authority"),
-                    "pid": node.text,
-                }
-            )
-        return items
-
-    @v2_list.setter
-    def v2_list(self, items):
-        """
-        Recebe uma lista de dicts na mesma estrutura retornada pelo
-        getter `v2_list` (chaves "assigning-authority" e "pid") e
-        atualiza o XML, adicionando ou substituindo o article-id
-        scielo-v2 correspondente a cada `assigning-authority`.
-
-        "assigning-authority" == None representa o PID v2 "clássico"
-        (sem coleção / compatibilidade retroativa).
-
-        Não remove article-id que não estejam presentes em `items`.
-
-        Parameters
-        ----------
-        items : list of dict
-            [{"assigning-authority": str or None, "pid": str}, ...]
-
-        Raises
-        ------
-        ValueError
-        """
-        if not items:
-            return
-        for item in items:
-            item = item or {}
-            self._set_v2_item(item.get("assigning-authority"), item.get("pid"))
-
-    def _set_v2_item(self, assigning_authority, pid):
-        """
-        Adiciona ou atualiza um único article-id scielo-v2,
-        identificado por `assigning_authority` (None == PID v2
-        clássico, sem coleção).
-        """
-        pid = pid and pid.strip()
-        if not pid or len(pid) != 23:
-            raise ValueError(
-                "can't set attribute XMLWithPre.v2_list. "
-                "Expected pid value must have 23 characters. Got: %s" % pid
-            )
-        if assigning_authority:
-            matches = self.xmltree.xpath(
-                './/article-id[@specific-use="scielo-v2" and @assigning-authority=$aa]',
-                aa=assigning_authority,
-            )
-        else:
-            matches = self.xmltree.xpath(
-                './/article-id[@specific-use="scielo-v2" and not(@assigning-authority)]'
-            )
-        try:
-            node = matches[0]
-        except IndexError:
-            node = etree.Element("article-id")
-            node.set("pub-id-type", "publisher-id")
-            node.set("specific-use", "scielo-v2")
-            if assigning_authority:
-                node.set("assigning-authority", assigning_authority)
-            parent = self.article_id_parent
-            existing_article_ids = parent.findall("article-id")
-            if existing_article_ids:
-                # insere após o último article-id já existente, preservando
-                # a ordem de criação quando vários itens são adicionados
-                # em sequência (ex.: via setter v2_list)
-                existing_article_ids[-1].addnext(node)
-            else:
-                parent.insert(0, node)
-        node.text = pid
-
-    @property
-    def v2_prefix(self):
-        return (
-            f"S{self.journal_issn_electronic or self.journal_issn_print}{self.pub_year}"
-        )
-
-    @cached_property
-    def _doi_with_lang(self):
-        return DoiWithLang(self.xmltree)
-
-    @cached_property
-    def article_doi_with_lang(self):
-        # [{"lang": "en", "value": "DOI"}]
-        return self._doi_with_lang.data
-
-    @cached_property
-    def main_doi(self):
-        # [{"lang": "en", "value": "DOI"}]
-        return self._doi_with_lang.main_doi
-
-    @cached_property
-    def main_toc_section(self):
-        """
-        <subj-group subj-group-type="heading">
-            <subject>Articles</subject>
-        </subj-group>
-        """
-        node = self.xmltree.find('.//subj-group[@subj-group-type="heading"]')
-        if node is not None:
-            return node.findtext("./subject")
-
-    @cached_property
-    def issns(self):
-        # [{"type": "epub", "value": "1234-9876"}]
-        return {item["type"]: item["value"] for item in ISSN(self.xmltree).data}
-
-    @cached_property
-    def is_aop(self):
-        if self.volume:
-            return False
-        if self.number:
-            return False
-        return True
-
-    @cached_property
-    def article_meta_issue(self):
-        # artigos podem ser publicados sem estarem associados a um fascículo
-        # Neste caso, não há volume, número, suppl, fpage, fpage_seq, lpage
-        # Mas deve ter ano de publicação em qualquer caso
-        return ArticleMetaIssue(self.xmltree)
-
-    @cached_property
-    def volume(self):
-        return self.article_meta_issue.volume
-
-    @cached_property
-    def number(self):
-        return self.article_meta_issue.number
-
-    @cached_property
-    def suppl(self):
-        return self.article_meta_issue.suppl
-
-    @cached_property
-    def fpage(self):
-        return self.article_meta_issue.fpage
-
-    @cached_property
-    def fpage_seq(self):
-        return self.article_meta_issue.fpage_seq
-
-    @cached_property
-    def lpage(self):
-        return self.article_meta_issue.lpage
-
-    @cached_property
-    def elocation_id(self):
-        return self.article_meta_issue.elocation_id
-
-    @cached_property
-    def pub_year(self):
-        return self.collection_pub_year or self.article_pub_year
-
-    @cached_property
-    def authors(self):
-        names = []
-        collab = None
-
-        contrib_group = self.xmltree.find(".//article-meta//contrib-group")
-        if contrib_group is not None:
-            for item in contrib_group.xpath(".//surname"):
-                content = " ".join(
-                    [
-                        text.strip()
-                        for text in item.xpath(".//text()")
-                        if (text or "").strip()
-                    ]
-                )
-                names.append({"surname": content})
-
-            for item in contrib_group.xpath(".//collab"):
-                content = " ".join(
-                    [
-                        text.strip()
-                        for text in item.xpath(".//text()")
-                        if (text or "").strip()
-                    ]
-                )
-                collab = content
-
-        return {
-            "person": names,
-            "collab": collab,
-        }
-
-    @cached_property
-    def article_titles(self):
-        # list of dict which keys are lang and text
-        xpath = "|".join(
-            [
-                ".//article-meta//article-title",
-                ".//article-meta//trans-title",
-                ".//front-stub//article-title",
-                ".//front-stub//trans-title",
-            ]
-        )
-        titles = []
-        for item in self.xmltree.xpath(xpath):
-            title = " ".join(
-                [
-                    text.strip()
-                    for text in item.xpath(".//text()")
-                    if text and text.strip()
-                ]
-            )
-            titles.append(title)
-        return sorted(titles)
-
-    @cached_property
-    def partial_body(self):
-        try:
-            body = Body(self.xmltree)
-            for text in body.main_body_texts:
-                if (text or "").strip():
-                    return text
-        except AttributeError:
-            pass
-        return None
-
-    @cached_property
-    def collab(self):
-        return self.authors.get("collab")
-
-    @cached_property
-    def journal_title(self):
-        return Title(self.xmltree).journal_title
-
-    @cached_property
-    def journal_issn_print(self):
-        # list of dict which keys are
-        # href, ext-link-type, related-article-type
-        return self.issns.get("ppub")
-
-    @cached_property
-    def journal_issn_electronic(self):
-        # list of dict which keys are
-        # href, ext-link-type, related-article-type
-        return self.issns.get("epub")
-
-    @property
-    def _article_dates(self):
-        return ArticleDates(self.xmltree)
-
-    def get_complete_publication_date(self, default_month=6, default_day=15):
-        try:
-            xml = self._article_dates
-            return xml.article_date_isoformat
-        except Exception as e:
-            pass
-        try:
-            year = month = day = None
-            data = xml.article_date
-            if data:
-                year = data.get("year")
-                month = data.get("month")
-                day = data.get("day")
-            return date(
-                int(year or self.pub_year),
-                int(month or default_month),
-                int(day or default_day),
-            ).isoformat()
-        except (TypeError, KeyError):
-            raise XMLWithPreArticlePublicationDateError(
-                f"Unable to get complete publication date from {data}"
-            )
-
-    @property
-    def article_publication_date(self):
-        try:
-            return self._article_dates.article_date_isoformat
-        except Exception as e:
-            return self.pub_year
-
-    @article_publication_date.setter
-    def article_publication_date(self, value):
-        """
-        value : dict (keys: year, month, day)
-        """
-        try:
-            if isinstance(value, str):
-                parts = value.split("-")
-                value = {
-                    "day": parts[2],
-                    "month": parts[1],
-                    "year": parts[0],
-                }
-            formatted = format_date(**value)
-        except Exception as e:
-            raise XMLWithPreArticlePublicationDateError(
-                f"Unable to set article_publication_date with {value}. Date with valid year, month, day is required"
-            )
-
-        try:
-            node = self.xmltree.xpath(
-                ".//article-meta//pub-date[@date-type='pub' or @pub-type='epub' or @pub-type='epub-ppub']"
-            )[0]
-            if node.get("pub-type") == "epub-ppub":
-                node.set("pub-type", "collection")
-                raise IndexError  # força criar novo nó pub-date (epub)
-        except IndexError:
-            node = etree.Element("pub-date")
-            if self.xmltree.xpath(".//article-meta//pub-date[@pub-type]"):
-                # mais antigo
-                node.set("pub-type", "epub")
-            else:
-                # mais recente
-                node.set("date-type", "pub")
-                node.set("publication-format", "electronic")
-
-            # https://jats.nlm.nih.gov/publishing/tag-library/1.3/element/article-meta.html
-            pub_date_preceding_siblings = (
-                "pub-date",
-                "author-notes",
-                "aff",
-                "contrib-group",
-                "title-group",
-                "article-categories",
-                "article-version-alternatives",
-                "article-version",
-                "article-id",
-            )
-            articlemeta_node = self.xmltree.find(".//article-meta")
-            added = False
-            for sibling_name in pub_date_preceding_siblings:
-                try:
-                    articlemeta_node.find(sibling_name).addnext(node)
-                    added = True
-                    break
-                except AttributeError:
-                    continue
-            if not added:
-                pub_date_following_siblings = (
-                    "volume",
-                    "volume-id",
-                    "volume-series",
-                    "issue",
-                    "issue-id",
-                    "issue-title",
-                    "issue-title-group",
-                    "issue-sponsor",
-                    "issue-part",
-                    "volume-issue-group",
-                    "isbn",
-                    "supplement",
-                    "fpage",
-                    "lpage",
-                    "page-range",
-                    "elocation-id",
-                    "email",
-                    "ext-link",
-                    "uri",
-                    "product",
-                    "supplementary-material",
-                    "history",
-                    "pub-history",
-                    "permissions",
-                    "self-uri",
-                    "related-article",
-                    "related-object",
-                    "abstract",
-                    "trans-abstract",
-                    "kwd-group",
-                    "funding-group",
-                    "support-group",
-                    "conference",
-                    "counts",
-                    "custom-meta-group",
-                )
-                articlemeta_node = self.xmltree.find(".//article-meta")
-                for sibling_name in pub_date_following_siblings:
-                    try:
-                        articlemeta_node.find(sibling_name).addprevious(node)
-                        added = True
-                        break
-                    except AttributeError:
-                        continue
-            if not added:
-                articlemeta_node.append(node)
-        previous = None
-        for name, val in zip(("day", "month", "year"), reversed(formatted.split("-"))):
-            elem = node.find(name)
-            if elem is None:
-                elem = etree.Element(name)
-                if previous is None:
-                    node.insert(0, elem)
-                else:
-                    previous.addnext(elem)
-            elem.text = val
-            previous = elem
-
-    @property
-    def article_pub_year(self):
-        return self._article_dates.article_year
-
-    @cached_property
-    def collection_pub_year(self):
-        return self._article_dates.collection_year
-
-    @cached_property
-    def article_titles_texts(self):
-        return self.article_titles
-
-    def get_body_fragment(self, max_length):
-        # obtém qualquer texto do corpo do artigo, removendo espaços extras e limitando o tamanho
-        # não é recomendável filtrar por p ou outro subelemento específico,
-        # pois se a estrutura do XML mudar impactará no retorno do método
-        text = " ".join(
-            " ".join(
-                self.xmltree.xpath(".//body//text()")
-            ).split())
-        if max_length:
-            return text[:max_length].lower()
-        return text.lower()
-
-    @property
-    def body_fragment_fingerprint(self):
-        # gera um novo fingerprint do XML, para ser usado na comparação com o fingerprint registrado
-        return generate_finger_print(self.get_body_fragment(300))
-
-    @property
-    def finger_print(self):
-        if self.xmltree.xpath(".//comment()"):
-            for item in XMLWithPre.create(
-                xml_content=self.tostring(pretty_print=self.pretty_print)
-            ):
-                remove_comments(item.xmltree)
-                return generate_finger_print(item.tostring(pretty_print=True))
-        else:
-            return generate_finger_print(self.tostring(pretty_print=self.pretty_print))
-
-    @cached_property
-    def _article_and_subarticles(self):
-        return ArticleAndSubArticles(self.xmltree)
-
-    @cached_property
-    def main_lang(self):
-        return self._article_and_subarticles.main_lang
-
-    @cached_property
-    def langs(self):
-        for item in self._article_and_subarticles.data:
-            yield item["lang"]
-
+    # --------------------------------------------------------------------------
+    # Componentes, Assets e Renditions
+    # --------------------------------------------------------------------------
     @property
     def components(self):
         _components = {}
@@ -1340,6 +511,311 @@ class XMLWithPre:
                 "component_type": "rendition",
                 "main": item.is_main_language,
             }
+
+
+# ==============================================================================
+# 3. NOMEAÇÃO DO PACOTE SCIELO (SPS PKG NAME)
+# ==============================================================================
+class PackageNamingMixin:
+    """Regras de montagem do sps_pkg_name e suas variações históricas/deprecated."""
+
+    @cached_property
+    def sps_pkg_name_suffix(self):
+        if self.elocation_id:
+            return self.elocation_id
+        if self.sps_pkg_name_fpage:
+            return self.sps_pkg_name_fpage
+        if self.main_doi:
+            doi = self.main_doi
+            if "/" in doi:
+                doi = doi[doi.rfind("/") + 1 :]
+            return doi.replace(".", "-")
+
+    @cached_property
+    def sps_pkg_name_fpage(self):
+        fpage = fix_number(self.fpage)
+        if not fpage:
+            return None
+        seq = self.fpage_seq
+        if not seq:
+            if self.lpage == fpage:
+                seq = self.v2 and self.v2[-5:]
+        if seq:
+            return f"{fpage}_{seq}"
+        return fpage
+
+    @cached_property
+    def deprecated_sps_pkg_name_fpage(self):
+        fpage = fix_number(self.fpage)
+        if not fpage:
+            return None
+        seq = self.fpage_seq or ""
+        return f"{fpage}{seq}"
+
+    @cached_property
+    def alternative_sps_pkg_name_suffix(self):
+        return self.order or self.filename
+
+    def get_pkg_name_prefix(self, suppl):
+        parts = [
+            self.journal_issn_electronic or self.journal_issn_print,
+            self.journal_acron,
+            self.volume,
+            self.number and self.number.zfill(2),
+            suppl,
+        ]
+        return "-".join([part for part in parts if part])
+
+    def get_pkg_name_suffix(self):
+        parts = [
+            self.elocation_id,
+            self.fpage,
+            self.fpage_seq,
+            self.lpage,
+            self.order or (self.v2 and self.v2[-5:]),
+            self.source_filename,
+        ]
+        if not parts:
+            raise ValueError("Unable to get pkg name suffix. No valid parts found.")
+        return "_".join([part for part in parts if part])
+
+    @cached_property
+    def sps_pkg_name(self):
+        if self.source_ext == ".xml":
+            return self.source_filename
+
+        parts = [
+            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
+            self.get_pkg_name_suffix(),
+        ]
+        return "-".join([part for part in parts if part])
+
+    @cached_property
+    def deprecated_sps_pkg_name_version_2(self):
+        """Problema com o sufixo - número de páginas se repete por erro humano, usar mais dados para desambiguar."""
+        parts = [
+            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
+            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
+        ]
+        return "-".join([part for part in parts if part])
+
+    @cached_property
+    def deprecated_sps_pkg_name(self):
+        """Tinha defeito na parte referente ao suppl (ausente o 's' antes do número)."""
+        parts = [
+            self.get_pkg_name_prefix(suppl=self.deprecated_sps_pkg_name_suppl),
+            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
+        ]
+        return "-".join([part for part in parts if part])
+
+    @cached_property
+    def deprecated_sps_pkg_name_list(self):
+        return [
+            self.deprecated_sps_pkg_name,
+            self.deprecated_sps_pkg_name_version_2,
+        ]
+
+    @property
+    def deprecated_sps_pkg_name_suppl(self):
+        suppl = self.suppl
+        if not suppl:
+            return None
+        try:
+            if int(suppl) == 0:
+                return "suppl"
+        except (TypeError, ValueError):
+            pass
+        return suppl
+
+    @property
+    def sps_pkg_name_suppl(self):
+        suppl = self.deprecated_sps_pkg_name_suppl
+        if not suppl or suppl == "suppl":
+            return suppl
+        return f"s{suppl}"
+
+
+# ==============================================================================
+# 4. IDENTIFICADORES (PIDs: v2, v3, aop_pid, order)
+# ==============================================================================
+class IdentifiersMixin:
+    """Manipulação e geração de IDs SciELO (article-id)."""
+
+    @cached_property
+    def article_id_parent(self):
+        """Retorna o nó pai dos elementos article-id."""
+        try:
+            return self.xmltree.xpath(".//article-meta")[0]
+        except IndexError:
+            node = self.xmltree.find(".")
+            front = node.find("front")
+            if front is None:
+                front = etree.Element("front")
+                node.append(front)
+            parent = etree.Element("article-meta")
+            front.append(parent)
+            return parent
+
+    @property
+    def article_ids(self):
+        return ArticleIds(self.xmltree)
+
+    @property
+    def v3(self):
+        return self.article_ids.v3
+
+    @v3.setter
+    def v3(self, value):
+        value = value and value.strip()
+        if not value or len(value) != 23:
+            raise ValueError(
+                f"can't set attribute XMLWithPre.v3. Expected value must have 23 characters. Got: {value}"
+            )
+        try:
+            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v3"]')[0]
+        except IndexError:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "publisher-id")
+            node.set("specific-use", "scielo-v3")
+            parent = self.article_id_parent
+            parent.insert(1, node)
+        node.text = value
+
+    @property
+    def v2(self):
+        return self.article_ids.v2
+
+    @v2.setter
+    def v2(self, value):
+        value = value and value.strip()
+        if not value or len(value) != 23:
+            raise ValueError(
+                f"can't set attribute XMLWithPre.v2. Expected value must have 23 characters. Got: {value}"
+            )
+        try:
+            node = self.xmltree.xpath('.//article-id[@specific-use="scielo-v2"]')[0]
+        except IndexError:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "publisher-id")
+            node.set("specific-use", "scielo-v2")
+            parent = self.article_id_parent
+            parent.insert(1, node)
+        node.text = value
+
+    @property
+    def aop_pid(self):
+        return self.article_ids.aop_pid
+
+    @aop_pid.setter
+    def aop_pid(self, value):
+        value = value and value.strip()
+        if not value or len(value) != 23:
+            raise ValueError(
+                f"can't set attribute XMLWithPre.aop_pid. Expected value must have 23 characters. Got: {value}"
+            )
+        try:
+            node = self.xmltree.xpath(
+                './/article-id[@specific-use="previous-pid" and @pub-id-type="publisher-id"]'
+            )[0]
+        except IndexError:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "publisher-id")
+            node.set("specific-use", "previous-pid")
+            parent = self.article_id_parent
+            parent.insert(1, node)
+        node.text = value
+
+    @property
+    def order(self):
+        return self.article_ids.other
+
+    @order.setter
+    def order(self, value):
+        try:
+            new_value = str(int(value)).zfill(5)
+        except (TypeError, ValueError, AttributeError):
+            new_value = None
+
+        if not new_value or len(new_value) > 5:
+            raise ValueError(
+                f"can't set attribute XMLWithPre.order. Expected value must a 5 characters digit. Got: {value}"
+            )
+        try:
+            node = self.xmltree.xpath('.//article-id[@pub-id-type="other"]')[0]
+        except IndexError:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "other")
+            parent = self.article_id_parent
+            parent.insert(1, node)
+        node.text = new_value
+
+    def update_ids(self, v3, v2, aop_pid):
+        """Atualiza todos os elementos article-id (v2, v3, aop_pid)."""
+        self.article_ids.v3 = v3
+        self.article_ids.v2 = v2
+        if aop_pid:
+            self.article_ids.aop_pid = aop_pid
+
+    # --------------------------------------------------------------------------
+    # Suporte a Múltiplos PIDs v2 (v2_list)
+    # --------------------------------------------------------------------------
+    @property
+    def v2_list(self):
+        items = []
+        for node in self.xmltree.xpath('.//article-id[@specific-use="scielo-v2"]'):
+            items.append(
+                {
+                    "assigning-authority": node.get("assigning-authority"),
+                    "pid": node.text,
+                }
+            )
+        return items
+
+    @v2_list.setter
+    def v2_list(self, items):
+        if not items:
+            return
+        for item in items:
+            item = item or {}
+            self._set_v2_item(item.get("assigning-authority"), item.get("pid"))
+
+    def _set_v2_item(self, assigning_authority, pid):
+        pid = pid and pid.strip()
+        if not pid or len(pid) != 23:
+            raise ValueError(
+                f"can't set attribute XMLWithPre.v2_list. Expected pid value must have 23 characters. Got: {pid}"
+            )
+        if assigning_authority:
+            matches = self.xmltree.xpath(
+                './/article-id[@specific-use="scielo-v2" and @assigning-authority=$aa]',
+                aa=assigning_authority,
+            )
+        else:
+            matches = self.xmltree.xpath(
+                './/article-id[@specific-use="scielo-v2" and not(@assigning-authority)]'
+            )
+        try:
+            node = matches[0]
+        except IndexError:
+            node = etree.Element("article-id")
+            node.set("pub-id-type", "publisher-id")
+            node.set("specific-use", "scielo-v2")
+            if assigning_authority:
+                node.set("assigning-authority", assigning_authority)
+            parent = self.article_id_parent
+            existing_article_ids = parent.findall("article-id")
+            if existing_article_ids:
+                existing_article_ids[-1].addnext(node)
+            else:
+                parent.insert(0, node)
+        node.text = pid
+
+    # --------------------------------------------------------------------------
+    # Algoritmo de Geração Dinâmica de PID v2
+    # --------------------------------------------------------------------------
+    @property
+    def v2_prefix(self):
+        return f"S{self.journal_issn_electronic or self.journal_issn_print}{self.pub_year}"
 
     def get_article_pid_suffix(self):
         return self.elocation_id or self.fpage or self.order or ""
@@ -1390,6 +866,442 @@ class XMLWithPre:
             return pid_v2
         raise ValueError(f"Unable to generate pid v2: {parts} {pid_v2}")
 
+
+# ==============================================================================
+# 5. METADADOS DO ARTIGO (Datas, Títulos, Autores, Corpo, Periódico)
+# ==============================================================================
+class ArticleMetadataMixin:
+    """Extração e manipulação de metadados do artigo JATS."""
+
+    # --------------------------------------------------------------------------
+    # Periódico & Seções
+    # --------------------------------------------------------------------------
+    @cached_property
+    def journal_acron(self):
+        return Acronym(self.xmltree).text
+
+    @cached_property
+    def journal_title(self):
+        return Title(self.xmltree).journal_title
+
+    @cached_property
+    def issns(self):
+        return {item["type"]: item["value"] for item in ISSN(self.xmltree).data}
+
+    @cached_property
+    def journal_issn_print(self):
+        return self.issns.get("ppub")
+
+    @cached_property
+    def journal_issn_electronic(self):
+        return self.issns.get("epub")
+
+    @cached_property
+    def main_toc_section(self):
+        node = self.xmltree.find('.//subj-group[@subj-group-type="heading"]')
+        if node is not None:
+            return node.findtext("./subject")
+
+    # --------------------------------------------------------------------------
+    # Fascículo / Edição
+    # --------------------------------------------------------------------------
+    @cached_property
+    def article_meta_issue(self):
+        return ArticleMetaIssue(self.xmltree)
+
+    @cached_property
+    def is_aop(self):
+        return not (self.volume or self.number)
+
+    @cached_property
+    def volume(self):
+        return self.article_meta_issue.volume
+
+    @cached_property
+    def number(self):
+        return self.article_meta_issue.number
+
+    @cached_property
+    def suppl(self):
+        return self.article_meta_issue.suppl
+
+    @cached_property
+    def fpage(self):
+        return self.article_meta_issue.fpage
+
+    @cached_property
+    def fpage_seq(self):
+        return self.article_meta_issue.fpage_seq
+
+    @cached_property
+    def lpage(self):
+        return self.article_meta_issue.lpage
+
+    @cached_property
+    def elocation_id(self):
+        return self.article_meta_issue.elocation_id
+
+    # --------------------------------------------------------------------------
+    # Datas de Publicação
+    # --------------------------------------------------------------------------
+    @property
+    def _article_dates(self):
+        return ArticleDates(self.xmltree)
+
+    @cached_property
+    def pub_year(self):
+        return self.collection_pub_year or self.article_pub_year
+
+    @property
+    def article_pub_year(self):
+        return self._article_dates.article_year
+
+    @cached_property
+    def collection_pub_year(self):
+        return self._article_dates.collection_year
+
+    @property
+    def article_publication_date(self):
+        try:
+            return self._article_dates.article_date_isoformat
+        except Exception:
+            return self.pub_year
+
+    @article_publication_date.setter
+    def article_publication_date(self, value):
+        try:
+            if isinstance(value, str):
+                parts = value.split("-")
+                value = {"day": parts[2], "month": parts[1], "year": parts[0]}
+            formatted = format_date(**value)
+        except Exception:
+            raise XMLWithPreArticlePublicationDateError(
+                f"Unable to set article_publication_date with {value}. Date with valid year, month, day is required"
+            )
+
+        try:
+            node = self.xmltree.xpath(
+                ".//article-meta//pub-date[@date-type='pub' or @pub-type='epub' or @pub-type='epub-ppub']"
+            )[0]
+            if node.get("pub-type") == "epub-ppub":
+                node.set("pub-type", "collection")
+                raise IndexError
+        except IndexError:
+            node = etree.Element("pub-date")
+            if self.xmltree.xpath(".//article-meta//pub-date[@pub-type]"):
+                node.set("pub-type", "epub")
+            else:
+                node.set("date-type", "pub")
+                node.set("publication-format", "electronic")
+
+            pub_date_preceding_siblings = (
+                "pub-date", "author-notes", "aff", "contrib-group",
+                "title-group", "article-categories", "article-version-alternatives",
+                "article-version", "article-id",
+            )
+            articlemeta_node = self.xmltree.find(".//article-meta")
+            added = False
+            for sibling_name in pub_date_preceding_siblings:
+                try:
+                    articlemeta_node.find(sibling_name).addnext(node)
+                    added = True
+                    break
+                except AttributeError:
+                    continue
+            if not added:
+                pub_date_following_siblings = (
+                    "volume", "volume-id", "volume-series", "issue", "issue-id",
+                    "issue-title", "issue-title-group", "issue-sponsor", "issue-part",
+                    "volume-issue-group", "isbn", "supplement", "fpage", "lpage",
+                    "page-range", "elocation-id", "email", "ext-link", "uri",
+                    "product", "supplementary-material", "history", "pub-history",
+                    "permissions", "self-uri", "related-article", "related-object",
+                    "abstract", "trans-abstract", "kwd-group", "funding-group",
+                    "support-group", "conference", "counts", "custom-meta-group",
+                )
+                for sibling_name in pub_date_following_siblings:
+                    try:
+                        articlemeta_node.find(sibling_name).addprevious(node)
+                        added = True
+                        break
+                    except AttributeError:
+                        continue
+            if not added:
+                articlemeta_node.append(node)
+
+        previous = None
+        for name, val in zip(("day", "month", "year"), reversed(formatted.split("-"))):
+            elem = node.find(name)
+            if elem is None:
+                elem = etree.Element(name)
+                if previous is None:
+                    node.insert(0, elem)
+                else:
+                    previous.addnext(elem)
+            elem.text = val
+            previous = elem
+
+    def get_complete_publication_date(self, default_month=6, default_day=15):
+        try:
+            return self._article_dates.article_date_isoformat
+        except Exception:
+            pass
+        try:
+            year = month = day = None
+            data = self._article_dates.article_date
+            if data:
+                year = data.get("year")
+                month = data.get("month")
+                day = data.get("day")
+            return date(
+                int(year or self.pub_year),
+                int(month or default_month),
+                int(day or default_day),
+            ).isoformat()
+        except (TypeError, KeyError):
+            raise XMLWithPreArticlePublicationDateError(
+                f"Unable to get complete publication date from {data}"
+            )
+
+    # --------------------------------------------------------------------------
+    # Autores, Títulos e Conteúdo do Artigo
+    # --------------------------------------------------------------------------
+    @cached_property
+    def authors(self):
+        names = []
+        collab = None
+
+        contrib_group = self.xmltree.find(".//article-meta//contrib-group")
+        if contrib_group is not None:
+            for item in contrib_group.xpath(".//surname"):
+                content = " ".join(
+                    [
+                        text.strip()
+                        for text in item.xpath(".//text()")
+                        if (text or "").strip()
+                    ]
+                )
+                names.append({"surname": content})
+
+            for item in contrib_group.xpath(".//collab"):
+                content = " ".join(
+                    [
+                        text.strip()
+                        for text in item.xpath(".//text()")
+                        if (text or "").strip()
+                    ]
+                )
+                collab = content
+
+        return {"person": names, "collab": collab}
+
+    @cached_property
+    def collab(self):
+        return self.authors.get("collab")
+
+    @cached_property
+    def article_titles(self):
+        xpath = "|".join([
+            ".//article-meta//article-title",
+            ".//article-meta//trans-title",
+            ".//front-stub//article-title",
+            ".//front-stub//trans-title",
+        ])
+        titles = []
+        for item in self.xmltree.xpath(xpath):
+            title = " ".join(
+                [text.strip() for text in item.xpath(".//text()") if text and text.strip()]
+            )
+            titles.append(title)
+        return sorted(titles)
+
+    @cached_property
+    def article_titles_texts(self):
+        return self.article_titles
+
+    @cached_property
+    def partial_body(self):
+        try:
+            body = Body(self.xmltree)
+            for text in body.main_body_texts:
+                if (text or "").strip():
+                    return text
+        except AttributeError:
+            pass
+        return None
+
+    def get_body_fragment(self, max_length):
+        text = " ".join(" ".join(self.xmltree.xpath(".//body//text()")).split())
+        if max_length:
+            return text[:max_length].lower()
+        return text.lower()
+
+    @property
+    def body_fragment_fingerprint(self):
+        return generate_finger_print(self.get_body_fragment(300))
+
+    def get_article_data(self, max_body_fragment_length=300):
+        try:
+            persons = self.authors.get("person") or []
+            surnames = [p.get("surname") for p in persons if p.get("surname")]
+        except Exception:
+            surnames = []
+        return {
+            "surnames": surnames,
+            "collab": self.collab,
+            "links": self.links,
+            "article_titles": self.article_titles_texts,
+            "partial_body": self.partial_body,
+            "body_fragment": self.get_body_fragment(max_body_fragment_length),
+        }
+
+    # --------------------------------------------------------------------------
+    # Idiomas, DOIs e Relacionamentos
+    # --------------------------------------------------------------------------
+    @cached_property
+    def _article_and_subarticles(self):
+        return ArticleAndSubArticles(self.xmltree)
+
+    @cached_property
+    def main_lang(self):
+        return self._article_and_subarticles.main_lang
+
+    @cached_property
+    def langs(self):
+        for item in self._article_and_subarticles.data:
+            yield item["lang"]
+
+    @cached_property
+    def _doi_with_lang(self):
+        return DoiWithLang(self.xmltree)
+
+    @cached_property
+    def article_doi_with_lang(self):
+        return self._doi_with_lang.data
+
+    @cached_property
+    def main_doi(self):
+        return self._doi_with_lang.main_doi
+
+    @cached_property
+    def related_items(self):
+        return RelatedItems(self.xmltree).related_articles
+
+    @cached_property
+    def links(self):
+        return [item["href"] for item in self.related_items if item.get("href")]
+
+
+# ==============================================================================
+# 6. CLASSE PRINCIPAL: XMLWithPre
+# ==============================================================================
+class XMLWithPre(
+    DOCTYPEParserMixin,
+    PackagingAndFilesMixin,
+    PackageNamingMixin,
+    IdentifiersMixin,
+    ArticleMetadataMixin,
+):
+    """Preserva o texto anterior ao elemento `root` e agrupa a manipulação do XML SciELO."""
+
+    def __init__(self, xmlpre, xmltree, pretty_print=True):
+        self.xmltree = xmltree
+        self.xmlpre = xmlpre or ""
+
+        # DOCTYPE
+        self.DOCTYPE = None
+        self.public_id = None
+        self.system_id = None
+        if self.xmlpre and "<!DOCTYPE" in self.xmlpre:
+            self.parse_doctype()
+
+        # Atributos gerais
+        self.pretty_print = pretty_print
+        self.uri = None
+        self.zip_file_path = None
+        self.xml_file_path = None
+        self.relative_system_id = None
+        self._sps_version = None
+        self.errors = None
+        self.pkg_name_version = None
+
+        # Atributos de arquivo
+        self.xml_name = None
+        self.zip_basenames = None
+        self.zip_namelist = None
+        self.submitted_filename = None
+        self.submitted_ext = None
+
+    # --------------------------------------------------------------------------
+    # Construtores & Serializadores
+    # --------------------------------------------------------------------------
+    @classmethod
+    def create(
+        cls, path=None, uri=None, xml_content=None, capture_errors=False, timeout=30
+    ):
+        """Retorna gerador de instâncias de XMLWithPre."""
+        if path:
+            errors = []
+            xml_with_pre = None
+            for item in get_xml_items(path):
+                if not item:
+                    continue
+                try:
+                    xml_with_pre = item["xml_with_pre"]
+                    yield xml_with_pre
+                except KeyError:
+                    errors.append(item)
+            if not xml_with_pre or errors:
+                raise GetXmlWithPreError(f"Unable to get xml with pre {errors}")
+        if xml_content:
+            yield get_xml_with_pre(xml_content)
+            return
+        if uri:
+            yield get_xml_with_pre_from_uri(uri, timeout)
+            return
+
+    def tostring(self, pretty_print=False):
+        return self.xmlpre + etree.tostring(
+            self.xmltree,
+            encoding="utf-8",
+            pretty_print=pretty_print,
+        ).decode("utf-8")
+
+    @cached_property
+    def sps_version(self):
+        try:
+            return self.xmltree.find(".").get("specific-use")
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    @property
+    def finger_print(self):
+        if self.xmltree.xpath(".//comment()"):
+            for item in XMLWithPre.create(
+                xml_content=self.tostring(pretty_print=self.pretty_print)
+            ):
+                remove_comments(item.xmltree)
+                return generate_finger_print(item.tostring(pretty_print=True))
+        else:
+            return generate_finger_print(self.tostring(pretty_print=self.pretty_print))
+
+    @property
+    def data(self):
+        return dict(
+            sps_pkg_name=self.sps_pkg_name,
+            pid_v3=self.v3,
+            pid_v2=self.v2,
+            aop_pid=self.aop_pid,
+            submitted_filename=self.submitted_filename,
+            submitted_ext=self.submitted_ext,
+            xml_name=self.xml_name,
+            zip_namelist=self.zip_namelist,
+            zip_basenames=self.zip_basenames,
+            filename=self.filename,
+            files=self.files,
+            filenames=self.filenames,
+            pkg_names=self.deprecated_sps_pkg_name_list,
+        )
 
 def string_to_5_digits(input_string):
     return str((crc32(input_string.encode()) & 0xFFFFFFFF) % 100000)

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -382,6 +382,8 @@ class XMLWithPre:
         self.xml_name = None # nome original encontrado no xml ou no zip
         self.zip_basenames = None # nome original encontrado no xml ou no zip, exceto xml
         self.zip_namelist = None # nome original encontrado no xml ou no zip, exceto xml
+        self.submitted_filename = None
+        self.submitted_ext = None
 
     @property
     def filename(self):
@@ -407,6 +409,22 @@ class XMLWithPre:
     def filenames(self, value):
         self.zip_basenames = value
 
+    @property
+    def source_filename(self):
+        return self.submitted_filename
+
+    @source_filename.setter
+    def source_filename(self, value):
+        self.submitted_filename = value
+
+    @property
+    def source_ext(self):
+        return self.submitted_ext
+
+    @source_ext.setter
+    def source_ext(self, value):
+        self.submitted_ext = value
+
     def add_xml_info(self, xml_name, xml_file_path=None):
         self.xml_name = xml_name
         self.xml_file_path = xml_file_path
@@ -418,7 +436,7 @@ class XMLWithPre:
 
     def add_pkg_name_components(self, source_filename, pkg_name_version=3):
         self.pkg_name_version = pkg_name_version
-        self.submitted_file = source_filename
+        self.submitted_filename, self.submitted_ext = os.path.splitext(source_filename)
 
     @property
     def data(self):
@@ -427,6 +445,11 @@ class XMLWithPre:
             pid_v3=self.v3,
             pid_v2=self.v2,
             aop_pid=self.aop_pid,
+            submitted_filename=self.submitted_filename,
+            submitted_ext=self.submitted_ext,
+            xml_name=self.xml_name,
+            zip_namelist=self.zip_namelist,
+            zip_basenames=self.zip_basenames,
             filename=self.filename,
             files=self.files,
             filenames=self.filenames,

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import re
 import traceback
 from datetime import date
 from functools import cached_property
@@ -33,6 +34,9 @@ from packtools.sps.pid_provider.models.related_articles import RelatedItems
 
 LOGGER = logging.getLogger(__name__)
 LOGGER_FMT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+class XMLWithPreMissingISSNError(Exception): ...
 
 
 class GetXmlWithPreError(Exception): ...
@@ -425,7 +429,7 @@ class PackagingAndFilesMixin:
 
     @property
     def source_filename(self):
-        return self.submitted_filename
+        return self._submitted_filename
 
     @source_filename.setter
     def source_filename(self, value):
@@ -433,11 +437,35 @@ class PackagingAndFilesMixin:
 
     @property
     def source_ext(self):
-        return self.submitted_ext
+        return self._submitted_ext
 
     @source_ext.setter
     def source_ext(self, value):
-        self.submitted_ext = value
+        self._submitted_ext = value
+
+    @property
+    def submitted_filename(self) -> str:
+        if self._submitted_filename:
+            return f"{self._submitted_filename}{self._submitted_ext}"
+
+    @submitted_filename.setter
+    def submitted_filename(self, value: str):
+        """Atribui o nome submetido e extrai/separa a extensão automaticamente."""
+        if not value:
+            self._submitted_filename = None
+            self._submitted_ext = None
+            return
+
+        self._submitted_filename, ext = os.path.splitext(value)
+        if ext:
+            self._submitted_ext = ext.lower()
+        self.is_html_source = bool(self.is_html_source or self.submitted_ext in [".html", ".htm"])
+
+    @property
+    def submitted_ext(self) -> str:
+        """Extensão do arquivo submetido (ex: '.html', '.xml')."""
+        if self._submitted_ext:
+            return self._submitted_ext
 
     # --------------------------------------------------------------------------
     # Métodos Mutadores de Informações do Pacote
@@ -453,7 +481,9 @@ class PackagingAndFilesMixin:
 
     def add_pkg_name_components(self, source_filename, pkg_name_version=3):
         self.pkg_name_version = pkg_name_version
-        self.submitted_filename, self.submitted_ext = os.path.splitext(source_filename)
+        self.submitted_filename = source_filename
+        if source_filename and source_filename.endswith(".xml"):
+            self.provided_sps_pkg_name = source_filename[:-4]  # Remove .xml extension
 
     def get_zip_content(self, xml_filename, pretty_print=False):
         zip_content = None
@@ -514,17 +544,17 @@ class PackagingAndFilesMixin:
 
 
 # ==============================================================================
-# 3. NOMEAÇÃO DO PACOTE SCIELO (SPS PKG NAME)
+# 3. NOMEAÇÃO DO PACOTE
 # ==============================================================================
-class PackageNamingMixin:
+class LegacyPackageNamingMixin:
     """Regras de montagem do sps_pkg_name e suas variações históricas/deprecated."""
 
     @cached_property
-    def sps_pkg_name_suffix(self):
+    def legacy_sps_pkg_name_suffix(self):
         if self.elocation_id:
             return self.elocation_id
-        if self.sps_pkg_name_fpage:
-            return self.sps_pkg_name_fpage
+        if self.legacy_sps_pkg_name_fpage:
+            return self.legacy_sps_pkg_name_fpage
         if self.main_doi:
             doi = self.main_doi
             if "/" in doi:
@@ -532,7 +562,7 @@ class PackageNamingMixin:
             return doi.replace(".", "-")
 
     @cached_property
-    def sps_pkg_name_fpage(self):
+    def legacy_sps_pkg_name_fpage(self):
         fpage = fix_number(self.fpage)
         if not fpage:
             return None
@@ -553,10 +583,10 @@ class PackageNamingMixin:
         return f"{fpage}{seq}"
 
     @cached_property
-    def alternative_sps_pkg_name_suffix(self):
+    def legacy_alternative_sps_pkg_name_suffix(self):
         return self.order or self.filename
 
-    def get_pkg_name_prefix(self, suppl):
+    def legacy_get_pkg_name_prefix(self, suppl):
         parts = [
             self.journal_issn_electronic or self.journal_issn_print,
             self.journal_acron,
@@ -566,7 +596,7 @@ class PackageNamingMixin:
         ]
         return "-".join([part for part in parts if part])
 
-    def get_pkg_name_suffix(self):
+    def legacy_get_pkg_name_suffix(self):
         parts = [
             self.elocation_id,
             self.fpage,
@@ -580,13 +610,14 @@ class PackageNamingMixin:
         return "_".join([part for part in parts if part])
 
     @cached_property
-    def sps_pkg_name(self):
+    def deprecated_sps_pkg_name_version_3(self):
+        """Nome ficou muito diferente do que guia sps requer"""               
         if self.source_ext == ".xml":
             return self.source_filename
 
         parts = [
-            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
-            self.get_pkg_name_suffix(),
+            self.legacy_get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
+            self.legacy_get_pkg_name_suffix(),
         ]
         return "-".join([part for part in parts if part])
 
@@ -594,8 +625,8 @@ class PackageNamingMixin:
     def deprecated_sps_pkg_name_version_2(self):
         """Problema com o sufixo - número de páginas se repete por erro humano, usar mais dados para desambiguar."""
         parts = [
-            self.get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
-            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
+            self.legacy_get_pkg_name_prefix(suppl=self.sps_pkg_name_suppl),
+            self.legacy_sps_pkg_name_suffix or self.legacy_alternative_sps_pkg_name_suffix,
         ]
         return "-".join([part for part in parts if part])
 
@@ -603,8 +634,8 @@ class PackageNamingMixin:
     def deprecated_sps_pkg_name(self):
         """Tinha defeito na parte referente ao suppl (ausente o 's' antes do número)."""
         parts = [
-            self.get_pkg_name_prefix(suppl=self.deprecated_sps_pkg_name_suppl),
-            self.sps_pkg_name_suffix or self.alternative_sps_pkg_name_suffix,
+            self.legacy_get_pkg_name_prefix(suppl=self.incorrect_sps_pkg_name_suppl),
+            self.legacy_sps_pkg_name_suffix or self.legacy_alternative_sps_pkg_name_suffix,
         ]
         return "-".join([part for part in parts if part])
 
@@ -613,10 +644,11 @@ class PackageNamingMixin:
         return [
             self.deprecated_sps_pkg_name,
             self.deprecated_sps_pkg_name_version_2,
+            self.deprecated_sps_pkg_name_version_3,
         ]
 
     @property
-    def deprecated_sps_pkg_name_suppl(self):
+    def incorrect_sps_pkg_name_suppl(self):
         suppl = self.suppl
         if not suppl:
             return None
@@ -629,10 +661,347 @@ class PackageNamingMixin:
 
     @property
     def sps_pkg_name_suppl(self):
-        suppl = self.deprecated_sps_pkg_name_suppl
+        suppl = self.incorrect_sps_pkg_name_suppl
         if not suppl or suppl == "suppl":
             return suppl
         return f"s{suppl}"
+
+
+class PackageNamingMixin:
+    """
+    Mixin para gerenciamento transparente e desacoplado da nomenclatura de pacotes.
+    """
+    # -------------------------------------------------------------------------
+    # HIGIENIZAÇÃO SPS ESTREITA
+    # -------------------------------------------------------------------------
+    def get_fpage_for_pkg_name_suffix(self):
+        """
+        xml nativo: fpage pode ser usada para desambiguar, pois forma o nome do pacote,
+        html: fpage não é confiável, pois o order ou o submitted_file são usados no nome do pacote,
+        fpage pode gerar ambiguidade
+        """
+        if not self.fpage:
+            return None
+        if not self.order:
+            return None
+        order = str(int(self.order))
+        if order == self.fpage:
+            return self.fpage
+        return self.order
+
+    def get_fpage_suffix(self) -> str:
+        """
+        Calcula o sufixo de paginação combinando fpage + fpage_seq SEM separador.
+        Retorna None se for detectado fpage 'fake'.
+        Exemplo válido: fpage='365', fpage_seq='a' -> '365a'
+        """
+        fpage = self.get_fpage_for_pkg_name_suffix()
+        if not fpage:
+            return None
+
+        seq = self.fpage_seq or ""
+        return f"{fpage}{seq}"
+
+    def get_page_suffix(self) -> str:
+        """
+        Calcula o sufixo de paginação combinando fpage + fpage_seq SEM separador.
+        Retorna None se for detectado fpage 'fake'.
+        Exemplo válido: fpage='365', fpage_seq='a' -> '365a'
+        """
+        fpage = self.get_fpage_for_pkg_name_suffix()
+        if not fpage:
+            return None
+
+        seq = self.fpage_seq or ""
+        lpage = self.lpage and f"-{self.lpage}" or ""
+        return f"{fpage}{seq}{lpage}"
+
+    def get_main_doi_for_pkg_name_suffix(self) -> str:
+        """
+        Retorna o sufixo do DOI principal (após a barra) para uso no nome do pacote.
+        Exemplo: '10.1234/abcd.efgh' -> 'abcd.efgh'
+        """
+        main_doi = self.main_doi
+        if not main_doi or "/" not in main_doi:
+            return None
+        return main_doi.split("/")[-1]
+
+    def get_body_fragment_for_pkg_name_suffix(self) -> str:
+        """
+        Gera um fragmento de hash do corpo do artigo para uso no nome do pacote.
+        Útil quando outros identificadores não estão disponíveis.
+        """
+        body_content = self.get_body_fragment(max_length=300)
+        if not body_content:
+            return None
+        # Gerar um hash MD5 do conteúdo do corpo e retornar os primeiros 8 caracteres
+        return hashlib.md5(body_content.encode("utf-8").lower()).hexdigest()[:8]
+
+    def get_submitted_filename_for_pkg_name_suffix(self) -> str:
+        """
+        Retorna o nome do arquivo submetido (sem extensão) para uso no nome do pacote.
+        Útil quando outros identificadores não estão disponíveis.
+        """
+        if not self.submitted_filename:
+            return None
+        return self._submitted_filename.lower()
+
+    def get_lang_suffix(self, lang):
+        lang_suffix = ""
+        main_lang = getattr(self, "main_lang", "")
+        if lang and main_lang and lang.lower() != main_lang.lower():
+            lang_suffix = f"-{lang.lower()}"
+        return lang_suffix
+
+    def get_suppl_for_pkg_name_suffix(self):
+        """
+        Retorna o sufixo do pacote SPS para suplementos:
+        'suppl' para valor 0
+        's{valor}' para valores diferentes de 0
+        """
+        suppl = self.suppl
+        if suppl is None:
+            return None
+        try:
+            if int(suppl) == 0:
+                return "suppl"
+        except (TypeError, ValueError):
+            pass
+        return f"s{suppl}"
+
+    # -------------------------------------------------------------------------
+    # RESOLUÇÃO DE SUFIXO (Estratégias Sequenciais)
+    # -------------------------------------------------------------------------
+    def get_pkg_suffix(self, strategies: list = None) -> str:
+        """
+        Avalia a lista ordenada de estratégias e retorna o PRIMEIRO dado válido.
+
+        Estratégias suportadas:
+        - 'elocation_id': ID de localização eletrônica
+        - 'fpage': fpage + fpage_seq (desconsiderando fpage fake)
+        - 'page': fpage + fpage_seq + lpage (desconsiderando fpage fake)
+        - 'order': Ordem do artigo
+        - 'body_fragment': usando body_fragment_fingerprint
+        - 'submitted_filename': Nome do arquivo enviado pelo produtor
+        - 'doi_suffix': Sufixo após a barra do DOI
+        """
+        if not strategies:
+            strategies = [
+                "elocation_id",
+                "submitted_filename",
+                "order",
+                "fpage",
+                "page",
+                "body_fragment",
+                "doi_suffix",
+            ]
+
+        for strategy in strategies:
+            val = None
+            if strategy == "elocation_id":
+                val = self.elocation_id
+            elif strategy == "order":
+                val = getattr(self, "order", None)
+            elif strategy == "fpage":
+                val = self.get_fpage_suffix()
+            elif strategy == "page":
+                val = self.get_page_suffix()
+            elif strategy == "submitted_filename":
+                val = self.get_submitted_filename_for_pkg_name_suffix()
+            elif strategy == "doi_suffix":
+                 val = self.get_main_doi_for_pkg_name_suffix()
+            elif strategy == "body_fragment":
+                val = self.get_body_fragment_for_pkg_name_suffix()
+            if val:
+                sanitized = sanitize_name(val)
+                if sanitized:
+                    return sanitized
+
+        raise ValueError(
+            f"Unable to get pkg name suffix. No valid strategy produced a value. Strategies tried: {strategies}"
+        )
+
+    # -------------------------------------------------------------------------
+    # RESOLUÇÃO DE PREFIXO
+    # -------------------------------------------------------------------------
+    @cached_property
+    def sps_issue_segment(self):
+        """
+        Segmento volume-número-suplemento, usado por XMLNamingMixin.get_sps_prefix
+        para montar variações genéricas de nome (matching ORM).
+        """
+        parts = [
+            self.volume,
+            self.number and self.number.zfill(2),
+            self.get_suppl_for_pkg_name_suffix(),
+        ]
+        if not any(parts):
+            parts = [self.pub_year]
+        return "-".join(p for p in parts if p)
+
+    def get_sps_prefix(self, issn: str = None) -> str:
+        """Gera o prefixo determinístico: ISSN-Acrônimo-Volume-Número-Suplemento."""
+        chosen_issn = issn or self.sps_issn
+        if not chosen_issn:
+            raise ValueError(
+                "Unable to get SPS prefix. No ISSN available. Provide an ISSN or ensure the XML has a valid journal_issn_electronic or journal_issn_print."
+            )
+        if not self.journal_acron:
+            raise ValueError(
+                "Unable to get SPS prefix. No journal acronym available. Ensure the XML has a valid journal_acron."
+            )
+        if not self.sps_issue_segment:
+            raise ValueError(
+                "Unable to get SPS prefix. No issue segment available. Ensure the XML has valid volume, number, and/or suppl."
+            )
+        prefix_parts = [
+            chosen_issn,
+            self.journal_acron,
+            self.sps_issue_segment,
+        ]
+        return "-".join([p for p in prefix_parts if p])
+
+    # -------------------------------------------------------------------------
+    # CONSTRUTOR DE PACOTES
+    # -------------------------------------------------------------------------
+    def build_pkg_name(self, suffix: str, prefix: str = None, lang: str = None) -> str:
+        """Junta o prefixo fornecido/gerado com o sufixo e idioma secundário."""
+        if not suffix:
+            raise ValueError("Suffix is required to build package name.")
+        base_prefix = prefix or self.get_sps_prefix()
+        lang_suffix = self.get_lang_suffix(lang)
+        return sanitize_name(f"{base_prefix}-{suffix}{lang_suffix}")
+
+    # -------------------------------------------------------------------------
+    # CONVENÇÕES PADRÃO
+    # -------------------------------------------------------------------------
+    def build_sps_pkg_name(self, lang: str = None, issn: str = None) -> str:
+        """Gera o nome do pacote no padrão SPS utilizando a busca de sufixo padrão."""
+        prefix = self.get_sps_prefix(issn=issn)
+        suffix = self.get_pkg_suffix(
+            strategies=["elocation_id", "order", "submitted_filename"]
+        )
+        return sanitize_sps_name(self.build_pkg_name(suffix=suffix, prefix=prefix, lang=lang))
+
+    def get_pmc_pkg_name(self, revision_number=None) -> str:
+        """Gera o nome do pacote no padrão PMC (jour-vol-iss-uid)."""
+        acron = getattr(self, "journal_acron", None) or "jour"
+        vol = getattr(self, "volume", None) or "0"
+        iss = getattr(self, "number", None) or "0"
+        uid = self.get_pkg_suffix(
+            strategies=["elocation_id", "fpage", "order", "uid"]
+        )
+        revision = ""
+        if revision_number:
+            revision = f".r{revision_number}"
+        return sanitize_name(f"{acron}-{vol}-{iss}-{uid}{revision}")
+
+    # -------------------------------------------------------------------------
+    # VARIAÇÕES PARA DJANGO ORM E VISÃO DICTIONARY
+    # -------------------------------------------------------------------------
+    @property
+    def pkg_name_variations(self) -> list:
+        """
+        Retorna TODAS as variações de nomes para buscas de match no Django ORM.
+        Considera ISSN eletrônico, impresso, originais e traduções.
+        """
+        variations = set()
+
+        if self.submitted_filename:
+            variations.add(self.submitted_filename)
+
+        for issn in self.available_issns:
+            variations.add(self.build_sps_pkg_name(issn=issn))
+
+        variations.update(self.deprecated_sps_pkg_name_list)
+
+        try:
+            variations.add(self.built_sps_pkg_name)
+        except ValueError:
+            pass
+
+        if provided_sps_pkg_name := self.provided_sps_pkg_name:
+            variations.add(provided_sps_pkg_name)
+
+        return variations
+
+    @property
+    def built_sps_pkg_name(self) -> str:
+        """Retorna o nome do pacote SPS construído com base nas regras atuais."""
+        return self._built_sps_pkg_name
+
+    @property
+    def provided_sps_pkg_name(self) -> str:
+        """Retorna o nome do pacote SPS fornecido no XML, se presente."""
+        return self._provided_sps_pkg_name
+
+    @provided_sps_pkg_name.setter
+    def provided_sps_pkg_name(self, value):
+        if not value:
+            self._provided_sps_pkg_name = None
+            return
+        # não sanitizar, pois pode ser nome legado
+        self._provided_sps_pkg_name = value
+
+    @property
+    def sps_pkg_name(self):
+        if name := self.provided_sps_pkg_name:
+            return name
+        if name := self.built_sps_pkg_name:
+            return name
+        # comportamento defensivo em caso de não ajuste no upload / core
+        # versão mais compatível com o guia sps 1.10
+        return self.deprecated_sps_pkg_name_version_2
+
+    @property
+    def sps_pkg_name_origin(self):
+        if name := self.provided_sps_pkg_name:
+            return "provided_sps_pkg_name"
+        if name := self.built_sps_pkg_name:
+            return "built_sps_pkg_name"
+        # comportamento defensivo em caso de não ajuste no upload / core
+        # versão mais compatível com o guia sps 1.10
+        return "deprecated_sps_pkg_name_version_2"
+
+    @sps_pkg_name.setter
+    def sps_pkg_name(self, value):
+        self.provided_sps_pkg_name = value
+
+    @property
+    def pkg_names_dict(self) -> dict:
+        """Panorama estruturado dos nomes do documento."""
+        return {
+            "pmc_pkg_name": self.get_pmc_pkg_name(),
+            "built_sps_pkg_name": self.built_sps_pkg_name,
+            "provided_sps_pkg_name": self.provided_sps_pkg_name,
+            "sps_pkg_name": self.sps_pkg_name,
+            "sps_pkg_name_origin": self.sps_pkg_name_origin,
+            "pkg_name_list": self.pkg_name_variations,}
+
+    @property
+    def sps_pkg_names_dict(self):
+        return {
+            "sps_pkg_name": self.sps_pkg_name,
+            "sps_pkg_name_origin": self.sps_pkg_name_origin,
+            "pkg_name_list": self.pkg_name_variations,
+            "built_sps_pkg_name": self.built_sps_pkg_name,
+            "built_sps_pkg_name_now": self.build_sps_pkg_name(),
+            "provided_sps_pkg_name": self.provided_sps_pkg_name,
+        }
+
+    @property
+    def input_files_dict(self):
+        return {
+            "xml_name": self.xml_name,
+            "zip_namelist": self.zip_namelist,
+            "zip_basenames": self.zip_basenames,
+            "zip_file_path": self.zip_file_path,
+            "xml_file_path": self.xml_file_path,
+            "submitted_filename": self.submitted_filename,
+            "submitted_ext": self.submitted_ext,
+            "is_html": self.is_html_source,
+            "provided_sps_pkg_name": self.provided_sps_pkg_name,
+        }
 
 
 # ==============================================================================
@@ -896,6 +1265,28 @@ class ArticleMetadataMixin:
     def journal_issn_electronic(self):
         return self.issns.get("epub")
 
+    @property
+    def available_issns(self) -> list:
+        """
+        Retorna a lista de ISSNs disponíveis (eletrônico e impresso).
+
+        Raises
+        ------
+        XMLWithPreMissingISSNError: Se nenhum ISSN for encontrado no XML.
+        """
+        issns = [item for item in self.issns.values() if item]
+        if not issns:
+            raise XMLWithPreMissingISSNError(
+                f"Não foi possível determinar o nome do pacote para o arquivo '{self}': "
+                f"Nenhum ISSN (eletrônico ou impresso) foi encontrado no XML."
+            )
+        return issns
+
+    @property
+    def sps_issn(self) -> str:
+        """Retorna o ISSN principal (eletrônico priorizado, ou primeiro disponível)."""
+        return self.available_issns[0]
+
     @cached_property
     def main_toc_section(self):
         node = self.xmltree.find('.//subj-group[@subj-group-type="heading"]')
@@ -1137,6 +1528,10 @@ class ArticleMetadataMixin:
         return text.lower()
 
     @property
+    def body_fingerprint(self):
+        return generate_finger_print(self.get_body_fragment(max_length=None))
+
+    @property
     def body_fragment_fingerprint(self):
         return generate_finger_print(self.get_body_fragment(300))
 
@@ -1199,6 +1594,7 @@ class XMLWithPre(
     DOCTYPEParserMixin,
     PackagingAndFilesMixin,
     PackageNamingMixin,
+    LegacyPackageNamingMixin,
     IdentifiersMixin,
     ArticleMetadataMixin,
 ):
@@ -1229,15 +1625,24 @@ class XMLWithPre(
         self.xml_name = None
         self.zip_basenames = None
         self.zip_namelist = None
-        self.submitted_filename = None
-        self.submitted_ext = None
+        self._submitted_filename = None
+        self._submitted_ext = None
+        self._provided_sps_pkg_name = None
+        self._built_sps_pkg_name = None
+        self.is_html_source = None
+
+    def __str__(self):
+        return self.xml_name or self.submitted_filename or self.zip_file_path or self.uri or "<XMLWithPre>"
 
     # --------------------------------------------------------------------------
     # Construtores & Serializadores
     # --------------------------------------------------------------------------
     @classmethod
     def create(
-        cls, path=None, uri=None, xml_content=None, capture_errors=False, timeout=30
+        cls, path=None, uri=None, xml_content=None, capture_errors=False, timeout=30,
+        xml_native_name=None,
+        html_name=None,
+        built_name=None,
     ):
         """Retorna gerador de instâncias de XMLWithPre."""
         if path:
@@ -1248,8 +1653,16 @@ class XMLWithPre(
                     continue
                 try:
                     xml_with_pre = item["xml_with_pre"]
+                    if xml_native_name:
+                        xml_with_pre.provided_sps_pkg_name = xml_native_name
+                    if xml_native_name or html_name:
+                        xml_with_pre.submitted_filename = xml_native_name or html_name
+                    if built_name:
+                        xml_with_pre._built_sps_pkg_name = built_name
+                    if not xml_native_name and not built_name:
+                        xml_with_pre._built_sps_pkg_name = xml_with_pre.build_sps_pkg_name()
                     yield xml_with_pre
-                except KeyError:
+                except (KeyError, ValueError) as e:
                     errors.append(item)
             if not xml_with_pre or errors:
                 raise GetXmlWithPreError(f"Unable to get xml with pre {errors}")
@@ -1287,21 +1700,30 @@ class XMLWithPre(
 
     @property
     def data(self):
-        return dict(
+        data = dict(
             sps_pkg_name=self.sps_pkg_name,
             pid_v3=self.v3,
             pid_v2=self.v2,
             aop_pid=self.aop_pid,
-            submitted_filename=self.submitted_filename,
-            submitted_ext=self.submitted_ext,
-            xml_name=self.xml_name,
-            zip_namelist=self.zip_namelist,
-            zip_basenames=self.zip_basenames,
             filename=self.filename,
             files=self.files,
             filenames=self.filenames,
             pkg_names=self.deprecated_sps_pkg_name_list,
         )
+        return data
+
+    def get_data(self, input_files=None, sps_pkg_names=None, pkg_names=False, article=False, max_body_fragment_length=300):
+        data = self.data
+        if input_files:
+            data.update(self.input_files_dict)
+        if pkg_names:
+            data.update(self.pkg_names_dict)
+        if sps_pkg_names:
+            data.update(self.sps_pkg_names_dict)
+        if article:
+            data.update(self.get_article_data(max_body_fragment_length))
+        return data
+    
 
 def string_to_5_digits(input_string):
     return str((crc32(input_string.encode()) & 0xFFFFFFFF) % 100000)
@@ -1341,3 +1763,27 @@ def remove_comments(xmltree):
         parent = comment.getparent()
         if parent is not None:
             parent.remove(comment)
+
+
+def sanitize_name(value: str) -> str:
+    """
+    Regra estrita do SPS: Proibido underline (_), ponto (.),
+    acentuação, espaços ou caracteres especiais. Permite apenas [a-zA-Z0-9-].
+    """
+    if not value:
+        return ""
+    clean = str(value).replace(" ", "")
+    clean = re.sub(r"[^a-zA-Z0-9\-]", "", clean)
+    return re.sub(r"-+", "-", clean).strip("-")
+
+
+def sanitize_sps_name(value: str) -> str:
+    """
+    Regra estrita do SPS: Proibido underline (_), ponto (.),
+    acentuação, espaços ou caracteres especiais. Permite apenas [a-zA-Z0-9-].
+    """
+    if not value:
+        return ""
+    clean = str(value).replace("_", "-").replace(".", "-").replace(" ", "")
+    clean = re.sub(r"[^a-zA-Z0-9\-]", "", clean)
+    return re.sub(r"-+", "-", clean).strip("-")

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -13,7 +13,6 @@ from lxml import etree
 
 from packtools.sps.libs.requester import fetch_data
 from packtools.sps.pid_provider.name2number import fix_pre_loading
-
 # 4.7.1 packtools.sps.models.*
 from packtools.sps.pid_provider.models.article_assets import ArticleAssets
 from packtools.sps.pid_provider.models.article_and_subarticles import (
@@ -379,9 +378,6 @@ class XMLWithPre:
         self._sps_version = None
         self.errors = None
         self.pkg_name_version = None
-        # html or xml
-        self.source_filename = None
-        self.source_ext = None
 
         self.xml_name = None # nome original encontrado no xml ou no zip
         self.zip_basenames = None # nome original encontrado no xml ou no zip, exceto xml
@@ -422,7 +418,7 @@ class XMLWithPre:
 
     def add_pkg_name_components(self, source_filename, pkg_name_version=3):
         self.pkg_name_version = pkg_name_version
-        self.source_filename, self.source_ext = os.path.splitext(source_filename)
+        self.submitted_file = source_filename
 
     @property
     def data(self):
@@ -1252,7 +1248,7 @@ class XMLWithPre:
     @property
     def body_fragment_fingerprint(self):
         # gera um novo fingerprint do XML, para ser usado na comparação com o fingerprint registrado
-        return generate_finger_print(self.get_body_fragment(max_length=None))
+        return generate_finger_print(self.get_body_fragment(300))
 
     @property
     def finger_print(self):

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -527,19 +527,38 @@ class PackagingAndFilesMixin:
 
     @property
     def renditions(self):
+        if not self.zip_namelist:
+            return []
+
+        xml_name = self.xml_name
+        if not xml_name:
+            raise ValueError("XMLWithPre.renditions: Missing xml_name")
+
         xml_renditions = ArticleRenditions(self.xmltree)
+        sps_pkg_name = self.sps_pkg_name
+
+        namelist = {}
+        for item in self.zip_namelist:
+            key = os.path.basename(item)
+            namelist[key] = item
+
+        items = []
         for item in xml_renditions.article_renditions:
-            name = (
-                self.sps_pkg_name + ".pdf"
-                if item.is_main_language
-                else f"{self.sps_pkg_name}-{item.language}.pdf"
-            )
-            yield {
+            suffix = ".pdf"
+            if not item.is_main_language:
+                suffix = f"-{item.language}.pdf"
+
+            name = f"{xml_name}{suffix}"
+            
+            items.append({
                 "name": name,
                 "lang": item.language,
                 "component_type": "rendition",
                 "main": item.is_main_language,
-            }
+                "sps_pkg_name": f"{sps_pkg_name}{suffix}",
+                "path_in_zip": namelist.get(name),
+            })
+        return items
 
 
 # ==============================================================================

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '4.16.9'
+__version__ = '4.16.10'

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -2,12 +2,15 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
+from zipfile import ZipFile, ZIP_DEFLATED
 
 from packtools.sps.pid_provider.xml_sps_lib import (
     XMLWithPre,
     XMLWithPreArticlePublicationDateError,
     XMLWithPreMissingISSNError,
     GetXmlWithPreError,
+    get_xml_with_pre_from_xml_file,
+    get_xml_with_pre_from_zip_file,
 )
 
 class XMLWithPreTestMixin:
@@ -792,8 +795,15 @@ class TestSPSPkgNameSuffix(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.legacy_alternative_sps_pkg_name_suffix, "00001")
 
     def test_legacy_alternative_sps_pkg_name_suffix_filename(self):
+        # legacy_alternative_sps_pkg_name_suffix cai para `filename` quando
+        # não há `order`. `filename` NÃO tem setter: é sempre derivado de
+        # xml_name (via add_xml_info) — aqui, sem zip_file_path, filename ==
+        # f"{xml_name}.xml".
         xml_with_pre = self._make_xml(vol="10", num="2")
-        xml_with_pre.filename = "article.xml"
+        xml_with_pre.add_xml_info("article")
+        self.assertIsNone(xml_with_pre.order)
+        self.assertEqual(xml_with_pre.xml_name, "article")
+        self.assertEqual(xml_with_pre.filename, "article.xml")
         self.assertEqual(xml_with_pre.legacy_alternative_sps_pkg_name_suffix, "article.xml")
 
 
@@ -981,25 +991,41 @@ class TestV2List(XMLWithPreTestMixin, TestCase):
 
 
 class TestXMLWithPrePropertiesAndMetadata(XMLWithPreTestMixin, TestCase):
-    """Testes para aliases (filename, files, filenames), data e manipulação de DOCTYPE."""
+    """Testes para aliases (files, filenames), data e manipulação de DOCTYPE.
 
-    def test_filename_files_filenames_getters_and_setters(self):
+    `filename` (singular) NÃO possui setter — é sempre derivado de
+    xml_name/xml_file_path/zip_file_path, atribuídos via add_xml_info /
+    add_zip_info. Já `files`/`filenames` (plural) SÃO aliases graváveis
+    para zip_namelist/zip_basenames.
+    """
+
+    def test_files_and_filenames_getters_and_setters(self):
         xml_with_pre = self._make_xml(vol="10", num="2")
-        
-        # Atribuição via setters
-        xml_with_pre.filename = "artigo.xml"
+
+        # Atribuição via setters (aliases de zip_namelist/zip_basenames)
         xml_with_pre.files = ["artigo.xml", "imagem.jpg"]
         xml_with_pre.filenames = ["artigo.xml", "imagem.jpg"]
-
-        # Verificação via getters e propriedades de suporte
-        self.assertEqual(xml_with_pre.filename, "artigo.xml")
-        self.assertEqual(xml_with_pre.xml_name, "artigo.xml")
 
         self.assertEqual(xml_with_pre.files, ["artigo.xml", "imagem.jpg"])
         self.assertEqual(xml_with_pre.zip_namelist, ["artigo.xml", "imagem.jpg"])
 
         self.assertEqual(xml_with_pre.filenames, ["artigo.xml", "imagem.jpg"])
         self.assertEqual(xml_with_pre.zip_basenames, ["artigo.xml", "imagem.jpg"])
+
+    def test_filename_singular_has_no_setter(self):
+        # `filename` é somente leitura; tentar atribuí-lo diretamente
+        # deve falhar (não existe filename.setter no código-fonte).
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        with self.assertRaises(AttributeError):
+            xml_with_pre.filename = "artigo.xml"
+
+    def test_filename_getter_uses_xml_name_when_set_via_add_xml_info(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_xml_info("artigo", "/tmp/uploads/artigo.xml")
+        self.assertEqual(xml_with_pre.xml_name, "artigo")
+        # sem zip_file_path, filename ignora o path completo do arquivo e
+        # usa somente xml_name + ".xml"
+        self.assertEqual(xml_with_pre.filename, "artigo.xml")
 
     def test_data_property(self):
         xml_with_pre = self._make_xml(
@@ -1010,7 +1036,7 @@ class TestXMLWithPrePropertiesAndMetadata(XMLWithPreTestMixin, TestCase):
             acron="abc",
             elocation="e100",
         )
-        xml_with_pre.filename = "artigo.xml"
+        xml_with_pre.add_xml_info("artigo")
         xml_with_pre.files = ["artigo.xml"]
         xml_with_pre.filenames = ["artigo.xml"]
 
@@ -1447,6 +1473,7 @@ Foco:
     - get_pmc_pkg_name (com e sem revision_number)
     - pkg_names_dict / sps_pkg_names_dict / input_files_dict / data
     - get_data (composição condicional dos dicionários acima)
+    - xml_name vs filename conforme a origem (arquivo .xml avulso x .zip)
 
 Arquivo independente (contém sua própria mixin de fabricação de XML).
 """
@@ -1479,6 +1506,17 @@ class TestSpsPkgNameOrigin(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "provided_sps_pkg_name")
         # sps_pkg_name e sps_pkg_name_origin devem ser sempre consistentes
         self.assertEqual(xml_with_pre.sps_pkg_name, "provided-name")
+
+    def test_origin_is_xml_name_when_only_xml_name_is_set(self):
+        # xml_name é atribuído via add_xml_info (não confundir com
+        # provided_sps_pkg_name / built_sps_pkg_name)
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_xml_info("nome-do-arquivo")
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertIsNone(xml_with_pre.built_sps_pkg_name)
+        self.assertEqual(xml_with_pre.xml_name, "nome-do-arquivo")
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "xml_name")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "nome-do-arquivo")
 
 
 # ==============================================================================
@@ -1578,7 +1616,7 @@ class TestDictProperties(XMLWithPreTestMixin, TestCase):
         # "vazam" de volta para `data` por engano em uma futura refatoração.
         xml_with_pre = self._make_base_xml()
         xml_with_pre.submitted_filename = "artigo.xml"
-        xml_with_pre.xml_name = "artigo"
+        xml_with_pre.add_xml_info("artigo")
         data = xml_with_pre.data
         self.assertNotIn("submitted_filename", data)
         self.assertNotIn("submitted_ext", data)
@@ -1762,6 +1800,117 @@ class TestGetData(XMLWithPreTestMixin, TestCase):
 
 
 # ==============================================================================
+# xml_name vs filename: comportamento conforme a origem (arquivo .xml
+# avulso versus item dentro de um .zip)
+# ==============================================================================
+class TestXmlNameVsFilenameOrigin(XMLWithPreTestMixin, TestCase):
+    """
+    `xml_name` e `filename` NÃO são a mesma coisa:
+
+    - `xml_name`: nome "lógico" do XML, sem extensão. É atribuído
+      explicitamente via `add_xml_info(xml_name, xml_file_path=None)` — seja
+      manualmente, seja internamente por `get_xml_with_pre_from_xml_file`
+      (nome do arquivo, sem ".xml") ou por `get_xml_with_pre_from_zip_file`
+      (nome-base do item do zip, sem ".xml").
+
+    - `filename` (propriedade só de leitura, sem setter): nome "físico"
+      calculado a partir de `zip_file_path`/`xml_file_path`/`xml_name`:
+        * SEM zip (zip_file_path vazio): filename = f"{xml_name}.xml"
+          (o path completo em xml_file_path é ignorado).
+        * COM zip (zip_file_path setado): filename = xml_file_path, ou
+          seja, o caminho do XML *dentro do zip* — que pode incluir
+          subpastas e diferir de f"{xml_name}.xml".
+
+    Ou seja: a mesma instância pode ter xml_name="artigo" e filename
+    "artigo.xml" (origem: arquivo avulso) ou filename
+    "subpasta/artigo.xml" (origem: zip com o XML dentro de uma subpasta).
+    """
+
+    def test_filename_from_plain_xml_equals_xml_name_plus_extension(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_xml_info("artigo", "/tmp/uploads/artigo.xml")
+
+        self.assertEqual(xml_with_pre.xml_name, "artigo")
+        self.assertIsNone(xml_with_pre.zip_file_path)
+        # sem zip, filename ignora o path completo e usa apenas
+        # xml_name + ".xml"
+        self.assertEqual(xml_with_pre.filename, "artigo.xml")
+
+    def test_filename_from_zip_uses_xml_file_path_not_xml_name(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        # xml_name é o nome lógico (sem extensão); xml_file_path é o
+        # caminho do item dentro do zip, que pode ter subpastas e diferir
+        # do valor de xml_name
+        xml_with_pre.add_xml_info("artigo", "pasta/artigo.xml")
+        xml_with_pre.add_zip_info("/tmp/pacote.zip", ["pasta/artigo.xml"], ["artigo.xml"])
+
+        self.assertEqual(xml_with_pre.xml_name, "artigo")
+        self.assertEqual(xml_with_pre.zip_file_path, "/tmp/pacote.zip")
+        # com zip, filename é o path do XML dentro do zip (xml_file_path),
+        # não xml_name + ".xml"
+        self.assertEqual(xml_with_pre.filename, "pasta/artigo.xml")
+        self.assertNotEqual(xml_with_pre.filename, f"{xml_with_pre.xml_name}.xml")
+
+    def test_filename_from_zip_when_xml_file_path_matches_xml_name(self):
+        # Caso comum: sem subpastas, xml_file_path coincide com
+        # xml_name + ".xml", mas ainda assim é xml_file_path (não xml_name)
+        # quem determina o valor de filename.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_xml_info("artigo", "artigo.xml")
+        xml_with_pre.add_zip_info("/tmp/pacote.zip", ["artigo.xml"], ["artigo.xml"])
+
+        self.assertEqual(xml_with_pre.filename, "artigo.xml")
+        self.assertEqual(xml_with_pre.filename, f"{xml_with_pre.xml_name}.xml")
+
+    def test_xml_name_is_not_changed_by_add_zip_info(self):
+        # add_zip_info altera zip_file_path/zip_namelist/zip_basenames, mas
+        # nunca xml_name — só add_xml_info define/altera xml_name.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_xml_info("artigo", "artigo.xml")
+        self.assertEqual(xml_with_pre.xml_name, "artigo")
+
+        xml_with_pre.add_zip_info(
+            "/tmp/pacote.zip", ["artigo.xml", "artigo.pdf"], ["artigo.xml", "artigo.pdf"]
+        )
+        self.assertEqual(xml_with_pre.xml_name, "artigo")  # inalterado
+
+    def test_get_xml_with_pre_from_xml_file_sets_xml_name_from_basename_without_extension(self):
+        xml_content = self._make_base_xml().tostring()
+        with TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "meu-artigo-123.xml")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(xml_content)
+
+            result = get_xml_with_pre_from_xml_file(file_path)
+            xml_with_pre = result["xml_with_pre"]
+
+            self.assertEqual(xml_with_pre.xml_name, "meu-artigo-123")
+            self.assertIsNone(xml_with_pre.zip_file_path)
+            # sem zip, filename = xml_name + ".xml"
+            self.assertEqual(xml_with_pre.filename, "meu-artigo-123.xml")
+
+    def test_get_xml_with_pre_from_zip_file_sets_xml_name_and_filename_from_zip_item(self):
+        xml_content = self._make_base_xml().tostring()
+        with TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, "pacote.zip")
+            with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
+                zf.writestr("subpasta/meu-artigo-123.xml", xml_content)
+
+            items = get_xml_with_pre_from_zip_file(zip_path)
+            self.assertEqual(len(items), 1)
+            xml_with_pre = items[0]["xml_with_pre"]
+
+            # xml_name vem apenas do nome-base do item, sem extensão e sem
+            # subpasta
+            self.assertEqual(xml_with_pre.xml_name, "meu-artigo-123")
+            self.assertEqual(xml_with_pre.zip_file_path, zip_path)
+            # filename, por outro lado, é o path COMPLETO do XML dentro do
+            # zip (inclui a subpasta) — diferente de f"{xml_name}.xml"
+            self.assertEqual(xml_with_pre.filename, "subpasta/meu-artigo-123.xml")
+            self.assertNotEqual(xml_with_pre.filename, f"{xml_with_pre.xml_name}.xml")
+
+
+# ==============================================================================
 # 1. TESTES PARA XMLWithPre.create
 # ==============================================================================
 class TestXMLWithPreCreate(XMLWithPreTestMixin, TestCase):
@@ -1792,6 +1941,9 @@ class TestXMLWithPreCreate(XMLWithPreTestMixin, TestCase):
             self.assertIsInstance(instances[0], XMLWithPre)
             self.assertEqual(instances[0].journal_acron, "xyz")
             self.assertEqual(instances[0].xml_name, "test_doc")
+            # origem: arquivo .xml avulso -> filename = xml_name + ".xml"
+            self.assertIsNone(instances[0].zip_file_path)
+            self.assertEqual(instances[0].filename, "test_doc.xml")
 
     def test_create_from_path_with_custom_names(self):
         xml_content = """<?xml version="1.0" encoding="UTF-8"?>
@@ -1814,6 +1966,10 @@ class TestXMLWithPreCreate(XMLWithPreTestMixin, TestCase):
             self.assertEqual(instances[0].provided_sps_pkg_name, "custom_native")
             self.assertEqual(instances[0].built_sps_pkg_name, "custom_built")
             self.assertEqual(instances[0].submitted_filename, "custom_native.xml")
+            # xml_name continua vindo do nome físico do arquivo lido (doc),
+            # independente de xml_native_name/built_name, que afetam apenas
+            # provided/built_sps_pkg_name e submitted_filename
+            self.assertEqual(instances[0].xml_name, "doc")
 
     @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre_from_uri")
     def test_create_from_uri(self, mock_get_from_uri):
@@ -1912,7 +2068,7 @@ class TestPkgNameVariations(XMLWithPreTestMixin, TestCase):
 
     def test_pkg_name_variations_includes_xml_name(self):
         xml_with_pre = self._make_base_xml()
-        xml_with_pre.xml_name = "artigo_parsed"
+        xml_with_pre.add_xml_info("artigo_parsed")
         variations = xml_with_pre.pkg_name_variations
         self.assertIn("artigo_parsed", variations)
 
@@ -1946,7 +2102,7 @@ class TestSpsPkgNameComprehensive(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         xml_with_pre.provided_sps_pkg_name = "1-provided"
         xml_with_pre._built_sps_pkg_name = "2-built"
-        xml_with_pre.xml_name = "3-xml-name"
+        xml_with_pre.add_xml_info("3-xml-name")
 
         self.assertEqual(xml_with_pre.sps_pkg_name, "1-provided")
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "provided_sps_pkg_name")
@@ -1955,7 +2111,7 @@ class TestSpsPkgNameComprehensive(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         xml_with_pre.provided_sps_pkg_name = None
         xml_with_pre._built_sps_pkg_name = "2-built"
-        xml_with_pre.xml_name = "3-xml-name"
+        xml_with_pre.add_xml_info("3-xml-name")
 
         self.assertEqual(xml_with_pre.sps_pkg_name, "2-built")
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "built_sps_pkg_name")
@@ -1964,17 +2120,16 @@ class TestSpsPkgNameComprehensive(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         xml_with_pre.provided_sps_pkg_name = None
         xml_with_pre._built_sps_pkg_name = None
-        xml_with_pre.xml_name = "3-xml-name"
+        xml_with_pre.add_xml_info("3-xml-name")
 
         self.assertEqual(xml_with_pre.sps_pkg_name, "3-xml-name")
-        # Nota: O código atual mantém fallback de origem como 'deprecated_sps_pkg_name_version_2'
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "xml_name")
 
     def test_sps_pkg_name_hierarchy_4_deprecated_v2_as_final_fallback(self):
         xml_with_pre = self._make_base_xml()
         xml_with_pre.provided_sps_pkg_name = None
         xml_with_pre._built_sps_pkg_name = None
-        xml_with_pre.xml_name = None
+        self.assertIsNone(xml_with_pre.xml_name)
 
         self.assertEqual(xml_with_pre.sps_pkg_name, xml_with_pre.deprecated_sps_pkg_name_version_2)
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "deprecated_sps_pkg_name_version_2")

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -1,11 +1,13 @@
+import os
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
-from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
 
 from packtools.sps.pid_provider.xml_sps_lib import (
     XMLWithPre,
     XMLWithPreArticlePublicationDateError,
     XMLWithPreMissingISSNError,
+    GetXmlWithPreError,
 )
 
 class XMLWithPreTestMixin:
@@ -1318,7 +1320,7 @@ class TestSpsPkgNamePriority(XMLWithPreTestMixin, TestCase):
 
     def test_sps_pkg_name_setter_sets_provided_name(self):
         xml_with_pre = self._make_xml(vol="10", num="2")
-        xml_with_pre.sps_pkg_name = "meu-pacote-1"
+        xml_with_pre.provided_sps_pkg_name = "meu-pacote-1"
         self.assertEqual(xml_with_pre.provided_sps_pkg_name, "meu-pacote-1")
         self.assertEqual(xml_with_pre.sps_pkg_name, "meu-pacote-1")
 
@@ -1457,11 +1459,12 @@ class TestSpsPkgNameOrigin(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
         self.assertIsNone(xml_with_pre.built_sps_pkg_name)
+        self.assertIsNone(xml_with_pre.xml_name)                
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "deprecated_sps_pkg_name_version_2")
 
     def test_origin_is_built_when_built_name_is_set(self):
         xml_with_pre = self._make_base_xml()
-        xml_with_pre._built_sps_pkg_name = "built-name"
+        xml_with_pre.built_sps_pkg_name = "built-name"
         self.assertEqual(xml_with_pre.sps_pkg_name_origin, "built_sps_pkg_name")
 
     def test_origin_is_provided_when_provided_name_is_set(self):
@@ -1758,6 +1761,225 @@ class TestGetData(XMLWithPreTestMixin, TestCase):
             self.assertIn(key, result)
 
 
-if __name__ == "__main__":
-    import unittest
-    unittest.main()
+# ==============================================================================
+# 1. TESTES PARA XMLWithPre.create
+# ==============================================================================
+class TestXMLWithPreCreate(XMLWithPreTestMixin, TestCase):
+    """Testes para o método construtor alternativo e gerador XMLWithPre.create."""
+
+    def test_create_from_xml_content_string(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <article article-type="research-article" xml:lang="en">
+            <front><journal-meta><journal-id journal-id-type="publisher-id">abc</journal-id></journal-meta></front>
+        </article>"""
+        instances = list(XMLWithPre.create(xml_content=xml_content))
+        self.assertEqual(len(instances), 1)
+        self.assertIsInstance(instances[0], XMLWithPre)
+        self.assertEqual(instances[0].journal_acron, "abc")
+
+    def test_create_from_path_single_xml_file(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <article article-type="research-article" xml:lang="en">
+            <front><journal-meta><journal-id journal-id-type="publisher-id">xyz</journal-id></journal-meta></front>
+        </article>"""
+        with TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "test_doc.xml")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(xml_content)
+
+            instances = list(XMLWithPre.create(path=file_path))
+            self.assertEqual(len(instances), 1)
+            self.assertIsInstance(instances[0], XMLWithPre)
+            self.assertEqual(instances[0].journal_acron, "xyz")
+            self.assertEqual(instances[0].xml_name, "test_doc")
+
+    def test_create_from_path_with_custom_names(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <article article-type="research-article" xml:lang="en">
+            <front><journal-meta><journal-id journal-id-type="publisher-id">abc</journal-id></journal-meta></front>
+        </article>"""
+        with TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "doc.xml")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(xml_content)
+
+            instances = list(
+                XMLWithPre.create(
+                    path=file_path,
+                    xml_native_name="custom_native",
+                    built_name="custom_built",
+                )
+            )
+            self.assertEqual(len(instances), 1)
+            self.assertEqual(instances[0].provided_sps_pkg_name, "custom_native")
+            self.assertEqual(instances[0].built_sps_pkg_name, "custom_built")
+            self.assertEqual(instances[0].submitted_filename, "custom_native.xml")
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre_from_uri")
+    def test_create_from_uri(self, mock_get_from_uri):
+        mock_instance = self._make_base_xml()
+        mock_get_from_uri.return_value = mock_instance
+
+        instances = list(XMLWithPre.create(uri="https://scielo.org/sample.xml"))
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0], mock_instance)
+        mock_get_from_uri.assert_called_once_with("https://scielo.org/sample.xml", 30)
+
+    def test_create_from_path_invalid_file_raises_get_xml_with_pre_error(self):
+        with TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "invalid.xml")
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write("CONTEUDO_XML_INVALIDO_SEM_TAGS")
+
+            with self.assertRaises(GetXmlWithPreError):
+                list(XMLWithPre.create(path=file_path))
+
+
+# ==============================================================================
+# 2. TESTES PARA XMLWithPre.add_pkg_name
+# ==============================================================================
+class TestAddPkgName(XMLWithPreTestMixin, TestCase):
+    """Testes de atribuição explícita de nomes via add_pkg_name."""
+
+    def test_add_pkg_name_with_xml_native_name(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_pkg_name(xml_native_name="native-pkg-name")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "native-pkg-name")
+        self.assertEqual(xml_with_pre.submitted_filename, "native-pkg-name.xml")
+        self.assertEqual(xml_with_pre.source_filename, "native-pkg-name")
+        self.assertEqual(xml_with_pre.source_ext, ".xml")
+
+    def test_add_pkg_name_with_html_name(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_pkg_name(html_name="legacy_page")
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertEqual(xml_with_pre.submitted_filename, "legacy_page.html")
+        self.assertEqual(xml_with_pre.source_filename, "legacy_page")
+        self.assertEqual(xml_with_pre.source_ext, ".html")
+        self.assertTrue(xml_with_pre.is_html_source)
+
+    def test_add_pkg_name_with_built_name(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_pkg_name(built_name="constructed-name-v1")
+        self.assertEqual(xml_with_pre.built_sps_pkg_name, "constructed-name-v1")
+
+    def test_add_pkg_name_xml_native_precedes_html_name(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_pkg_name(xml_native_name="native_win", html_name="html_lose")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "native_win")
+        self.assertEqual(xml_with_pre.submitted_filename, "native_win.xml")
+
+    def test_add_pkg_name_combining_native_and_built(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_pkg_name(xml_native_name="pkg-123", built_name="built-123")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "pkg-123")
+        self.assertEqual(xml_with_pre.built_sps_pkg_name, "built-123")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "pkg-123")
+
+
+# ==============================================================================
+# 3. TESTES PARA XMLWithPre.pkg_name_variations
+# ==============================================================================
+class TestPkgNameVariations(XMLWithPreTestMixin, TestCase):
+    """Testes para geração de variações de nomes utilizadas em buscas/queries do Django ORM."""
+
+    def test_pkg_name_variations_includes_multi_issn(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            issn_ppub="8765-4321",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+        )
+        variations = xml_with_pre.pkg_name_variations
+        self.assertIn("1234-5678-abc-10-02-e100", variations)
+        self.assertIn("8765-4321-abc-10-02-e100", variations)
+
+    def test_pkg_name_variations_includes_submitted_filename(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.submitted_filename = "artigo_original.xml"
+        variations = xml_with_pre.pkg_name_variations
+        self.assertIn("artigo_original.xml", variations)
+
+    def test_pkg_name_variations_includes_provided_and_built_names(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "provided-name"
+        xml_with_pre._built_sps_pkg_name = "built-name"
+        variations = xml_with_pre.pkg_name_variations
+        self.assertIn("provided-name", variations)
+        self.assertIn("built-name", variations)
+
+    def test_pkg_name_variations_includes_xml_name(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = "artigo_parsed"
+        variations = xml_with_pre.pkg_name_variations
+        self.assertIn("artigo_parsed", variations)
+
+    def test_pkg_name_variations_includes_deprecated_list(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        variations = xml_with_pre.pkg_name_variations
+        for dep_name in xml_with_pre.deprecated_sps_pkg_name_list:
+            self.assertIn(dep_name, variations)
+
+    def test_pkg_name_variations_returns_set(self):
+        xml_with_pre = self._make_base_xml()
+        variations = xml_with_pre.pkg_name_variations
+        self.assertIsInstance(variations, set)
+
+
+# ==============================================================================
+# 4. TESTES PARA XMLWithPre.sps_pkg_name (Regras Globais de Precedência e Fallback)
+# ==============================================================================
+class TestSpsPkgNameComprehensive(XMLWithPreTestMixin, TestCase):
+    """Testes de alta cobertura cobrindo a hierarquia completa de sps_pkg_name."""
+
+    def test_sps_pkg_name_hierarchy_1_provided_has_top_priority(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "1-provided"
+        xml_with_pre._built_sps_pkg_name = "2-built"
+        xml_with_pre.xml_name = "3-xml-name"
+
+        self.assertEqual(xml_with_pre.sps_pkg_name, "1-provided")
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "provided_sps_pkg_name")
+
+    def test_sps_pkg_name_hierarchy_2_built_has_second_priority(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = None
+        xml_with_pre._built_sps_pkg_name = "2-built"
+        xml_with_pre.xml_name = "3-xml-name"
+
+        self.assertEqual(xml_with_pre.sps_pkg_name, "2-built")
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "built_sps_pkg_name")
+
+    def test_sps_pkg_name_hierarchy_3_xml_name_has_third_priority(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = None
+        xml_with_pre._built_sps_pkg_name = None
+        xml_with_pre.xml_name = "3-xml-name"
+
+        self.assertEqual(xml_with_pre.sps_pkg_name, "3-xml-name")
+        # Nota: O código atual mantém fallback de origem como 'deprecated_sps_pkg_name_version_2'
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "xml_name")
+
+    def test_sps_pkg_name_hierarchy_4_deprecated_v2_as_final_fallback(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = None
+        xml_with_pre._built_sps_pkg_name = None
+        xml_with_pre.xml_name = None
+
+        self.assertEqual(xml_with_pre.sps_pkg_name, xml_with_pre.deprecated_sps_pkg_name_version_2)
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "deprecated_sps_pkg_name_version_2")
+
+    def test_sps_pkg_name_setter_is_rejected(self):
+        xml_with_pre = self._make_base_xml()
+        with self.assertRaises(AttributeError):
+            xml_with_pre.sps_pkg_name = "new-set-name"

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -5,6 +5,7 @@ from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
 from packtools.sps.pid_provider.xml_sps_lib import (
     XMLWithPre,
     XMLWithPreArticlePublicationDateError,
+    XMLWithPreMissingISSNError,
 )
 
 class XMLWithPreTestMixin:
@@ -88,6 +89,21 @@ class XMLWithPreTestMixin:
         for item in XMLWithPre.create(xml_content=xml_content):
             return item
 
+    def _make_base_xml(self):
+        """
+        Configuração canônica usada nos testes de dicionário: ISSN eletrônico
+        único, sem suplemento/fpage/lpage/order/submitted_filename — produz
+        valores 100% determinísticos para sps_pkg_name, pkg_name_variations,
+        get_pmc_pkg_name etc.
+        """
+        return self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e12345",
+        )
+ 
 
 class TestSPSPkgNameSuppl(XMLWithPreTestMixin, TestCase):
     """Testes para sps_pkg_name_suppl e deprecated_sps_pkg_name_suppl"""
@@ -117,21 +133,21 @@ class TestSPSPkgNameSuppl(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.suppl, "A")
         self.assertEqual(xml_with_pre.sps_pkg_name_suppl, "sA")
 
-    def test_deprecated_sps_pkg_name_suppl_none(self):
+    def test_incorrect_sps_pkg_name_suppl_none(self):
         xml_with_pre = self._make_xml(vol="10", num="2")
-        self.assertIsNone(xml_with_pre.deprecated_sps_pkg_name_suppl)
+        self.assertIsNone(xml_with_pre.incorrect_sps_pkg_name_suppl)
 
-    def test_deprecated_sps_pkg_name_suppl_zero(self):
+    def test_incorrect_sps_pkg_name_suppl_zero(self):
         xml_with_pre = self._make_xml(vol="10", num="2", suppl="0")
-        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_suppl, "suppl")
+        self.assertEqual(xml_with_pre.incorrect_sps_pkg_name_suppl, "suppl")
 
-    def test_deprecated_sps_pkg_name_suppl_numeric(self):
+    def test_incorrect_sps_pkg_name_suppl_numeric(self):
         xml_with_pre = self._make_xml(vol="10", num="2", suppl="1")
-        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_suppl, "1")
+        self.assertEqual(xml_with_pre.incorrect_sps_pkg_name_suppl, "1")
 
-    def test_deprecated_sps_pkg_name_suppl_text(self):
+    def test_incorrect_sps_pkg_name_suppl_text(self):
         xml_with_pre = self._make_xml(vol="10", num="2", suppl="A")
-        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_suppl, "A")
+        self.assertEqual(xml_with_pre.incorrect_sps_pkg_name_suppl, "A")
 
 
 class TestSPSPkgNameFpage(XMLWithPreTestMixin, TestCase):
@@ -140,23 +156,23 @@ class TestSPSPkgNameFpage(XMLWithPreTestMixin, TestCase):
     def test_sps_pkg_name_fpage_none(self):
         xml_with_pre = self._make_xml(vol="10", num="2", elocation="e123")
         self.assertIsNone(xml_with_pre.fpage)
-        self.assertIsNone(xml_with_pre.sps_pkg_name_fpage)
+        self.assertIsNone(xml_with_pre.legacy_sps_pkg_name_fpage)
 
     def test_sps_pkg_name_fpage_zero(self):
         xml_with_pre = self._make_xml(vol="10", num="2", fpage="0", lpage="0")
         self.assertIsNone(xml_with_pre.fpage)
-        self.assertIsNone(xml_with_pre.sps_pkg_name_fpage)
+        self.assertIsNone(xml_with_pre.legacy_sps_pkg_name_fpage)
 
     def test_sps_pkg_name_fpage_simple(self):
         xml_with_pre = self._make_xml(vol="10", num="2", fpage="123", lpage="130")
         self.assertEqual(xml_with_pre.fpage, "123")
-        self.assertEqual(xml_with_pre.sps_pkg_name_fpage, "123")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_fpage, "123")
 
     def test_sps_pkg_name_fpage_with_seq(self):
         xml_with_pre = self._make_xml(vol="10", num="2", fpage="123", fpage_seq="a", lpage="130")
         self.assertEqual(xml_with_pre.fpage, "123")
         self.assertEqual(xml_with_pre.fpage_seq, "a")
-        self.assertEqual(xml_with_pre.sps_pkg_name_fpage, "123_a")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_fpage, "123_a")
 
     def test_sps_pkg_name_fpage_same_fpage_lpage_with_v2(self):
         xml_with_pre = self._make_xml(
@@ -165,18 +181,18 @@ class TestSPSPkgNameFpage(XMLWithPreTestMixin, TestCase):
         )
         self.assertEqual(xml_with_pre.fpage, "123")
         self.assertEqual(xml_with_pre.lpage, "123")
-        self.assertEqual(xml_with_pre.sps_pkg_name_fpage, "123_00123")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_fpage, "123_00123")
 
     def test_sps_pkg_name_fpage_same_fpage_lpage_without_v2(self):
         xml_with_pre = self._make_xml(vol="10", num="2", fpage="123", lpage="123")
         self.assertEqual(xml_with_pre.fpage, "123")
         self.assertEqual(xml_with_pre.lpage, "123")
-        self.assertEqual(xml_with_pre.sps_pkg_name_fpage, "123")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_fpage, "123")
 
     def test_sps_pkg_name_fpage_alphanumeric(self):
         xml_with_pre = self._make_xml(vol="10", num="2", fpage="e123", lpage="e130")
         self.assertEqual(xml_with_pre.fpage, "e123")
-        self.assertEqual(xml_with_pre.sps_pkg_name_fpage, "e123")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_fpage, "e123")
 
     def test_deprecated_sps_pkg_name_fpage_none(self):
         xml_with_pre = self._make_xml(vol="10", num="2", elocation="e123")
@@ -219,7 +235,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
             fpage="100",
             lpage="110",
         )
-        self.assertEqual(xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-s1-100_110")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-s1-100")
 
     def test_sps_pkg_name_ppub_fallback(self):
         xml_with_pre = self._make_xml(
@@ -308,6 +324,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
             [
                 "1234-5678-abc-10-02-1-100",
                 "1234-5678-abc-10-02-s1-100",
+                "1234-5678-abc-10-02-s1-100_110",                              
             ],
         )
 
@@ -368,7 +385,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.source_filename, "1989")
         self.assertEqual(xml_with_pre.source_ext, ".htm")
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-100_110_1989"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-100"
         )
 
     def test_sps_pkg_name_with_htm_source_filename_and_suppl(self):
@@ -383,7 +400,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         )
         xml_with_pre.add_pkg_name_components("1989.htm")
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-s1-100_110_1989"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-s1-100"
         )
 
     # -------- sps_pkg_name com order e/ou v2 --------
@@ -413,7 +430,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         self.assertEqual(xml_with_pre.order, "00001")
         self.assertIsNone(xml_with_pre.v2)
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100_00001"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100"
         )
 
     def test_sps_pkg_name_with_v2_only(self):
@@ -428,7 +445,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         self.assertIsNone(xml_with_pre.order)
         self.assertEqual(xml_with_pre.v2, "S0101-01011999000100123")
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100_00123"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100"
         )
 
     def test_sps_pkg_name_with_order_and_v2_order_takes_precedence(self):
@@ -443,7 +460,7 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         )
         # order ("00001") prevalece sobre v2[-5:] ("00123")
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100_00001"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100"
         )
 
     def test_sps_pkg_name_with_order_v2_and_htm_source_filename(self):
@@ -458,12 +475,280 @@ class TestSPSPkgName(XMLWithPreTestMixin, TestCase):
         )
         xml_with_pre.add_pkg_name_components("1989.htm")
         self.assertEqual(
-            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100_00001_1989"
+            xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100"
+        )
+
+
+class TestLegacySPSPkgName(XMLWithPreTestMixin, TestCase):
+    """Testes para sps_pkg_name e deprecated_sps_pkg_name"""
+
+    def test_deprecated_v3_sps_pkg_name_complete(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            issn_ppub="8765-4321",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e12345",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e12345")
+
+    def test_deprecated_v3_sps_pkg_name_with_suppl(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-s1-100_110")
+
+    def test_deprecated_v3_sps_pkg_name_ppub_fallback(self):
+        xml_with_pre = self._make_xml(
+            issn_ppub="8765-4321",
+            acron="xyz",
+            vol="5",
+            elocation="e001",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "8765-4321-xyz-5-e001")
+
+    def test_deprecated_v3_sps_pkg_name_no_volume_no_number(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1111-2222",
+            acron="rev",
+            elocation="e999",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1111-2222-rev-e999")
+
+    def test_deprecated_sps_pkg_name_with_suppl(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name, "1234-5678-abc-10-02-1-100")
+
+    def test_deprecated_sps_pkg_name_suppl_zero(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="0",
+            fpage="100",
+            lpage="110",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name, "1234-5678-abc-10-02-suppl-100")
+
+    def test_deprecated_sps_pkg_name_version_2_with_suppl(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        # version_2 usa o mesmo suppl de sps_pkg_name (com "s"), mas o
+        # sufixo de sps_pkg_name_suffix (não o antigo get_pkg_name_suffix)
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_2,
+            "1234-5678-abc-10-02-s1-100",
+        )
+
+    def test_deprecated_sps_pkg_name_version_2_no_suppl(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            fpage="123",
+            lpage="123",
+        )
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_2,
+            "1234-5678-abc-10-02-123",
+        )
+
+    def test_deprecated_sps_pkg_name_list(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_list,
+            [
+                "1234-5678-abc-10-02-1-100",
+                "1234-5678-abc-10-02-s1-100",
+                "1234-5678-abc-10-02-s1-100_110"
+            ],
+        )
+
+    # -------- add_pkg_name_components --------
+
+    def test_add_pkg_name_components_stores_source_filename_and_ext(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1234-5678-abc-10-02-s1-100.xml")
+        self.assertEqual(xml_with_pre.source_filename, "1234-5678-abc-10-02-s1-100")
+        self.assertEqual(xml_with_pre.source_ext, ".xml")
+
+    def test_add_pkg_name_components_default_pkg_name_version(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1989.htm")
+        self.assertEqual(xml_with_pre.pkg_name_version, 3)
+
+    def test_add_pkg_name_components_custom_pkg_name_version(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1989.htm", pkg_name_version=2)
+        self.assertEqual(xml_with_pre.pkg_name_version, 2)
+
+    def test_deprecated_v3_sps_pkg_name_with_xml_source_filename_bypasses_computation(self):
+        # source_filename já é o próprio sps_pkg_name (extensão .xml):
+        # sps_pkg_name deve retorná-lo tal como está, ignorando
+        # issn/acron/volume/numero/suppl/fpage/etc.
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        xml_with_pre.add_pkg_name_components("1234-5678-abc-10-02-s1-100.xml")
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-s1-100")
+
+    def test_deprecated_v3_sps_pkg_name_with_xml_source_filename_bypasses_even_without_metadata(self):
+        # mesmo sem volume/numero/issn, com extensão .xml o nome do
+        # pacote é o próprio source_filename (sem extensão)
+        xml_with_pre = self._make_xml()
+        xml_with_pre.add_pkg_name_components("1234-5678-abc-10-02-s1-100.xml")
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-s1-100")
+
+    def test_deprecated_v3_sps_pkg_name_with_htm_source_filename_appends_as_suffix(self):
+        # com extensão diferente de .xml (ex.: .htm, conversão do site
+        # clássico), o source_filename ("1989") é incorporado ao
+        # sufixo calculado (get_pkg_name_suffix), não substitui o nome
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            fpage="100",
+            lpage="110",
+        )
+        xml_with_pre.add_pkg_name_components("1989.htm")
+        self.assertEqual(xml_with_pre.source_filename, "1989")
+        self.assertEqual(xml_with_pre.source_ext, ".htm")
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-100_110_1989"
+        )
+
+    def test_deprecated_v3_sps_pkg_name_with_htm_source_filename_and_suppl(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            suppl="1",
+            fpage="100",
+            lpage="110",
+        )
+        xml_with_pre.add_pkg_name_components("1989.htm")
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-s1-100_110_1989"
+        )
+
+    # -------- sps_pkg_name com order e/ou v2 --------
+    # get_pkg_name_suffix inclui `self.order or self.v2 and self.v2[-5:]`
+    # como parte do sufixo: order tem precedência sobre os 5 últimos
+    # dígitos do v2 quando ambos estão presentes.
+
+    def test_deprecated_v3_sps_pkg_name_without_order_and_without_v2(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+        )
+        self.assertEqual(xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e100")
+
+    def test_deprecated_v3_sps_pkg_name_with_order_only(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+            order="00001",
+        )
+        self.assertEqual(xml_with_pre.order, "00001")
+        self.assertIsNone(xml_with_pre.v2)
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e100_00001"
+        )
+
+    def test_deprecated_v3_sps_pkg_name_with_v2_only(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+            v2="S0101-01011999000100123",
+        )
+        self.assertIsNone(xml_with_pre.order)
+        self.assertEqual(xml_with_pre.v2, "S0101-01011999000100123")
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e100_00123"
+        )
+
+    def test_deprecated_v3_sps_pkg_name_with_order_and_v2_order_takes_precedence(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+            order="00001",
+            v2="S0101-01011999000100123",
+        )
+        # order ("00001") prevalece sobre v2[-5:] ("00123")
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e100_00001"
+        )
+
+    def test_deprecated_v3_sps_pkg_name_with_order_v2_and_htm_source_filename(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678",
+            acron="abc",
+            vol="10",
+            num="2",
+            elocation="e100",
+            order="00001",
+            v2="S0101-01011999000100123",
+        )
+        xml_with_pre.add_pkg_name_components("1989.htm")
+        self.assertEqual(
+            xml_with_pre.deprecated_sps_pkg_name_version_3, "1234-5678-abc-10-02-e100_00001_1989"
         )
 
 
 class TestSPSPkgNameSuffix(XMLWithPreTestMixin, TestCase):
-    """Testes para sps_pkg_name_suffix e alternative_sps_pkg_name_suffix"""
+    """Testes para sps_pkg_name_suffix e legacy_alternative_sps_pkg_name_suffix"""
 
     def test_sps_pkg_name_suffix_elocation_id(self):
         xml_with_pre = self._make_xml(
@@ -472,7 +757,7 @@ class TestSPSPkgNameSuffix(XMLWithPreTestMixin, TestCase):
             fpage="100", lpage="110",
             doi="10.1590/1234",
         )
-        self.assertEqual(xml_with_pre.sps_pkg_name_suffix, "e12345")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_suffix, "e12345")
 
     def test_sps_pkg_name_suffix_fpage(self):
         xml_with_pre = self._make_xml(
@@ -480,34 +765,34 @@ class TestSPSPkgNameSuffix(XMLWithPreTestMixin, TestCase):
             fpage="100", lpage="110",
             doi="10.1590/1234",
         )
-        self.assertEqual(xml_with_pre.sps_pkg_name_suffix, "100")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_suffix, "100")
 
     def test_sps_pkg_name_suffix_doi(self):
         xml_with_pre = self._make_xml(
             vol="10", num="2",
             doi="10.1590/0001-3714.2020.v1.n2.1234",
         )
-        self.assertEqual(xml_with_pre.sps_pkg_name_suffix, "0001-3714-2020-v1-n2-1234")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_suffix, "0001-3714-2020-v1-n2-1234")
 
     def test_sps_pkg_name_suffix_doi_simple(self):
         xml_with_pre = self._make_xml(
             vol="10", num="2",
             doi="10.1590/abc123",
         )
-        self.assertEqual(xml_with_pre.sps_pkg_name_suffix, "abc123")
+        self.assertEqual(xml_with_pre.legacy_sps_pkg_name_suffix, "abc123")
 
     def test_sps_pkg_name_suffix_none(self):
         xml_with_pre = self._make_xml(vol="10", num="2")
-        self.assertIsNone(xml_with_pre.sps_pkg_name_suffix)
+        self.assertIsNone(xml_with_pre.legacy_sps_pkg_name_suffix)
 
-    def test_alternative_sps_pkg_name_suffix_order(self):
+    def test_legacy_alternative_sps_pkg_name_suffix_order(self):
         xml_with_pre = self._make_xml(vol="10", num="2", order="00001")
-        self.assertEqual(xml_with_pre.alternative_sps_pkg_name_suffix, "00001")
+        self.assertEqual(xml_with_pre.legacy_alternative_sps_pkg_name_suffix, "00001")
 
-    def test_alternative_sps_pkg_name_suffix_filename(self):
+    def test_legacy_alternative_sps_pkg_name_suffix_filename(self):
         xml_with_pre = self._make_xml(vol="10", num="2")
         xml_with_pre.filename = "article.xml"
-        self.assertEqual(xml_with_pre.alternative_sps_pkg_name_suffix, "article.xml")
+        self.assertEqual(xml_with_pre.legacy_alternative_sps_pkg_name_suffix, "article.xml")
 
 
 class TestV2List(XMLWithPreTestMixin, TestCase):
@@ -860,6 +1145,617 @@ class TestXMLWithPrePIDV2Generation(XMLWithPreTestMixin, TestCase):
         for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
             with self.assertRaises(ValueError):
                 xml_with_pre.generated_pid_v2()
+
+
+# ==============================================================================
+# submitted_filename / source_filename / source_ext
+# ==============================================================================
+class TestSubmittedFilename(XMLWithPreTestMixin, TestCase):
+
+    def test_submitted_filename_setter_splits_name_and_lowercases_extension(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "artigo.XML"
+        self.assertEqual(xml_with_pre._submitted_filename, "artigo")
+        self.assertEqual(xml_with_pre._submitted_ext, ".xml")
+        self.assertEqual(xml_with_pre.submitted_filename, "artigo.xml")
+
+    def test_submitted_filename_getter_none_when_not_set(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        self.assertIsNone(xml_with_pre.submitted_filename)
+        self.assertIsNone(xml_with_pre.submitted_ext)
+
+    def test_submitted_filename_setter_none_clears_name_and_ext(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "artigo.xml"
+        xml_with_pre.submitted_filename = None
+        self.assertIsNone(xml_with_pre._submitted_filename)
+        self.assertIsNone(xml_with_pre._submitted_ext)
+        self.assertIsNone(xml_with_pre.submitted_filename)
+
+    def test_submitted_filename_setter_empty_string_clears_name_and_ext(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "artigo.xml"
+        xml_with_pre.submitted_filename = ""
+        self.assertIsNone(xml_with_pre._submitted_filename)
+        self.assertIsNone(xml_with_pre.submitted_filename)
+
+    def test_submitted_filename_without_extension_keeps_previous_extension(self):
+        # Comportamento sutil: se o novo valor não tem extensão, a extensão
+        # anterior é mantida (o setter só atualiza _submitted_ext quando
+        # `ext` é verdadeiro).
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "artigo.xml"
+        xml_with_pre.submitted_filename = "outro_nome_sem_extensao"
+        self.assertEqual(xml_with_pre._submitted_filename, "outro_nome_sem_extensao")
+        self.assertEqual(xml_with_pre._submitted_ext, ".xml")
+        self.assertEqual(xml_with_pre.submitted_filename, "outro_nome_sem_extensao.xml")
+
+    def test_source_filename_and_source_ext_aliases(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.source_filename = "documento.pdf"
+        self.assertEqual(xml_with_pre.source_filename, "documento")
+        self.assertEqual(xml_with_pre.source_ext, ".pdf")
+        # o getter "cheio" (submitted_filename) reconstrói nome + extensão
+        self.assertEqual(xml_with_pre.submitted_filename, "documento.pdf")
+
+    def test_source_ext_setter_direct(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.source_filename = "documento.pdf"
+        xml_with_pre.source_ext = ".xml"
+        self.assertEqual(xml_with_pre.source_ext, ".xml")
+        self.assertEqual(xml_with_pre.submitted_filename, "documento.xml")
+
+    def test_is_html_source_true_for_html_and_htm(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "pagina.html"
+        self.assertTrue(xml_with_pre.is_html_source)
+
+        xml_with_pre.submitted_filename = "outra.htm"
+        self.assertTrue(xml_with_pre.is_html_source)
+
+    def test_is_html_source_false_for_xml(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.submitted_filename = "artigo.xml"
+        self.assertFalse(xml_with_pre.is_html_source)
+
+    def test_is_html_source_false_when_no_extension_set(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        self.assertFalse(xml_with_pre.is_html_source)
+
+
+# ==============================================================================
+# add_pkg_name_components
+# ==============================================================================
+class TestAddPkgNameComponentsExtended(XMLWithPreTestMixin, TestCase):
+
+    def test_add_pkg_name_components_with_xml_sets_provided_sps_pkg_name(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1234-5678-abc-10-02-e100.xml")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "1234-5678-abc-10-02-e100")
+        # sps_pkg_name deve retornar diretamente o valor "provided", sem
+        # nenhum cálculo adicional baseado em issn/acron/volume/etc.
+        self.assertEqual(xml_with_pre.sps_pkg_name, "1234-5678-abc-10-02-e100")
+
+    def test_add_pkg_name_components_with_non_xml_extension_does_not_set_provided_name(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", elocation="e100"
+        )
+        xml_with_pre.add_pkg_name_components("1989.htm")
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertEqual(xml_with_pre.source_filename, "1989")
+        self.assertEqual(xml_with_pre.source_ext, ".htm")
+        # sem provided/built, cai no fallback deprecated_sps_pkg_name_version_2
+        self.assertEqual(xml_with_pre.sps_pkg_name, xml_with_pre.deprecated_sps_pkg_name_version_2)
+
+    def test_add_pkg_name_components_with_underscore_in_xml_name_keeps_legacy_name(self):
+        # "_" não segue o padrão SPS (sanitize_sps_name trocaria por "-"),
+        # mas por ser um nome legado o valor original é preservado em vez
+        # de lançar ValueError.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1234_5678_abc.xml")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "1234_5678_abc")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "1234_5678_abc")
+
+    def test_add_pkg_name_components_with_extra_dot_before_xml_ext_keeps_legacy_name(self):
+        # "1234-5678.v2.xml" -> remove apenas os últimos 4 caracteres (".xml"),
+        # sobrando "1234-5678.v2", que contém "." e seria alterado por
+        # sanitize_sps_name ("1234-5678-v2"); como é legado, o valor original
+        # com ponto é mantido.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1234-5678.v2.xml")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "1234-5678.v2")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "1234-5678.v2")
+
+    def test_add_pkg_name_components_with_extra_dot_and_non_xml_ext_is_allowed(self):
+        # Mesmo nome com pontos, mas extensão diferente de ".xml": não passa
+        # pela validação de provided_sps_pkg_name, então não há erro.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("1234-5678.v2.htm")
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertEqual(xml_with_pre.source_filename, "1234-5678.v2")
+        self.assertEqual(xml_with_pre.source_ext, ".htm")
+
+    def test_add_pkg_name_components_overwrites_previous_call(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.add_pkg_name_components("primeiro-nome.xml")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "primeiro-nome")
+
+        xml_with_pre.add_pkg_name_components("segundo-nome.xml")
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "segundo-nome")
+        self.assertEqual(xml_with_pre.submitted_filename, "segundo-nome.xml")
+
+    def test_add_pkg_name_components_sets_pkg_name_version_attribute(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        self.assertIsNone(xml_with_pre.pkg_name_version)
+        xml_with_pre.add_pkg_name_components("artigo.xml", pkg_name_version=2)
+        self.assertEqual(xml_with_pre.pkg_name_version, 2)
+
+
+# ==============================================================================
+# sps_pkg_name (precedência provided > built > deprecated_v2)
+# ==============================================================================
+class TestSpsPkgNamePriority(XMLWithPreTestMixin, TestCase):
+
+    def test_sps_pkg_name_falls_back_to_deprecated_version_2_by_default(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", fpage="100", lpage="110"
+        )
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertIsNone(xml_with_pre.built_sps_pkg_name)
+        self.assertEqual(xml_with_pre.sps_pkg_name, xml_with_pre.deprecated_sps_pkg_name_version_2)
+
+    def test_sps_pkg_name_prefers_provided_over_built(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre._built_sps_pkg_name = "built-name"
+        xml_with_pre.provided_sps_pkg_name = "provided-name"
+        self.assertEqual(xml_with_pre.sps_pkg_name, "provided-name")
+
+    def test_sps_pkg_name_uses_built_when_no_provided(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre._built_sps_pkg_name = "built-name"
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertEqual(xml_with_pre.sps_pkg_name, "built-name")
+
+    def test_sps_pkg_name_setter_sets_provided_name(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.sps_pkg_name = "meu-pacote-1"
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "meu-pacote-1")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "meu-pacote-1")
+
+    def test_provided_sps_pkg_name_setter_keeps_legacy_name_when_sanitize_differs(self):
+        # Nome fora do padrão SPS (contém "_" e "."), mas tratado como
+        # legado: o valor original é preservado em vez de lançar ValueError.
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.provided_sps_pkg_name = "nome_invalido.com"
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "nome_invalido.com")
+
+    def test_provided_sps_pkg_name_setter_keeps_sanitized_value_when_already_valid(self):
+        # Quando o valor já está no padrão SPS, sanitize_sps_name não altera
+        # nada e o valor é aceito normalmente (sem passar pelo caminho de
+        # "nome legado").
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.provided_sps_pkg_name = "nome-valido-123"
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "nome-valido-123")
+
+    def test_provided_sps_pkg_name_setter_none_clears_value(self):
+        xml_with_pre = self._make_xml(vol="10", num="2")
+        xml_with_pre.provided_sps_pkg_name = "nome-valido"
+        xml_with_pre.provided_sps_pkg_name = None
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+
+
+# ==============================================================================
+# build_sps_pkg_name
+# ==============================================================================
+class TestBuildSpsPkgName(XMLWithPreTestMixin, TestCase):
+
+    def test_build_sps_pkg_name_using_elocation_id(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", elocation="e100"
+        )
+        self.assertEqual(xml_with_pre.build_sps_pkg_name(), "1234-5678-abc-10-02-e100")
+
+    def test_build_sps_pkg_name_uses_order_when_no_elocation(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", order="00007"
+        )
+        self.assertEqual(xml_with_pre.build_sps_pkg_name(), "1234-5678-abc-10-02-00007")
+
+    def test_build_sps_pkg_name_uses_submitted_filename_when_no_elocation_or_order(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2"
+        )
+        xml_with_pre.submitted_filename = "MeuArquivo.xml"
+        self.assertEqual(xml_with_pre.build_sps_pkg_name(), "1234-5678-abc-10-02-meuarquivo")
+
+    def test_build_sps_pkg_name_elocation_takes_precedence_over_order(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2",
+            elocation="e100", order="00007",
+        )
+        self.assertEqual(xml_with_pre.build_sps_pkg_name(), "1234-5678-abc-10-02-e100")
+
+    def test_build_sps_pkg_name_order_takes_precedence_over_submitted_filename(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", order="00007"
+        )
+        xml_with_pre.submitted_filename = "MeuArquivo.xml"
+        self.assertEqual(xml_with_pre.build_sps_pkg_name(), "1234-5678-abc-10-02-00007")
+
+    def test_build_sps_pkg_name_with_custom_issn(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", issn_ppub="8765-4321",
+            acron="abc", vol="10", num="2", elocation="e100",
+        )
+        self.assertEqual(
+            xml_with_pre.build_sps_pkg_name(issn="8765-4321"),
+            "8765-4321-abc-10-02-e100",
+        )
+
+    def test_build_sps_pkg_name_with_lang_suffix_when_different_from_main_lang(self):
+        # o XML gerado pelo mixin de testes usa xml:lang="en"
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", elocation="e100"
+        )
+        self.assertEqual(
+            xml_with_pre.build_sps_pkg_name(lang="pt"), "1234-5678-abc-10-02-e100-pt"
+        )
+
+    def test_build_sps_pkg_name_no_lang_suffix_when_same_as_main_lang(self):
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2", elocation="e100"
+        )
+        self.assertEqual(
+            xml_with_pre.build_sps_pkg_name(lang="en"), "1234-5678-abc-10-02-e100"
+        )
+
+    def test_build_sps_pkg_name_missing_issn_raises(self):
+        xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article" xml:lang="en">
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type="publisher-id">abc</journal-id>
+    </journal-meta>
+    <article-meta>
+      <volume>10</volume>
+      <issue>2</issue>
+      <elocation-id>e100</elocation-id>
+    </article-meta>
+  </front>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            with self.assertRaises(XMLWithPreMissingISSNError):
+                xml_with_pre.build_sps_pkg_name()
+
+    def test_build_sps_pkg_name_missing_suffix_raises_value_error(self):
+        # sem elocation_id, order ou submitted_filename disponíveis, nenhuma
+        # das estratégias padrão de build_sps_pkg_name produz um sufixo válido
+        xml_with_pre = self._make_xml(
+            issn_epub="1234-5678", acron="abc", vol="10", num="2"
+        )
+        with self.assertRaises(ValueError):
+            xml_with_pre.build_sps_pkg_name()
+
+"""
+Testes complementares para packtools.sps.pid_provider.xml_sps_lib.XMLWithPre
+
+Foco:
+    - sps_pkg_name_origin
+    - provided_sps_pkg_name (setter sem sanitização — nomes legados)
+    - get_pmc_pkg_name (com e sem revision_number)
+    - pkg_names_dict / sps_pkg_names_dict / input_files_dict / data
+    - get_data (composição condicional dos dicionários acima)
+
+Arquivo independente (contém sua própria mixin de fabricação de XML).
+"""
+# ==============================================================================
+# sps_pkg_name_origin
+# ==============================================================================
+class TestSpsPkgNameOrigin(XMLWithPreTestMixin, TestCase):
+
+    def test_origin_is_deprecated_version_2_by_default(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+        self.assertIsNone(xml_with_pre.built_sps_pkg_name)
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "deprecated_sps_pkg_name_version_2")
+
+    def test_origin_is_built_when_built_name_is_set(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre._built_sps_pkg_name = "built-name"
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "built_sps_pkg_name")
+
+    def test_origin_is_provided_when_provided_name_is_set(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "provided-name"
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "provided_sps_pkg_name")
+
+    def test_origin_provided_takes_precedence_over_built(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre._built_sps_pkg_name = "built-name"
+        xml_with_pre.provided_sps_pkg_name = "provided-name"
+        self.assertEqual(xml_with_pre.sps_pkg_name_origin, "provided_sps_pkg_name")
+        # sps_pkg_name e sps_pkg_name_origin devem ser sempre consistentes
+        self.assertEqual(xml_with_pre.sps_pkg_name, "provided-name")
+
+
+# ==============================================================================
+# provided_sps_pkg_name: setter não sanitiza mais (nomes legados)
+# ==============================================================================
+class TestProvidedSpsPkgNameLegacyBehavior(XMLWithPreTestMixin, TestCase):
+
+    def test_setter_keeps_value_as_is_even_with_characters_invalid_for_sps(self):
+        # "_" e "." não são permitidos pelo padrão SPS estrito (ver
+        # sanitize_sps_name), mas o setter atual não valida/sanitiza mais,
+        # justamente para preservar nomes legados de pacotes antigos.
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "nome_legado.v2"
+        self.assertEqual(xml_with_pre.provided_sps_pkg_name, "nome_legado.v2")
+        self.assertEqual(xml_with_pre.sps_pkg_name, "nome_legado.v2")
+
+    def test_setter_none_clears_value(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "nome-valido"
+        xml_with_pre.provided_sps_pkg_name = None
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+
+    def test_setter_empty_string_clears_value(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "nome-valido"
+        xml_with_pre.provided_sps_pkg_name = ""
+        self.assertIsNone(xml_with_pre.provided_sps_pkg_name)
+
+
+# ==============================================================================
+# get_pmc_pkg_name
+# ==============================================================================
+class TestGetPmcPkgName(XMLWithPreTestMixin, TestCase):
+
+    def test_get_pmc_pkg_name_without_revision(self):
+        xml_with_pre = self._make_base_xml()
+        # acron-vol-iss-uid ; iss NÃO é zero-padded aqui (diferente do prefixo SPS)
+        self.assertEqual(xml_with_pre.get_pmc_pkg_name(), "abc-10-2-e12345")
+
+    def test_get_pmc_pkg_name_with_revision_number(self):
+        # ATENÇÃO: sanitize_name remove o "." do sufixo ".r{n}" (ele não é um
+        # caractere permitido), então o resultado final NÃO preserva o ponto
+        # entre o uid e o "r{n}" — comportamento atual, possivelmente não
+        # intencional, documentado aqui.
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.get_pmc_pkg_name(revision_number=2), "abc-10-2-e12345r2")
+
+    def test_get_pmc_pkg_name_with_revision_number_falsy_is_ignored(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.get_pmc_pkg_name(revision_number=0), "abc-10-2-e12345")
+
+
+# ==============================================================================
+# data / input_files_dict / pkg_names_dict / sps_pkg_names_dict
+# ==============================================================================
+class TestDictProperties(XMLWithPreTestMixin, TestCase):
+
+    def test_data_contains_only_expected_keys(self):
+        xml_with_pre = self._make_base_xml()
+        data = xml_with_pre.data
+        self.assertEqual(
+            set(data.keys()),
+            {
+                "sps_pkg_name",
+                "pid_v3",
+                "pid_v2",
+                "aop_pid",
+                "filename",
+                "files",
+                "filenames",
+                "pkg_names",
+            },
+        )
+
+    def test_data_values_for_base_xml(self):
+        xml_with_pre = self._make_base_xml()
+        data = xml_with_pre.data
+        self.assertEqual(data["sps_pkg_name"], "1234-5678-abc-10-02-e12345")
+        self.assertIsNone(data["pid_v3"])
+        self.assertIsNone(data["pid_v2"])
+        self.assertIsNone(data["aop_pid"])
+        self.assertIsNone(data["filename"])
+        self.assertIsNone(data["files"])
+        self.assertIsNone(data["filenames"])
+        # sem fpage/lpage/suppl, as 3 variações deprecated coincidem
+        self.assertEqual(
+            data["pkg_names"],
+            [
+                "1234-5678-abc-10-02-e12345",
+                "1234-5678-abc-10-02-e12345",
+                "1234-5678-abc-10-02-e12345",
+            ],
+        )
+
+    def test_data_no_longer_contains_submitted_filename_or_xml_name(self):
+        # Esses campos migraram para input_files_dict; garantir que não
+        # "vazam" de volta para `data` por engano em uma futura refatoração.
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.submitted_filename = "artigo.xml"
+        xml_with_pre.xml_name = "artigo"
+        data = xml_with_pre.data
+        self.assertNotIn("submitted_filename", data)
+        self.assertNotIn("submitted_ext", data)
+        self.assertNotIn("xml_name", data)
+        self.assertNotIn("zip_namelist", data)
+        self.assertNotIn("zip_basenames", data)
+
+    def test_input_files_dict_keys_and_values(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.add_xml_info("artigo", "/tmp/artigo.xml")
+        xml_with_pre.add_zip_info("/tmp/pacote.zip", ["artigo.xml"], ["artigo.xml"])
+        xml_with_pre.submitted_filename = "Artigo.HTM"
+
+        expected = {
+            "xml_name": "artigo",
+            "zip_namelist": ["artigo.xml"],
+            "zip_basenames": ["artigo.xml"],
+            "zip_file_path": "/tmp/pacote.zip",
+            "xml_file_path": "/tmp/artigo.xml",
+            "submitted_filename": "Artigo.htm",
+            "submitted_ext": ".htm",
+            "is_html": True,
+            "provided_sps_pkg_name": None,
+        }
+        self.assertEqual(xml_with_pre.input_files_dict, expected)
+
+    def test_input_files_dict_defaults_when_nothing_set(self):
+        xml_with_pre = self._make_base_xml()
+        expected = {
+            "xml_name": None,
+            "zip_namelist": None,
+            "zip_basenames": None,
+            "zip_file_path": None,
+            "xml_file_path": None,
+            "submitted_filename": None,
+            "submitted_ext": None,
+            "is_html": None,
+            "provided_sps_pkg_name": None,
+        }
+        self.assertEqual(xml_with_pre.input_files_dict, expected)
+
+    def test_pkg_names_dict_keys(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(
+            set(xml_with_pre.pkg_names_dict.keys()),
+            {
+                "pmc_pkg_name",
+                "built_sps_pkg_name",
+                "provided_sps_pkg_name",
+                "sps_pkg_name",
+                "sps_pkg_name_origin",
+                "pkg_name_list",
+            },
+        )
+
+    def test_pkg_names_dict_values_for_base_xml(self):
+        xml_with_pre = self._make_base_xml()
+        pkg_names = xml_with_pre.pkg_names_dict
+        self.assertEqual(pkg_names["pmc_pkg_name"], "abc-10-2-e12345")
+        self.assertIsNone(pkg_names["built_sps_pkg_name"])
+        self.assertIsNone(pkg_names["provided_sps_pkg_name"])
+        self.assertEqual(pkg_names["sps_pkg_name"], "1234-5678-abc-10-02-e12345")
+        self.assertEqual(pkg_names["sps_pkg_name_origin"], "deprecated_sps_pkg_name_version_2")
+        # ATENÇÃO: pkg_name_variations sempre inclui `None` quando
+        # built_sps_pkg_name não foi definido, pois o try/except em
+        # pkg_name_variations não captura nenhuma exceção real (a property
+        # built_sps_pkg_name nunca lança ValueError, apenas retorna None).
+        self.assertEqual(
+            pkg_names["pkg_name_list"],
+            {"1234-5678-abc-10-02-e12345", None},
+        )
+
+    def test_pkg_names_dict_reflects_provided_name_when_set(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.provided_sps_pkg_name = "meu-pacote"
+        pkg_names = xml_with_pre.pkg_names_dict
+        self.assertEqual(pkg_names["sps_pkg_name"], "meu-pacote")
+        self.assertEqual(pkg_names["sps_pkg_name_origin"], "provided_sps_pkg_name")
+        self.assertIn("meu-pacote", pkg_names["pkg_name_list"])
+
+    def test_sps_pkg_names_dict_keys(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(
+            set(xml_with_pre.sps_pkg_names_dict.keys()),
+            {
+                "sps_pkg_name",
+                "sps_pkg_name_origin",
+                "pkg_name_list",
+                "built_sps_pkg_name",
+                "built_sps_pkg_name_now",
+                "provided_sps_pkg_name",
+            },
+        )
+
+    def test_sps_pkg_names_dict_values_for_base_xml(self):
+        xml_with_pre = self._make_base_xml()
+        sps_pkg_names = xml_with_pre.sps_pkg_names_dict
+        self.assertEqual(sps_pkg_names["sps_pkg_name"], "1234-5678-abc-10-02-e12345")
+        self.assertEqual(sps_pkg_names["sps_pkg_name_origin"], "deprecated_sps_pkg_name_version_2")
+        self.assertIsNone(sps_pkg_names["built_sps_pkg_name"])
+        self.assertIsNone(sps_pkg_names["provided_sps_pkg_name"])
+        # built_sps_pkg_name_now é calculado na hora (build_sps_pkg_name()),
+        # e não depende de `built_sps_pkg_name` ter sido definido antes
+        self.assertEqual(sps_pkg_names["built_sps_pkg_name_now"], "1234-5678-abc-10-02-e12345")
+
+    def test_sps_pkg_names_dict_raises_when_no_suffix_strategy_matches(self):
+        # build_sps_pkg_name() (chamado dentro de sps_pkg_names_dict) usa
+        # apenas as estratégias elocation_id/order/submitted_filename; sem
+        # nenhuma delas, uma ValueError se propaga ao acessar o dicionário.
+        xml_with_pre = self._make_xml(issn_epub="1234-5678", acron="abc", vol="10", num="2")
+        with self.assertRaises(ValueError):
+            xml_with_pre.sps_pkg_names_dict
+
+
+# ==============================================================================
+# get_data
+# ==============================================================================
+class TestGetData(XMLWithPreTestMixin, TestCase):
+
+    def test_get_data_default_equals_data_property(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.get_data(), xml_with_pre.data)
+
+    def test_get_data_with_input_files_true_adds_input_files_dict_keys(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.submitted_filename = "artigo.xml"
+        result = xml_with_pre.get_data(input_files=True)
+        for key in xml_with_pre.input_files_dict:
+            self.assertIn(key, result)
+        self.assertEqual(result["submitted_filename"], "artigo.xml")
+        # chaves originais de `data` continuam presentes
+        self.assertIn("sps_pkg_name", result)
+
+    def test_get_data_with_pkg_names_true_adds_pkg_names_dict_keys(self):
+        xml_with_pre = self._make_base_xml()
+        result = xml_with_pre.get_data(pkg_names=True)
+        for key in xml_with_pre.pkg_names_dict:
+            self.assertIn(key, result)
+        self.assertEqual(result["pmc_pkg_name"], "abc-10-2-e12345")
+        self.assertEqual(result["sps_pkg_name_origin"], "deprecated_sps_pkg_name_version_2")
+
+    def test_get_data_with_sps_pkg_names_true_adds_sps_pkg_names_dict_keys(self):
+        xml_with_pre = self._make_base_xml()
+        result = xml_with_pre.get_data(sps_pkg_names=True)
+        for key in xml_with_pre.sps_pkg_names_dict:
+            self.assertIn(key, result)
+        self.assertEqual(result["built_sps_pkg_name_now"], "1234-5678-abc-10-02-e12345")
+
+    def test_get_data_with_article_true_adds_article_data_keys(self):
+        xml_with_pre = self._make_base_xml()
+        result = xml_with_pre.get_data(article=True)
+        for key in ("surnames", "collab", "links", "article_titles", "partial_body", "body_fragment"):
+            self.assertIn(key, result)
+        # XML de teste não tem corpo, autores nem títulos
+        self.assertEqual(result["surnames"], [])
+        self.assertIsNone(result["collab"])
+        self.assertIsNone(result["partial_body"])
+        self.assertEqual(result["body_fragment"], "")
+
+    def test_get_data_default_flags_do_not_add_extra_dict_keys(self):
+        # input_files, sps_pkg_names e pkg_names/article são opt-in;
+        # por padrão nenhum deles deve aparecer no resultado.
+        xml_with_pre = self._make_base_xml()
+        result = xml_with_pre.get_data()
+        self.assertNotIn("pmc_pkg_name", result)
+        self.assertNotIn("built_sps_pkg_name_now", result)
+        self.assertNotIn("submitted_filename", result)
+        self.assertNotIn("surnames", result)
+
+    def test_get_data_combining_multiple_flags(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.submitted_filename = "artigo.xml"
+        result = xml_with_pre.get_data(input_files=True, pkg_names=True, article=True)
+        # chaves de cada dicionário combinado devem estar todas presentes
+        for key in xml_with_pre.input_files_dict:
+            self.assertIn(key, result)
+        for key in xml_with_pre.pkg_names_dict:
+            self.assertIn(key, result)
+        for key in ("surnames", "collab", "links", "article_titles", "partial_body", "body_fragment"):
+            self.assertIn(key, result)
 
 
 if __name__ == "__main__":

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -2360,14 +2360,14 @@ class TestRenditionsContent(XMLWithPreTestMixin, TestCase):
 
     def test_sps_pkg_name_uses_direct_fstring_not_replace(self):
         xml_with_pre = self._setup(
-            xml_name="pt", zip_namelist=["pt-pt.pdf"], provided_name="pt"
+            xml_name="xmlname", zip_namelist=["xmlname-pt.pdf"], provided_name="provided"
         )
         _patch_article_renditions([SimpleNamespace(is_main_language=False, language="pt")])
 
         result = xml_with_pre.renditions
 
-        self.assertEqual(result[0]["name"], "pt-pt.pdf")
-        self.assertEqual(result[0]["sps_pkg_name"], "pt-pt.pdf")
+        self.assertEqual(result[0]["name"], "xmlname-pt.pdf")
+        self.assertEqual(result[0]["sps_pkg_name"], "provided-pt.pdf")
 
     def test_uses_deprecated_fallback_sps_pkg_name_when_nothing_provided(self):
         xml_with_pre = self._setup(zip_namelist=["artigo.pdf"], provided_name=None)

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -2138,3 +2138,261 @@ class TestSpsPkgNameComprehensive(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         with self.assertRaises(AttributeError):
             xml_with_pre.sps_pkg_name = "new-set-name"
+
+"""
+Testes complementares para packtools.sps.pid_provider.xml_sps_lib.XMLWithPre.renditions
+
+Última versão de `renditions`:
+    1. O "portão" agora verifica `self.zip_namelist` (não mais
+       `zip_basenames`) — se falsy, retorna [] imediatamente.
+    2. Constrói um mapa {basename: caminho_completo} a partir de
+       `self.zip_namelist` usando os.path.basename, permitindo localizar um
+       arquivo mesmo que esteja dentro de subpastas no zip.
+    3. Troca o campo booleano "in_zip" por "path_in_zip": o CAMINHO COMPLETO
+       (conforme está no zip) do arquivo cujo basename bate com "name", ou
+       None se não houver correspondência.
+    4. "sps_pkg_name" continua sendo montado por f-string direta.
+
+`ArticleRenditions` é mockado para isolar a lógica própria da property.
+"""
+from types import SimpleNamespace
+
+
+def _patch_article_renditions(items):
+    """Mocka ArticleRenditions(...).article_renditions com `items`."""
+    patcher = patch("packtools.sps.pid_provider.xml_sps_lib.ArticleRenditions")
+    mock_class = patcher.start()
+    mock_class.return_value.article_renditions = items
+    return mock_class
+
+
+class TestRenditionsGating(XMLWithPreTestMixin, TestCase):
+    """Testa o "portão" baseado em zip_namelist (não mais zip_basenames)."""
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_returns_empty_list_when_zip_namelist_is_none(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = "artigo"
+        self.assertIsNone(xml_with_pre.zip_namelist)
+
+        mock_class = _patch_article_renditions(
+            [SimpleNamespace(is_main_language=True, language="en")]
+        )
+        self.assertEqual(xml_with_pre.renditions, [])
+        mock_class.assert_not_called()
+
+    def test_returns_empty_list_when_zip_namelist_is_empty_list(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = "artigo"
+        xml_with_pre.zip_namelist = []
+
+        mock_class = _patch_article_renditions(
+            [SimpleNamespace(is_main_language=True, language="en")]
+        )
+        self.assertEqual(xml_with_pre.renditions, [])
+        mock_class.assert_not_called()
+
+    def test_zip_basenames_no_longer_gates_anything(self):
+        # zip_basenames (usado em versões anteriores) deixou de importar:
+        # com zip_namelist preenchido e zip_basenames vazio/None, a property
+        # deve funcionar normalmente.
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = "artigo"
+        xml_with_pre.zip_namelist = ["artigo.pdf"]
+        xml_with_pre.zip_basenames = None
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+        self.assertEqual(len(result), 1)
+
+        # e o inverso: zip_basenames preenchido mas zip_namelist vazio ->
+        # continua retornando []
+        xml_with_pre2 = self._make_base_xml()
+        xml_with_pre2.xml_name = "artigo"
+        xml_with_pre2.zip_namelist = []
+        xml_with_pre2.zip_basenames = ["artigo.pdf"]
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+        self.assertEqual(xml_with_pre2.renditions, [])
+
+    def test_raises_value_error_immediately_on_property_access(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.zip_namelist = ["artigo.xml"]
+        # xml_name nunca foi atribuído (permanece None)
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        with self.assertRaises(ValueError):
+            xml_with_pre.renditions
+
+    def test_no_error_when_xml_name_missing_but_zip_namelist_falsy(self):
+        xml_with_pre = self._make_base_xml()
+        # nem xml_name nem zip_namelist foram definidos
+        mock_class = _patch_article_renditions(
+            [SimpleNamespace(is_main_language=True, language="en")]
+        )
+        self.assertEqual(xml_with_pre.renditions, [])
+        mock_class.assert_not_called()
+
+
+class TestRenditionsPathInZip(XMLWithPreTestMixin, TestCase):
+    """Testa o mapeamento basename -> caminho completo e o campo path_in_zip."""
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _setup(self, xml_name="artigo", zip_namelist=None, provided_name="1234-5678-abc-10-02-e100"):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = xml_name
+        xml_with_pre.zip_namelist = zip_namelist if zip_namelist is not None else []
+        if provided_name is not None:
+            xml_with_pre.provided_sps_pkg_name = provided_name
+        return xml_with_pre
+
+    def test_path_in_zip_equals_full_path_when_file_is_at_zip_root(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+        self.assertEqual(result[0]["path_in_zip"], "artigo.pdf")
+
+    def test_path_in_zip_resolves_via_basename_when_file_is_in_subfolder(self):
+        # zip_namelist guarda o caminho completo dentro do zip; o match é
+        # feito pelo basename, mas o valor retornado é o caminho ORIGINAL.
+        xml_with_pre = self._setup(zip_namelist=["pkg/subpasta/artigo.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+        self.assertEqual(result[0]["name"], "artigo.pdf")
+        self.assertEqual(result[0]["path_in_zip"], "pkg/subpasta/artigo.pdf")
+
+    def test_path_in_zip_is_none_when_no_matching_basename(self):
+        xml_with_pre = self._setup(zip_namelist=["outro-arquivo.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+        self.assertIsNone(result[0]["path_in_zip"])
+
+    def test_duplicate_basenames_last_entry_in_zip_namelist_wins(self):
+        # Se dois caminhos no zip tiverem o MESMO basename (situação
+        # incomum, mas possível), o dict `namelist` é sobrescrito em ordem —
+        # o último item de zip_namelist "vence".
+        xml_with_pre = self._setup(
+            zip_namelist=["dir1/artigo.pdf", "dir2/artigo.pdf"]
+        )
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+        self.assertEqual(result[0]["path_in_zip"], "dir2/artigo.pdf")
+
+    def test_multiple_renditions_with_mixed_path_in_zip(self):
+        xml_with_pre = self._setup(
+            zip_namelist=["artigo.pdf", "pkg/artigo-pt.pdf"]
+        )
+        fake_items = [
+            SimpleNamespace(is_main_language=True, language="en"),
+            SimpleNamespace(is_main_language=False, language="pt"),
+            SimpleNamespace(is_main_language=False, language="es"),
+        ]
+        _patch_article_renditions(fake_items)
+
+        result = xml_with_pre.renditions
+
+        self.assertEqual(
+            [item["name"] for item in result],
+            ["artigo.pdf", "artigo-pt.pdf", "artigo-es.pdf"],
+        )
+        self.assertEqual(
+            [item["path_in_zip"] for item in result],
+            ["artigo.pdf", "pkg/artigo-pt.pdf", None],
+        )
+
+
+class TestRenditionsContent(XMLWithPreTestMixin, TestCase):
+    """Testa as demais chaves do dicionário retornado."""
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _setup(self, xml_name="artigo", zip_namelist=None, provided_name="1234-5678-abc-10-02-e100"):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.xml_name = xml_name
+        xml_with_pre.zip_namelist = zip_namelist if zip_namelist is not None else []
+        if provided_name is not None:
+            xml_with_pre.provided_sps_pkg_name = provided_name
+        return xml_with_pre
+
+    def test_return_type_is_a_plain_list(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+        self.assertIsInstance(xml_with_pre.renditions, list)
+
+    def test_main_language_dict_shape_and_values(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+
+        self.assertEqual(len(result), 1)
+        item = result[0]
+        self.assertEqual(
+            set(item.keys()),
+            {"name", "lang", "component_type", "main", "sps_pkg_name", "path_in_zip"},
+        )
+        self.assertEqual(item["name"], "artigo.pdf")
+        self.assertEqual(item["lang"], "en")
+        self.assertEqual(item["component_type"], "rendition")
+        self.assertTrue(item["main"])
+        self.assertEqual(item["sps_pkg_name"], "1234-5678-abc-10-02-e100.pdf")
+        self.assertEqual(item["path_in_zip"], "artigo.pdf")
+
+    def test_translation_dict_shape_and_values(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo-pt.pdf"])
+        _patch_article_renditions([SimpleNamespace(is_main_language=False, language="pt")])
+
+        result = xml_with_pre.renditions
+
+        item = result[0]
+        self.assertEqual(item["name"], "artigo-pt.pdf")
+        self.assertEqual(item["lang"], "pt")
+        self.assertFalse(item["main"])
+        self.assertEqual(item["sps_pkg_name"], "1234-5678-abc-10-02-e100-pt.pdf")
+
+    def test_sps_pkg_name_uses_direct_fstring_not_replace(self):
+        xml_with_pre = self._setup(
+            xml_name="pt", zip_namelist=["pt-pt.pdf"], provided_name="pt"
+        )
+        _patch_article_renditions([SimpleNamespace(is_main_language=False, language="pt")])
+
+        result = xml_with_pre.renditions
+
+        self.assertEqual(result[0]["name"], "pt-pt.pdf")
+        self.assertEqual(result[0]["sps_pkg_name"], "pt-pt.pdf")
+
+    def test_uses_deprecated_fallback_sps_pkg_name_when_nothing_provided(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"], provided_name=None)
+        _patch_article_renditions([SimpleNamespace(is_main_language=True, language="en")])
+
+        result = xml_with_pre.renditions
+
+        self.assertEqual(result[0]["name"], "artigo.pdf")
+        self.assertEqual(result[0]["sps_pkg_name"], "artigo.pdf")
+
+    def test_empty_result_when_article_renditions_has_no_items(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"])
+        _patch_article_renditions([])
+
+        self.assertEqual(xml_with_pre.renditions, [])
+
+    def test_article_renditions_called_with_xmltree_only_after_gate_passes(self):
+        xml_with_pre = self._setup(zip_namelist=["artigo.pdf"])
+        mock_class = _patch_article_renditions([])
+
+        xml_with_pre.renditions
+
+        mock_class.assert_called_once_with(xml_with_pre.xmltree)
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/tests/sps/pid_provider/test_xml_sps_lib_functions.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib_functions.py
@@ -1,0 +1,159 @@
+import os
+import unittest
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import MagicMock, mock_open, patch
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from lxml import etree
+
+from packtools.sps.pid_provider.xml_sps_lib import (
+    GetXMLItemsError,
+    XMLWithPre,
+    get_xml_items,
+    get_xml_with_pre_from_xml_file,
+)
+
+class TestGetXmlWithPreFromXmlFile(unittest.TestCase):
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open", new_callable=mock_open, read_data="<xml>conteudo utf-8</xml>")
+    def test_get_xml_with_pre_from_xml_file_sucesso_utf8(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa o fluxo de sucesso lendo o arquivo em UTF-8 de primeira."""
+        path_ficticio = os.path.join("caminho", "falso", "artigo.xml")
+        mock_xml_obj = XMLWithPre("", etree.fromstring("<article/>"))
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        # Garante que tentou abrir em utf-8
+        mock_file_open.assert_called_once_with(path_ficticio, encoding="utf-8")
+        mock_get_xml_with_pre.assert_called_once_with("<xml>conteudo utf-8</xml>")
+
+        # Valida os atributos injetados no objeto XML
+        self.assertEqual(mock_xml_obj.xml_file_path, path_ficticio)
+        self.assertEqual(mock_xml_obj.filename, "artigo.xml")
+        self.assertEqual(mock_xml_obj.xml_name, "artigo")
+
+        # Valida o dicionário retornado
+        self.assertEqual(
+            resultado,
+            {
+                "xml_name": "artigo",
+                "xml_with_pre": mock_xml_obj,
+            },
+        )
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open")
+    def test_get_xml_with_pre_from_xml_file_fallback_encoding_iso(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa se recorre ao iso-8859-1 caso ocorra erro ao abrir/ler em utf-8."""
+        path_ficticio = "artigo_latin.xml"
+        mock_xml_obj = MagicMock()
+        mock_get_xml_with_pre.return_value = mock_xml_obj
+
+        # Simula falha na 1ª abertura (utf-8) e sucesso na 2ª (iso-8859-1)
+        handle_utf8 = mock_open(read_data="").return_value
+        handle_utf8.read.side_effect = UnicodeDecodeError("utf-8", b"", 0, 1, "erro")
+        
+        handle_iso = mock_open(read_data="<xml>conteudo latin1</xml>").return_value
+
+        mock_file_open.side_effect = [handle_utf8, handle_iso]
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        # Verifica se tentou abrir com ambos os encodings
+        self.assertEqual(mock_file_open.call_count, 2)
+        mock_file_open.assert_any_call(path_ficticio, encoding="utf-8")
+        mock_file_open.assert_any_call(path_ficticio, encoding="iso-8859-1")
+
+        mock_get_xml_with_pre.assert_called_once_with("<xml>conteudo latin1</xml>")
+        self.assertEqual(resultado["xml_name"], "artigo_latin")
+        self.assertEqual(resultado["xml_with_pre"], mock_xml_obj)
+
+    @patch("packtools.sps.pid_provider.xml_sps_lib.get_xml_with_pre")
+    @patch("builtins.open", new_callable=mock_open, read_data="<xml>invalido")
+    def test_get_xml_with_pre_from_xml_file_erro_no_parser(
+        self, mock_file_open, mock_get_xml_with_pre
+    ):
+        """Testa o retorno do dicionário com informações de erro quando o parser falha."""
+        path_ficticio = "documento_corrompido.xml"
+        mock_get_xml_with_pre.side_effect = ValueError("Falha de Parse no XML")
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        self.assertEqual(resultado["xml_name"], "documento_corrompido")
+        self.assertEqual(resultado["error_message"], "Falha de Parse no XML")
+        self.assertIn("ValueError", resultado["error_type"])
+        self.assertIn("traceback", resultado)
+
+    @patch("builtins.open", side_effect=FileNotFoundError("Arquivo inexistente"))
+    def test_get_xml_with_pre_from_xml_file_erro_arquivo_nao_encontrado(self, mock_file_open):
+        """Testa a captura de erro de arquivo inexistente em ambos os blocos try."""
+        path_ficticio = "inexistente.xml"
+
+        resultado = get_xml_with_pre_from_xml_file(path_ficticio)
+
+        self.assertEqual(resultado["xml_name"], "inexistente")
+        self.assertEqual(resultado["error_message"], "Arquivo inexistente")
+        self.assertIn("FileNotFoundError", resultado["error_type"])
+        self.assertIn("traceback", resultado)
+
+
+class TestGetXmlItems(TestCase):
+    """Testes para a função get_xml_items."""
+
+    def test_get_xml_items_single_xml_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
+
+        with NamedTemporaryFile(
+            suffix=".xml", mode="w", encoding="utf-8", delete=False
+        ) as tmp:
+            tmp.write(xml_content)
+            tmp_path = tmp.name
+
+        try:
+            items = get_xml_items(tmp_path)
+            self.assertEqual(len(items), 1)
+            self.assertIn("xml_with_pre", items[0])
+            self.assertEqual(items[0]["xml_with_pre"].filename, os.path.basename(tmp_path))
+            self.assertEqual(items[0]["xml_with_pre"].xml_name, os.path.basename(tmp_path)[:-4])
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_get_xml_items_invalid_extension_raises_error(self):
+        with NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tmp:
+            tmp.write("invalid")
+            tmp_path = tmp.name
+
+        try:
+            with self.assertRaises(GetXMLItemsError):
+                get_xml_items(tmp_path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_get_xml_items_zip_file(self):
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+        <article><front><journal-meta><journal-id>abc</journal-id></journal-meta></front></article>"""
+
+        with TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, "package.zip")
+            with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as zf:
+                zf.writestr("article1.xml", xml_content)
+
+            items = list(get_xml_items(zip_path))
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]["xml_with_pre"].xml_name, "article1")
+            self.assertEqual(items[0]["xml_with_pre"].filename, "article1.xml")
+            self.assertIn("xml_with_pre", items[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que esse PR faz?
O PR introduz uma nova estratégia determinística de geração de `sps_pkg_name`, com precedência explícita entre:
- **`provided_sps_pkg_name`** — nome fornecido/legado, sem sanitização, para preservar pacotes antigos;
- **`built_sps_pkg_name`** — nome construído pela nova regra (`build_sps_pkg_name()`, baseada em prefixo SPS: ISSN-Acrônimo-Volume-Número-Suplemento + sufixo por estratégias ordenadas);
- **`xml_name`** - nome no zip ou do xml
- **`deprecated_sps_pkg_name_version_2`** — fallback da regra antiga, mantido por compatibilidade.

Também refatora `XMLWithPre` (`packtools/sps/pid_provider/xml_sps_lib.py`), que antes concentrava em um único bloco monolítico o parsing de DOCTYPE, a manipulação de arquivos/zip/assets/renditions, a geração de nomes de pacote (`sps_pkg_name`), os identificadores (v2/v3/aop_pid/order) e os metadados do artigo. A classe passa a ser composta por mixins coesos (`DOCTYPEParserMixin`, `PackagingAndFilesMixin`, `LegacyPackageNamingMixin`, `PackageNamingMixin`, `IdentifiersMixin`, `ArticleMetadataMixin`).

Corrige o resultado de `body_fragment_fingerprint` e cria `body_fingerprint` (fingerprint do corpo completo, sem truncamento, separado do fingerprint do fragmento de 300 caracteres).

Outras features adicionadas:
- `XMLWithPreMissingISSNError` e propriedades `available_issns`/`sps_issn`.
- `sps_pkg_name_origin`, para rastrear qual estratégia gerou o nome atual.
- `source_filename`/`source_ext` como aliases de `submitted_filename`/`submitted_ext`, com detecção automática de `is_html_source`.
- `add_pkg_name_components` passa a atribuir automaticamente `provided_sps_pkg_name` quando o `source_filename` recebido termina em `.xml` (antes só separava nome/extensão).
- `get_pmc_pkg_name(revision_number=None)` — novo método que gera nome de pacote no padrão PMC (`jour-vol-iss-uid`, com sufixo opcional de revisão).
- Dicionários estruturados para consumo externo: `data`, `input_files_dict`, `pkg_names_dict`, `sps_pkg_names_dict`, e o método `get_data()` como composição opt-in desses dicionários.
- Funções utilitárias `sanitize_name`/`sanitize_sps_name`.
- `classmethod create()` passa a aceitar `xml_native_name`, `html_name`, `built_name` para já popular `provided_sps_pkg_name`/`submitted_filename`/`built_sps_pkg_name` na criação da instância.

**Duas mudanças de comportamento que merecem atenção (detalhadas em "Algum cenário de contexto"):**
- A propriedade `filename` **perdeu o setter**. Agora é somente leitura e calculada a partir de `zip_file_path`/`xml_file_path`/`xml_name` (definidos via `add_xml_info`/`add_zip_info`).
- `renditions` foi reescrita: o acesso de disponibilidade passou a verificar `zip_namelist` (antes não havia portão explícito), passa a levantar `ValueError` se `xml_name` não estiver definido, adiciona a chave `path_in_zip` (resolvida por `basename`, cobrindo XMLs dentro de subpastas do zip) e o campo `name` agora é montado a partir de `xml_name` — o nome baseado em `sps_pkg_name` foi movido para a chave separada `sps_pkg_name` de cada item.

## Onde a revisão poderia começar?
- `packtools/sps/pid_provider/xml_sps_lib.py`:
  - `XMLWithPre.__init__` e a lista de mixins na declaração da classe (ordem de resolução de método).
  - `PackageNamingMixin.get_pkg_suffix` e `build_sps_pkg_name` — núcleo da nova regra de nomeação.
  - `sps_pkg_name` / `sps_pkg_name_origin` — lógica de precedência provided → built → deprecated.
  - `provided_sps_pkg_name.setter` — decisão deliberada de **não sanitizar** (preservar nomes legados).
  - `PackagingAndFilesMixin.filename` (getter sem setter) — mudança de contrato da API.
  - `PackagingAndFilesMixin.renditions` — novo gate por `zip_namelist`, `ValueError` em `xml_name` ausente, `path_in_zip`.
  - `LegacyPackageNamingMixin.get_pmc_pkg_name` — novo padrão de nome PMC.
- `tests/sps/pid_provider/test_xml_sps_lib.py` — cobertura correspondente a cada ponto acima.
- `tests/sps/pid_provider/test_xml_sps_lib_functions.py` (novo arquivo) — testes de `get_xml_with_pre_from_xml_file` (fallback de encoding utf-8 → iso-8859-1, tratamento de erro de parser/arquivo inexistente) e `get_xml_items` (arquivo `.xml` único, extensão inválida, pacote `.zip`).

## Como este poderia ser testado manualmente?
1. Rodar a suíte de testes completa do módulo:

```bash
python -m unittest tests/sps/pid_provider/test_*
```

(o número total de testes aumentou em relação à última execução registrada, por conta do novo arquivo `test_xml_sps_lib_functions.py` e das novas classes de teste — confirmar que todos passam antes do merge.)

2. Conferir especialmente as classes:
   - `TestSpsPkgNamePriority` / `TestSpsPkgNameComprehensive` (precedência provided > built > xml_name > deprecated_v2)
   - `TestBuildSpsPkgName` (estratégias de sufixo e exceção `XMLWithPreMissingISSNError`)
   - `TestProvidedSpsPkgNameLegacyBehavior` (não sanitização de nomes legados com `_`/`.`)
   - `TestGetPmcPkgName`, `TestDictProperties`, `TestGetData` (novos dicionários estruturados)
   - `TestXmlNameVsFilenameOrigin` (comportamento de `filename` sem setter, com e sem zip)
   - `TestRenditionsGating`, `TestRenditionsPathInZip`, `TestRenditionsContent` (novo comportamento de `renditions`)
3. Testar manualmente em shell Python, criando um `XMLWithPre` a partir de um XML de exemplo e comparando `xml_with_pre.sps_pkg_name`, `xml_with_pre.pkg_names_dict`, `xml_with_pre.get_data(pkg_names=True)` e `xml_with_pre.renditions` antes e depois da mudança, usando um pacote real já processado em produção para validar que o nome final e os componentes/renditions não mudam de forma inesperada para casos já publicados.

## Algum cenário de contexto que queira dar?
Esta é uma mudança que **quebra compatibilidade de nomes públicos e de contrato de atributos**:

1. Vários métodos/atributos foram renomeados com prefixo `legacy_`/`deprecated_`/`incorrect_` (ex.: `sps_pkg_name_suffix` → `legacy_sps_pkg_name_suffix`, `sps_pkg_name_fpage` → `legacy_sps_pkg_name_fpage`, `alternative_sps_pkg_name_suffix` → `legacy_alternative_sps_pkg_name_suffix`, `get_pkg_name_prefix`/`get_pkg_name_suffix` → `legacy_get_pkg_name_prefix`/`legacy_get_pkg_name_suffix`, `deprecated_sps_pkg_name_suppl` → `incorrect_sps_pkg_name_suppl`, e a antiga `sps_pkg_name` legada → `deprecated_sps_pkg_name_version_3`). Qualquer código consumidor em `scms-upload`/`core` que referencie esses nomes diretamente precisa ser atualizado **antes** do deploy conjunto — recomenda-se buscar essas ocorrências nos repositórios dependentes antes de subir a nova versão do `packtools`.

2. O comportamento de `sps_pkg_name` mudou: antes era sempre calculado pela regra antiga; agora segue a precedência `provided → built → xml_name → deprecated_v2`, o que pode alterar o valor retornado em cenários onde não havia distinção entre "nome fornecido" e "nome calculado" — importante validar contra uma amostra de pacotes já publicados para garantir que não há regressão de nomes já registrados no pid_provider.

3. **`filename` deixou de ter setter.** Qualquer código que faça `xml_with_pre.filename = "algo.xml"` diretamente vai passar a lançar `AttributeError`. O caminho correto passa a ser `add_xml_info(xml_name, xml_file_path=None)` (e, quando aplicável, `add_zip_info(...)`). Isso é especialmente sensível porque `filename` também muda de significado: sem zip, é `f"{xml_name}.xml"` (ignora `xml_file_path` completo); com zip, é o `xml_file_path` (caminho do XML dentro do zip, que pode incluir subpastas). Recomenda-se buscar por atribuições diretas a `.filename` nos repositórios consumidores.

4. **`renditions` teve mudança de contrato**: antes não existia um acesso de disponibilidade nem exceção — agora, se `zip_namelist` estiver vazio/`None`, retorna lista vazia; se houver `zip_namelist` mas `xml_name` não estiver definido, levanta `ValueError`. Além disso, a chave `name` de cada rendition agora é baseada em `xml_name` (não mais em `sps_pkg_name`); quem dependia do nome de arquivo da rendition ser derivado do `sps_pkg_name` deve passar a consumir a nova chave `sps_pkg_name` do dicionário retornado. A nova chave `path_in_zip` resolve o caminho completo dentro do zip por correspondência de `basename`, útil quando o XML/renditions estão em subpastas.

## Screenshots
N/A — mudança restrita à biblioteca Python `packtools`, sem interface gráfica.

## Quais são os tickets relevantes?
#1269

## Referências
- Guia de nomenclatura de pacotes SPS (SciELO Publishing Schema), versão 1.10.
- Convenções internas de PID v2/v3 do `pid_provider`.
- Convenção de nomenclatura PMC (`jour-vol-iss-uid`), usada como referência para `get_pmc_pkg_name`.

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não — a mudança manipula apenas metadados bibliográficos de artigos (ISSN, DOI, datas de publicação, sobrenomes de autores já públicos em XML JATS), sem introduzir novo tratamento de dados pessoais sensíveis.

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não — não há qualquer lógica de autenticação/autorização nesta biblioteca.

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não — apenas o módulo `re` da stdlib foi adicionado como import; nenhuma dependência externa nova.

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): aguardando execução do pipeline de CI padrão antes do merge; nenhuma alteração de infraestrutura ou dependência que exija validação adicional.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não — não há geração de SQL/HTML/JS; `sanitize_name`/`sanitize_sps_name` tratam apenas strings para compor nomes de arquivo/pacote via regex, sem execução de código.

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não — mudança restrita à biblioteca `packtools`, sem exposição de endpoint/tela/serviço.

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)