### PR TITLE
chore: eleva piso de compatibilidade para Python 3.11 (fase 9, #1251)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import codecs
 import sys
 
 
-if sys.version_info[0:2] < (3, 9):
-    raise RuntimeError('Requires Python 3.9 or newer')
+if sys.version_info[0:2] < (3, 11):
+    raise RuntimeError('Requires Python 3.11 or newer')
 
 
 LOCALE_DIR = Path(__file__).resolve().parent / "packtools" / "sps" / "locale"
@@ -101,11 +101,10 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    python_requires=">=3.11",
     tests_require=TESTS_REQUIRE,
     test_suite='tests',
     install_requires=INSTALL_REQUIRES,

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = {py39,py310,py311}-lxml{492}
+envlist = {py311}-lxml{492}
 
 [testenv]
 isolated_build=true
 basepython =
-    py39: python3.9
-    py310: python3.10
     py311: python3.11
 deps =
     lxml492: lxml==4.9.2


### PR DESCRIPTION
## O que esse PR faz?

Eleva o piso oficial de compatibilidade de Python de 3.9 para **3.11**, removendo o suporte a 3.9 e 3.10 de `setup.py` (classifiers, checagem em runtime, novo `python_requires=">=3.11"`) e de `tox.ini` (envlist e `basepython`).

Decisão registrada na issue #1251: ao validar a subtarefa "as dependências devem funcionar em python 3.11", foi identificado que as versões mais recentes de `Pillow`, `aiohttp`, `requests` e `tox` (já usadas nos PRs #1280-#1287) não são mais compatíveis com Python 3.9. Ficou definido que o packtools passa a considerar oficialmente apenas Python 3.11 em diante, o que também simplifica a matriz de testes.

## Onde a revisão poderia começar?

`setup.py` (checagem de versão no topo, `classifiers` e `python_requires`) e `tox.ini` (`envlist`/`basepython`).

## Como este poderia ser testado manualmente?

```
python3.11 -m tox -e py311-lxml492
```

Rodei essa validação: `Ran 5975 tests`, `failures=23, errors=19` — idêntico à baseline pré-existente já documentada na issue #1276 (o `tox.ini` deste branch ainda não tem a correção de descoberta de testes da fase 8/#1287, daí a pequena diferença de contagem em relação ao `pytest` puro; nada relacionado a esta mudança).

## Algum cenário de contexto que queira dar?

Este PR é independente dos demais PRs abertos da issue #1251 (#1280-#1287) — não há sobreposição de arquivos. Pode ser mergeado em qualquer ordem em relação a eles.

## Quais são os tickets relevantes?

Parte da issue #1251.

## Referências

Comentário com a decisão: https://github.com/scieloorg/packtools/issues/1251#issuecomment-5310871557

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não — apenas altera o piso de versão do interpretador Python suportado, nenhuma dependência de terceiros é adicionada, atualizada ou removida.

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): SonarQube/Trivy não estão configurados neste repositório (ver `SECURITY_ADHERENCE.md`); os gates reais (Snyk e GitGuardian) rodam automaticamente neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
