### PR TITLE
fix(packaging): compila os catalogos i18n antes do build (closes #1267)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include packtools *.xsd *.sch *.xml *.ent *.dtd *.mod *.xslt *.json *.xsl *.html *.ico *.css *.txt *.png *.js
-recursive-include packtools/sps/locale *.mo
+recursive-include packtools/sps/locale *.mo *.po
 recursive-exclude tests *
 include README.md HISTORY.md
 exclude tox.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=68", "wheel", "Babel>=2.12"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 #coding:utf-8
 from __future__ import unicode_literals
+from pathlib import Path
 from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
 import setuptools
 import codecs
 import sys
@@ -9,6 +11,34 @@ import sys
 
 if sys.version_info[0:2] < (3, 9):
     raise RuntimeError('Requires Python 3.9 or newer')
+
+
+LOCALE_DIR = Path(__file__).resolve().parent / "packtools" / "sps" / "locale"
+
+
+def compile_sps_i18n_catalogs():
+    """Compila packtools/sps/locale/*/LC_MESSAGES/*.po para .mo.
+
+    MANIFEST.in so inclui *.mo (nao *.po) na distribuicao, entao sem esse
+    passo os catalogos ficam de fora do sdist/wheel e
+    packtools.sps.i18n.set_locale() nunca encontra traducao nenhuma - ver
+    issue #1267.
+    """
+    from babel.messages.mofile import write_mo
+    from babel.messages.pofile import read_po
+
+    for po_path in sorted(LOCALE_DIR.glob("*/LC_MESSAGES/*.po")):
+        with po_path.open("rb") as po_file:
+            catalog = read_po(po_file)
+        mo_path = po_path.with_suffix(".mo")
+        with mo_path.open("wb") as mo_file:
+            write_mo(mo_file, catalog)
+
+
+class build_py(_build_py):
+    def run(self):
+        compile_sps_i18n_catalogs()
+        super().run()
 
 
 # adds version to the local namespace
@@ -67,6 +97,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests", "docs"]
     ),
     include_package_data=True,
+    cmdclass={"build_py": build_py},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tests/sps/test_i18n_packaging.py
+++ b/tests/sps/test_i18n_packaging.py
@@ -1,0 +1,96 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import venv
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+KNOWN_MSGID = "Got {obtained}, expected {expected}"
+
+
+class BuildIncludesI18nCatalogsTest(unittest.TestCase):
+    """Constroi o wheel do packtools e instala num venv limpo, reproduzindo
+    os passos da issue #1267, pra garantir que os catalogos i18n de
+    packtools/sps sao empacotados de verdade (nao so presentes no
+    checkout do git) e que set_locale() funciona de ponta a ponta.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_dir = Path(tempfile.mkdtemp(prefix="packtools_build_test_"))
+
+        wheel_dir = cls.tmp_dir / "wheel"
+        wheel_dir.mkdir()
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "wheel",
+                str(REPO_ROOT),
+                "--no-deps",
+                "-w",
+                str(wheel_dir),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        wheels = list(wheel_dir.glob("packtools-*.whl"))
+        assert len(wheels) == 1, f"esperava 1 wheel, encontrou {wheels}"
+        cls.wheel_path = wheels[0]
+
+        venv_dir = cls.tmp_dir / "venv"
+        venv.EnvBuilder(with_pip=True).create(venv_dir)
+        cls.venv_python = venv_dir / "bin" / "python"
+        subprocess.run(
+            [str(cls.venv_python), "-m", "pip", "install", "--quiet", str(cls.wheel_path)],
+            check=True,
+            capture_output=True,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_dir, ignore_errors=True)
+
+    def _run_in_clean_venv(self, code):
+        result = subprocess.run(
+            [str(self.venv_python), "-c", code],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def test_locale_dir_is_installed(self):
+        output = self._run_in_clean_venv(
+            "from packtools.sps import i18n; print(i18n.LOCALE_DIR.exists())"
+        )
+        self.assertEqual(output, "True")
+
+    def test_set_locale_pt_br_translates_known_message(self):
+        output = self._run_in_clean_venv(
+            "from packtools.sps import i18n; "
+            f"i18n.set_locale('pt_BR'); print(i18n._({KNOWN_MSGID!r}))"
+        )
+        self.assertEqual(output, "Obtido {obtained}, esperado {expected}")
+
+    def test_set_locale_es_translates_known_message(self):
+        output = self._run_in_clean_venv(
+            "from packtools.sps import i18n; "
+            f"i18n.set_locale('es'); print(i18n._({KNOWN_MSGID!r}))"
+        )
+        self.assertEqual(output, "Se obtuvo {obtained}, se esperaba {expected}")
+
+    def test_set_locale_en_keeps_source_message(self):
+        output = self._run_in_clean_venv(
+            "from packtools.sps import i18n; "
+            f"i18n.set_locale('en'); print(i18n._({KNOWN_MSGID!r}))"
+        )
+        self.assertEqual(output, KNOWN_MSGID)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1267: a release `4.16.9` não inclui os catálogos `.mo` compilados quando o packtools é instalado via `pip install packtools @ git+https://...` — a forma como aplicações consumidoras (ex.: SPS Validator) consomem essa dependência hoje. Isso faz `packtools.sps.i18n.set_locale()` cair silenciosamente no fallback (`fallback=True`) e manter todas as mensagens de validação em inglês, mesmo com o locale certo selecionado.

**Causa raiz**: `MANIFEST.in` só incluía `*.mo` na distribuição (não os `.po` fonte), e não havia nenhuma etapa de build que gerasse esses `.mo` a partir dos `.po` — sem workflow de CI/release configurado, o único jeito de obter os `.mo` seria rodar manualmente `make compile_messages` antes de publicar, o que nunca foi feito para a `4.16.9`.

**Correção**:
1. Adiciona `pyproject.toml` com `[build-system]` declarando `Babel>=2.12` como dependência de build (o `setup.py` não tinha esse arquivo, então o `pip` buildava num ambiente isolado sem acesso a bibliotecas extras).
2. Novo comando `build_py` customizado em `setup.py` (`compile_sps_i18n_catalogs`) que compila `packtools/sps/locale/*/LC_MESSAGES/*.po` para `.mo` antes do `build_py` original rodar, garantindo que os `.mo` existam no disco antes da resolução de `package_data`/manifest.
3. `MANIFEST.in` passa a incluir também `*.po` (fallback: catálogos fonte sempre disponíveis, mesmo se o passo de compilação for pulado por algum motivo).
4. Teste automatizado (`tests/sps/test_i18n_packaging.py`) que builda o wheel e instala num venv limpo, exatamente como a issue sugeriu.

## Onde a revisão poderia começar?

- `setup.py` — `compile_sps_i18n_catalogs()` e o `cmdclass={"build_py": build_py}`.
- `pyproject.toml` — novo, declara Babel como dependência de build.
- `MANIFEST.in` — inclusão de `*.po` além de `*.mo`.
- `tests/sps/test_i18n_packaging.py` — teste de build+instalação em venv limpo.

## Como este poderia ser testado manualmente?

Reproduzindo os mesmos passos da issue #1267, mas após esta correção:

```bash
python -m venv .venv-clean
source .venv-clean/bin/activate
python -m pip install "packtools @ git+https://github.com/Rossi-Luciano/packtools@fix/1267-package-locale-mo"

python - <<'PY'
from packtools.sps import i18n
print(i18n.LOCALE_DIR.exists())  # True

i18n.set_locale("pt_BR")
print(i18n._("Got {obtained}, expected {expected}"))
# Obtido {obtained}, esperado {expected}

i18n.set_locale("es")
print(i18n._("Got {obtained}, expected {expected}"))
# Se obtuvo {obtained}, se esperaba {expected}
PY
```

Também dá pra rodar o teste automatizado novo isoladamente: `pytest tests/sps/test_i18n_packaging.py -v` (builda o wheel e instala num venv limpo próprio, ~20s).

Testei localmente das duas formas (wheel builda via `pip wheel . --no-deps` e instalação via `git+file://...`) e confirmei que o resultado bate exatamente com o "Comportamento esperado" descrito na issue.

## Algum cenário de contexto que queira dar?

Essa issue foi aberta pelo próprio pitangainnovare durante a revisão de um PR no SPS Validator (scieloorg/spsvalidator#38), que estava atualizando o pin do packtools para `4.16.9` e tentando conectar `set_locale()` ao locale do Flask-Babel — o wiring do lado do spsvalidator já está pronto e só vai ter efeito prático depois que esta correção for mesclada e uma nova tag/release for cortada.

## Quais são os tickets relevantes?

Closes #1267. Relacionado a #1257 (i18n das mensagens de validação, que introduziu `set_locale()`) e a scieloorg/spsvalidator#38.

## Referências

- https://github.com/scieloorg/packtools/issues/1267
- https://github.com/scieloorg/spsvalidator/pull/38

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — adiciona `Babel>=2.12` como dependência **de build** (via `pyproject.toml`, `[build-system] requires`), não como dependência de runtime instalada junto com o pacote. Já era usada como dependência opcional do extra `webapp` (`optional-requirements.txt`), agora também declarada formalmente para a etapa de build.
  - [x] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR — repositório não tem pipeline de Sonar/Trivy configurado; validação feita via suíte de testes local (`tests/sps/test_i18n.py`, `tests/sps/test_i18n_packaging.py`) e build/instalação manual em venv limpo.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não — mudanças restritas a configuração de build/empacotamento (`setup.py`, `pyproject.toml`, `MANIFEST.in`) e um teste; nenhuma mudança em código de validação/runtime.

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não.

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
