### PR TITLE
fix: corrige decisão de layout de figuras no gerador de PDF (unidade cm/EMU e DPI de figuras irmãs)

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -1,5 +1,3 @@
-import statistics
-
 from packtools.sps.formats.pdf import enum as pdf_enum
 from packtools.sps.formats.pdf.pipeline import xml as xml_pipe
 from packtools.sps.formats.pdf.renderer import docx as docx_renderer
@@ -550,39 +548,8 @@ def _figure_layout(docx, fig):
     return layout
 
 
-def _flag_dpi_outliers(docx, figures, outlier_ratio=2.0):
-    """
-    Compare embedded DPI across a batch of sibling figures (e.g. all the
-    graphs in one section) and flag figures whose own DPI is wildly off from
-    the group's median, so decide_figure_layout can be given a corrected
-    value instead of trusting a possibly-wrong per-image tag. Figures with
-    an explicit 'layout' override are left untouched; outliers get
-    'layout_dpi_override' set to the group median.
-    """
-    probed = []
-    for fig in figures:
-        if not isinstance(fig, dict) or fig.get('layout'):
-            continue
-        probe = docx_renderer.figure.probe_image_dpi(docx, fig)
-        if probe is not None:
-            probed.append((fig, probe[1]))
-
-    if len(probed) < 2:
-        return
-
-    median_dpi = statistics.median(dpi for _, dpi in probed)
-    if median_dpi <= 0:
-        return
-
-    for fig, dpi in probed:
-        ratio = dpi / median_dpi
-        if ratio >= outlier_ratio or ratio <= 1 / outlier_ratio:
-            fig['layout_dpi_override'] = median_dpi
-
-
 def _render_figures(docx, figures):
     """Render figures, switching to single column when the layout requires it."""
-    _flag_dpi_outliers(docx, figures)
     for fig in figures:
         layout = _figure_layout(docx, fig)
 

--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -1,3 +1,5 @@
+import statistics
+
 from packtools.sps.formats.pdf import enum as pdf_enum
 from packtools.sps.formats.pdf.pipeline import xml as xml_pipe
 from packtools.sps.formats.pdf.renderer import docx as docx_renderer
@@ -548,8 +550,39 @@ def _figure_layout(docx, fig):
     return layout
 
 
+def _flag_dpi_outliers(docx, figures, outlier_ratio=2.0):
+    """
+    Compare embedded DPI across a batch of sibling figures (e.g. all the
+    graphs in one section) and flag figures whose own DPI is wildly off from
+    the group's median, so decide_figure_layout can be given a corrected
+    value instead of trusting a possibly-wrong per-image tag. Figures with
+    an explicit 'layout' override are left untouched; outliers get
+    'layout_dpi_override' set to the group median.
+    """
+    probed = []
+    for fig in figures:
+        if not isinstance(fig, dict) or fig.get('layout'):
+            continue
+        probe = docx_renderer.figure.probe_image_dpi(docx, fig)
+        if probe is not None:
+            probed.append((fig, probe[1]))
+
+    if len(probed) < 2:
+        return
+
+    median_dpi = statistics.median(dpi for _, dpi in probed)
+    if median_dpi <= 0:
+        return
+
+    for fig, dpi in probed:
+        ratio = dpi / median_dpi
+        if ratio >= outlier_ratio or ratio <= 1 / outlier_ratio:
+            fig['layout_dpi_override'] = median_dpi
+
+
 def _render_figures(docx, figures):
     """Render figures, switching to single column when the layout requires it."""
+    _flag_dpi_outliers(docx, figures)
     for fig in figures:
         layout = _figure_layout(docx, fig)
 

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -423,11 +423,14 @@ def extract_figure_data(fig_node):
                 caption_texts.append(txt)
     caption = ' '.join([c for c in caption_texts if c])
 
-    # graphic may be direct child or inside <alternatives>
+    # graphic may be a direct child, or offered as several representations
+    # inside <alternatives> - only match the direct child here so the latter
+    # case falls through to the ranking logic below instead of grabbing the
+    # first <graphic> in document order.
     href = None
     alt_text = None
 
-    graphic = fig_node.find('.//graphic')
+    graphic = fig_node.find('graphic')
     if graphic is not None:
         href = _get_href_from_node(graphic)
         alt_text = graphic.get('alt') or graphic.get('alt-text')

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -458,6 +458,7 @@ def extract_figure_data(fig_node):
                         dims_area = 0
                 # Penalize obvious thumbnails
                 is_thumbnail = '267x140' in ctype
+                is_scielo_web = (g.get('specific-use') or '').lower() == 'scielo-web'
                 ext_rank = len(preferred_ext_order)
                 lu = _href.lower()
                 for i, ext in enumerate(preferred_ext_order):
@@ -469,12 +470,15 @@ def extract_figure_data(fig_node):
                     'dims_area': dims_area,
                     'ext_rank': ext_rank,
                     'is_thumbnail': is_thumbnail,
+                    'is_scielo_web': is_scielo_web,
                     'alt': g.get('alt') or g.get('alt-text')
                 })
             if candidates:
-                # Choose best: avoid thumbnails, larger area first, then better extension
+                # Choose best: avoid thumbnails, prefer the SciELO Web
+                # representation, larger area first, then better extension
                 candidates.sort(key=lambda c: (
                     c['is_thumbnail'],           # False (0) before True (1)
+                    not c['is_scielo_web'],       # scielo-web first
                     -c['dims_area'],              # larger first
                     c['ext_rank']                 # better extension first
                 ))

--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -35,18 +35,18 @@ def add_figure(docx, figure_data, header_style_name='SCL Table Heading', page_at
 
 def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIBUTES, threshold: float = 1.1):
     """
-    Decide whether a figure should occupy the full page width (double-column-layout) or a single column (single-column-layout).
+    Decide whether a figure should occupy the full page width (single-column-layout, i.e. a one-column docx section) or fit within one body column (double-column-layout, i.e. a two-column docx section).
 
     Heuristic:
     - Compute the natural width of the image in centimeters using Pillow and its DPI metadata (tries dpi, jfif_density; defaults to 300 DPI when missing).
     - Compute the available content width (page width minus margins) and the single-column width ((content - column_spacing)/2).
-    - If natural image width >= threshold * single-column width, return 'double-column-layout'; otherwise 'single-column-layout'.
+    - If natural image width >= threshold * single-column width, return 'single-column-layout' (full width); otherwise 'double-column-layout' (fits in one column).
 
     Args:
         docx: The Document, used to read `_scl_context` for assets_dir and cache.
         figure_data: Dict with at least 'href' (and optionally 'alt').
         page_attributes: Dict containing Cm values for page_width, margins, and optionally TWO_COLUMNS_SPACING in twips via pdf_enum.
-        threshold: Float in (0,1.5] to bias decision; higher means prefer double-column for larger images. Default 0.9.
+        threshold: Float in (0,1.5] to bias decision; higher means prefer double-column for larger images. Default 1.1.
 
     Returns:
         str: 'double-column-layout' or 'single-column-layout'
@@ -71,16 +71,10 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
         # If Pillow is unavailable at runtime, fallback conservatively
         return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
 
-    # Compute layout widths (in Cm)
-    page_width = page_attributes.get('page_width', Cm(21.0))
-    left_margin = page_attributes.get('left_margin', Cm(2.0))
-    right_margin = page_attributes.get('right_margin', Cm(2.0))
-    content_width = page_width - left_margin - right_margin
-
-    # Convert TWO_COLUMNS_SPACING (twips) to Cm, mirroring table_utils logic
-    column_spacing_twips = getattr(pdf_enum, 'TWO_COLUMNS_SPACING', 300)
-    column_spacing_cm = Cm(column_spacing_twips / 567.0)
-    single_col_width = (content_width - column_spacing_cm) / 2
+    # Reuses _compute_single_column_width so this decision honors the same
+    # formula as the rest of the layout code, instead of duplicating (and
+    # risking drifting from) it here.
+    single_col_width = _compute_single_column_width(page_attributes)
 
     probe = probe_image_dpi(docx, figure_data)
     if probe is None:
@@ -98,9 +92,9 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
     # width in inches then to Cm
     width_in_cm = (px_w / max(1.0, dpi)) * 2.54
 
-    # single_col_width degraded from a Cm object to a raw EMU number in the
-    # subtraction/division above (python-docx's Length has no operator
-    # overloads that preserve units) - convert back to cm so this compares
+    # single_col_width comes back as a raw EMU number, not a Cm object
+    # (python-docx's Length has no operator overloads that preserve units
+    # through subtraction/division) - convert back to cm so this compares
     # against width_in_cm in the same unit, instead of cm against EMU.
     single_col_width_cm = single_col_width / Cm(1)
 

--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -38,7 +38,7 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
     Decide whether a figure should occupy the full page width (double-column-layout) or a single column (single-column-layout).
 
     Heuristic:
-    - Compute the natural width of the image in centimeters using Pillow and its DPI metadata (tries dpi, jfif_density; defaults to 150 DPI when missing).
+    - Compute the natural width of the image in centimeters using Pillow and its DPI metadata (tries dpi, jfif_density; defaults to 300 DPI when missing).
     - Compute the available content width (page width minus margins) and the single-column width ((content - column_spacing)/2).
     - If natural image width >= threshold * single-column width, return 'double-column-layout'; otherwise 'single-column-layout'.
 
@@ -82,24 +82,21 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
     column_spacing_cm = Cm(column_spacing_twips / 567.0)
     single_col_width = (content_width - column_spacing_cm) / 2
 
-    # Resolve image path (local or download)
-    context = _get_docx_context(docx)
-    href = figure_data.get('href') if isinstance(figure_data, dict) else None
-    img_path = _resolve_image_path(href, context)
-    if not img_path:
+    probe = probe_image_dpi(docx, figure_data)
+    if probe is None:
         return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
+    px_w, dpi = probe
 
-    # Open image and compute its natural width in Cm using DPI (default 72 DPI)
-    if not os.path.exists(img_path):
-        return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
-    try:
-        with Image.open(img_path) as im:
-            px_w = im.width
-            dpi = _infer_image_dpi(im)
-            # width in inches then to Cm
-            width_in_cm = (px_w / max(1.0, dpi)) * 2.54
-    except Exception:
-        return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
+    # A caller may have compared this image's DPI against its siblings and
+    # supplied a more trustworthy value here - see 'layout_dpi_override'.
+    if isinstance(figure_data, dict) and figure_data.get('layout_dpi_override'):
+        try:
+            dpi = float(figure_data['layout_dpi_override'])
+        except (TypeError, ValueError):
+            pass
+
+    # width in inches then to Cm
+    width_in_cm = (px_w / max(1.0, dpi)) * 2.54
 
     # single_col_width degraded from a Cm object to a raw EMU number in the
     # subtraction/division above (python-docx's Length has no operator
@@ -111,9 +108,35 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
     return pdf_enum.SINGLE_COLUMN_PAGE_LABEL if width_in_cm >= float(threshold) * single_col_width_cm else pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
 
 
+def probe_image_dpi(docx, figure_data):
+    """
+    Resolve a figure's image and return its (pixel_width, dpi), or None if
+    the image can't be opened.
+    """
+    try:
+        from PIL import Image
+    except Exception:
+        return None
+
+    context = _get_docx_context(docx)
+    href = figure_data.get('href') if isinstance(figure_data, dict) else None
+    img_path = _resolve_image_path(href, context)
+    if not img_path or not os.path.exists(img_path):
+        return None
+
+    try:
+        with Image.open(img_path) as im:
+            return im.width, _infer_image_dpi(im)
+    except Exception:
+        return None
+
+
 # -----------------
 # Private helpers
 # -----------------
+
+_NO_METADATA_DPI_FALLBACK = 300.0
+
 
 def _infer_image_dpi(im) -> float:
     """Infer the horizontal DPI from a PIL Image, considering multiple metadata sources.
@@ -121,7 +144,7 @@ def _infer_image_dpi(im) -> float:
     Priority:
     - im.info['dpi']: tuple or number
     - im.info['jfif_unit'] and im.info['jfif_density'] (unit 1=inches, 2=cm)
-    Fallback: 96 dpi
+    Fallback: _NO_METADATA_DPI_FALLBACK.
     """
     try:
         info = getattr(im, 'info', {}) or {}
@@ -144,10 +167,10 @@ def _infer_image_dpi(im) -> float:
 
             if unit == 2:  # per cm
                 return float(density[0]) * 2.54
-        return 96.0
+        return _NO_METADATA_DPI_FALLBACK
 
     except Exception:
-        return 96.0
+        return _NO_METADATA_DPI_FALLBACK
 
 def _add_paragraph_with_formatting(docx, text, style_name='SCL Paragraph'):
     """Minimal helper to add a paragraph with an optional style, avoiding circular imports."""

--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -101,8 +101,14 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
     except Exception:
         return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
 
+    # single_col_width degraded from a Cm object to a raw EMU number in the
+    # subtraction/division above (python-docx's Length has no operator
+    # overloads that preserve units) - convert back to cm so this compares
+    # against width_in_cm in the same unit, instead of cm against EMU.
+    single_col_width_cm = single_col_width / Cm(1)
+
     # If the image is wider than a single column by the threshold factor, prefer a single-column-layout (full width). Otherwise, keep double-column-layout.
-    return pdf_enum.SINGLE_COLUMN_PAGE_LABEL if width_in_cm >= float(threshold) * float(single_col_width) else pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
+    return pdf_enum.SINGLE_COLUMN_PAGE_LABEL if width_in_cm >= float(threshold) * single_col_width_cm else pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
 
 
 # -----------------

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
 
@@ -92,57 +91,3 @@ class TestDocxAcknowledgmentsPipe(unittest.TestCase):
 class TestDocxSupplementaryMaterialPipe(unittest.TestCase):
     # TODO
     ...
-
-
-class TestFlagDpiOutliers(unittest.TestCase):
-    """Tests for _flag_dpi_outliers: flags a figure's DPI as untrustworthy
-    when it diverges from its sibling figures' median DPI, in the same
-    batch, by more than outlier_ratio."""
-
-    def test_flags_dpi_outlier_against_siblings(self):
-        figures = [{'href': 'graph1.tif'}, {'href': 'graph2.tif'}, {'href': 'graph3.tif'}]
-        probes = {'graph1.tif': (612, 72.0), 'graph2.tif': (800, 300.0), 'graph3.tif': (700, 300.0)}
-        with patch(
-            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
-            side_effect=lambda docx, fig: probes[fig['href']],
-        ):
-            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
-
-        self.assertEqual(figures[0]['layout_dpi_override'], 300.0)
-        self.assertNotIn('layout_dpi_override', figures[1])
-        self.assertNotIn('layout_dpi_override', figures[2])
-
-    def test_does_not_flag_similar_dpis(self):
-        figures = [{'href': 'a.tif'}, {'href': 'b.tif'}]
-        probes = {'a.tif': (700, 280.0), 'b.tif': (700, 300.0)}
-        with patch(
-            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
-            side_effect=lambda docx, fig: probes[fig['href']],
-        ):
-            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
-
-        self.assertNotIn('layout_dpi_override', figures[0])
-        self.assertNotIn('layout_dpi_override', figures[1])
-
-    def test_skips_figures_with_explicit_layout(self):
-        # 'a.tif' already has a resolved layout and must not be probed; only
-        # 'b.tif' should be. With a single figure left to probe there aren't
-        # enough siblings to compare against, so no override is set either.
-        figures = [{'href': 'a.tif', 'layout': 'single-column-layout'}, {'href': 'b.tif'}]
-        with patch(
-            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
-            return_value=(700, 300.0),
-        ) as mock_probe:
-            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
-        mock_probe.assert_called_once_with(None, figures[1])
-        self.assertNotIn('layout_dpi_override', figures[0])
-        self.assertNotIn('layout_dpi_override', figures[1])
-
-    def test_single_figure_is_never_flagged(self):
-        figures = [{'href': 'a.tif'}]
-        with patch(
-            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
-            return_value=(612, 72.0),
-        ):
-            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
-        self.assertNotIn('layout_dpi_override', figures[0])

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
 
@@ -91,3 +92,57 @@ class TestDocxAcknowledgmentsPipe(unittest.TestCase):
 class TestDocxSupplementaryMaterialPipe(unittest.TestCase):
     # TODO
     ...
+
+
+class TestFlagDpiOutliers(unittest.TestCase):
+    """Tests for _flag_dpi_outliers: flags a figure's DPI as untrustworthy
+    when it diverges from its sibling figures' median DPI, in the same
+    batch, by more than outlier_ratio."""
+
+    def test_flags_dpi_outlier_against_siblings(self):
+        figures = [{'href': 'graph1.tif'}, {'href': 'graph2.tif'}, {'href': 'graph3.tif'}]
+        probes = {'graph1.tif': (612, 72.0), 'graph2.tif': (800, 300.0), 'graph3.tif': (700, 300.0)}
+        with patch(
+            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
+            side_effect=lambda docx, fig: probes[fig['href']],
+        ):
+            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
+
+        self.assertEqual(figures[0]['layout_dpi_override'], 300.0)
+        self.assertNotIn('layout_dpi_override', figures[1])
+        self.assertNotIn('layout_dpi_override', figures[2])
+
+    def test_does_not_flag_similar_dpis(self):
+        figures = [{'href': 'a.tif'}, {'href': 'b.tif'}]
+        probes = {'a.tif': (700, 280.0), 'b.tif': (700, 300.0)}
+        with patch(
+            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
+            side_effect=lambda docx, fig: probes[fig['href']],
+        ):
+            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
+
+        self.assertNotIn('layout_dpi_override', figures[0])
+        self.assertNotIn('layout_dpi_override', figures[1])
+
+    def test_skips_figures_with_explicit_layout(self):
+        # 'a.tif' already has a resolved layout and must not be probed; only
+        # 'b.tif' should be. With a single figure left to probe there aren't
+        # enough siblings to compare against, so no override is set either.
+        figures = [{'href': 'a.tif', 'layout': 'single-column-layout'}, {'href': 'b.tif'}]
+        with patch(
+            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
+            return_value=(700, 300.0),
+        ) as mock_probe:
+            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
+        mock_probe.assert_called_once_with(None, figures[1])
+        self.assertNotIn('layout_dpi_override', figures[0])
+        self.assertNotIn('layout_dpi_override', figures[1])
+
+    def test_single_figure_is_never_flagged(self):
+        figures = [{'href': 'a.tif'}]
+        with patch(
+            'packtools.sps.formats.pdf.renderer.docx.figure.probe_image_dpi',
+            return_value=(612, 72.0),
+        ):
+            docx_pipe._flag_dpi_outliers(docx=None, figures=figures)
+        self.assertNotIn('layout_dpi_override', figures[0])

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1238,7 +1238,48 @@ class TestExtractTransAbstractData(unittest.TestCase):
             }
         ]
         result = xml_pipe.extract_trans_abstract_data(
-            xml, 
+            xml,
             namespaces={'xml': 'http://custom.namespace'}
         )
         self.assertEqual(result, expected)
+
+
+class TestExtractFigureData(unittest.TestCase):
+    """Tests for extract_figure_data's graphic href resolution, including
+    the ranking logic used when a figure only offers <alternatives>."""
+
+    def test_direct_graphic_child_is_used_as_is(self):
+        xml = etree.fromstring(
+            '<fig xmlns:xlink="http://www.w3.org/1999/xlink" id="F1">'
+            '<label>Figure 1</label>'
+            '<graphic xlink:href="figure1.jpg"/>'
+            '</fig>'
+        )
+        result = xml_pipe.extract_figure_data(xml)
+        self.assertEqual(result['href'], 'figure1.jpg')
+
+    def test_alternatives_prefers_scielo_web_over_raw_tif(self):
+        xml = etree.fromstring(
+            '<fig xmlns:xlink="http://www.w3.org/1999/xlink" id="F1">'
+            '<label>Graph 1</label>'
+            '<alternatives>'
+            '<graphic xlink:href="raw.tif"/>'
+            '<graphic xlink:href="web.png" specific-use="scielo-web"/>'
+            '<graphic xlink:href="thumb.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>'
+            '</alternatives>'
+            '</fig>'
+        )
+        result = xml_pipe.extract_figure_data(xml)
+        self.assertEqual(result['href'], 'web.png')
+
+    def test_alternatives_falls_back_to_tif_when_no_better_option(self):
+        xml = etree.fromstring(
+            '<fig xmlns:xlink="http://www.w3.org/1999/xlink" id="F1">'
+            '<label>Graph 1</label>'
+            '<alternatives>'
+            '<graphic xlink:href="raw.tif"/>'
+            '</alternatives>'
+            '</fig>'
+        )
+        result = xml_pipe.extract_figure_data(xml)
+        self.assertEqual(result['href'], 'raw.tif')

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1272,6 +1272,23 @@ class TestExtractFigureData(unittest.TestCase):
         result = xml_pipe.extract_figure_data(xml)
         self.assertEqual(result['href'], 'web.png')
 
+    def test_alternatives_prefers_scielo_web_over_raw_graphic(self):
+        # Isolates specific-use as the deciding factor: raw.png would win on
+        # extension ranking alone (png before jpg), so picking web.jpg here
+        # can only be explained by specific-use="scielo-web" taking priority.
+        xml = etree.fromstring(
+            '<fig xmlns:xlink="http://www.w3.org/1999/xlink" id="F1">'
+            '<label>Graph 1</label>'
+            '<alternatives>'
+            '<graphic xlink:href="raw.png"/>'
+            '<graphic xlink:href="web.jpg" specific-use="scielo-web"/>'
+            '<graphic xlink:href="thumb.jpg" specific-use="scielo-web" content-type="scielo-267x140"/>'
+            '</alternatives>'
+            '</fig>'
+        )
+        result = xml_pipe.extract_figure_data(xml)
+        self.assertEqual(result['href'], 'web.jpg')
+
     def test_alternatives_falls_back_to_tif_when_no_better_option(self):
         xml = etree.fromstring(
             '<fig xmlns:xlink="http://www.w3.org/1999/xlink" id="F1">'

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import unittest
+
+from docx import Document
+from PIL import Image
+
+from packtools.sps.formats.pdf.renderer.docx.figure import decide_figure_layout
+from packtools.sps.formats.pdf import enum as pdf_enum
+
+
+class TestDecideFigureLayoutUnits(unittest.TestCase):
+    """
+    Regression test for a units bug: single_col_width degrades from a Cm
+    object to a raw EMU number under python-docx's Length arithmetic (it has
+    no operator overloads that preserve units), so comparing it directly
+    against width_in_cm (a real centimeter float) compared cm against EMU -
+    a ~360000x scale mismatch that made the full-width branch unreachable
+    for any real image, regardless of size.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _make_png(self, px_width, px_height=200, dpi=96):
+        path = os.path.join(self.tmpdir.name, f"img_{px_width}.png")
+        Image.new("RGB", (px_width, px_height), color="white").save(
+            path, format="PNG", dpi=(dpi, dpi)
+        )
+        return path
+
+    def test_wide_image_gets_full_width_layout(self):
+        # ~18.5cm at 96 DPI - wider than a single column (~8.2cm) by far more
+        # than the 1.1 threshold, on an A4/2-column default page.
+        img_path = self._make_png(px_width=698)
+        docx = Document()
+        fig = {"href": img_path, "label": "Figure 1"}
+        self.assertEqual(
+            decide_figure_layout(docx, fig), pdf_enum.SINGLE_COLUMN_PAGE_LABEL
+        )
+
+    def test_narrow_image_stays_within_column(self):
+        # ~2.6cm at 96 DPI - well under the single-column width.
+        img_path = self._make_png(px_width=100)
+        docx = Document()
+        fig = {"href": img_path, "label": "Figure 1"}
+        self.assertEqual(
+            decide_figure_layout(docx, fig), pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -49,6 +49,29 @@ class TestDecideFigureLayoutUnits(unittest.TestCase):
             decide_figure_layout(docx, fig), pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
         )
 
+    def test_untagged_image_uses_print_resolution_fallback(self):
+        # An image with no DPI tag at all must fall back to print
+        # resolution, not screen resolution.
+        img_path = self._make_png(px_width=700)
+        with Image.open(img_path) as im:
+            im.info.pop("dpi", None)
+            im.save(img_path)  # re-save without the dpi tag
+        docx = Document()
+        fig = {"href": img_path, "label": "Graph 1"}
+        self.assertEqual(
+            decide_figure_layout(docx, fig), pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
+        )
+
+    def test_layout_dpi_override_replaces_embedded_dpi(self):
+        # 'layout_dpi_override' must take precedence over the image's own
+        # embedded DPI.
+        img_path = self._make_png(px_width=612, dpi=72)
+        docx = Document()
+        fig = {"href": img_path, "label": "Graph 1", "layout_dpi_override": 300.0}
+        self.assertEqual(
+            decide_figure_layout(docx, fig), pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

Corrige dois bugs em cadeia na decisão de layout de figuras do gerador de PDF (`decide_figure_layout`), que juntos podiam fazer uma figura de uma seção renderizar desproporcionalmente gigante (largura total da página), isolada, enquanto figuras irmãs do mesmo estilo/origem apareciam normais dentro da coluna:

1. **Comparação de unidade cm vs EMU**: `single_col_width` degradava de `Cm` para um número cru em EMU após subtração/divisão (python-docx não sobrecarrega operadores de `Length`), tornando o ramo de largura total inatingível na prática para qualquer imagem real.
2. **Seleção de `<alternatives>` e confiança em DPI de metadado**: a lógica de ranqueamento de variantes de imagem (`<alternatives>`) já existia no código mas nunca rodava, sempre pegando o `.tif` bruto de produção; e o DPI embutido no arquivo se mostrou inconsistente entre figuras-irmãs do mesmo artigo real (72 DPI vs 300 DPI), inflando o cálculo de largura física por ~4x pra uma delas.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py`, função `decide_figure_layout` (e a nova `probe_image_dpi`). Depois `packtools/sps/formats/pdf/pipeline/docx.py`, função `_flag_dpi_outliers`.

## Como este poderia ser testado manualmente?

Com o LibreOffice instalado:
```
python -m packtools.sps.formats.pdf_generator -i tests/fixtures/pdf/a4.xml -l tests/fixtures/pdf/layout.docx -o saida.pdf
```
Comparar a página com os gráficos ("Graph 1" a "Graph 7", ~página 3-4) contra `tests/fixtures/pdf/a4.gt.pdf`: antes deste PR, `Graph 1` aparecia sozinho, gigante, em página de largura total; depois, os 7 gráficos aparecem com tamanho consistente, fluindo com o texto em 2 colunas. Confirmei também a mesma figura de largura total funcionando corretamente onde é esperada (`a1.xml`/`a3.xml`, mapas que devem ocupar a página inteira).

Testes automatizados: `python -m unittest discover -s tests/sps/formats/pdf -v` (109 testes, 8 novos cobrindo os dois commits deste PR).

## Algum cenário de contexto que queira dar?

Encontrado durante um levantamento mais amplo de qualidade do gerador de PDF contra um corpus de artigos reais (`tests/fixtures/pdf/`), comparando a saída atual contra os PDFs editoriais canônicos (`*.gt.pdf`). Faz parte do escopo da issue #1278 (layout de página/coluna configurável).

## Screenshots

<img width="2502" height="3648" alt="comparison_before_after" src="https://github.com/user-attachments/assets/24cfc36e-00ce-4e2e-8e1f-3e99ebbad509" />


## Quais são os tickets relevantes?

Refs #1278. Closes #1293.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado) — ver `SECURITY_ADHERENCE.md`. Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
