### PR TITLE
fix(security): bump lxml para 6.1.1, corrige XXE de leitura de arquivo local (fase 4, #1251)

### DIFF
--- a/packtools/sps/pid_provider/xml_loader.py
+++ b/packtools/sps/pid_provider/xml_loader.py
@@ -83,7 +83,7 @@ def xml_parser_ent2char(xml):
     ao invés de convertidas para seus caracteres correspondentes.
     """
     try:
-        parser = etree.XMLParser(recover=True, encoding="utf-8")
+        parser = etree.XMLParser(recover=True, encoding="utf-8", resolve_entities="internal")
         root = etree.fromstring(xml, parser)
         return etree.tostring(root, method="xml", encoding="utf-8").decode("utf-8")
     except Exception as e:

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -43,10 +43,14 @@ def process_xref(node, footnote_markers=None):
             _next = xref.getnext()
             if _next is None or _next.tag != "xref":
                 e = etree.Element("EMPTYTAGTOKEEPXREFTAIL")
-                # Move o tail explicitamente antes do addnext: em lxml >= 5,
-                # addnext() deixou de transferir o tail automaticamente para
-                # o elemento inserido, o que fazia parent.remove(xref) (abaixo)
-                # descartar esse texto junto com o xref removido.
+                # Em lxml >= 5, addnext() não move mais o tail automaticamente:
+                # >>> root = etree.fromstring("<p>text <xref/>depois <b/></p>")
+                # >>> xref = root.find(".//xref")
+                # >>> xref.addnext(etree.Element("EMPTYTAGTOKEEPXREFTAIL"))
+                # >>> etree.tostring(root)
+                # b'<p>text <xref/>depois <EMPTYTAGTOKEEPXREFTAIL/><b/></p>'
+                # ("depois" ficou com o xref, não com o marcador) — por isso
+                # movemos o tail na mão antes de remover o xref abaixo.
                 e.tail = xref.tail
                 xref.tail = None
                 xref.addnext(e)

--- a/packtools/sps/utils/xml_utils.py
+++ b/packtools/sps/utils/xml_utils.py
@@ -43,6 +43,12 @@ def process_xref(node, footnote_markers=None):
             _next = xref.getnext()
             if _next is None or _next.tag != "xref":
                 e = etree.Element("EMPTYTAGTOKEEPXREFTAIL")
+                # Move o tail explicitamente antes do addnext: em lxml >= 5,
+                # addnext() deixou de transferir o tail automaticamente para
+                # o elemento inserido, o que fazia parent.remove(xref) (abaixo)
+                # descartar esse texto junto com o xref removido.
+                e.tail = xref.tail
+                xref.tail = None
                 xref.addnext(e)
 
     for xref in node.findall(".//xref"):
@@ -138,7 +144,7 @@ def _get_xml_content(xml):
 
 
 def get_xml_tree(content):
-    parser = etree.XMLParser(remove_blank_text=True, no_network=True)
+    parser = etree.XMLParser(remove_blank_text=True, no_network=True, resolve_entities="internal")
     try:
         content = _get_xml_content(content)
         xml_tree = etree.XML(content, parser)

--- a/packtools/utils.py
+++ b/packtools/utils.py
@@ -31,11 +31,11 @@ PY2 = sys.version_info[0] == 2
 
 try:
     # available on lxml >= 3.4.0
-    NOIDS_XMLPARSER = etree.XMLParser(collect_ids=False)
+    NOIDS_XMLPARSER = etree.XMLParser(collect_ids=False, resolve_entities="internal")
 except TypeError:
     LOGGER.info('cannot instantiate an XML parser that avoids the collection '
                 'of ids from elements.')
-    NOIDS_XMLPARSER = etree.XMLParser()
+    NOIDS_XMLPARSER = etree.XMLParser(resolve_entities="internal")
 
 
 def setdefault(object, attribute, producer):
@@ -96,7 +96,8 @@ def XML(file, no_network=True, load_dtd=True):
     """
     parser = etree.XMLParser(remove_blank_text=True,
                              load_dtd=load_dtd,
-                             no_network=no_network)
+                             no_network=no_network,
+                             resolve_entities="internal")
     xml = etree.parse(file, parser)
 
     return xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3==2.2.2
-lxml==4.9.3
+lxml==6.1.1
 Pillow==10.1.0
 minio==7.2.0
 requests==2.32.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ with open('packtools/version.py') as fp:
 
 INSTALL_REQUIRES = [
     'aiohttp>=3.9.1',
-    'lxml>=4.9.2',
+    'lxml>=6.1.0',
     'langcodes>=3.3.0',
     'langdetect>=1.0.9',
     'picles.plumber>=0.11',

--- a/tests/sps/pid_provider/test_xml_loader.py
+++ b/tests/sps/pid_provider/test_xml_loader.py
@@ -1,0 +1,46 @@
+import os
+import tempfile
+import unittest
+
+from packtools.sps.pid_provider.xml_loader import xml_parser_ent2char
+
+
+class XmlParserEnt2CharXXEProtectionTest(unittest.TestCase):
+    """
+    lxml < 6.1.0 resolve entidades externas por padrão, permitindo que um XML
+    malicioso leia arquivos locais via `<!ENTITY xxe SYSTEM "file://...">`.
+    xml_parser_ent2char() usa recover=True, então uma entidade externa
+    bloqueada não levanta exceção: o parser recupera e descarta o conteúdo
+    não resolvido. O que importa é que o conteúdo do arquivo nunca apareça
+    no resultado.
+    """
+
+    def setUp(self):
+        self.secret_content = "conteudo-secreto-que-nao-pode-vazar"
+        fd, self.secret_path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write(self.secret_content)
+
+    def tearDown(self):
+        os.unlink(self.secret_path)
+
+    def test_external_entity_file_content_never_leaks(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY xxe SYSTEM "file://{}"> ]>'
+            "<article><body>&xxe;</body></article>"
+        ).format(self.secret_path)
+
+        result = xml_parser_ent2char(xml)
+
+        self.assertIsNotNone(result)
+        self.assertNotIn(self.secret_content, result)
+
+    def test_internal_character_entity_still_resolved(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY ok "texto interno"> ]>'
+            "<article><body>&ok;</body></article>"
+        )
+        result = xml_parser_ent2char(xml)
+        self.assertIn("texto interno", result)

--- a/tests/sps/utils/test_xml_utils.py
+++ b/tests/sps/utils/test_xml_utils.py
@@ -108,6 +108,26 @@ class ProcessXrefTailPreservationTest(unittest.TestCase):
         result = xml_utils.process_xref(node)
         self.assertEqual("a  c", "".join(result.xpath(".//text()")))
 
+    def test_addnext_no_longer_moves_tail_automatically(self):
+        # Canário: isola só o addnext() da lxml, sem passar pelo restante da
+        # lógica de process_xref(). Documenta a premissa por trás do fix
+        # acima (e da revisão em code review, PR #1283): em lxml 4.9.3,
+        # addnext() movia o .tail do elemento original para o elemento
+        # inserido como efeito colateral automático; a partir do lxml 5.x
+        # (validado também na 6.1.1, versão-alvo desta PR) isso não acontece
+        # mais — o tail permanece no elemento original. Se a lxml reverter
+        # esse comportamento no futuro, este teste é o primeiro a acusar, e
+        # o fix manual em process_xref() (e.tail = xref.tail; xref.tail =
+        # None) pode então ser reavaliado.
+        original = etree.SubElement(etree.Element("root"), "xref")
+        original.tail = " after"
+        inserted = etree.Element("MARKER")
+
+        original.addnext(inserted)
+
+        self.assertEqual(" after", original.tail)
+        self.assertIsNone(inserted.tail)
+
     def test_no_marker_tag_leaks_into_final_result(self):
         node = etree.fromstring(
             '<p>a <xref ref-type="fn">1</xref> b</p>'

--- a/tests/sps/utils/test_xml_utils.py
+++ b/tests/sps/utils/test_xml_utils.py
@@ -1,8 +1,11 @@
 # coding: utf-8
+import os
+import tempfile
 import unittest
 
 from lxml import etree
 
+from packtools.sps import exceptions
 from packtools.sps.utils import xml_utils
 
 
@@ -30,4 +33,128 @@ class XMLUtilsTest(unittest.TestCase):
         node = xml.find(".//title")
         result = xml_utils.node_text_without_fn_xref(node)
         self.assertEqual(expected, result)
+
+
+class ProcessXrefTailPreservationTest(unittest.TestCase):
+    """
+    A partir do lxml 5.x, Element.addnext() deixou de mover automaticamente
+    o `.tail` do elemento original para o elemento inserido (comportamento
+    presente no lxml 4.9.3, usado até então). O workaround em process_xref()
+    (marcador EMPTYTAGTOKEEPXREFTAIL) depende de preservar esse tail antes de
+    `parent.remove(xref)` descartá-lo junto com o xref. Estes testes travam
+    esse comportamento contra qualquer versão do lxml.
+    """
+
+    def test_tail_preserved_when_numeric_fn_xref_removed(self):
+        node = etree.fromstring(
+            '<p>a <xref ref-type="fn">1</xref> b</p>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertEqual("a  b", "".join(result.xpath(".//text()")))
+        self.assertIsNone(result.find(".//xref"))
+
+    def test_tail_preserved_when_punctuation_marker_xref_removed(self):
+        node = etree.fromstring(
+            '<p>a <xref ref-type="fn">*</xref> b</p>'
+        )
+        result = xml_utils.process_xref(node, footnote_markers=["*"])
+        self.assertEqual("a  b", "".join(result.xpath(".//text()")))
+        self.assertIsNone(result.find(".//xref"))
+
+    def test_no_tail_when_xref_is_last_child(self):
+        node = etree.fromstring(
+            '<p>a <xref ref-type="fn">1</xref></p>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertEqual("a ", "".join(result.xpath(".//text()")))
+        self.assertIsNone(result.find(".//EMPTYTAGTOKEEPXREFTAIL"))
+
+    def test_xref_not_removed_when_not_fn_nor_marker_nor_numeric(self):
+        node = etree.fromstring(
+            '<p>see <xref ref-type="bibr">Silva 2020</xref> for details</p>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertEqual(
+            "see Silva 2020 for details",
+            "".join(result.xpath(".//text()")),
+        )
+
+    def test_tail_preserved_for_fn_xrefs_in_different_parents(self):
+        # xrefs em <p> distintos: cada um é o único filho do seu parent, sem
+        # irmão xref, então cai no caminho "cria marcador" (getnext() is None)
+        # em vez do caminho "pula marcador porque o próximo irmão é um xref"
+        # (ver test_sibling_fn_xrefs_lose_intervening_text_known_bug abaixo).
+        node = etree.fromstring(
+            '<body><p>a <xref ref-type="fn">1</xref> b</p>'
+            '<p>c <xref ref-type="fn">2</xref> d</p></body>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertEqual("a  bc  d", "".join(result.xpath(".//text()")))
+        self.assertIsNone(result.find(".//xref"))
+
+    def test_sibling_fn_xrefs_lose_intervening_text_known_bug(self):
+        # Bug pré-existente (não introduzido por esta PR, replicado aqui só
+        # para documentar/travar o comportamento atual): quando dois <xref>
+        # são irmãos diretos sob o mesmo parent, xref.getnext() aponta pro
+        # próximo xref independente de haver texto (tail) entre eles, então
+        # o código deliberadamente NÃO cria o marcador de preservação pro
+        # primeiro xref. Se esse primeiro xref for removido, seu tail (o
+        # texto entre os dois xrefs) é descartado junto. Ver issue aberta
+        # para acompanhamento; process_xref segue com esse comportamento.
+        node = etree.fromstring(
+            '<p>a <xref ref-type="fn">1</xref> b '
+            '<xref ref-type="fn">2</xref> c</p>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertEqual("a  c", "".join(result.xpath(".//text()")))
+
+    def test_no_marker_tag_leaks_into_final_result(self):
+        node = etree.fromstring(
+            '<p>a <xref ref-type="fn">1</xref> b</p>'
+        )
+        result = xml_utils.process_xref(node)
+        self.assertNotIn(
+            "EMPTYTAGTOKEEPXREFTAIL", etree.tostring(result, encoding="unicode")
+        )
+
+
+class GetXmlTreeXXEProtectionTest(unittest.TestCase):
+    """
+    lxml < 6.1.0 resolve entidades externas por padrão (resolve_entities=True),
+    permitindo que um XML malicioso leia arquivos locais via
+    `<!ENTITY xxe SYSTEM "file://...">`. get_xml_tree() precisa continuar
+    bloqueando isso mesmo após o bump para lxml 6.1.1 (PYSEC-2026-87).
+    """
+
+    def setUp(self):
+        self.secret_content = "conteudo-secreto-que-nao-pode-vazar"
+        fd, self.secret_path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write(self.secret_content)
+
+    def tearDown(self):
+        os.unlink(self.secret_path)
+
+    def test_external_entity_file_read_is_blocked(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY xxe SYSTEM "file://{}"> ]>'
+            "<article><body>&xxe;</body></article>"
+        ).format(self.secret_path)
+
+        with self.assertRaises(exceptions.SPSLoadToXMLError) as ctx:
+            xml_utils.get_xml_tree(xml)
+
+        self.assertNotIn(self.secret_content, str(ctx.exception))
+
+    def test_internal_character_entity_still_resolved(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY ok "texto interno"> ]>'
+            "<article><body>&ok;</body></article>"
+        )
+        result = xml_utils.get_xml_tree(xml)
+        self.assertEqual(
+            "texto interno", "".join(result.xpath(".//text()"))
+        )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1144,3 +1144,44 @@ class TestSPPackage(unittest.TestCase):
                     image_element.attrib["{http://www.w3.org/1999/xlink}href"],
                     expected_href,
                 )
+
+
+class XMLXXEProtectionTests(unittest.TestCase):
+    """
+    lxml < 6.1.0 resolve entidades externas por padrão, permitindo que um XML
+    malicioso leia arquivos locais via `<!ENTITY xxe SYSTEM "file://...">`.
+    utils.XML() é o parser principal de packtools (usado com load_dtd=True,
+    no_network=True); no_network só bloqueia esquemas de rede (http/ftp), não
+    file://, então precisa continuar bloqueado via resolve_entities="internal"
+    mesmo após o bump para lxml 6.1.1 (PYSEC-2026-87).
+    """
+
+    def setUp(self):
+        self.secret_content = "conteudo-secreto-que-nao-pode-vazar"
+        fd, self.secret_path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write(self.secret_content)
+
+    def tearDown(self):
+        os.unlink(self.secret_path)
+
+    def test_external_entity_file_read_is_blocked(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY xxe SYSTEM "file://{}"> ]>'
+            "<article><body>&xxe;</body></article>"
+        ).format(self.secret_path)
+
+        with self.assertRaises(etree.XMLSyntaxError):
+            utils.XML(io.BytesIO(xml.encode("utf-8")))
+
+    def test_internal_character_entity_still_resolved(self):
+        xml = (
+            '<?xml version="1.0"?>'
+            '<!DOCTYPE article [ <!ENTITY ok "texto interno"> ]>'
+            "<article><body>&ok;</body></article>"
+        )
+        xml_tree = utils.XML(io.BytesIO(xml.encode("utf-8")))
+        self.assertEqual(
+            "texto interno", "".join(xml_tree.xpath(".//text()"))
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py39,py310,py311}-lxml{492}
+envlist = {py39,py310,py311}-lxml{611}
 
 [testenv]
 isolated_build=true
@@ -8,7 +8,7 @@ basepython =
     py310: python3.10
     py311: python3.11
 deps =
-    lxml492: lxml==4.9.2
+    lxml611: lxml==6.1.1
     Flask-Testing
     flask-babel
     python-magic


### PR DESCRIPTION
## O que esse PR faz?

Fase 4 da estratégia de atualização de dependências definida na issue #1251: `lxml` 4.9.3 → 6.1.1. Prioridade elevada em relação às fases anteriores: não é só uma CVE rotineira, é uma vulnerabilidade ativa neste repositório.

### Vulnerabilidade corrigida (PYSEC-2026-87)

`lxml < 6.1.0` resolve entidades externas por padrão (`resolve_entities=True`), permitindo que um XML não confiável leia arquivos locais via `<!ENTITY xxe SYSTEM "file://...">`.

Confirmei empiricamente que este repositório está exposto: um XML malicioso processado por `packtools.XML()` (o parser principal, com `load_dtd=True`, `no_network=True`) conseguia vazar o conteúdo de um arquivo local arbitrário. `no_network` só bloqueia esquemas de rede (http/ftp), não `file://`. Como o packtools processa pacotes XML de terceiros por definição, esse é um vetor de exfiltração de arquivo local ativo, não teórico.

### Correções aplicadas

1. `lxml` 4.9.3 → 6.1.1 em `requirements.txt` (muda o default para `resolve_entities='internal'` a partir da 6.1.0).
2. Endurecimento explícito: `resolve_entities="internal"` adicionado nos 5 pontos onde `XMLParser()` é instanciado (`packtools/utils.py`, `packtools/sps/pid_provider/xml_loader.py`, `packtools/sps/utils/xml_utils.py`), para não depender só do default da biblioteca. Escolhi `'internal'` (não `False`) porque preserva a resolução de entidades internas (ex.: entidades de caractere definidas inline no DOCTYPE) e bloqueia só as externas: testei e confirmei que `resolve_entities=False` quebraria entidades internas legítimas.
3. `setup.py`: piso de `lxml>=4.9.2` para `lxml>=6.1.0`. Isso é uma exceção pontual à regra geral de deixar `setup.py` para a fase 8 (sincronizar bounds), justificada pela gravidade: manter o piso solto deixaria `pip install packtools` (sem passar por `requirements.txt`) potencialmente vulnerável mesmo depois deste fix.
4. `tox.ini`: fator `lxml492` → `lxml611`, para não testar mais deliberadamente contra uma versão do lxml com CVE conhecida em aberto.

### Regressão real encontrada e corrigida (não relacionada a segurança)

Rodar a suíte completa com `lxml` 6.1.1 sozinho (sem o endurecimento acima) revelou 15 falhas novas em `packtools/sps/utils/xml_utils.py` e `test_article_titles.py`, além do flake já conhecido de `test_i18n.py`.

Isolei a causa com uma reprodução mínima comparando lxml 4.9.3 vs 6.1.1: `Element.addnext()` deixou de mover automaticamente o `.tail` do elemento de origem para o elemento inserido. O workaround existente em `process_xref()` (marcador `EMPTYTAGTOKEEPXREFTAIL`, usado para preservar o texto após um `<xref>` antes de `parent.remove(xref)` descartá-lo) dependia desse efeito colateral implícito do lxml 4.x para funcionar. Corrigi movendo o `tail` explicitamente (`e.tail = xref.tail; xref.tail = None`) antes do `addnext()`, o que funciona identicamente em ambas as versões (validei nas duas).

## Onde a revisão poderia começar?

- `packtools/sps/utils/xml_utils.py`, função `process_xref()`: o fix da regressão de `tail`.
- Os 5 pontos com `resolve_entities="internal"` novo.
- `setup.py`/`tox.ini`: mudança de piso, fora do escopo usual desta fase, mas justificada acima.

## Como este poderia ser testado manualmente?

```python
from lxml import etree
import packtools, tempfile, os

secret = "conteudo-secreto"
with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
    f.write(secret)
    path = f.name

xml = f'''<?xml version="1.0"?>
<!DOCTYPE article [ <!ENTITY xxe SYSTEM "file://{path}"> ]>
<article><body>&xxe;</body></article>
'''.encode()

with tempfile.NamedTemporaryFile("wb", suffix=".xml", delete=False) as xf:
    xf.write(xml)
    xml_path = xf.name

tree = packtools.XML(xml_path, no_network=True)  # deve levantar XMLSyntaxError após o fix
```

Antes deste PR (lxml 4.9.3): retorna o conteúdo do arquivo local. Depois (lxml 6.1.1 + `resolve_entities="internal"`): levanta `XMLSyntaxError: Entity 'xxe' not defined`.

`pytest -q` deve dar o mesmo resultado do master (40 failed pré-existentes, 5973 passed, 30 skipped).

## Algum cenário de contexto que queira dar?

Independente das fases 1-3 (PR #1280/#1281/#1282): parte direto do master.

Validação: `pytest` completo com venv isolado (só lxml + os 3 arquivos de código alterados, resto igual ao master). Antes do fix do `process_xref`: 55 failed (a regressão real). Depois: duas rodadas deram 40 failed / 5973 passed / 30 skipped, idêntico ao baseline.

Também rodei `tox -e py310-lxml611` (único Python 3.9/3.10/3.11 disponível localmente): 23 failures + 19 errors, sem relação com este bump de lxml. **Correção (2026-08-16, adicionada após a fase 8/#1287):** originalmente atribuí esse resultado a "Pillow sem pin em setup.py", isso estava errado. Investigando a fundo na fase 8, descobri que são exatamente as mesmas 40 falhas pré-existentes da issue #1276 (18 do `htmlgenerator` + 22 outras), só contadas de forma diferente pelo `unittest`, mais 2 `ERROR` espúrios causados por um bug de descoberta de testes em `tox.ini` (`python -m unittest -vvv` tentando importar `packtools/sps/sps_versions/sps-1.9`/`sps-1.10` como módulo de teste). Ambos corrigidos no PR #1287.

## Screenshots

N/A (mudança de dependência + parsing XML, sem interface).

## Quais são os tickets relevantes?

Parte de #1251 (fase 4 da estratégia de atualização de dependências). Corrige PYSEC-2026-87.

## Referências

Estratégia priorizada descrita nos comentários de progresso da issue #1251. Advisory: https://github.com/lxml/lxml/security/advisories (PYSEC-2026-87, GHSA correspondente).

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [x] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:

  Este repositório não usa Trivy/SBOM (é biblioteca, não serviço containerizado, conforme `SECURITY_ADHERENCE.md` seção 3). O gate real de dependências é o **Snyk**, que roda automaticamente neste PR. Verifiquei manualmente com `pip-audit` e confirmei empiricamente (ver seção acima) que a versão-alvo corrige a CVE PYSEC-2026-87 ativa nesta versão do lxml.
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): SonarQube e Trivy não estão configurados neste repositório (`SECURITY_ADHERENCE.md` seção 3). Os gates automáticos reais (Snyk e GitGuardian) rodam neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não, mas é adjacente: este PR trata diretamente de uma classe de vulnerabilidade de parsing de XML não confiável (XXE/entidade externa, PYSEC-2026-87), não SQL/HTML/JS. Ver a seção "O que esse PR faz?" acima para os detalhes e a prova de conceito.

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim