### PR TITLE
fix: evita duplicacao e mau posicionamento de tabela em subsecao aninhada

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -357,8 +357,10 @@ def extract_body_data(xml_tree):
             if para_text:
                 sec['paragraphs'].append(para_text)
 
-        # Tables within the section
         for table_wrap in document_section.findall('.//table-wrap'):
+            closest_sec = table_wrap.xpath('ancestor::sec[1]')
+            if closest_sec and closest_sec[0] is not document_section:
+                continue
             sec['tables'].append(extract_table_data(table_wrap))
 
         # Figures within the section (deduplicated across the body)

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1146,6 +1146,110 @@ class TestExtractTableData(unittest.TestCase):
         self.assertEqual(expected, result)
 
 
+class TestExtractBodyDataTableDedup(unittest.TestCase):
+    """
+    Regression tests for a table-wrap inside a nested <sec> being collected
+    once, by its closest section ancestor, at its natural position. It was
+    previously collected by every ancestor section too (findall('.//sec')
+    yields each nested <sec> as its own entry, and each searches all
+    table-wrap descendants), duplicating the table and hoisting one copy of
+    it into a block ahead of the subsection's own text.
+    """
+
+    def test_table_in_nested_subsection_is_not_duplicated(self):
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Parent</title>'
+            '<sec>'
+            '<title>Child</title>'
+            '<table-wrap id="t1">'
+            '<label>Table 1</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table>'
+            '</table-wrap>'
+            '</sec>'
+            '</sec>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        all_tables = [t for sec in result for t in sec['tables']]
+        self.assertEqual(len(all_tables), 1)
+
+    def test_table_in_nested_subsection_stays_at_its_natural_position(self):
+        # Not just deduplicated: the surviving copy must belong to the Child
+        # section (its actual position in the text), not get hoisted up to
+        # Parent (a table-id-keyed dedup that kept "whichever copy is seen
+        # first" would have kept the wrong one, since findall('.//sec') visits
+        # Parent before Child).
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Parent</title>'
+            '<sec>'
+            '<title>Child</title>'
+            '<table-wrap id="t1">'
+            '<label>Table 1</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table>'
+            '</table-wrap>'
+            '</sec>'
+            '</sec>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        parent_sec = next(s for s in result if s['title'] == 'Parent')
+        child_sec = next(s for s in result if s['title'] == 'Child')
+        self.assertEqual(len(parent_sec['tables']), 0)
+        self.assertEqual(len(child_sec['tables']), 1)
+
+    def test_tables_without_id_still_avoid_duplication_and_hoisting(self):
+        # The fix doesn't rely on @id at all (unlike the figure dedup it was
+        # modeled after): it's based on each table-wrap's closest <sec>
+        # ancestor, so this must work the same with or without an id.
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Parent</title>'
+            '<sec>'
+            '<title>Child</title>'
+            '<table-wrap>'
+            '<label>Table 1</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table>'
+            '</table-wrap>'
+            '</sec>'
+            '</sec>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        all_tables = [t for sec in result for t in sec['tables']]
+        self.assertEqual(len(all_tables), 1)
+        parent_sec = next(s for s in result if s['title'] == 'Parent')
+        self.assertEqual(len(parent_sec['tables']), 0)
+
+    def test_table_directly_in_parent_is_not_skipped(self):
+        # A table that's a direct child of Parent (not inside Child) must
+        # still be collected by Parent, the fix must not over-correct into
+        # skipping every table above the deepest section.
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Parent</title>'
+            '<table-wrap id="t1"><label>Table 1</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>'
+            '<sec>'
+            '<title>Child</title>'
+            '<table-wrap id="t2"><label>Table 2</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>'
+            '</sec>'
+            '</sec>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        parent_sec = next(s for s in result if s['title'] == 'Parent')
+        child_sec = next(s for s in result if s['title'] == 'Child')
+        self.assertEqual([t['label'] for t in parent_sec['tables']], ['Table 1'])
+        self.assertEqual([t['label'] for t in child_sec['tables']], ['Table 2'])
+
+
 class TestExtractTransAbstractData(unittest.TestCase):
 
     def test_extract_trans_abstract_data_basic(self):


### PR DESCRIPTION

## O que esse PR faz?

Corrige `extract_body_data` (`packtools/sps/formats/pdf/pipeline/xml.py`) para que uma `<table-wrap>` dentro de uma subseção aninhada seja coletada uma única vez, na seção certa, em vez de ser duplicada (uma cópia despejada em bloco na seção-pai, antes de qualquer parágrafo, e outra na posição natural dentro da subseção).

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, função `extract_body_data`, no loop `for table_wrap in document_section.findall('.//table-wrap')`. A correção checa se a `<sec>` ancestral mais próxima da tabela (`table_wrap.xpath('ancestor::sec[1]')`) é a própria seção em processamento; se não for, a tabela é pulada ali e coletada quando o loop chegar na seção certa. Não depende de `@id` (funciona mesmo sem ele, diferente do dedup por chave que existe pra figura).

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a1.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a1.pdf --libreoffice-binary libreoffice
```

Testes automatizados novos em `tests/sps/formats/pdf/pipeline/test_xml.py::TestExtractBodyDataTableDedup` cobrem: tabela em subseção não duplica, tabela fica na seção certa (não sobe pra seção-pai), funciona sem `@id`, e tabela direta na seção-pai não é pulada por engano.

## Algum cenário de contexto que queira dar?

Achado durante uma auditoria do gerador de PDF contra um corpus de 26 artigos reais publicados. Renderizando `a5.xml` (5 tabelas, várias em subseção) via LibreOffice, cada tabela aparecia 2-3 vezes no PDF gerado, a primeira leva delas despejada em bloco logo após o título de "2. MATERIALS AND METHODS", antes de qualquer parágrafo de corpo. A causa raiz é que `findall('.//sec')` visita cada seção aninhada como entrada própria, e cada uma busca `.//table-wrap` em todos os descendentes, então uma tabela numa subseção é coletada tanto pela seção-pai quanto pela subseção. O loop de figuras já tinha proteção equivalente (`seen_fig_keys`), o de tabelas não tinha.

## Screenshots

<img width="2554" height="1872" alt="case1_before_after" src="https://github.com/user-attachments/assets/798e0278-ba25-49d4-8a5d-ce2ffdf77bfb" />
## Quais são os tickets relevantes?

Closes #1313.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (correção de extração de dados internos, sem novas dependências ou superfícies expostas)

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
