### PR TITLE
fix: move import de PIL.Image para o topo do módulo e remove duplicação de cálculo de largura natural em figure.py

### DIFF
--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -1,5 +1,6 @@
 import os
 
+from PIL import Image
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.shared import Cm
 
@@ -66,12 +67,6 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
         except Exception:
             pass
 
-    try:
-        from PIL import Image
-    except Exception:
-        # If Pillow is unavailable at runtime, fallback conservatively
-        return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
-
     # Reuses _compute_single_column_width so this decision honors the same
     # formula as the rest of the layout code, instead of duplicating (and
     # risking drifting from) it here.
@@ -90,8 +85,7 @@ def decide_figure_layout(docx, figure_data, page_attributes=pdf_enum.PAGE_ATTRIB
         except (TypeError, ValueError):
             pass
 
-    # width in inches then to Cm
-    width_in_cm = (px_w / max(1.0, dpi)) * 2.54
+    width_in_cm = _natural_width_cm(px_w, dpi) / Cm(1)
 
     # single_col_width comes back as a raw EMU number, not a Cm object
     # (python-docx's Length has no operator overloads that preserve units
@@ -108,11 +102,6 @@ def probe_image_dpi(docx, figure_data):
     Resolve a figure's image and return its (pixel_width, dpi), or None if
     the image can't be opened.
     """
-    try:
-        from PIL import Image
-    except Exception:
-        return None
-
     context = _get_docx_context(docx)
     href = figure_data.get('href') if isinstance(figure_data, dict) else None
     img_path = _resolve_image_path(href, context)
@@ -216,6 +205,10 @@ def _resolve_image_path(href, context):
 
     return img_path
 
+def _natural_width_cm(px_w, dpi):
+    """Compute an image's natural width in Cm from its pixel width and DPI."""
+    return Cm((px_w / max(1.0, dpi)) * 2.54)
+
 def _natural_width_capped(img_path, ceiling_width):
     """
     Compute the image's natural width from its DPI metadata, capped at
@@ -224,12 +217,8 @@ def _natural_width_capped(img_path, ceiling_width):
     if not (img_path and os.path.exists(img_path)):
         return ceiling_width
     try:
-        from PIL import Image
-
         with Image.open(img_path) as im:
-            px_w = im.width
-            dpi = _infer_image_dpi(im)
-            natural_width = Cm((px_w / max(1.0, dpi)) * 2.54)
+            natural_width = _natural_width_cm(im.width, _infer_image_dpi(im))
         return natural_width if natural_width < ceiling_width else ceiling_width
     except Exception:
         return ceiling_width


### PR DESCRIPTION
## O que esse PR faz?

Endereça os 2 comentários de review deixados em aberto pelo pitangainnovare no #1300 (já mesclado), em `packtools/sps/formats/pdf/renderer/docx/figure.py`:

1. Move os 3 imports locais `from PIL import Image` (em `decide_figure_layout`, `probe_image_dpi` e `_natural_width_capped`) para um único import no topo do módulo. O try/except em torno deles servia para lidar com Pillow ausente, mas Pillow já é dependência obrigatória do pacote desde a fase 3 do #1251 (`Pillow>=12.3.0` em `setup.py`), então o fallback nunca dispara na prática.
2. Extrai o trecho duplicado que calcula a largura natural de uma imagem a partir de pixels e DPI (presente em `decide_figure_layout` e `_natural_width_capped`) em um helper único, `_natural_width_cm(px_w, dpi)`, que devolve sempre um `Cm`. Os dois fluxos agora convertem a partir do mesmo `Cm`, eliminando o risco de decisão de layout e largura de inserção divergirem por interpretação de unidade.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py`, função `_natural_width_cm` e os dois pontos que passam a chamá-la (`decide_figure_layout` e `_natural_width_capped`).

## Como este poderia ser testado manualmente?

Rodar `tests/sps/formats/pdf/` (136 testes passando após a mudança, mesma baseline de antes).

## Algum cenário de contexto que queira dar?

Os 2 comentários ficaram deliberadamente adiados no #1300 porque o trecho a tocar era o que o #1294 estava reescrevendo na época; o #1294 já foi mesclado, então essa razão para adiar não se aplica mais.

## Screenshots

Não aplicável, mudança interna sem efeito visual (mesmo comportamento, mesmos testes passando).

## Quais são os tickets relevantes?

Segue os comentários de review não resolvidos em #1300.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (mudança interna de organização de código, sem novas dependências ou superfícies expostas)

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
