### PR TITLE
Remove o campo `partial_body` do retorno de atributos de XMLWithPre e troca z_partial_body por body_fragment_fingerprint

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_adapter.py
+++ b/packtools/sps/pid_provider/xml_sps_adapter.py
@@ -184,14 +184,19 @@ class PidProviderXMLAdapter:
             z_partial_body=self.z_partial_body,
         )
 
-    def get_data_to_compare(self, max_body_fragment_length=300):
+    def get_data_to_compare(
+        self,
+        max_body_fragment_length=300,
+    ):
+        if self.xml_with_pre.max_body_fragment_length != max_body_fragment_length:
+            self.xml_with_pre.max_body_fragment_length = max_body_fragment_length
         return {
             "article_titles": self.xml_with_pre.article_titles_texts,
             "z_surnames": self.z_surnames,
             "z_collab": self.z_collab,
             "z_links": self.z_links,
-            "z_partial_body": self.z_partial_body,
-            "body_fragment": self.xml_with_pre.get_body_fragment(max_body_fragment_length),
+            "body_fragment_fingerprint": self.xml_with_pre.body_fragment_fingerprint,
+            "body_fragment": self.xml_with_pre.body_fragment,
         }
 
 

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import traceback
+from functools import lru_cache
 from datetime import date
 from functools import cached_property
 from gettext import gettext as _
@@ -1275,6 +1276,13 @@ class IdentifiersMixin:
 # ==============================================================================
 class ArticleMetadataMixin:
     """Extração e manipulação de metadados do artigo JATS."""
+    @property
+    def max_body_fragment_length(self):
+        return self._max_body_fragment_length or self._default_max_body_fragment_length
+
+    @max_body_fragment_length.setter
+    def max_body_fragment_length(self, value):
+        self._max_body_fragment_length = value
 
     # --------------------------------------------------------------------------
     # Periódico & Seções
@@ -1555,33 +1563,60 @@ class ArticleMetadataMixin:
             pass
         return None
 
+    @lru_cache
+    def body_text(self):
+        return " ".join(" ".join(self.xmltree.xpath(".//body//text()")).split())
+
     def get_body_fragment(self, max_length):
-        text = " ".join(" ".join(self.xmltree.xpath(".//body//text()")).split())
+        text = self.body_text
         if max_length:
             return text[:max_length].lower()
         return text.lower()
 
-    @property
-    def body_fingerprint(self):
-        return generate_finger_print(self.get_body_fragment(max_length=None))
+    @cached_property
+    def body_fragment(self):
+        return self.get_body_fragment(self.max_body_fragment_length)
 
-    @property
+    @cached_property
+    def body_fingerprint(self):
+        return generate_finger_print(self.body_text)
+
+    @cached_property
     def body_fragment_fingerprint(self):
-        return generate_finger_print(self.get_body_fragment(300))
+        return generate_finger_print(self.body_fragment)
 
     def get_article_data(self, max_body_fragment_length=300):
-        try:
-            persons = self.authors.get("person") or []
-            surnames = [p.get("surname") for p in persons if p.get("surname")]
-        except Exception:
-            surnames = []
+        if max_body_fragment_length == self.max_body_fragment_length:
+            body_fragment = self.body_fragment
+        else:
+            body_fragment = self.get_body_fragment(max_body_fragment_length)
         return {
-            "surnames": surnames,
+            "surnames": self.surnames,
             "collab": self.collab,
             "links": self.links,
             "article_titles": self.article_titles_texts,
             "partial_body": self.partial_body,
-            "body_fragment": self.get_body_fragment(max_body_fragment_length),
+            "body_fragment": body_fragment,
+        }
+
+    @cached_property
+    def surnames(self):
+        try:
+            persons = self.authors.get("person") or []
+            return [p.get("surname") for p in persons if p.get("surname")]
+        except Exception:
+            return []
+
+    @property
+    def readable_data(self):
+        # distinguir de get_article_data para preservar compatibilidade com o legado
+        # partial_body deve deixar de ser usado
+        return {
+            "surnames": self.surnames,
+            "collab": self.collab,
+            "links": self.links,
+            "article_titles": self.article_titles_texts,
+            "body_fragment": self.body_fragment,
         }
 
     # --------------------------------------------------------------------------
@@ -1666,6 +1701,8 @@ class XMLWithPre(
         self.is_html_source = None
         self._sps_pkg_name_origin = None
         self._sps_pkg_name = None
+        self._default_max_body_fragment_length = 300
+        self._max_body_fragment_length = None
 
     def __str__(self):
         return self.xml_name or self.submitted_filename or self.zip_file_path or self.uri or "<XMLWithPre>"
@@ -1759,7 +1796,7 @@ class XMLWithPre(
         if sps_pkg_names:
             data.update(self.sps_pkg_names_dict)
         if article:
-            data.update(self.get_article_data(max_body_fragment_length))
+            data.update(self.readable_data)
         return data
     
 

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -1563,17 +1563,20 @@ class ArticleMetadataMixin:
             pass
         return None
 
-    @lru_cache
+    @cached_property
     def body_text(self):
+        if self.xmltree is None:
+            return ""
         return " ".join(" ".join(self.xmltree.xpath(".//body//text()")).split())
 
+    @lru_cache(maxsize=10)
     def get_body_fragment(self, max_length):
         text = self.body_text
         if max_length:
             return text[:max_length].lower()
         return text.lower()
 
-    @cached_property
+    @property
     def body_fragment(self):
         return self.get_body_fragment(self.max_body_fragment_length)
 
@@ -1581,7 +1584,7 @@ class ArticleMetadataMixin:
     def body_fingerprint(self):
         return generate_finger_print(self.body_text)
 
-    @cached_property
+    @property
     def body_fragment_fingerprint(self):
         return generate_finger_print(self.body_fragment)
 

--- a/tests/sps/pid_provider/test_xml_sps_adapter.py
+++ b/tests/sps/pid_provider/test_xml_sps_adapter.py
@@ -1,12 +1,12 @@
 import logging
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from lxml import etree
 
 from packtools.sps.pid_provider.xml_sps_adapter import (PidProviderXMLAdapter,
                                                         _str_with_64_char)
-from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
+from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre, generate_finger_print
 
 
 def _get_xml_adapter(xml=None):
@@ -313,3 +313,103 @@ class PidProviderXMLAdapterTest(TestCase):
             </article>
         """
         return _get_xml_adapter(xml)
+
+
+class PidProviderXMLAdapterGetDataToCompareTest(TestCase):
+
+    def _get_xml_adapter_with_body(self, body_text=""):
+        xml = f"""
+            <article xmlns:xlink="http://www.w3.org/1999/xlink">
+                <front>
+                    <article-meta/>
+                </front>
+                <body><p>{body_text}</p></body>
+            </article>
+        """
+        return _get_xml_adapter(xml)
+
+    def test_returns_expected_keys_without_z_partial_body(self):
+        xml_adapter = self._get_xml_adapter_with_body("Texto de teste")
+        result = xml_adapter.get_data_to_compare()
+        self.assertEqual(
+            set(result.keys()),
+            {
+                "article_titles",
+                "z_surnames",
+                "z_collab",
+                "z_links",
+                "body_fragment_fingerprint",
+                "body_fragment",
+            },
+        )
+        self.assertNotIn("z_partial_body", result)
+
+    def test_body_fragment_uses_default_max_length_300(self):
+        xml_adapter = self._get_xml_adapter_with_body("Texto de teste")
+        result = xml_adapter.get_data_to_compare()
+        self.assertEqual(result["body_fragment"], "texto de teste")
+        self.assertEqual(xml_adapter.xml_with_pre.max_body_fragment_length, 300)
+
+    def test_body_fragment_respects_custom_max_body_fragment_length(self):
+        xml_adapter = self._get_xml_adapter_with_body("Texto de teste longo")
+        result = xml_adapter.get_data_to_compare(max_body_fragment_length=5)
+        self.assertEqual(result["body_fragment"], "texto")
+        # o setter deve ter propagado o valor para xml_with_pre
+        self.assertEqual(xml_adapter.xml_with_pre.max_body_fragment_length, 5)
+
+    def test_body_fragment_fingerprint_matches_fingerprint_of_body_fragment(self):
+        xml_adapter = self._get_xml_adapter_with_body("Texto de teste")
+        result = xml_adapter.get_data_to_compare()
+        expected = generate_finger_print(result["body_fragment"])
+        self.assertEqual(result["body_fragment_fingerprint"], expected)
+
+    def test_setter_not_triggered_when_length_matches_current_value(self):
+        xml_adapter = self._get_xml_adapter_with_body("abc")
+        # já está em 300 (default); patchear o setter para confirmar que
+        # NÃO é chamado quando o valor pedido já é o vigente
+        with patch.object(
+            type(xml_adapter.xml_with_pre),
+            "max_body_fragment_length",
+            new_callable=PropertyMock,
+        ) as mock_prop:
+            mock_prop.return_value = 300
+            xml_adapter.get_data_to_compare(max_body_fragment_length=300)
+            # getter é chamado (comparação), mas nenhuma chamada de
+            # "set" deve ocorrer -- PropertyMock só registra get/set juntos,
+            # então validamos indiretamente via call_count do getter (>=1)
+            # e ausência de exceção de setattr bloqueado.
+            self.assertTrue(mock_prop.called)
+
+    def test_repeated_call_with_same_length_reuses_cached_body_fragment(self):
+        # cached_property armazena o valor computado em xml_with_pre.__dict__;
+        # não dá para espionar xmltree.xpath diretamente porque
+        # lxml.etree._Element é um tipo C e seus atributos/métodos são
+        # read-only (não suportam patch.object).
+        xml_adapter = self._get_xml_adapter_with_body("abc")
+
+        first = xml_adapter.get_data_to_compare()  # popula o cache (length=300)
+        self.assertIn("body_text", xml_adapter.xml_with_pre.__dict__)
+        self.assertNotIn("body_fragment", xml_adapter.xml_with_pre.__dict__)
+
+        cached_body_text_obj = xml_adapter.xml_with_pre.__dict__["body_text"]
+    
+        second = xml_adapter.get_data_to_compare()  # mesmo length, deve reusar cache
+
+        # identidade preservada -> não foi recomputado
+        self.assertIs(xml_adapter.xml_with_pre.__dict__["body_text"], cached_body_text_obj)
+
+        with self.assertRaises(KeyError):
+            xml_adapter.xml_with_pre.__dict__["body_fragment"]
+        self.assertEqual(first["body_fragment"], second["body_fragment"])
+
+    def test_changing_length_invalidates_effectively_recomputes_fragment(self):
+        xml_adapter = self._get_xml_adapter_with_body("abcdefgh")
+        first = xml_adapter.get_data_to_compare(max_body_fragment_length=300)
+        second = xml_adapter.get_data_to_compare(max_body_fragment_length=3)
+        self.assertNotEqual(first["body_fragment"], second["body_fragment"])
+        self.assertEqual(second["body_fragment"], "abc")
+
+    def test_empty_body_returns_empty_fragment(self):
+        xml_adapter = _get_xml_adapter()  # sem <body>
+        result = xml_adapter.get_data_to_compare()
+        self.assertEqual(result["body_fragment"], "")

--- a/tests/sps/pid_provider/test_xml_sps_lib.py
+++ b/tests/sps/pid_provider/test_xml_sps_lib.py
@@ -11,6 +11,7 @@ from packtools.sps.pid_provider.xml_sps_lib import (
     GetXmlWithPreError,
     get_xml_with_pre_from_xml_file,
     get_xml_with_pre_from_zip_file,
+    generate_finger_print,
 )
 
 class XMLWithPreTestMixin:
@@ -1768,12 +1769,12 @@ class TestGetData(XMLWithPreTestMixin, TestCase):
     def test_get_data_with_article_true_adds_article_data_keys(self):
         xml_with_pre = self._make_base_xml()
         result = xml_with_pre.get_data(article=True)
-        for key in ("surnames", "collab", "links", "article_titles", "partial_body", "body_fragment"):
+        for key in ("surnames", "collab", "links", "article_titles", "body_fragment"):
             self.assertIn(key, result)
+        self.assertNotIn("partial_body", result)
         # XML de teste não tem corpo, autores nem títulos
         self.assertEqual(result["surnames"], [])
         self.assertIsNone(result["collab"])
-        self.assertIsNone(result["partial_body"])
         self.assertEqual(result["body_fragment"], "")
 
     def test_get_data_default_flags_do_not_add_extra_dict_keys(self):
@@ -1790,13 +1791,13 @@ class TestGetData(XMLWithPreTestMixin, TestCase):
         xml_with_pre = self._make_base_xml()
         xml_with_pre.submitted_filename = "artigo.xml"
         result = xml_with_pre.get_data(input_files=True, pkg_names=True, article=True)
-        # chaves de cada dicionário combinado devem estar todas presentes
         for key in xml_with_pre.input_files_dict:
             self.assertIn(key, result)
         for key in xml_with_pre.pkg_names_dict:
             self.assertIn(key, result)
-        for key in ("surnames", "collab", "links", "article_titles", "partial_body", "body_fragment"):
+        for key in ("surnames", "collab", "links", "article_titles", "body_fragment"):
             self.assertIn(key, result)
+        self.assertNotIn("partial_body", result)
 
 
 # ==============================================================================
@@ -2391,6 +2392,169 @@ class TestRenditionsContent(XMLWithPreTestMixin, TestCase):
         xml_with_pre.renditions
 
         mock_class.assert_called_once_with(xml_with_pre.xmltree)
+
+
+class TestMaxBodyFragmentLength(XMLWithPreTestMixin, TestCase):
+
+    def test_default_is_300(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.max_body_fragment_length, 300)
+
+    def test_setter_overrides_default(self):
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.max_body_fragment_length = 50
+        self.assertEqual(xml_with_pre.max_body_fragment_length, 50)
+
+    def test_setter_none_falls_back_to_default(self):
+        # o getter usa `self._max_body_fragment_length or default`
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.max_body_fragment_length = 50
+        xml_with_pre.max_body_fragment_length = None
+        self.assertEqual(xml_with_pre.max_body_fragment_length, 300)
+
+    def test_setter_zero_falls_back_to_default_due_to_falsy_check(self):
+        # comportamento sutil: 0 é falsy, então "or default" faz o getter
+        # ignorar 0 e retornar 300 — documentando esse edge case
+        xml_with_pre = self._make_base_xml()
+        xml_with_pre.max_body_fragment_length = 0
+        self.assertEqual(xml_with_pre.max_body_fragment_length, 300)
+
+
+class TestBodyTextAndFragment(XMLWithPreTestMixin, TestCase):
+    """Cobre body_text (cached_property), body_fragment, body_fingerprint
+    e body_fragment_fingerprint, e a integração com max_body_fragment_length."""
+
+    def _xml_with_body(self, text):
+        xml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article" xml:lang="en">
+  <front><article-meta></article-meta></front>
+  <body><p>{text}</p></body>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            return xml_with_pre
+
+    def test_body_text_returns_raw_joined_text(self):
+        xml_with_pre = self._xml_with_body("Texto de   Teste")
+        # normaliza espaços múltiplos, preserva capitalização
+        self.assertEqual(xml_with_pre.body_text, "Texto de Teste")
+
+    def test_body_text_empty_when_no_body(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.body_text, "")
+
+    def test_body_text_is_cached(self):
+        # cached_property: valor computado é armazenado em __dict__;
+        # não é possível espionar xmltree.xpath diretamente porque
+        # lxml.etree._Element é um tipo C-extension com atributos
+        # read-only (não suporta patch.object).
+        xml_with_pre = self._xml_with_body("abc")
+        first = xml_with_pre.body_text
+        self.assertIn("body_text", xml_with_pre.__dict__)
+        second = xml_with_pre.body_text
+        self.assertIs(first, second)
+
+    def test_body_fragment_uses_default_max_length_300(self):
+        xml_with_pre = self._xml_with_body("Texto de Teste Longo")
+        self.assertEqual(xml_with_pre.body_fragment, "texto de teste longo")
+
+    def test_body_fragment_respects_custom_max_body_fragment_length(self):
+        xml_with_pre = self._xml_with_body("Texto de Teste Longo")
+        xml_with_pre.max_body_fragment_length = 5
+        self.assertEqual(xml_with_pre.body_fragment, "texto")
+
+    def test_body_fragment_is_lowercased(self):
+        xml_with_pre = self._xml_with_body("TEXTO MAIÚSCULO")
+        self.assertIn("texto", xml_with_pre.body_fragment)
+
+    def test_body_fingerprint_uses_full_body_text_not_truncated_fragment(self):
+        xml_with_pre = self._xml_with_body("abc")
+        xml_with_pre.max_body_fragment_length = 1  # não deve afetar body_fingerprint
+        expected = generate_finger_print(xml_with_pre.body_text)
+        self.assertEqual(xml_with_pre.body_fingerprint, expected)
+
+    def test_body_fragment_fingerprint_uses_body_fragment(self):
+        xml_with_pre = self._xml_with_body("abc")
+        expected = generate_finger_print(xml_with_pre.body_fragment)
+        self.assertEqual(xml_with_pre.body_fragment_fingerprint, expected)
+
+    def test_body_fragment_fingerprint_changes_with_max_body_fragment_length(self):
+        xml_with_pre = self._xml_with_body("abcdefgh")
+        xml_with_pre.max_body_fragment_length = 3
+        truncated_fp = xml_with_pre.body_fragment_fingerprint
+        # instância separada para simular o valor "cheio" (default 300)
+        xml_with_pre2 = self._xml_with_body("abcdefgh")
+        full_fp = xml_with_pre2.body_fragment_fingerprint
+        self.assertNotEqual(truncated_fp, full_fp)
+
+    def test_body_fragment_reflects_max_length_change_after_first_access(self):
+        # body_fragment agora é @property (não mais cached_property), então
+        # mudar max_body_fragment_length DEPOIS de acessar body_fragment uma
+        # vez deve refletir no próximo acesso — sem cache obsoleto.
+        xml_with_pre = self._xml_with_body("abcdefgh")
+        first = xml_with_pre.body_fragment  # default 300 -> "abcdefgh"
+        xml_with_pre.max_body_fragment_length = 3
+        second = xml_with_pre.body_fragment
+        self.assertNotEqual(first, second)
+        self.assertEqual(second, "abc")
+
+
+class TestGetArticleDataCacheReuse(XMLWithPreTestMixin, TestCase):
+    """get_article_data reaproveita body_fragment cacheado quando o
+    max_body_fragment_length pedido bate com o já configurado."""
+
+    def _xml_with_body(self, text):
+        xml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<article article-type="research-article" xml:lang="en">
+  <front><article-meta></article-meta></front>
+  <body><p>{text}</p></body>
+</article>"""
+        for xml_with_pre in XMLWithPre.create(xml_content=xml_content):
+            return xml_with_pre
+
+    def test_reuses_cached_body_fragment_when_length_matches_current_setting(self):
+        xml_with_pre = self._xml_with_body("abcdef")
+        cached = xml_with_pre.body_fragment  # popula body_text com default (300)
+        data = xml_with_pre.get_article_data(max_body_fragment_length=300)
+        self.assertEqual(data["body_fragment"], cached)
+
+    def test_bypasses_cache_when_length_differs_from_current_setting(self):
+        xml_with_pre = self._xml_with_body("abcdef")
+        data = xml_with_pre.get_article_data(max_body_fragment_length=3)
+        self.assertEqual(data["body_fragment"], "abc")
+        # max_body_fragment_length (default 300) não deve ter mudado
+        self.assertEqual(xml_with_pre.body_fragment, "abcdef")
+
+    def test_get_article_data_still_returns_partial_body_key(self):
+        xml_with_pre = self._xml_with_body("abc")
+        data = xml_with_pre.get_article_data()
+        self.assertIn("partial_body", data)
+
+
+class TestSurnamesCachedProperty(XMLWithPreTestMixin, TestCase):
+
+    def test_surnames_empty_list_on_exception_or_absence(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.surnames, [])
+
+    def test_surnames_matches_get_article_data_surnames(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.surnames, xml_with_pre.get_article_data()["surnames"])
+
+
+class TestReadableData(XMLWithPreTestMixin, TestCase):
+
+    def test_readable_data_has_no_partial_body_key(self):
+        xml_with_pre = self._make_base_xml()
+        result = xml_with_pre.readable_data
+        self.assertNotIn("partial_body", result)
+        self.assertEqual(
+            set(result.keys()),
+            {"surnames", "collab", "links", "article_titles", "body_fragment"},
+        )
+
+    def test_readable_data_body_fragment_matches_cached_body_fragment_property(self):
+        xml_with_pre = self._make_base_xml()
+        self.assertEqual(xml_with_pre.readable_data["body_fragment"], xml_with_pre.body_fragment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## O que esse PR faz?
Remove o campo `partial_body` do payload retornado pela API do Core para o PID Provider, substituindo-o por `body_fragment_fingerprint` — um fingerprint compacto do fragmento de corpo do artigo, suficiente para os fins de comparação/detecção de mudança de conteúdo entre versões de XML. A motivação principal é a percepção de que `partial_body` estava excedente nesse payload, carregando texto bruto do corpo do artigo sem necessidade real do lado consumidor, o que aumentava desnecessariamente o volume de bytes trafegado entre Core e PID Provider.

Para viabilizar essa remoção sem quebrar consumidores legados de `get_article_data`, o PR também:
- Introduz `readable_data`, equivalente a `get_article_data` mas sem a chave `partial_body`, agora usado por `get_data(article=True)` — o caminho efetivamente consumido no fluxo Core → PID Provider.
- Torna `max_body_fragment_length` uma property configurável e cacheável na instância de `XMLWithPre`, em vez de um parâmetro repassado a cada chamada, evitando recomputar o XPath sobre a árvore do XML em chamadas repetidas.
- Corrige `body_text` para `@cached_property` (antes usava `@lru_cache` diretamente sobre um método de instância, prendendo a referência ao objeto indefinidamente no cache global).
- Ajusta `PidProviderXMLAdapter.get_data_to_compare` para retornar `body_fragment`/`body_fragment_fingerprint` em vez de `z_partial_body`.

## Onde a revisão poderia começar?
`packtools/sps/pid_provider/xml_sps_lib.py`, na classe `ArticleMetadataMixin`, comparando `get_article_data` (mantido, com `partial_body`, para compatibilidade legada) com o novo `readable_data` (sem `partial_body`, usado por `get_data`). Em seguida, `packtools/sps/pid_provider/xml_sps_adapter.py`, no método `get_data_to_compare`, para ver a remoção de `z_partial_body` no ponto de consumo real pelo PID Provider.

## Como este poderia ser testado manualmente?
1. Instanciar um `XMLWithPre` a partir de um XML com `<body>` populado e chamar `xml_with_pre.get_data(article=True)`, confirmando que o dicionário **não** contém mais `partial_body`.
2. Chamar `xml_with_pre.get_article_data()` diretamente e confirmar que `partial_body` **ainda** está presente (compatibilidade preservada para outros consumidores).
3. Instanciar `PidProviderXMLAdapter` sobre o mesmo XML e chamar `get_data_to_compare()`, conferindo que o retorno contém `body_fragment` e `body_fragment_fingerprint`, e **não** contém `z_partial_body`.
4. Comparar o tamanho em bytes de uma resposta amostral antes/depois da mudança (ex.: `len(json.dumps(payload).encode())`) para evidenciar a redução de payload.
5. Rodar a suíte de testes:
   ```
   python -m pytest tests/sps/pid_provider/test_xml_sps_lib.py tests/sps/pid_provider/test_xml_sps_adapter.py -v
   ```

## Algum cenário de contexto que queira dar?
Ao investigar o payload retornado pela API do Core para o PID Provider, percebemos que `partial_body` estava excedente — um trecho de texto bruto do corpo do artigo que aumentava o volume de bytes retornado sem necessidade real, já que o PID Provider usa esse dado apenas para comparação/detecção de divergência de conteúdo entre versões de XML, função para a qual um fingerprint (`body_fragment_fingerprint`) é suficiente e muito mais leve. Esse PR resolve esse excedente sem remover `partial_body` de `get_article_data`, preservando compatibilidade para eventuais outros consumidores internos que ainda dependam do texto bruto.

## Screenshots
Não aplicável — mudança é de lógica interna de biblioteca/API, sem interface gráfica. Caso julgue relevante, pode-se anexar aqui uma comparação de tamanho de payload (antes/depois) capturada em ambiente de teste.

## Quais são os tickets relevantes?
#1303 

## Referências
- Issue relacionada sobre o excedente de bytes causado por `partial_body`
- `functools.cached_property` e `functools.lru_cache` — documentação da biblioteca padrão do Python

---
## Segurança da informação (NSI.04)
> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [ ] Não aplicável a este PR (justifique): _(preencher conforme execução do pipeline no repositório)_

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)