### PR TITLE
fix: extrai e renderiza nota de table-wrap-foot, hoje descartada

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -600,12 +600,15 @@ def extract_table_data(table_wrap):
             - 'rows': A list of lists, where each inner list represents the text content of the table data cells.
             - 'layout': A string indicating the table layout ('single-column-layout' or 'double-column-layout').
             - 'column_widths': A list of calculated column widths based on content.
+            - 'foot': A list of footnote/attribution strings from <table-wrap-foot>, if present.
     """
     table_label = table_wrap.find('.//label')
     label_text = table_label.text if table_label is not None else ""
 
     table_title = table_wrap.find('.//title')
     title_text = table_title.text if table_title is not None else ""
+
+    foot_notes = _extract_table_foot(table_wrap)
 
     headers = []
     rows = []
@@ -641,6 +644,7 @@ def extract_table_data(table_wrap):
         'column_widths': column_widths,
         'header_spans': header_spans,
         'row_spans': row_spans,
+        'foot': foot_notes,
     }
 
 def determine_table_layout(table_wrap):
@@ -894,6 +898,33 @@ def _calculate_max_columns(table_section, cell_tag):
         max_cols = max(max_cols, current_cols)
     
     return max_cols
+
+def _extract_table_foot(table_wrap):
+    """
+    Extracts footnote/attribution text from a table's <table-wrap-foot>, if present.
+
+    Args:
+        table_wrap (ElementTree): The XML table-wrap element to extract from.
+
+    Returns:
+        list: One string per <fn> or <attrib> child found, in document order.
+    """
+    notes = []
+    foot = table_wrap.find('.//table-wrap-foot')
+    if foot is None:
+        return notes
+
+    for fn in foot.findall('fn'):
+        text = ' '.join(' '.join(fn.itertext()).split()).strip()
+        if text:
+            notes.append(text)
+
+    for attrib in foot.findall('attrib'):
+        text = ' '.join(' '.join(attrib.itertext()).split()).strip()
+        if text:
+            notes.append(text)
+
+    return notes
 
 def _calculate_column_widths(headers, rows, min_width=50, max_width=200):
     """

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -907,20 +907,15 @@ def _extract_table_foot(table_wrap):
         table_wrap (ElementTree): The XML table-wrap element to extract from.
 
     Returns:
-        list: One string per <fn> or <attrib> child found, in document order.
+        list: One string per <p>, <fn> or <attrib> child found, in document order.
     """
     notes = []
     foot = table_wrap.find('.//table-wrap-foot')
     if foot is None:
         return notes
 
-    for fn in foot.findall('fn'):
-        text = ' '.join(' '.join(fn.itertext()).split()).strip()
-        if text:
-            notes.append(text)
-
-    for attrib in foot.findall('attrib'):
-        text = ' '.join(' '.join(attrib.itertext()).split()).strip()
+    for node in foot.xpath('./p | ./fn | ./attrib | ./fn-group/fn'):
+        text = ' '.join(' '.join(node.itertext()).split()).strip()
         if text:
             notes.append(text)
 

--- a/packtools/sps/formats/pdf/renderer/docx/table.py
+++ b/packtools/sps/formats/pdf/renderer/docx/table.py
@@ -58,6 +58,8 @@ def add_table(docx, table_data, header_style_name='SCL Table Heading', page_attr
 		wrap_distance_twips = int(table_data.get('wrap_distance_twips', 0))
 		_make_table_full_width_floating(table, wrap_distance_twips=wrap_distance_twips)
 
+	_add_table_foot_paragraphs(docx, table_data)
+
 
 # -----------------
 # Private helpers: cell styling
@@ -183,6 +185,17 @@ def _add_caption_paragraph(docx, table_data, header_style_name):
 		pass
 	
 	return p
+
+def _add_table_foot_paragraphs(docx, table_data):
+	"""Add one paragraph per <table-wrap-foot> note below the table, if any."""
+	notes = table_data.get('foot') or []
+	for i, note in enumerate(notes):
+		p = docx.add_paragraph()
+		p.alignment = WD_ALIGN_PARAGRAPH.JUSTIFY
+		p.paragraph_format.space_before = Pt(6) if i == 0 else Pt(0)
+		run = p.add_run(note)
+		run.italic = True
+		run.font.size = Pt(7)
 
 def _extract_table_data(table_data):
 	"""Extract relevant data from the table_data dictionary."""

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -334,6 +334,7 @@ class TestExtractBodyData(unittest.TestCase):
                         'column_widths': [50],
                         'header_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Header'}]],
                         'row_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Data'}]],
+                        'foot': [],
                     }
                 ],
                 'figures': [],
@@ -406,6 +407,7 @@ class TestExtractBodyData(unittest.TestCase):
                         'column_widths': [50],
                         'header_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Header'}]],
                         'row_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Data'}]],
+                        'foot': [],
                     }
                 ],
                 'figures': [],
@@ -1068,6 +1070,7 @@ class TestExtractTableData(unittest.TestCase):
                            {'colspan': 1, 'rowspan': 1, 'text': '25'}],
                           [{'colspan': 1, 'rowspan': 1, 'text': 'Jane'},
                            {'colspan': 1, 'rowspan': 1, 'text': '30'}]],
+            'foot': [],
         }
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
@@ -1095,6 +1098,7 @@ class TestExtractTableData(unittest.TestCase):
             'column_widths': [50],
             'header_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Col1'}]],
             'row_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Data1'}]],
+            'foot': [],
         }
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
@@ -1120,6 +1124,7 @@ class TestExtractTableData(unittest.TestCase):
             'column_widths': [],
             'header_spans': [],
             'row_spans': [],
+            'foot': [],
         }
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
@@ -1141,6 +1146,7 @@ class TestExtractTableData(unittest.TestCase):
             'column_widths': [],
             'header_spans': [],
             'row_spans': [],
+            'foot': [],
         }
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
@@ -1173,9 +1179,36 @@ class TestExtractTableData(unittest.TestCase):
                                {'colspan': 1, 'rowspan': 1, 'text': 'SubCol2'}]],
             'row_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Val1'},
                            {'colspan': 1, 'rowspan': 1, 'text': 'Val2'}]],
+            'foot': [],
         }
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(expected, result)
+
+    def test_extract_table_data_foot_with_fn_and_attrib(self):
+        xml_str = """
+            <table-wrap>
+                <table>
+                    <tbody><tr><td>Data</td></tr></tbody>
+                </table>
+                <table-wrap-foot>
+                    <fn id="TFN1"><p>Source: Authors.</p></fn>
+                    <fn id="TFN2"><p>* p &lt; 0.05.</p></fn>
+                    <attrib>Adapted from Smith (2020).</attrib>
+                </table-wrap-foot>
+            </table-wrap>
+        """
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap)
+        self.assertEqual(
+            result['foot'],
+            ['Source: Authors.', '* p < 0.05.', 'Adapted from Smith (2020).'],
+        )
+
+    def test_extract_table_data_no_foot_defaults_to_empty_list(self):
+        xml_str = "<table-wrap><table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>"
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap)
+        self.assertEqual(result['foot'], [])
 
 
 class TestExtractBodyDataTableDedup(unittest.TestCase):

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1204,6 +1204,47 @@ class TestExtractTableData(unittest.TestCase):
             ['Source: Authors.', '* p < 0.05.', 'Adapted from Smith (2020).'],
         )
 
+    def test_extract_table_data_foot_with_direct_p_elements(self):
+        # Regression: table-wrap-foot can hold <p> children directly, not
+        # only wrapped in <fn> or <attrib> (e.g. Table 2 of a2.xml fixture).
+        xml_str = """
+            <table-wrap>
+                <table>
+                    <tbody><tr><td>Data</td></tr></tbody>
+                </table>
+                <table-wrap-foot>
+                    <p>Legenda: Outros (BR): 87 titulos.</p>
+                    <p>Fonte: Dados da pesquisa (Florianopolis, 2022).</p>
+                </table-wrap-foot>
+            </table-wrap>
+        """
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap)
+        self.assertEqual(
+            result['foot'],
+            ['Legenda: Outros (BR): 87 titulos.', 'Fonte: Dados da pesquisa (Florianopolis, 2022).'],
+        )
+
+    def test_extract_table_data_foot_preserves_mixed_document_order(self):
+        xml_str = """
+            <table-wrap>
+                <table>
+                    <tbody><tr><td>Data</td></tr></tbody>
+                </table>
+                <table-wrap-foot>
+                    <p>Legenda solta.</p>
+                    <fn id="TFN1"><p>Nota de rodape.</p></fn>
+                    <attrib>Fonte: Autores.</attrib>
+                </table-wrap-foot>
+            </table-wrap>
+        """
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap)
+        self.assertEqual(
+            result['foot'],
+            ['Legenda solta.', 'Nota de rodape.', 'Fonte: Autores.'],
+        )
+
     def test_extract_table_data_no_foot_defaults_to_empty_list(self):
         xml_str = "<table-wrap><table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>"
         table_wrap = etree.fromstring(xml_str)

--- a/tests/sps/formats/pdf/renderer/docx/test_table.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_table.py
@@ -1,8 +1,9 @@
 import unittest
 
+from docx import Document
 from docx.shared import Cm
 
-from packtools.sps.formats.pdf.renderer.docx.table import _compute_table_width
+from packtools.sps.formats.pdf.renderer.docx.table import _compute_table_width, add_table
 from packtools.sps.formats.pdf import enum as pdf_enum
 
 
@@ -46,6 +47,40 @@ class TestComputeTableWidth(unittest.TestCase):
         )
         self.assertEqual(table_width, content_width)
         self.assertEqual(layout, pdf_enum.SINGLE_COLUMN_PAGE_LABEL)
+
+
+class TestAddTableFoot(unittest.TestCase):
+    """
+    Regression tests: <table-wrap-foot> notes extracted into table_data['foot']
+    must be rendered as paragraphs below the table, they were previously
+    dropped silently since nothing in the renderer read that key.
+    """
+
+    def _table_data(self, foot):
+        return {
+            'label': 'Table 1',
+            'title': 'Sample',
+            'headers': [['Col1']],
+            'rows': [['Data1']],
+            'layout': pdf_enum.DOUBLE_COLUMN_PAGE_LABEL,
+            'column_widths': [50],
+            'header_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Col1'}]],
+            'row_spans': [[{'colspan': 1, 'rowspan': 1, 'text': 'Data1'}]],
+            'foot': foot,
+        }
+
+    def test_foot_notes_are_rendered_as_paragraphs(self):
+        docx = Document()
+        add_table(docx, self._table_data(['Source: Authors.', '* p < 0.05.']))
+        body_text = [p.text for p in docx.paragraphs]
+        self.assertIn('Source: Authors.', body_text)
+        self.assertIn('* p < 0.05.', body_text)
+
+    def test_no_foot_notes_adds_no_extra_paragraphs(self):
+        docx = Document()
+        add_table(docx, self._table_data([]))
+        body_text = [p.text for p in docx.paragraphs]
+        self.assertNotIn('Source: Authors.', body_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## O que esse PR faz?

Adiciona extração e renderização de `<table-wrap-foot>` (notas de rodapé de tabela: fonte, atribuição, marcas de significância). Hoje esse conteúdo não é lido em nenhum lugar do gerador de PDF, mesmo estando presente no XML fonte, é perda de conteúdo silenciosa.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, nova função `_extract_table_foot`, chamada em `extract_table_data` (novo campo `'foot'` no dict retornado). Depois `packtools/sps/formats/pdf/renderer/docx/table.py`, nova função `_add_table_foot_paragraphs`, chamada no final de `add_table`.

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a1.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a1.pdf --libreoffice-binary libreoffice
```

Testes novos: `test_xml.py::TestExtractTableData::test_extract_table_data_foot_with_fn_and_attrib` (lida com múltiplos `<fn>` e `<attrib>` no mesmo rodapé) e `test_table.py::TestAddTableFoot` (confere que as notas viram parágrafo no documento).

## Algum cenário de contexto que queira dar?

Achado na mesma auditoria de corpus real que motivou o PR #1314. `<table-wrap-foot>` está presente em 18 dos 26 artigos do corpus (`layout_examples_rafael`), majoritariamente como `<fn><p>texto</p></fn>` (às vezes múltiplos `<fn>` no mesmo rodapé), com alguns usando `<attrib>` direto. A extração cobre os dois casos.

## Screenshots

<img width="2554" height="1872" alt="case2_before_after" src="https://github.com/user-attachments/assets/b5ca040b-72f7-434e-9307-b402affa1473" />

## Quais são os tickets relevantes?

Closes #1315.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (extração/renderização de texto já presente no XML fonte, sem novas dependências)

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
