### PR TITLE
chore: remove cap desatualizado de charset-normalizer<3.0 (fase 5, #1251)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ minio==7.2.0
 requests==2.32.0
 tenacity==8.2.3
 picles.plumber==0.11
-charset-normalizer<3.0
+charset-normalizer==3.5.1
 aiohttp==3.9.1
 python-magic==0.4.27
 tox==4.11.4

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ TESTS_REQUIRE = [
     'flask-babel',
     'Flask-WTF>=1.2.0',
     'python-magic',
-    'charset-normalizer<3.0',
+    'charset-normalizer>=3.5.1',
 ]
 
 


### PR DESCRIPTION
## O que esse PR faz?

Fase 5 da estratégia de atualização de dependências definida na issue #1251: investiga e remove o cap `charset-normalizer<3.0` em `requirements.txt` e `setup.py` (`TESTS_REQUIRE`), atualizando para a versão atual `3.5.1`.

### Investigação

Rastreei a origem do cap via `git log -S "charset-normalizer" -- requirements.txt`: foi introduzido no commit `f33136cc` (jan/2023), num commit genérico de "atualiza os requirements", sem justificativa registrada na mensagem.

`charset-normalizer` não é importado em nenhum lugar do código do packtools (confirmei via grep), é apenas dependência transitiva de `requests`, que já declara suporte oficial a `charset_normalizer<4,>=2` (confirmei via `importlib.metadata.requires("requests")` na versão 2.34.2, já atualizada na fase 1). Sem CVE aberta nem na versão pinada (2.1.1) nem na nova (3.5.1): não era um bloqueio de segurança, apenas um cap desatualizado sem razão documentada.

## Onde a revisão poderia começar?

`requirements.txt` e `setup.py` (`TESTS_REQUIRE`), únicos arquivos alterados.

## Como este poderia ser testado manualmente?

```
pip install -r requirements.txt
pytest -q
```

Deve dar o mesmo resultado do master (40 failed pré-existentes, 5973 passed, 30 skipped).

## Algum cenário de contexto que queira dar?

Independente das fases 1-4 (PR #1280/#1281/#1282/#1283): parte direto do master.

Validação: `pytest` completo com venv isolado (só `charset-normalizer` alterado, resto igual ao master). Duas rodadas deram 40 failed / 5973 passed / 30 skipped, idêntico ao baseline (a primeira rodada mostrou 44 failed pelo flake já conhecido de `test_i18n.py`, que já apareceu nas fases 1, 2 e 3 e sumiu na repetição, confirmando não ser regressão).

## Screenshots

N/A (mudança de dependências, sem interface).

## Quais são os tickets relevantes?

Parte de #1251 (fase 5 da estratégia de atualização de dependências).

## Referências

Estratégia priorizada descrita nos comentários de progresso da issue #1251.

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [x] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:

  Este repositório não usa Trivy/SBOM (é biblioteca, não serviço containerizado, conforme `SECURITY_ADHERENCE.md` seção 3). O gate real de dependências é o **Snyk**, que roda automaticamente neste PR. Verifiquei manualmente com `pip-audit`: nem a versão antiga nem a nova têm CVE aberta, essa mudança não é motivada por segurança, é remoção de um cap desatualizado sem justificativa registrada.
- [ ] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): SonarQube e Trivy não estão configurados neste repositório (`SECURITY_ADHERENCE.md` seção 3). Os gates automáticos reais (Snyk e GitGuardian) rodam neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
