### PR TITLE
chore: bump urllib3, requests, minio, python-docx e tenacity (fase 1, #1251)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-urllib3==2.2.2
+urllib3==2.7.0
 lxml==4.9.3
 Pillow==10.1.0
-minio==7.2.0
-requests==2.32.0
-tenacity==8.2.3
+minio==7.2.20
+requests==2.34.2
+tenacity==8.5.0
 picles.plumber==0.11
 charset-normalizer<3.0
 aiohttp==3.9.1
@@ -13,5 +13,5 @@ langcodes==3.3.0
 -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data
 ipdb==0.13.13
 langdetect~=1.0.9
-python-docx==1.1.2
+python-docx==1.2.0
 openpyxl==3.1.5


### PR DESCRIPTION
## O que esse PR faz?

Fase 1 da estratégia de atualização de dependências definida na issue #1251: bumps de baixo risco em `requirements.txt` (mesmo major, uso raso no código, sem breaking changes esperadas).

| Pacote | Antes | Depois | Motivo |
|---|---|---|---|
| `urllib3` | 2.2.2 | 2.7.0 | corrige 6 CVEs (fix versions entre 2.5.0 e 2.7.0) |
| `requests` | 2.32.0 | 2.34.2 | corrige 2 CVEs; a versão 2.32.0 está **yanked** no PyPI por conflito com a mitigação da CVE-2024-35195 |
| `minio` | 7.2.0 | 7.2.20 | sem CVE, patch dentro do mesmo minor |
| `python-docx` | 1.1.2 | 1.2.0 | sem CVE, bump menor |
| `tenacity` | 8.2.3 | 8.5.0 | sem CVE; mantido no major 8.x, não pulei para o major 9.x disponível para preservar o baixo risco desta fase |

`setup.py`/`tox.ini` não foram tocados (fica para a fase 8 da estratégia, que trata de sincronizar os bounds soltos do `setup.py` com o que é de fato testado).

## Onde a revisão poderia começar?

`requirements.txt`, único arquivo alterado.

## Como este poderia ser testado manualmente?

```
pip install -r requirements.txt
pytest -q
```

Deve dar o mesmo resultado do master (40 failed pré-existentes, 5973 passed, 30 skipped).

## Algum cenário de contexto que queira dar?

Validação feita rodando `pytest` completo (não só os arquivos relacionados) com os pins exatos deste `requirements.txt`, comparando contra o master:

- Duas rodadas com as versões novas: 40 failed / 5973 passed / 30 skipped em ambas.
- Uma rodada com as versões antigas revertidas no mesmo ambiente (baseline real): 40 failed / 5973 passed / 30 skipped, exatamente igual.
- Uma rodada intermediária mostrou 44 failed por um flake isolado em `test_i18n.py` (passa sozinho, passa na repetição, não reproduz de forma determinística), sem relação com este bump.

Também rodei `tox -e py310-lxml492` (única versão de Python 3.9/3.10/3.11 disponível neste ambiente). Ele mostrou mais falhas, mas isso não tem relação com este PR: `tox.ini` resolve as dependências pelos bounds soltos do `setup.py` (`deps=` do `[testenv]`), não pelos pins de `requirements.txt`, então não é sensível a esta mudança. Esse resultado já reflete o estado atual do master e é o mesmo gap que a fase 8 da estratégia pretende corrigir.

## Screenshots

N/A (mudança de dependências, sem interface).

## Quais são os tickets relevantes?

Parte de #1251 (fase 1 da estratégia de atualização de dependências).

## Referências

Estratégia priorizada descrita nos comentários de progresso da issue #1251.

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [x] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:

  Este repositório não usa Trivy/SBOM (é biblioteca, não serviço containerizado, conforme `SECURITY_ADHERENCE.md` seção 3). O gate real de dependências é o **Snyk**, que já rodou automaticamente neste PR com resultado `success`. Verifiquei manualmente com `pip-audit` antes de abrir o PR, confirmando que as versões-alvo corrigem as CVEs listadas na tabela acima.
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): SonarQube e Trivy não estão configurados neste repositório (`SECURITY_ADHERENCE.md` seção 3). Os gates automáticos reais (Snyk e GitGuardian) rodaram neste PR com status `success`.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim