### PR TITLE
fix: numera páginas do PDF na ordem natural das folhas quando não há fpage

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -90,11 +90,13 @@ def pipeline_docx(xml_tree, data):
     # setting it only on the first section makes LibreOffice promote the
     # continuous break back into a real page break. fpage (not fpage + 1)
     # is used because the PAGE field already increments naturally within
-    # the continuous flow.
+    # the continuous flow. When there's no fpage (continuous-publication
+    # articles), numbering falls back to the sheets' natural order, so the
+    # first physical page is "1", not "0" (see issue #1302).
     try:
         start_page_number = int(footer_data['fpage'])
     except ValueError:
-        start_page_number = 0
+        start_page_number = 1
     for section in docx.sections:
         docx_renderer.section.set_start_page_number(section, start_page_number)
 
@@ -385,6 +387,12 @@ def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL F
     """
     Adds the page, volume, issue, and year information to the first page footer of the DOCX document.
 
+    Uses the same dynamic PAGE field as docx_second_footer_pipe (rather than
+    writing footer_data['fpage'] as static text) so the two footers share one
+    numbering mechanism. A static fpage would render blank when the article
+    has no fpage (continuous-publication articles), while the PAGE field
+    always reflects the actual restart value set on the section.
+
     Args:
         docx (python-docx.Document): The DOCX document object.
         footer_data (dict): The data to be added to the footer.
@@ -397,7 +405,8 @@ def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL F
     para = footer.add_paragraph()
 
     para.style = docx.styles[paragraph_style_name]
-    para.add_run(f"{footer_data['fpage']} | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
+    docx_renderer.text.add_field_run(para, "PAGE \\* MERGEFORMAT")
+    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
 
 def docx_body_pipe(docx, body_data):
     """

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -7,6 +7,9 @@ from docx import Document
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
 from packtools.sps.formats.pdf.renderer import docx as docx_renderer
 from packtools.sps.formats.pdf import enum as pdf_enum
+from packtools.sps.utils import xml_utils
+
+WML_NS = '{http://schemas.openxmlformats.org/wordprocessingml/2006/main}'
 
 FIXTURES_DIR = Path(__file__).resolve().parents[4] / "fixtures" / "pdf"
 
@@ -17,8 +20,23 @@ def _docx_with_layout_styles():
 
 
 class TestPipelineDocx(unittest.TestCase):
-    # TODO
-    ...
+
+    def _start_page_number(self, section):
+        pg_num_type = section._sectPr.find(f'{WML_NS}pgNumType')
+        return pg_num_type.get(f'{WML_NS}start')
+
+    def _pipeline_docx(self, xml_filename):
+        xml_tree = xml_utils.get_xml_tree(str(FIXTURES_DIR / xml_filename))
+        data = {"base_layout": str(FIXTURES_DIR / "layout.docx"), "assets_dir": str(FIXTURES_DIR)}
+        return docx_pipe.pipeline_docx(xml_tree, data)
+
+    def test_start_page_number_uses_fpage_when_present(self):
+        docx = self._pipeline_docx("a1.xml")
+        self.assertEqual(self._start_page_number(docx.sections[0]), '271')
+
+    def test_start_page_number_defaults_to_one_without_fpage(self):
+        docx = self._pipeline_docx("a4.xml")
+        self.assertEqual(self._start_page_number(docx.sections[0]), '1')
 
 
 class TestJournalTitlePipe(unittest.TestLoader):

--- a/tests/sps/formats/pdf/test_rendered_page_layout.py
+++ b/tests/sps/formats/pdf/test_rendered_page_layout.py
@@ -56,6 +56,12 @@ class TestBodyStartsPageOneRenderedPageNumbers(unittest.TestCase):
     other, invisible to structural assertions on the docx object, since
     the .docx XML looked correct either way. Only inspecting the actual
     rendered PDF catches that.
+
+    The no-fpage expectation below was revised by #1302: #1295/#1296 had
+    landed on "page 2 shows 1" (the first physical sheet left unnumbered)
+    as a side effect of fixing the layout issue, not a deliberate choice
+    about numbering. #1302 supersedes that: sheets are numbered in their
+    natural order starting at 1, so the first physical sheet must show 1.
     """
 
     def test_body_starts_page_one_with_editorial_numbering(self):
@@ -68,9 +74,10 @@ class TestBodyStartsPageOneRenderedPageNumbers(unittest.TestCase):
             # Body content (not just front matter) must already be on page 1.
             self.assertIn("biodiversity", page1_text.lower())
 
-    def test_body_starts_page_one_without_fpage_defaults_to_one(self):
+    def test_body_starts_page_one_without_fpage_numbers_sheets_naturally(self):
         with tempfile.TemporaryDirectory() as tmp:
             page1_text, page2_text = _render_page_texts("a4.xml", Path(tmp))
 
-            # a4.xml has no fpage: page 2 must start numbering at 1.
-            self.assertIn("1 | VOL.", page2_text)
+            # a4.xml has no fpage: sheets follow their natural order (#1302).
+            self.assertIn("1 | VOL.", page1_text)
+            self.assertIn("2 | VOL.", page2_text)


### PR DESCRIPTION
## O que esse PR faz?

Corrige a parte de numeração de página da issue #1302, que não foi coberta pelo #1309 (fases 1+2): quando não há `<fpage>` (artigos de publicação contínua), a numeração de página do PDF ficava incorreta.

- Antes: `start_page_number` caía para `0` na ausência de `fpage`, então a 1ª folha ficava sem número visível e a 2ª mostrava `"1"`.
- Depois: o fallback passa a ser `1`, então a numeração segue a ordem natural das folhas (folha 1 → "1", folha 2 → "2", ...), como pede a #1302.

Também unifica o mecanismo de numeração entre a 1ª página e as demais: `docx_page_vol_issue_year_pipe` passa a usar o mesmo campo `PAGE` dinâmico do Word que `docx_second_footer_pipe`, em vez de escrever `footer_data['fpage']` como texto estático (que ficava vazio quando não há `fpage`).

**Nota sobre o teste alterado:** `test_rendered_page_layout.py::test_body_starts_page_one_without_fpage_defaults_to_one` (dos PRs #1295/#1296) afirmava que a página 2 mostrar `"1"` era o comportamento correto. Isso foi um efeito colateral de uma correção de *layout* (o corpo do artigo passando a começar na página 1), não uma decisão deliberada sobre numeração. A #1302 identificou que esse comportamento está errado, e a observação da #1302 prevalece. O teste foi renomeado e atualizado para refletir o novo comportamento esperado.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/docx.py`, função `pipeline_docx` (fallback de `start_page_number`) e `docx_page_vol_issue_year_pipe` (troca de texto estático por campo `PAGE`).

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a4.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a4.pdf --libreoffice-binary libreoffice
```
Páginas 1, 2 e 3: devem mostrar `1 | VOL...`, `2 | VOL...`, `3 | VOL...` respectivamente (antes: página 1 sem número, página 2 mostrava `1`).

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a1.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a1.pdf --libreoffice-binary libreoffice
```
Artigo com `fpage=271`: páginas 1 a 11 devem continuar mostrando `271` a `281` normalmente (sem regressão).

Testes automatizados: `pytest tests/sps/formats/pdf` (inclui o teste de renderização real via LibreOffice, que já roda neste ambiente).

## Algum cenário de contexto que queira dar?

Depende do #1309 (fases 1+2 da mesma issue #1302) já estar mergeado ou revisado antes deste, já que a branch parte dele. Fecha a parte de numeração de página da #1302; a issue pode ser fechada depois que os dois PRs forem mergeados.

## Screenshots

Antes/depois da numeração de páginas 1 e 2 de `a4.xml` (sem `fpage`):

<img width="1281" height="750" alt="comparison_page_numbering_before_after" src="https://github.com/user-attachments/assets/e5d1bdaa-6da9-41ad-af48-9a329c2c3ec7" />

## Quais são os tickets relevantes?

Closes #1302 (em conjunto com #1309).

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado). Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
