### PR TITLE
fix: migra PAGE_ATTRIBUTES hardcoded para JSON de configuração (Fase 1, #1278)

### DIFF
--- a/packtools/sps/formats/pdf/default_layout.json
+++ b/packtools/sps/formats/pdf/default_layout.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "page": {
+    "page_width_pt": 595.275591,
+    "page_height_pt": 841.889764,
+    "orientation": "portrait",
+    "top_margin_pt": 99.212598,
+    "left_margin_pt": 56.692913,
+    "right_margin_pt": 56.692913,
+    "bottom_margin_pt": 56.692913,
+    "header_distance_pt": 28.346457,
+    "footer_distance_pt": 28.346457,
+    "gutter_pt": 0,
+    "different_first_page_header_footer": true,
+    "body_start_type": "continuous",
+    "default_column_count": 2,
+    "column_spacing_pt": 15.0
+  }
+}

--- a/packtools/sps/formats/pdf/enum.py
+++ b/packtools/sps/formats/pdf/enum.py
@@ -1,35 +1,25 @@
 from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.section import WD_ORIENT, WD_SECTION
-from docx.shared import Cm
+
+from packtools.sps.formats.pdf import layout_config
 
 
 NAMESPACES = {'xml': 'http://www.w3.org/XML/1998/namespace'}
 
-PAGE_ATTRIBUTES = {
-    "top_margin": Cm(3.5), 
-    "left_margin": Cm(2),
-    "right_margin": Cm(2), 
-    "bottom_margin": Cm(2), 
-    "header_distance": Cm(1), 
-    "footer_distance": Cm(1), 
-    "gutter": Cm(0), 
-    "orientation": WD_ORIENT.PORTRAIT,
-    "page_width": Cm(21.0),
-    "page_height": Cm(29.7),
-    "different_first_page_header_footer": True,
-    "start_type": WD_SECTION.CONTINUOUS,
-    "default_column_count": 2,
-}
+# Page/layout attributes and column spacing come from default_layout.json
+# (packaged alongside this module) instead of being hardcoded here, so a
+# journal-specific layout can eventually override them by pointing the
+# loader at a different file.
+PAGE_ATTRIBUTES = layout_config.load_page_attributes()
+
+# TWO_COLUMNS_SPACING is the space between two columns in twocolumn layout, measured in twips (1/20 of a point).
+TWO_COLUMNS_SPACING = layout_config.load_column_spacing_twips()
 
 SUPPORTED_STYLES = [
     WD_STYLE_TYPE.CHARACTER,
     WD_STYLE_TYPE.PARAGRAPH,
     WD_STYLE_TYPE.TABLE,
 ]
-
-# TWO_COLUMNS_SPACING is the space between two columns in twocolumn layout, measured in twips (1/20 of a point).
-# 300 twips = 15 points = ~5.29 mm
-TWO_COLUMNS_SPACING = 300
 
 SINGLE_COLUMN_PAGE_LABEL = 'single-column-layout'
 DOUBLE_COLUMN_PAGE_LABEL = 'double-column-layout'

--- a/packtools/sps/formats/pdf/layout_config.py
+++ b/packtools/sps/formats/pdf/layout_config.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from docx.enum.section import WD_ORIENT, WD_SECTION
+from docx.shared import Pt
+
+_DEFAULT_PATH = Path(__file__).parent / "default_layout.json"
+
+_ORIENTATION_MAP = {
+    "portrait": WD_ORIENT.PORTRAIT,
+    "landscape": WD_ORIENT.LANDSCAPE,
+}
+
+_START_TYPE_MAP = {
+    "continuous": WD_SECTION.CONTINUOUS,
+    "new_page": WD_SECTION.NEW_PAGE,
+    "even_page": WD_SECTION.EVEN_PAGE,
+    "odd_page": WD_SECTION.ODD_PAGE,
+}
+
+
+def load_page_attributes(path=None):
+    """
+    Load page/layout attributes from a layout-config JSON, returning a dict
+    shaped like the legacy PAGE_ATTRIBUTES (Pt/Cm Length objects and
+    python-docx enums), for drop-in use wherever PAGE_ATTRIBUTES is passed
+    today.
+
+    `path` lets a caller point at a different file; defaults to the
+    packaged default_layout.json. Not wired to the CLI/API yet - that
+    comes with per-journal config support.
+    """
+    data = json.loads(Path(path or _DEFAULT_PATH).read_text())
+    page = data["page"]
+
+    return {
+        "top_margin": Pt(page["top_margin_pt"]),
+        "left_margin": Pt(page["left_margin_pt"]),
+        "right_margin": Pt(page["right_margin_pt"]),
+        "bottom_margin": Pt(page["bottom_margin_pt"]),
+        "header_distance": Pt(page["header_distance_pt"]),
+        "footer_distance": Pt(page["footer_distance_pt"]),
+        "gutter": Pt(page["gutter_pt"]),
+        "orientation": _ORIENTATION_MAP[page["orientation"]],
+        "page_width": Pt(page["page_width_pt"]),
+        "page_height": Pt(page["page_height_pt"]),
+        "different_first_page_header_footer": page["different_first_page_header_footer"],
+        "start_type": _START_TYPE_MAP[page["body_start_type"]],
+        "default_column_count": page["default_column_count"],
+    }
+
+
+def load_column_spacing_twips(path=None):
+    """
+    Load the column spacing (in twips, 1/20 of a point) from the same
+    layout-config JSON used by load_page_attributes.
+    """
+    data = json.loads(Path(path or _DEFAULT_PATH).read_text())
+    return round(data["page"]["column_spacing_pt"] * 20)

--- a/tests/sps/formats/pdf/test_layout_config.py
+++ b/tests/sps/formats/pdf/test_layout_config.py
@@ -1,0 +1,80 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from docx.enum.section import WD_ORIENT, WD_SECTION
+
+from packtools.sps.formats.pdf import layout_config
+
+
+class TestLoadPageAttributes(unittest.TestCase):
+    """
+    Regression tests for the JSON-backed replacement of the legacy hardcoded
+    PAGE_ATTRIBUTES dict. Length values are compared with a tolerance of a
+    few EMU: converting through a decimal pt value in JSON can't guarantee
+    perfect round-trip precision from the original Cm() literals, and a
+    handful of EMU (1/914400 inch) has no visible or functional effect.
+    """
+
+    def setUp(self):
+        self.attrs = layout_config.load_page_attributes()
+
+    def _assert_close(self, actual, expected, tolerance_emu=5):
+        self.assertLessEqual(abs(int(actual) - int(expected)), tolerance_emu)
+
+    def test_matches_legacy_hardcoded_values(self):
+        from docx.shared import Cm
+
+        self._assert_close(self.attrs['top_margin'], Cm(3.5))
+        self._assert_close(self.attrs['left_margin'], Cm(2))
+        self._assert_close(self.attrs['right_margin'], Cm(2))
+        self._assert_close(self.attrs['bottom_margin'], Cm(2))
+        self._assert_close(self.attrs['header_distance'], Cm(1))
+        self._assert_close(self.attrs['footer_distance'], Cm(1))
+        self._assert_close(self.attrs['gutter'], Cm(0))
+        self._assert_close(self.attrs['page_width'], Cm(21.0))
+        self._assert_close(self.attrs['page_height'], Cm(29.7))
+        self.assertEqual(self.attrs['orientation'], WD_ORIENT.PORTRAIT)
+        self.assertEqual(self.attrs['different_first_page_header_footer'], True)
+        self.assertEqual(self.attrs['start_type'], WD_SECTION.CONTINUOUS)
+        self.assertEqual(self.attrs['default_column_count'], 2)
+
+    def test_load_column_spacing_twips_matches_legacy_constant(self):
+        self.assertEqual(layout_config.load_column_spacing_twips(), 300)
+
+    def test_custom_path_overrides_default(self):
+        custom = {
+            "schema_version": 1,
+            "page": {
+                "page_width_pt": 400.0,
+                "page_height_pt": 600.0,
+                "orientation": "landscape",
+                "top_margin_pt": 10.0,
+                "left_margin_pt": 10.0,
+                "right_margin_pt": 10.0,
+                "bottom_margin_pt": 10.0,
+                "header_distance_pt": 5.0,
+                "footer_distance_pt": 5.0,
+                "gutter_pt": 0,
+                "different_first_page_header_footer": False,
+                "body_start_type": "new_page",
+                "default_column_count": 1,
+                "column_spacing_pt": 0,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "custom.json"
+            path.write_text(json.dumps(custom))
+
+            attrs = layout_config.load_page_attributes(path)
+            self.assertEqual(attrs['orientation'], WD_ORIENT.LANDSCAPE)
+            self.assertEqual(attrs['start_type'], WD_SECTION.NEW_PAGE)
+            self.assertEqual(attrs['default_column_count'], 1)
+            self.assertEqual(attrs['different_first_page_header_footer'], False)
+
+            self.assertEqual(layout_config.load_column_spacing_twips(path), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## O que esse PR faz?

Migra os atributos de página/coluna do gerador de PDF, hoje fixos em `enum.PAGE_ATTRIBUTES`/`TWO_COLUMNS_SPACING` (margens, tamanho de página, espaçamento de coluna), para um arquivo JSON de configuração (`packtools/sps/formats/pdf/default_layout.json`) lido por um loader dedicado. É a Fase 1 da issue #1278, com caminho fixo, sem flag de CLI ainda e sem camada de decisão de largura de tabela/figura: a saída do PDF permanece idêntica à atual.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/layout_config.py`, funções `load_page_attributes()` e `load_column_spacing_twips()`, que leem `default_layout.json` e devolvem os mesmos objetos `Pt`/enums do python-docx que `enum.PAGE_ATTRIBUTES` fornecia antes (agora em pontos, não centímetros, mas com os mesmos valores numéricos).

## Como este poderia ser testado manualmente?

1. Rodar `tests/sps/formats/pdf/test_layout_config.py` para conferir que o loader monta o dict/spacing corretos a partir do JSON.
2. Rodar `tests/sps/formats/pdf/test_rendered_page_layout.py` (requer LibreOffice e `pdftotext` instalados): gera um PDF real a partir de `tests/fixtures/pdf/a1.xml`/`a4.xml` e confere numeração de página no texto extraído, garantindo que a saída renderizada não mudou.

## Algum cenário de contexto que queira dar?

Continuação da issue #1278 (retomada após o fechamento do #1279, que tentava entregar tudo de uma vez). O objetivo final é permitir layout configurável por periódico; esta PR só troca a origem dos valores atuais (hardcoded → JSON), sem alterar comportamento. PRs anteriores desta mesma iniciativa (#1292, #1294, #1296, #1298, #1300) já foram mesclados.

## Screenshots

Não aplicável, sem mudança visual (saída do PDF idêntica à atual, validado pelo teste de renderização real).

## Quais são os tickets relevantes?

Relacionado a #1278 (Fase 1).

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (mudança interna de configuração de layout, sem novas dependências ou superfícies expostas)

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
