### PR TITLE
fix: extrai texto de abstract sem wrapper <p>/<sec>

### DIFF
--- a/packtools/sps/models/v2/abstract.py
+++ b/packtools/sps/models/v2/abstract.py
@@ -238,10 +238,13 @@ class Abstract:
         """
         Returns the concatenated text content of the abstract.
         - With sections: concatenates title and p from each section
-        - Without sections: concatenates p elements
+        - Without sections but with p: concatenates p elements
+        - Without sections or p (non-SPS-compliant legacy XML, e.g. some
+          migrated articles): falls back to the node's raw text, excluding
+          the title
         """
         text_parts = []
-        
+
         # Check if abstract has sections by querying the node directly
         if self.node.xpath("sec"):
             # With sections: include title and p from each section
@@ -251,12 +254,32 @@ class Abstract:
                 if section.get("p") and section["p"].get("plain_text"):
                     text_parts.append(section["p"]["plain_text"])
         else:
-            # Without sections: include only p elements
-            for p_item in self.p:
-                if p_item.get("plain_text"):
-                    text_parts.append(p_item["plain_text"])
-        
+            p_items = list(self.p)
+            if p_items:
+                # Without sections: include only p elements
+                for p_item in p_items:
+                    if p_item.get("plain_text"):
+                        text_parts.append(p_item["plain_text"])
+            else:
+                # Legacy/non-SPS-compliant abstracts: text sits directly
+                # under <abstract>/<trans-abstract>, not wrapped in <p>/<sec>
+                raw_text = self._raw_text_excluding_title
+                if raw_text:
+                    text_parts.append(raw_text)
+
         return " ".join(text_parts)
+
+    @property
+    def _raw_text_excluding_title(self):
+        full_text = " ".join(t.strip() for t in self.node.itertext() if t.strip())
+        title_node = self.node.find("title")
+        if title_node is not None:
+            title_text = " ".join(
+                t.strip() for t in title_node.itertext() if t.strip()
+            )
+            if title_text and full_text.startswith(title_text):
+                full_text = full_text[len(title_text):].strip()
+        return full_text
 
     @property
     def data(self):

--- a/tests/sps/models/v2/test_abstract.py
+++ b/tests/sps/models/v2/test_abstract.py
@@ -218,6 +218,70 @@ class AbstractTextMultipleParagraphsTest(TestCase):
         self.assertEqual(abstract.text, expected)
 
 
+class AbstractTextWithoutPWrapperTest(TestCase):
+    """Regression test for scieloorg/scms-upload#1031: some legacy migrated
+    XML (e.g. URY collection) has abstract text sitting directly under
+    <abstract>/<trans-abstract>, not wrapped in <p> or <sec>. packtools
+    never read this text, so it was silently dropped."""
+
+    def test_text_without_p_wrapper(self):
+        xml = """
+        <abstract xml:lang="es">
+            <title>Resumen:</title> Texto do resumo sem tag p.
+        </abstract>
+        """
+        node = etree.fromstring(xml)
+        abstract = Abstract(
+            node, lang="es",
+            tags_to_keep=None, tags_to_keep_with_content=None,
+            tags_to_remove_with_content=None, tags_to_convert_to_html=None
+        )
+        self.assertEqual(abstract.text, "Texto do resumo sem tag p.")
+
+    def test_data_text_value_without_p_wrapper(self):
+        xml = """
+        <trans-abstract xml:lang="en">
+            <title>Abstract:</title> Abstract text without a p tag.
+        </trans-abstract>
+        """
+        node = etree.fromstring(xml)
+        abstract = Abstract(
+            node, lang="en",
+            tags_to_keep=None, tags_to_keep_with_content=None,
+            tags_to_remove_with_content=None, tags_to_convert_to_html=None
+        )
+        self.assertEqual(abstract.data["text"], "Abstract text without a p tag.")
+
+    def test_without_p_wrapper_and_without_title(self):
+        """No title to strip, entire node text is the abstract."""
+        xml = """
+        <abstract xml:lang="en"> Just loose text, no title, no p.</abstract>
+        """
+        node = etree.fromstring(xml)
+        abstract = Abstract(
+            node, lang="en",
+            tags_to_keep=None, tags_to_keep_with_content=None,
+            tags_to_remove_with_content=None, tags_to_convert_to_html=None
+        )
+        self.assertEqual(abstract.text, "Just loose text, no title, no p.")
+
+    def test_only_title_still_returns_empty(self):
+        """Existing behavior must be preserved: a title with no further
+        loose text still yields an empty abstract text."""
+        xml = """
+        <abstract xml:lang="en">
+            <title>Abstract</title>
+        </abstract>
+        """
+        node = etree.fromstring(xml)
+        abstract = Abstract(
+            node, lang="en",
+            tags_to_keep=None, tags_to_keep_with_content=None,
+            tags_to_remove_with_content=None, tags_to_convert_to_html=None
+        )
+        self.assertEqual(abstract.text, "")
+
+
 class AbstractTextLanguageTest(TestCase):
     """Test the text property with different languages"""
 


### PR DESCRIPTION
## O que esse PR faz?

`Abstract.text` (e, por consequência, `Abstract.data["text"]`) só lia `title`/`p` dentro de `<sec>` ou `<p>` soltos sob o abstract, e retornava vazio quando o texto do resumo estava solto diretamente sob `<abstract>`/`<trans-abstract>`, fora de `<p>`/`<sec>`.

Isso ocorre em alguns XMLs legados migrados (ex.: coleção URY), convertidos por versões do `scielo_migration` anteriores à correção em [scieloorg/scielo_migration@2905ea5](https://github.com/scieloorg/scielo_migration/commit/2905ea5). Esse padrão nunca foi lido pelo packtools — independe da regressão da chave `"text"` corrigida em #1261 (já lançada em 4.16.9).

Este PR adiciona o fallback que faltava: quando não há `<sec>` nem `<p>` com conteúdo, extrai o texto bruto do nó (via `itertext()`), removendo o texto do `<title>` quando presente. O comportamento existente é preservado — um abstract só com `<title>`, sem texto solto, continua retornando `""` (coberto por teste de regressão).

## Onde a revisão poderia começar?

`packtools/sps/models/v2/abstract.py`, property `Abstract.text` e o novo helper `_raw_text_excluding_title`.

## Como este poderia ser testado manualmente?

`python -m pytest tests/sps/models/v2/test_abstract.py -q` — 4 novos testes na classe `AbstractTextWithoutPWrapperTest` cobrem: texto solto com título, texto solto sem título, `data["text"]` para `trans-abstract`, e a garantia de que título sozinho (sem texto solto) continua retornando `""`.

Rodei a suíte completa de `tests/sps/models/v2/test_abstract.py` (18 testes) e as suítes de `tests/sps/validation/test_article_abstract.py` + `tests/sps/models/test_article_abstract.py` (73 passed, 1 skipped) sem regressões.

## Algum cenário de contexto que queira dar?

Esse fix resolve, no packtools, a causa raiz de scieloorg/scms-upload#1031 no lado que ainda faltava: a chave `"text"` já tinha sido restaurada em #1261, mas o caso de texto sem `<p>` nunca foi tratado. Com este PR mergeado (e uma nova tag), o `scms-upload` pode voltar a consumir `Abstract.data["text"]` diretamente, sem a lógica de fallback local adicionada como workaround em scieloorg/scms-upload#1034 — que será revertida assim que esta correção estiver disponível.

## Quais são os tickets relevantes?

- Relacionado a scieloorg/scms-upload#1031
- Desbloqueia scieloorg/scms-upload#1034 (review do robertatakenaka pedindo que a correção fique no packtools, não em scms-upload)

## Referências

- #1261 — restaura a chave `"text"` em `Abstract.data` (regressão de #1064)
- [scieloorg/scielo_migration@2905ea5](https://github.com/scieloorg/scielo_migration/commit/2905ea5) — correção do migrador para novas conversões

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Não aplicável a este PR — sem novas dependências nem superfície de ataque nova

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado