### PR TITLE
fix: usa elocation-id no rodapé/CITE AS do PDF quando não há fpage/lpage

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -304,7 +304,7 @@ def docx_cite_as_pipe(
     Returns:
         None
     """
-    cite_as_part_two = f'{footer_data["volume"]}: {footer_data["fpage"]}-{footer_data["lpage"]}'
+    cite_as_part_two = f'{footer_data["volume"]}: {footer_data["location_label"]}'
 
     footer = docx_renderer.section.get_first_page_footer(docx)
     para = docx_renderer.text.get_first_paragraph(footer)
@@ -379,7 +379,7 @@ def docx_second_footer_pipe(docx, footer_data, paragraph_style_name='SCL Footer'
 
     docx_renderer.text.add_field_run(para, "PAGE \\* MERGEFORMAT")
 
-    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['fpage']}-{footer_data['lpage']}")
+    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
 
 def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL Footer'):
     """
@@ -397,7 +397,7 @@ def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL F
     para = footer.add_paragraph()
 
     para.style = docx.styles[paragraph_style_name]
-    para.add_run(f"{footer_data['fpage']} | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['fpage']}-{footer_data['lpage']}")
+    para.add_run(f"{footer_data['fpage']} | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
 
 def docx_body_pipe(docx, body_data):
     """
@@ -479,9 +479,11 @@ def docx_supplementary_material_pipe(docx, footer_data, supplementary_data, sect
 
     para = footer.add_paragraph()
     para.style = docx.styles['SCL Footer']
-    
-    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['fpage']}-{footer_data['lpage']}")
-    
+
+    # No PAGE field is added here: supplementary material has its own
+    # pagination, independent of the article body, so no leading " | " either.
+    para.add_run(f"VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
+
     docx_renderer.section.setup_section_columns(section, 1, pdf_enum.TWO_COLUMNS_SPACING)
 
     docx_renderer.text.add_heading_with_formatting(docx, supplementary_data['title'], section_style_name, 2)

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -257,10 +257,10 @@ def extract_keywords_data(xml_tree, lang='en', namespaces={'xml': 'http://www.w3
 def extract_footer_data(xmltree):
     """
     Extracts footer data from the given XML tree.
-    
+
     Args:
         xmltree (ElementTree): The XML tree to extract the footer data from.
-    
+
     Returns:
         dict: A dictionary containing the following keys:
             - 'year': The year value from the pub-date element.
@@ -269,21 +269,25 @@ def extract_footer_data(xmltree):
             - 'issue': The issue value from the front element.
             - 'fpage': The first page value from the front element, converted to an integer.
             - 'lpage': The last page value from the front element, converted to an integer.
+            - 'elocation_id': The elocation-id value from the front element.
+            - 'location_label': '{fpage}-{lpage}' when fpage is present, otherwise
+              elocation_id, otherwise an empty string. Continuous-publication
+              articles carry elocation-id instead of fpage/lpage.
     """
-    data = {'year': '', 'volume': '', 'issue': '', 'fpage': '', 'lpage': ''}
+    data = {'year': '', 'volume': '', 'issue': '', 'fpage': '', 'lpage': '', 'elocation_id': ''}
 
     pub_date_section = xmltree.find(".//pub-date[@date-type='collection'][@publication-format='electronic']")
     if pub_date_section is not None:
         node_year = pub_date_section.find('.//year')
         if node_year is not None:
             data['year'] = node_year.text
-   
+
         node_front = pub_date_section.getparent()
         if node_front is not None:
             node_fpage = node_front.find('.//fpage')
             if node_fpage is not None:
                 data['fpage'] = int(node_fpage.text)
-    
+
             node_lpage = node_front.find('.//lpage')
             if node_lpage is not None:
                 data['lpage'] = int(node_lpage.text)
@@ -295,6 +299,17 @@ def extract_footer_data(xmltree):
             node_issue = node_front.find('.//issue')
             if node_issue is not None:
                 data['issue'] = node_issue.text
+
+            node_elocation_id = node_front.find('.//elocation-id')
+            if node_elocation_id is not None:
+                data['elocation_id'] = node_elocation_id.text
+
+    if data['fpage']:
+        data['location_label'] = f"{data['fpage']}-{data['lpage']}"
+    elif data['elocation_id']:
+        data['location_label'] = data['elocation_id']
+    else:
+        data['location_label'] = ''
 
     return data
 

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -1,10 +1,19 @@
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from docx import Document
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
+from packtools.sps.formats.pdf.renderer import docx as docx_renderer
 from packtools.sps.formats.pdf import enum as pdf_enum
+
+FIXTURES_DIR = Path(__file__).resolve().parents[4] / "fixtures" / "pdf"
+
+
+def _docx_with_layout_styles():
+    """A fresh Document carrying the named styles the footer/cite-as pipes rely on."""
+    return docx_renderer.builder.init_docx({"base_layout": str(FIXTURES_DIR / "layout.docx")})
 
 
 class TestPipelineDocx(unittest.TestCase):
@@ -58,8 +67,27 @@ class TestDocxKeyworksPipe(unittest.TestCase):
 
 
 class TestDocxCiteAsPipe(unittest.TestCase):
-    # TODO
-    ...
+
+    def test_uses_fpage_lpage_range_when_present(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '10', 'issue': '2', 'year': '2023',
+                       'fpage': 123, 'lpage': 130, 'location_label': '123-130'}
+        docx_pipe.docx_cite_as_pipe(docx, 'Author AB. ', 'Journal Title', footer_data)
+
+        footer = docx_renderer.section.get_first_page_footer(docx)
+        para = docx_renderer.text.get_first_paragraph(footer)
+        self.assertIn('10: 123-130.', para.text)
+
+    def test_uses_elocation_id_when_fpage_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '33', 'issue': '3', 'year': '2024',
+                       'fpage': '', 'lpage': '', 'location_label': 'e282794'}
+        docx_pipe.docx_cite_as_pipe(docx, 'Author AB. ', 'Journal Title', footer_data)
+
+        footer = docx_renderer.section.get_first_page_footer(docx)
+        para = docx_renderer.text.get_first_paragraph(footer)
+        self.assertIn('33: e282794.', para.text)
+        self.assertNotIn('-.', para.text)
 
 
 class TestDocxSecondHeaderPipe(unittest.TestCase):
@@ -68,13 +96,51 @@ class TestDocxSecondHeaderPipe(unittest.TestCase):
 
 
 class TestDocxSecondFooterPipe(unittest.TestCase):
-    # TODO
-    ...
+
+    def test_uses_fpage_lpage_range_when_present(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '10', 'issue': '2', 'year': '2023',
+                       'fpage': 123, 'lpage': 130, 'location_label': '123-130'}
+        docx_pipe.docx_second_footer_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_second_footer(docx)
+        para = footer.paragraphs[0]
+        self.assertIn('VOL. 10 (2) 2023: 123-130', para.text)
+
+    def test_uses_elocation_id_when_fpage_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '33', 'issue': '3', 'year': '2024',
+                       'fpage': '', 'lpage': '', 'location_label': 'e282794'}
+        docx_pipe.docx_second_footer_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_second_footer(docx)
+        para = footer.paragraphs[0]
+        self.assertIn('VOL. 33 (3) 2024: e282794', para.text)
+        self.assertNotIn(': -', para.text)
 
 
 class TestDocxPageVolIssueYearPipe(unittest.TestCase):
-    # TODO
-    ...
+
+    def test_uses_fpage_lpage_range_when_present(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '10', 'issue': '2', 'year': '2023',
+                       'fpage': 123, 'lpage': 130, 'location_label': '123-130'}
+        docx_pipe.docx_page_vol_issue_year_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_first_page_footer(docx)
+        para = footer.paragraphs[-1]
+        self.assertIn('VOL. 10 (2) 2023: 123-130', para.text)
+
+    def test_uses_elocation_id_when_fpage_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '33', 'issue': '3', 'year': '2024',
+                       'fpage': '', 'lpage': '', 'location_label': 'e282794'}
+        docx_pipe.docx_page_vol_issue_year_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_first_page_footer(docx)
+        para = footer.paragraphs[-1]
+        self.assertIn('VOL. 33 (3) 2024: e282794', para.text)
+        self.assertNotIn(': -', para.text)
 
 
 class TestDocxBodyPipe(unittest.TestCase):
@@ -93,8 +159,30 @@ class TestDocxAcknowledgmentsPipe(unittest.TestCase):
 
 
 class TestDocxSupplementaryMaterialPipe(unittest.TestCase):
-    # TODO
-    ...
+
+    def test_footer_has_no_leading_pipe(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '53', 'issue': '4', 'year': '2023',
+                       'fpage': 271, 'lpage': 280, 'location_label': '271-280'}
+        docx_pipe.docx_supplementary_material_pipe(
+            docx, footer_data, {'title': 'Supplementary Material', 'elements': []}
+        )
+
+        footer = docx.sections[-1].footer
+        para = footer.paragraphs[-1]
+        self.assertEqual(para.text, 'VOL. 53 (4) 2023: 271-280')
+
+    def test_uses_elocation_id_when_fpage_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '33', 'issue': '3', 'year': '2024',
+                       'fpage': '', 'lpage': '', 'location_label': 'e282794'}
+        docx_pipe.docx_supplementary_material_pipe(
+            docx, footer_data, {'title': 'Supplementary Material', 'elements': []}
+        )
+
+        footer = docx.sections[-1].footer
+        para = footer.paragraphs[-1]
+        self.assertEqual(para.text, 'VOL. 33 (3) 2024: e282794')
 
 
 class TestBodyColumnConfiguration(unittest.TestCase):

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -718,7 +718,9 @@ class TestExtractFooterData(unittest.TestCase):
             'volume': '10',
             'issue': '2',
             'fpage': 123,
-            'lpage': 130
+            'lpage': 130,
+            'elocation_id': '',
+            'location_label': '123-130',
         }
         result = xml_pipe.extract_footer_data(xml)
         self.assertEqual(result, expected)
@@ -738,14 +740,44 @@ class TestExtractFooterData(unittest.TestCase):
             'volume': '',
             'issue': '',
             'fpage': '',
-            'lpage': ''
+            'lpage': '',
+            'elocation_id': '',
+            'location_label': '',
         }
         result = xml_pipe.extract_footer_data(xml)
         self.assertEqual(result, expected)
 
     def test_extract_footer_data_no_pub_date(self):
         xml = etree.fromstring('<article></article>')
-        expected = {'year': '', 'volume': '', 'issue': '', 'fpage': '', 'lpage': ''}
+        expected = {
+            'year': '', 'volume': '', 'issue': '', 'fpage': '', 'lpage': '',
+            'elocation_id': '', 'location_label': '',
+        }
+        result = xml_pipe.extract_footer_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_footer_data_uses_elocation_id_when_fpage_is_absent(self):
+        xml = etree.fromstring(
+            '<article>'
+            '<pub-date date-type="collection" publication-format="electronic">'
+            '<year>2024</year>'
+            '</pub-date>'
+            '<front>'
+            '<volume>33</volume>'
+            '<issue>3</issue>'
+            '<elocation-id>e282794</elocation-id>'
+            '</front>'
+            '</article>'
+        )
+        expected = {
+            'year': '2024',
+            'volume': '33',
+            'issue': '3',
+            'fpage': '',
+            'lpage': '',
+            'elocation_id': 'e282794',
+            'location_label': 'e282794',
+        }
         result = xml_pipe.extract_footer_data(xml)
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
## O que esse PR faz?

Corrige duas partes da issue #1302 (rodapé/CITE AS do PDF):

1. Suporte a `<elocation-id>` para artigos de publicação contínua. Hoje, quando não há `<fpage>`/`<lpage>`, o rodapé e o CITE AS mostram `: -.`/`: -` em vez do identificador eletrônico do artigo.
2. Remove o `|` inicial do rodapé do Material Suplementar, que hoje aparece mesmo essa seção nunca recebendo número de página (sua paginação é independente do corpo do artigo).

Este PR **não** mexe na numeração de página em si (o valor de `start_page_number` quando não há `fpage`, e a diferença de mecanismo entre a 1ª página, com texto estático, e as demais, com campo `PAGE` do Word). Isso fica para um PR separado, ver "Algum cenário de contexto" abaixo.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py::extract_footer_data`, que ganha o campo `location_label` (`{fpage}-{lpage}` quando há `fpage`, senão `elocation_id`, senão vazio). Depois `packtools/sps/formats/pdf/pipeline/docx.py`, nos 4 pontos que antes montavam `f'{fpage}-{lpage}'` manualmente (`docx_cite_as_pipe`, `docx_second_footer_pipe`, `docx_page_vol_issue_year_pipe`, `docx_supplementary_material_pipe`).

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a4.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a4.pdf --libreoffice-binary libreoffice
```
Página 1: o rodapé e o CITE AS devem mostrar `e282794` em vez de `-`.

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a1.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a1.pdf --libreoffice-binary libreoffice
```
Páginas do Material Suplementar (12 a 15): o rodapé deve começar direto em `VOL.`, sem `|` solto no início.

Testes automatizados: `pytest tests/sps/formats/pdf` (ou `python -m unittest discover -s tests/sps/formats/pdf -v`).

## Algum cenário de contexto que queira dar?

Levantado a partir da issue #1302. Essa issue também descreve um problema de numeração de página (artigos sem `fpage` deveriam numerar a partir de 1 na primeira folha, e não na segunda). Esse ponto não está coberto aqui porque entra em conflito direto com o comportamento fixado em `test_rendered_page_layout.py::test_body_starts_page_one_without_fpage_defaults_to_one` (adicionado pelos PRs #1295/#1296, que resolveram um problema de layout diferente e, como efeito colateral, assumiram um comportamento de numeração que a #1302 contesta). Fica para um PR à parte, que vai precisar revisar aquele teste.

## Screenshots

Antes/depois do CITE AS e rodapé de `a4.xml` (publicação contínua, sem `fpage`):

<img width="1241" height="460" alt="comparison_elocation_id_before_after" src="https://github.com/user-attachments/assets/23ba9785-46aa-4a3d-88e1-a1c05b85da03" />

Antes/depois do rodapé do Material Suplementar de `a1.xml`:

<img width="1241" height="460" alt="comparison_supplementary_pipe_before_after" src="https://github.com/user-attachments/assets/a8a22e57-c320-4b9f-8b43-97cdbbc768fc" />

## Quais são os tickets relevantes?

Refs #1302 (parcial: cobre elocation-id e rodapé do Material Suplementar; numeração de página fica para PR separado).

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado). Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
