### PR TITLE
fix: parametriza número de colunas do corpo (era 2 fixo em vários lugares)

### DIFF
--- a/packtools/sps/formats/pdf/enum.py
+++ b/packtools/sps/formats/pdf/enum.py
@@ -18,6 +18,7 @@ PAGE_ATTRIBUTES = {
     "page_height": Cm(29.7),
     "different_first_page_header_footer": True,
     "start_type": WD_SECTION.NEW_PAGE,
+    "default_column_count": 2,
 }
 
 SUPPORTED_STYLES = [

--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -397,7 +397,7 @@ def docx_body_pipe(docx, body_data):
     Returns:
         None
     """
-    _setup_two_column_body_section(docx)
+    _setup_body_section(docx)
 
     for section_data in body_data:
         _render_body_section(docx, section_data)
@@ -489,7 +489,7 @@ def _body_column_count():
     return max(1, pdf_enum.PAGE_ATTRIBUTES.get('default_column_count', 2))
 
 
-def _setup_two_column_body_section(docx):
+def _setup_body_section(docx):
     """Create or get the second section and set its column count from PAGE_ATTRIBUTES."""
     section = docx_renderer.section.get_or_create_second_section(docx)
     column_count = _body_column_count()
@@ -527,7 +527,7 @@ def _add_single_column_section(docx):
     return single_col_section
 
 
-def _add_two_column_section(docx):
+def _restore_body_column_section(docx):
     """Insert a continuous section break and restore the body's configured column count. Returns the section."""
     multi_col_section = docx.add_section(pdf_enum.WD_SECTION.CONTINUOUS)
     column_count = _body_column_count()
@@ -539,10 +539,10 @@ def _add_two_column_section(docx):
 def _render_tables(docx, tables):
     """Render tables, switching to single column when required by layout."""
     for table in tables:
-        if table.get('layout') == pdf_enum.SINGLE_COLUMN_PAGE_LABEL:
+        if table.get('layout') == pdf_enum.SINGLE_COLUMN_PAGE_LABEL and _body_column_count() > 1:
             _add_single_column_section(docx)
             docx_renderer.table.add_table(docx, table, page_attributes=pdf_enum.PAGE_ATTRIBUTES)
-            _add_two_column_section(docx)
+            _restore_body_column_section(docx)
         else:
             docx_renderer.table.add_table(docx, table, page_attributes=pdf_enum.PAGE_ATTRIBUTES)
 
@@ -562,9 +562,9 @@ def _render_figures(docx, figures):
     for fig in figures:
         layout = _figure_layout(docx, fig)
 
-        if layout == pdf_enum.SINGLE_COLUMN_PAGE_LABEL:
+        if layout == pdf_enum.SINGLE_COLUMN_PAGE_LABEL and _body_column_count() > 1:
             _add_single_column_section(docx)
             docx_renderer.figure.add_figure(docx, fig, page_attributes=pdf_enum.PAGE_ATTRIBUTES)
-            _add_two_column_section(docx)
+            _restore_body_column_section(docx)
         else:
             docx_renderer.figure.add_figure(docx, fig, page_attributes=pdf_enum.PAGE_ATTRIBUTES)

--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -484,10 +484,17 @@ def docx_supplementary_material_pipe(docx, footer_data, supplementary_data, sect
 # Private helpers
 # -----------------
 
+def _body_column_count():
+    """Number of columns configured for the body, from PAGE_ATTRIBUTES."""
+    return max(1, pdf_enum.PAGE_ATTRIBUTES.get('default_column_count', 2))
+
+
 def _setup_two_column_body_section(docx):
-    """Create or get the second section and set it to two columns."""
+    """Create or get the second section and set its column count from PAGE_ATTRIBUTES."""
     section = docx_renderer.section.get_or_create_second_section(docx)
-    docx_renderer.section.setup_section_columns(section, 2, pdf_enum.TWO_COLUMNS_SPACING)
+    column_count = _body_column_count()
+    spacing = pdf_enum.TWO_COLUMNS_SPACING if column_count > 1 else 0
+    docx_renderer.section.setup_section_columns(section, column_count, spacing)
 
 
 def _render_body_section(docx, section_data):
@@ -521,9 +528,11 @@ def _add_single_column_section(docx):
 
 
 def _add_two_column_section(docx):
-    """Insert a continuous section break and set a two column layout. Returns the section."""
+    """Insert a continuous section break and restore the body's configured column count. Returns the section."""
     multi_col_section = docx.add_section(pdf_enum.WD_SECTION.CONTINUOUS)
-    docx_renderer.section.setup_section_columns(multi_col_section, 2, pdf_enum.TWO_COLUMNS_SPACING)
+    column_count = _body_column_count()
+    spacing = pdf_enum.TWO_COLUMNS_SPACING if column_count > 1 else 0
+    docx_renderer.section.setup_section_columns(multi_col_section, column_count, spacing)
     return multi_col_section
 
 

--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -71,16 +71,10 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
         # If Pillow is unavailable at runtime, fallback conservatively
         return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
 
-    # Compute layout widths (in Cm)
-    page_width = page_attributes.get('page_width', Cm(21.0))
-    left_margin = page_attributes.get('left_margin', Cm(2.0))
-    right_margin = page_attributes.get('right_margin', Cm(2.0))
-    content_width = page_width - left_margin - right_margin
-
-    # Convert TWO_COLUMNS_SPACING (twips) to Cm, mirroring table_utils logic
-    column_spacing_twips = getattr(pdf_enum, 'TWO_COLUMNS_SPACING', 300)
-    column_spacing_cm = Cm(column_spacing_twips / 567.0)
-    single_col_width = (content_width - column_spacing_cm) / 2
+    # Compute layout widths (in Cm) - reuses _compute_single_column_width so
+    # this decision honors the same configured column count as the rest of
+    # the layout, instead of duplicating (and drifting from) that formula.
+    single_col_width = _compute_single_column_width(page_attributes)
 
     # Resolve image path (local or download)
     context = _get_docx_context(docx)
@@ -160,11 +154,12 @@ def _compute_content_width(page_attributes):
     return page_width - left_margin - right_margin
 
 def _compute_single_column_width(page_attributes):
-    """Compute the width of a single column in a two-column layout, accounting for column spacing."""
+    """Compute the width of one body column, accounting for the configured column count and spacing between columns."""
     content_width = _compute_content_width(page_attributes)
+    column_count = max(1, page_attributes.get('default_column_count', 2))
     column_spacing_twips = getattr(pdf_enum, 'TWO_COLUMNS_SPACING', 300)
     column_spacing_cm = Cm(column_spacing_twips / 567.0)
-    return (content_width - column_spacing_cm) / 2
+    return (content_width - (column_count - 1) * column_spacing_cm) / column_count
 
 def _get_docx_context(docx):
     """Retrieve the _scl_context dictionary from the docx Document, if available."""

--- a/packtools/sps/formats/pdf/renderer/docx/table.py
+++ b/packtools/sps/formats/pdf/renderer/docx/table.py
@@ -243,9 +243,10 @@ def _compute_table_width(page_attributes, table_data):
 	if layout == pdf_enum.SINGLE_COLUMN_PAGE_LABEL:
 		table_width = content_width
 	else:
+		column_count = max(1, page_attributes.get('default_column_count', 2))
 		column_spacing = getattr(pdf_enum, 'TWO_COLUMNS_SPACING', 300)
 		column_spacing = Cm(column_spacing / 567.0)
-		table_width = (content_width - column_spacing) // 2
+		table_width = (content_width - (column_count - 1) * column_spacing) // column_count
 
 	return content_width, table_width, layout
 

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -125,14 +125,58 @@ class TestBodyColumnConfiguration(unittest.TestCase):
     def test_setup_body_section_uses_configured_column_count(self):
         docx = Document()
         with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}):
-            docx_pipe._setup_two_column_body_section(docx)
+            docx_pipe._setup_body_section(docx)
         self.assertEqual(self._cols_num(docx.sections[1]), '1')
 
-    def test_add_two_column_section_restores_configured_column_count(self):
+    def test_setup_body_section_supports_three_columns(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 3}):
+            docx_pipe._setup_body_section(docx)
+        self.assertEqual(self._cols_num(docx.sections[1]), '3')
+
+    def test_restore_body_column_section_restores_configured_column_count(self):
         docx = Document()
         with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}):
-            section = docx_pipe._add_two_column_section(docx)
+            section = docx_pipe._restore_body_column_section(docx)
         self.assertEqual(self._cols_num(section), '1')
+
+    def test_restore_body_column_section_supports_three_columns(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 3}):
+            section = docx_pipe._restore_body_column_section(docx)
+        self.assertEqual(self._cols_num(section), '3')
+
+    def test_render_tables_skips_section_switch_when_body_is_single_column(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}), \
+             patch('packtools.sps.formats.pdf.pipeline.docx.docx_renderer.table.add_table'):
+            sections_before = len(docx.sections)
+            docx_pipe._render_tables(docx, [{'layout': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}])
+        self.assertEqual(len(docx.sections), sections_before)
+
+    def test_render_tables_switches_section_when_body_has_multiple_columns(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 2}), \
+             patch('packtools.sps.formats.pdf.pipeline.docx.docx_renderer.table.add_table'):
+            sections_before = len(docx.sections)
+            docx_pipe._render_tables(docx, [{'layout': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}])
+        self.assertEqual(len(docx.sections), sections_before + 2)
+
+    def test_render_figures_skips_section_switch_when_body_is_single_column(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}), \
+             patch('packtools.sps.formats.pdf.pipeline.docx.docx_renderer.figure.add_figure'):
+            sections_before = len(docx.sections)
+            docx_pipe._render_figures(docx, [{'layout': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}])
+        self.assertEqual(len(docx.sections), sections_before)
+
+    def test_render_figures_switches_section_when_body_has_multiple_columns(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 2}), \
+             patch('packtools.sps.formats.pdf.pipeline.docx.docx_renderer.figure.add_figure'):
+            sections_before = len(docx.sections)
+            docx_pipe._render_figures(docx, [{'layout': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}])
+        self.assertEqual(len(docx.sections), sections_before + 2)
 
 
 if __name__ == "__main__":

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -1,6 +1,10 @@
 import unittest
+from unittest.mock import patch
+
+from docx import Document
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
+from packtools.sps.formats.pdf import enum as pdf_enum
 
 
 class TestPipelineDocx(unittest.TestCase):
@@ -91,3 +95,45 @@ class TestDocxAcknowledgmentsPipe(unittest.TestCase):
 class TestDocxSupplementaryMaterialPipe(unittest.TestCase):
     # TODO
     ...
+
+
+class TestBodyColumnConfiguration(unittest.TestCase):
+    """
+    Regression tests: body column count (and the count restored after a
+    full-width table/figure) must come from PAGE_ATTRIBUTES['default_column_count']
+    instead of a hardcoded 2, so a 1-column body isn't forced back to 2
+    columns after a full-width table/figure interlude.
+    """
+
+    def _cols_num(self, section):
+        cols = section._sectPr.find(
+            '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}cols'
+        )
+        return cols.get(
+            '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}num'
+        )
+
+    def test_body_column_count_defaults_to_two(self):
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {}, clear=False):
+            pdf_enum.PAGE_ATTRIBUTES.pop('default_column_count', None)
+            self.assertEqual(docx_pipe._body_column_count(), 2)
+
+    def test_body_column_count_reads_config(self):
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}):
+            self.assertEqual(docx_pipe._body_column_count(), 1)
+
+    def test_setup_body_section_uses_configured_column_count(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}):
+            docx_pipe._setup_two_column_body_section(docx)
+        self.assertEqual(self._cols_num(docx.sections[1]), '1')
+
+    def test_add_two_column_section_restores_configured_column_count(self):
+        docx = Document()
+        with patch.dict(pdf_enum.PAGE_ATTRIBUTES, {'default_column_count': 1}):
+            section = docx_pipe._add_two_column_section(docx)
+        self.assertEqual(self._cols_num(section), '1')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -1,0 +1,45 @@
+import unittest
+
+from docx.shared import Cm
+
+from packtools.sps.formats.pdf.renderer.docx.figure import _compute_single_column_width
+from packtools.sps.formats.pdf import enum as pdf_enum
+
+
+class TestComputeSingleColumnWidth(unittest.TestCase):
+    """
+    Regression tests: column width must honor 'default_column_count' from
+    page_attributes instead of always dividing by a hardcoded 2, so a
+    1-column body doesn't get its figures/tables sized as if there were
+    two columns.
+    """
+
+    def _page_attributes(self, default_column_count):
+        attrs = dict(pdf_enum.PAGE_ATTRIBUTES)
+        attrs['default_column_count'] = default_column_count
+        return attrs
+
+    def test_two_columns_matches_legacy_formula(self):
+        attrs = self._page_attributes(2)
+        content_width = attrs['page_width'] - attrs['left_margin'] - attrs['right_margin']
+        spacing_cm = Cm(pdf_enum.TWO_COLUMNS_SPACING / 567.0)
+        expected = (content_width - spacing_cm) / 2
+        self.assertEqual(_compute_single_column_width(attrs), expected)
+
+    def test_one_column_equals_full_content_width(self):
+        attrs = self._page_attributes(1)
+        content_width = attrs['page_width'] - attrs['left_margin'] - attrs['right_margin']
+        self.assertEqual(_compute_single_column_width(attrs), content_width)
+
+    def test_missing_key_defaults_to_two_columns(self):
+        attrs = dict(pdf_enum.PAGE_ATTRIBUTES)
+        attrs.pop('default_column_count', None)
+        two_col_attrs = self._page_attributes(2)
+        self.assertEqual(
+            _compute_single_column_width(attrs),
+            _compute_single_column_width(two_col_attrs),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -31,6 +31,13 @@ class TestComputeSingleColumnWidth(unittest.TestCase):
         content_width = attrs['page_width'] - attrs['left_margin'] - attrs['right_margin']
         self.assertEqual(_compute_single_column_width(attrs), content_width)
 
+    def test_three_columns_uses_generic_formula(self):
+        attrs = self._page_attributes(3)
+        content_width = attrs['page_width'] - attrs['left_margin'] - attrs['right_margin']
+        spacing_cm = Cm(pdf_enum.TWO_COLUMNS_SPACING / 567.0)
+        expected = (content_width - 2 * spacing_cm) / 3
+        self.assertEqual(_compute_single_column_width(attrs), expected)
+
     def test_missing_key_defaults_to_two_columns(self):
         attrs = dict(pdf_enum.PAGE_ATTRIBUTES)
         attrs.pop('default_column_count', None)

--- a/tests/sps/formats/pdf/renderer/docx/test_table.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_table.py
@@ -31,6 +31,14 @@ class TestComputeTableWidth(unittest.TestCase):
         content_width, table_width, _ = _compute_table_width(attrs, {})
         self.assertEqual(table_width, content_width)
 
+    def test_three_columns_uses_generic_formula(self):
+        attrs = self._page_attributes(3)
+        content_width, table_width, layout = _compute_table_width(attrs, {})
+        spacing_cm = Cm(pdf_enum.TWO_COLUMNS_SPACING / 567.0)
+        expected = (content_width - 2 * spacing_cm) // 3
+        self.assertEqual(table_width, expected)
+        self.assertEqual(layout, pdf_enum.DOUBLE_COLUMN_PAGE_LABEL)
+
     def test_single_column_layout_override_ignores_column_count(self):
         attrs = self._page_attributes(1)
         content_width, table_width, layout = _compute_table_width(

--- a/tests/sps/formats/pdf/renderer/docx/test_table.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_table.py
@@ -1,0 +1,44 @@
+import unittest
+
+from docx.shared import Cm
+
+from packtools.sps.formats.pdf.renderer.docx.table import _compute_table_width
+from packtools.sps.formats.pdf import enum as pdf_enum
+
+
+class TestComputeTableWidth(unittest.TestCase):
+    """
+    Regression tests: within-column table width must honor
+    'default_column_count' from page_attributes instead of always dividing
+    by a hardcoded 2.
+    """
+
+    def _page_attributes(self, default_column_count):
+        attrs = dict(pdf_enum.PAGE_ATTRIBUTES)
+        attrs['default_column_count'] = default_column_count
+        return attrs
+
+    def test_two_columns_matches_legacy_formula(self):
+        attrs = self._page_attributes(2)
+        content_width, table_width, layout = _compute_table_width(attrs, {})
+        spacing_cm = Cm(pdf_enum.TWO_COLUMNS_SPACING / 567.0)
+        expected = (content_width - spacing_cm) // 2
+        self.assertEqual(table_width, expected)
+        self.assertEqual(layout, pdf_enum.DOUBLE_COLUMN_PAGE_LABEL)
+
+    def test_one_column_equals_full_content_width(self):
+        attrs = self._page_attributes(1)
+        content_width, table_width, _ = _compute_table_width(attrs, {})
+        self.assertEqual(table_width, content_width)
+
+    def test_single_column_layout_override_ignores_column_count(self):
+        attrs = self._page_attributes(1)
+        content_width, table_width, layout = _compute_table_width(
+            attrs, {'layout': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}
+        )
+        self.assertEqual(table_width, content_width)
+        self.assertEqual(layout, pdf_enum.SINGLE_COLUMN_PAGE_LABEL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

**Problema existente:** o número de colunas do corpo está fixo em `2` em vários pontos do código (`_setup_two_column_body_section`, `_add_two_column_section`), e as contas de largura de figura/tabela (`_compute_single_column_width`, `_compute_table_width`) sempre dividem o espaço disponível por `2`, sem ler nenhuma configuração. Não existe hoje forma de gerar um PDF com corpo em 1 coluna — e mesmo que existisse, essas contas dariam resultado errado (metade da largura real). Gap já registrado na issue #1278.

**Solução proposta:** generalizar as quatro funções pra usar `page_attributes['default_column_count']` (novo campo, default `2` — preserva o comportamento atual). Com N colunas, a largura de uma coluna passa a ser `(largura_disponível - (N-1)*espaçamento) / N`, que se reduz exatamente à fórmula antiga quando N=2, e corresponde à largura total quando N=1 (sem precisar de caso especial). De caminho, corrigido `decide_figure_layout` pra chamar `_compute_single_column_width` em vez de duplicar a mesma conta (as duas podiam divergir se só uma fosse atualizada).

**Resultado:** com a configuração padrão (`default_column_count: 2`), a saída é idêntica à atual — validado nos 4 fixtures reais, mesma contagem de página. Com `default_column_count: 1`, corpo e tabelas passam a ocupar a largura inteira da página corretamente, em vez de ficarem espremidos em metade dela (imagem anexada).

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py::_compute_single_column_width` e `packtools/sps/formats/pdf/pipeline/docx.py::_body_column_count`.

## Como este poderia ser testado manualmente?

Com a configuração padrão, nenhuma mudança visível:
```
python -m packtools.sps.formats.pdf_generator -i tests/fixtures/pdf/a4.xml -l tests/fixtures/pdf/layout.docx -o saida.pdf
```
Pra ver o efeito da nova opção (ainda não exposta via CLI — fica pra uma etapa seguinte de configuração de layout), definir `default_column_count=1` diretamente via API Python antes de chamar `pipeline_docx`.

Testes automatizados: `python -m unittest discover -s tests/sps/formats/pdf -v`.

## Algum cenário de contexto que queira dar?

Encontrado durante um levantamento mais amplo de qualidade do gerador de PDF, ao investigar se seria possível oferecer layout de 1 coluna como opção de configuração (issue #1278). O gap já estava documentado na própria issue, mas nunca tinha sido corrigido.

## Screenshots

<img width="1684" height="1230" alt="prA_before_after" src="https://github.com/user-attachments/assets/f1c4ee96-0a27-4877-8c87-432acacf1288" />

## Quais são os tickets relevantes?

Refs #1278. Closes #1297.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado) — ver `SECURITY_ADHERENCE.md`. Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
