### PR TITLE
fix: passa largura explícita ao inserir figura, evitando mismatch de DPI

### DIFF
--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -22,11 +22,12 @@ def add_figure(docx, figure_data, header_style_name='SCL Table Heading', page_at
 
     single_col_width = _compute_single_column_width(page_attributes)
 
-    target_width = content_width if layout == pdf_enum.SINGLE_COLUMN_PAGE_LABEL else single_col_width
+    ceiling_width = content_width if layout == pdf_enum.SINGLE_COLUMN_PAGE_LABEL else single_col_width
     context = _get_docx_context(docx)
     href, alt = _extract_figure_meta(figure_data)
     img_path = _resolve_image_path(href, context)
 
+    target_width = _natural_width_capped(img_path, ceiling_width)
     picture_added = _try_insert_picture(docx, img_path, target_width, page_attributes)
     if not picture_added:
         _add_alt_paragraph(docx, alt)
@@ -191,15 +192,44 @@ def _resolve_image_path(href, context):
 
     return img_path
 
+def _natural_width_capped(img_path, ceiling_width):
+    """
+    Compute the image's natural width from its DPI metadata, capped at
+    ceiling_width - only ever shrunk to fit, never enlarged.
+    """
+    if not (img_path and os.path.exists(img_path)):
+        return ceiling_width
+    try:
+        from PIL import Image
+
+        with Image.open(img_path) as im:
+            px_w = im.width
+            dpi = _infer_image_dpi(im)
+            natural_width = Cm((px_w / max(1.0, dpi)) * 2.54)
+        return natural_width if natural_width < ceiling_width else ceiling_width
+    except Exception:
+        return ceiling_width
+
 def _try_insert_picture(docx, img_path, content_width, page_attributes):
-    """Try to insert a picture into the document, scaling it to fit content width. Returns True if successful."""
+    """
+    Insert a picture at content_width explicitly, then apply
+    _scale_picture_to_fit as a height safety net. Returns True if successful.
+
+    content_width is passed to add_picture(width=...) instead of left for
+    python-docx to infer: python-docx reads DPI metadata independently of
+    _infer_image_dpi (used above to compute content_width in the first
+    place), and the two can disagree - e.g. a PNG without DPI metadata makes
+    python-docx default to 72 DPI while _infer_image_dpi defaults to 96 DPI,
+    a ~33% size difference. Passing the width explicitly makes content_width
+    the actual inserted size.
+    """
     if not (img_path and os.path.exists(img_path)):
         return False
     try:
         pic_para = docx.add_paragraph()
         run = pic_para.add_run()
-        picture = run.add_picture(img_path)
-        
+        picture = run.add_picture(img_path, width=content_width)
+
         _scale_picture_to_fit(picture, content_width, page_attributes)
         pic_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
         

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+import unittest
+
+from docx import Document
+from docx.shared import Cm
+from PIL import Image
+
+from packtools.sps.formats.pdf.renderer.docx.figure import (
+    _infer_image_dpi,
+    _natural_width_capped,
+    add_figure,
+)
+
+
+class TestNaturalWidthCapped(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _make_png(self, px_width=200, px_height=100, dpi=None):
+        path = os.path.join(self.tmpdir.name, "img.png")
+        im = Image.new("RGB", (px_width, px_height), color="white")
+        if dpi:
+            im.save(path, format="PNG", dpi=(dpi, dpi))
+        else:
+            im.save(path, format="PNG")
+        return path
+
+    def test_natural_width_shrinks_to_ceiling_when_larger(self):
+        img_path = self._make_png(px_width=4000, dpi=96)
+        ceiling = Cm(10)
+        result = _natural_width_capped(img_path, ceiling)
+        self.assertEqual(result, ceiling)
+
+    def test_natural_width_kept_when_smaller_than_ceiling(self):
+        img_path = self._make_png(px_width=200, dpi=96)
+        ceiling = Cm(10)
+        result = _natural_width_capped(img_path, ceiling)
+        expected = Cm((200 / 96) * 2.54)
+        # PNG's pHYs chunk stores pixels-per-meter (integer), so the DPI read
+        # back after a save/load round-trip is a close approximation, not
+        # bit-exact - allow a small tolerance instead of exact EMU equality.
+        self.assertAlmostEqual(int(result), int(expected), delta=5000)
+        self.assertLess(result, ceiling)
+
+    def test_missing_file_falls_back_to_ceiling(self):
+        ceiling = Cm(10)
+        result = _natural_width_capped("/no/such/file.png", ceiling)
+        self.assertEqual(result, ceiling)
+
+
+class TestAddFigureInsertedWidth(unittest.TestCase):
+    """
+    Regression test for the DPI mismatch between _infer_image_dpi (used to
+    decide the figure's width) and python-docx's own DPI reading (used when
+    add_picture() is called without an explicit width, defaulting to 72 DPI
+    vs _infer_image_dpi's 96 DPI fallback - a ~33% size difference).
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_inserted_picture_width_matches_infer_image_dpi_not_python_docx_default(self):
+        img_path = os.path.join(self.tmpdir.name, "no_dpi.png")
+        Image.new("RGB", (200, 100), color="white").save(img_path, format="PNG")
+
+        docx = Document()
+        figure_data = {"href": img_path, "label": "Figure 1", "caption": "test"}
+        add_figure(docx, figure_data)
+
+        self.assertEqual(len(docx.inline_shapes), 1)
+        inserted_width = docx.inline_shapes[0].width
+
+        with Image.open(img_path) as im:
+            dpi = _infer_image_dpi(im)
+        expected_width = int(Cm((200 / dpi) * 2.54))
+
+        self.assertEqual(inserted_width, expected_width)
+
+        # python-docx's own (unfixed) default would have produced 96/72 = 1.333x
+        # this width instead - assert we are NOT that value.
+        python_docx_default_width = int(Cm((200 / 72) * 2.54))
+        self.assertNotEqual(inserted_width, python_docx_default_width)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

**Problema existente:** `_try_insert_picture` chama `run.add_picture(img_path)` sem passar `width`. O python-docx então lê o DPI do arquivo por conta própria pra decidir o tamanho — independente de `_infer_image_dpi`, a função que o resto do código já usa (em `decide_figure_layout`) pra decidir se a figura cabe na coluna. As duas leituras de DPI podem discordar: sem metadado de DPI, o python-docx assume 72 DPI enquanto `_infer_image_dpi` assume outro valor — resultando em ~33% de diferença entre "a largura que o código decidiu" e "a largura que realmente foi inserida".

**Solução proposta:** calcular a largura natural da imagem via `_infer_image_dpi` (a mesma função já usada na decisão), capada ao teto disponível — nunca ampliando além do espaço da coluna/página — e passar esse valor explicitamente como `width=` no `add_picture()`, em vez de deixar o python-docx inferir sozinho.

**Resultado:** a largura inserida na figura passa a bater exatamente com a largura que o código decidiu. Construí um exemplo controlado (imagem de teste de 200px sem metadado de DPI, inserida numa cópia do `a1.xml`) pra medir a diferença de forma isolada: antes, a imagem era inserida a 7,06cm (72 DPI, inferência própria do python-docx); depois, a 5,29cm (96 DPI, `_infer_image_dpi`) — exatamente a razão 96/72 do bug descrito. Não consegui reproduzir esse caso específico com os 4 artigos reais de `tests/fixtures/pdf/` porque as imagens deles já têm DPI explícito no arquivo (divergência de DPI *entre* figuras, não ausência de DPI — esse é o achado #2, já em outro PR).

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py`, funções `add_figure`, `_natural_width_capped` (nova) e `_try_insert_picture`.

## Como este poderia ser testado manualmente?

Testes automatizados: `python -m unittest discover -s tests/sps/formats/pdf -v` (inclui teste de regressão que insere uma figura sem DPI e confirma que a largura bate com `_infer_image_dpi`, não com o default do python-docx).

Validado também ponta a ponta nos 4 fixtures reais (`a1`-`a4`): mesma contagem de página, sem regressão — o fix não afeta imagens que já têm DPI correto/consistente.

## Algum cenário de contexto que queira dar?

Encontrado e corrigido originalmente durante o trabalho do PR #1279 (fechado por ser grande demais — 14 arquivos, 54% de um módulo novo em docstring). O comentário de fechamento registra este bugfix como "já validado" e destinado a ser resubmetido separadamente, junto com outro (`/2` fixo no número de colunas, já em outro PR).

## Screenshots

<img width="1130" height="430" alt="demo_width_before_after" src="https://github.com/user-attachments/assets/b4c53d15-dff5-4104-93e4-8aae848d6c9d" />

## Quais são os tickets relevantes?

Closes #1299.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado) — ver `SECURITY_ADHERENCE.md`. Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
