### PR TITLE
Remove o decorator @lru_cache do método de instância XMLWithPre.get_body_fragment

### DIFF
--- a/packtools/sps/pid_provider/xml_sps_adapter.py
+++ b/packtools/sps/pid_provider/xml_sps_adapter.py
@@ -1,6 +1,6 @@
 import hashlib
 import logging
-from functools import lru_cache, cached_property
+from functools import cached_property
 
 
 LOGGER = logging.getLogger(__name__)

--- a/packtools/sps/pid_provider/xml_sps_lib.py
+++ b/packtools/sps/pid_provider/xml_sps_lib.py
@@ -1569,7 +1569,6 @@ class ArticleMetadataMixin:
             return ""
         return " ".join(" ".join(self.xmltree.xpath(".//body//text()")).split())
 
-    @lru_cache(maxsize=10)
     def get_body_fragment(self, max_length):
         text = self.body_text
         if max_length:


### PR DESCRIPTION
## O que esse PR faz?

Remove o decorator `@lru_cache` do método de instância `get_body_fragment` na classe `XMLWithPre` (ou na classe/função correspondente).

O `lru_cache` aplicado diretamente a métodos de instância mantém uma referência forte a `self` na chave de cache. Isso impede que as instâncias de `XMLWithPre` — e suas respectivas árvores XML em memória — sejam coletadas pelo Garbage Collector do Python enquanto a entrada permanecer no cache, causando **memory leaks** (vazamento de memória).

Como o atributo `body_text` já é decorado com `@cached_property` e o método `get_body_fragment` executa apenas operações leves de corte de string e conversão (`slice + lower()`), o benefício do cache neste método é insignificante quando comparado ao custo de retenção de memória.

## Onde a revisão poderia começar?

A revisão deve começar pelo arquivo onde a classe `XMLWithPre` está definida, especificamente no método `get_body_fragment` (ou local correlato retido na conversa da PR/código).

## Como este poderia ser testado manualmente?

O comportamento de retenção e liberação de memória pode ser validado via console Python ou script de teste utilizando a biblioteca `weakref`:

1. Instancie o objeto e invoque o método:
```python
import gc
import weakref

# 1. Criar instância e extrair o fragmento
obj = XMLWithPre(...)
ref = weakref.ref(obj)
_ = obj.get_body_fragment()

# 2. Deletar a referência principal e forçar a coleta de lixo
del obj
gc.collect()

# 3. Validar se o objeto foi liberado
assert ref() is None, "A instância ainda está mantida viva na memória!"

```


2. Executar a suíte de testes unitários do repositório para garantir que não houve regressão de funcionalidade:
```bash
pytest

```



## Algum cenário de contexto que queira dar?

Em execuções ou pipelines que processam grandes volumes de arquivos XML em lote, instâncias passadas de `XMLWithPre` continuavam acumuladas na RAM devido à retenção do `self` pelo `lru_cache`. O teste manual confirmou que, mesmo executando `gc.collect()`, a instância só era liberada após a chamada explícita de `cache_clear()`. A remoção do cache resolve a retenção indesejada de memória sem impacto perceptível de performance.

## Screenshots

N/A *(Ajuste de performance/gerenciamento de memória sem alterações de interface gráfica)*.

## Quais são os tickets relevantes?

* Aponta para a discussão no comentário da PR: [[GitHub PR #1304 (Comment r3884871455)](https://github.com/scieloorg/packtools/pull/1304/changes#r3884871455)](https://github.com/scieloorg/packtools/pull/1304/changes#r3884871455)

## Referências

* [Python Documentation: `functools.lru_cache](https://www.google.com/search?q=https://docs.python.org/3/library/functools.html%23functools.lru_cache)` *(nota sobre retenção de referências para métodos de instância)*

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

* [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
* [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

* [ ] Sim — descreva o que mudou e por quê:
* [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

* [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
* [ ] Verificado e aprovado
* [ ] Pendente / vulnerabilidade aceita com justificativa:


* [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

* [x] Sim — link do job: *(Adicionar link do pipeline da SciELO/GitHub Actions, se aplicável)*
* [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

* [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
* [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**

* [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
* [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

* [x] Não, nenhum segredo foi commitado
* [ ] Sim (bloquear merge e corrigir antes de prosseguir)