### PR TITLE
feat: permite forcar layout de tabela por id via table_layout_overrides

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -12,7 +12,10 @@ def pipeline_docx(xml_tree, data):
 
     Args:
         xml_tree: The XML tree containing the article data.
-        data: Additional data for the DOCX generation.
+        data: Additional data for the DOCX generation. Recognizes an optional
+            'table_layout_overrides' key: a dict mapping a table-wrap @id to a
+            forced 'single-column-layout'/'double-column-layout', bypassing the
+            automatic layout heuristic for that specific table.
 
     Returns:
         A DOCX Document object.
@@ -65,7 +68,7 @@ def pipeline_docx(xml_tree, data):
     docx_second_footer_pipe(docx, footer_data)
     
     # Main content
-    body_data = xml_pipe.extract_body_data(xml_tree)
+    body_data = xml_pipe.extract_body_data(xml_tree, table_layout_overrides=data.get('table_layout_overrides'))
     docx_body_pipe(docx, body_data)
     
     # Acknowledgments

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -649,9 +649,14 @@ def extract_table_data(table_wrap):
         'foot': foot_notes,
     }
 
+_PATHOLOGICAL_CELL_LENGTH = 400
+
 def determine_table_layout(table_wrap):
     """
-    Determines the layout of a table based on the number of columns it contains, considering merged cells.
+    Determines the layout of a table based on the number of columns it contains,
+    considering merged cells, with a guard against a single excessively long cell
+    (which the column-count heuristic alone can't catch: a table can have few
+    columns and still need full width).
 
     Args:
         table_wrap (ElementTree): The XML table-wrap element to analyze.
@@ -663,18 +668,21 @@ def determine_table_layout(table_wrap):
     if table is not None:
         # Check both thead and tbody for maximum columns
         max_columns = 0
-        
+
         thead = table.find('.//thead')
         if thead is not None:
             max_columns = max(max_columns, _calculate_max_columns(thead, 'th'))
-        
+
         tbody = table.find('.//tbody')
         if tbody is not None:
             max_columns = max(max_columns, _calculate_max_columns(tbody, 'td'))
-        
+
         if max_columns > 4:
             return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
-    
+
+        if _max_cell_text_length(table) > _PATHOLOGICAL_CELL_LENGTH:
+            return pdf_enum.SINGLE_COLUMN_PAGE_LABEL
+
     return pdf_enum.DOUBLE_COLUMN_PAGE_LABEL
 
 def get_table_column_info(headers, rows):
@@ -900,6 +908,14 @@ def _calculate_max_columns(table_section, cell_tag):
         max_cols = max(max_cols, current_cols)
     
     return max_cols
+
+def _max_cell_text_length(table):
+    """Returns the character length of the longest single cell's text in the table."""
+    max_len = 0
+    for cell in table.xpath('.//td | .//th'):
+        cell_len = len(''.join(cell.itertext()).strip())
+        max_len = max(max_len, cell_len)
+    return max_len
 
 def _extract_table_foot(table_wrap):
     """

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -336,13 +336,16 @@ def extract_cite_as_part_one(xml_tree, return_node=False):
             else:
                 return part_one.text
 
-def extract_body_data(xml_tree):
+def extract_body_data(xml_tree, table_layout_overrides=None):
     """
     Extracts the body data from an XML tree, including section titles, paragraphs, and tables.
-    
+
     Args:
         xml_tree (ElementTree): The XML tree to extract the body data from.
-    
+        table_layout_overrides (dict, optional): Maps a table-wrap @id to a forced
+            layout ('single-column-layout' or 'double-column-layout'), bypassing
+            `determine_table_layout`'s heuristic for that specific table.
+
     Returns:
         list: A list of dictionaries, where each dictionary represents a section in the body of the document. Each dictionary has the following keys:
             - 'level': The nesting level of the section.
@@ -378,7 +381,9 @@ def extract_body_data(xml_tree):
             closest_sec = table_wrap.xpath('ancestor::sec[1]')
             if closest_sec and closest_sec[0] is not document_section:
                 continue
-            sec['tables'].append(extract_table_data(table_wrap))
+            table_id = table_wrap.get('id') or table_wrap.get('xml:id')
+            override_layout = (table_layout_overrides or {}).get(table_id)
+            sec['tables'].append(extract_table_data(table_wrap, override_layout=override_layout))
 
         # Figures within the section (deduplicated across the body)
         for fig in document_section.findall('.//fig'):
@@ -587,13 +592,16 @@ def extract_supplementary_data(xml_tree):
                     })
     return data
 
-def extract_table_data(table_wrap):
+def extract_table_data(table_wrap, override_layout=None):
     """
     Extracts table data from an XML table-wrap element, handling merged cells.
-    
+
     Args:
         table_wrap (ElementTree): The XML table-wrap element to extract data from.
-    
+        override_layout (str, optional): Forces 'layout' to this value instead of
+            running `determine_table_layout`'s heuristic. Must be one of
+            pdf_enum.SINGLE_COLUMN_PAGE_LABEL/DOUBLE_COLUMN_PAGE_LABEL, otherwise ignored.
+
     Returns:
         dict: A dictionary containing the following keys:
             - 'label': The text content of the table label element, or an empty string if not found.
@@ -617,7 +625,7 @@ def extract_table_data(table_wrap):
     header_spans = []
     row_spans = []
     table = table_wrap.find('.//table')
-    layout = determine_table_layout(table_wrap)
+    layout = determine_table_layout(table_wrap, override=override_layout)
 
     if table is not None:
         thead = table.find('.//thead')
@@ -651,19 +659,25 @@ def extract_table_data(table_wrap):
 
 _PATHOLOGICAL_CELL_LENGTH = 400
 
-def determine_table_layout(table_wrap):
+def determine_table_layout(table_wrap, override=None):
     """
     Determines the layout of a table based on the number of columns it contains,
-    considering merged cells, with a guard against a single excessively long cell
-    (which the column-count heuristic alone can't catch: a table can have few
-    columns and still need full width).
+    considering merged cells, with an escape hatch for an explicit override and a
+    guard against a single excessively long cell (which the column-count heuristic
+    alone can't catch: a table can have few columns and still need full width).
 
     Args:
         table_wrap (ElementTree): The XML table-wrap element to analyze.
+        override (str, optional): Forces this layout instead of running the heuristic.
+            Must be one of pdf_enum.SINGLE_COLUMN_PAGE_LABEL/DOUBLE_COLUMN_PAGE_LABEL,
+            otherwise ignored.
 
     Returns:
         str: A string indicating the table layout. Possible values are 'single-column-layout' and 'double-column-layout'.
     """
+    if override in (pdf_enum.SINGLE_COLUMN_PAGE_LABEL, pdf_enum.DOUBLE_COLUMN_PAGE_LABEL):
+        return override
+
     table = table_wrap.find('.//table')
     if table is not None:
         # Check both thead and tbody for maximum columns

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -1304,6 +1304,20 @@ class TestExtractTableData(unittest.TestCase):
             pdf_enum.DOUBLE_COLUMN_PAGE_LABEL,
         )
 
+    def test_extract_table_data_override_layout_wins_over_heuristic(self):
+        xml_str = "<table-wrap><table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>"
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(
+            table_wrap, override_layout=pdf_enum.SINGLE_COLUMN_PAGE_LABEL
+        )
+        self.assertEqual(result['layout'], pdf_enum.SINGLE_COLUMN_PAGE_LABEL)
+
+    def test_extract_table_data_invalid_override_falls_back_to_heuristic(self):
+        xml_str = "<table-wrap><table><tbody><tr><td>Data</td></tr></tbody></table></table-wrap>"
+        table_wrap = etree.fromstring(xml_str)
+        result = xml_pipe.extract_table_data(table_wrap, override_layout='not-a-real-layout')
+        self.assertEqual(result['layout'], pdf_enum.DOUBLE_COLUMN_PAGE_LABEL)
+
 
 class TestExtractBodyDataTableDedup(unittest.TestCase):
     """
@@ -1407,6 +1421,23 @@ class TestExtractBodyDataTableDedup(unittest.TestCase):
         child_sec = next(s for s in result if s['title'] == 'Child')
         self.assertEqual([t['label'] for t in parent_sec['tables']], ['Table 1'])
         self.assertEqual([t['label'] for t in child_sec['tables']], ['Table 2'])
+
+    def test_table_layout_overrides_reach_extract_table_data(self):
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Parent</title>'
+            '<table-wrap id="t1">'
+            '<label>Table 1</label>'
+            '<table><tbody><tr><td>Data</td></tr></tbody></table>'
+            '</table-wrap>'
+            '</sec>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(
+            xml, table_layout_overrides={'t1': pdf_enum.SINGLE_COLUMN_PAGE_LABEL}
+        )
+        self.assertEqual(result[0]['tables'][0]['layout'], pdf_enum.SINGLE_COLUMN_PAGE_LABEL)
 
 
 class TestExtractTransAbstractData(unittest.TestCase):

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -3,6 +3,7 @@ import unittest
 from lxml import etree
 
 from packtools.sps.formats.pdf.pipeline import xml as xml_pipe
+from packtools.sps.formats.pdf import enum as pdf_enum
 
 
 class TestExtractAbstractData(unittest.TestCase):
@@ -1284,6 +1285,24 @@ class TestExtractTableData(unittest.TestCase):
         table_wrap = etree.fromstring(xml_str)
         result = xml_pipe.extract_table_data(table_wrap)
         self.assertEqual(result['foot'], [])
+
+    def test_determine_table_layout_single_long_cell_forces_single_column(self):
+        long_text = "x" * 500
+        xml_str = f"<table-wrap><table><tbody><tr><td>{long_text}</td></tr></tbody></table></table-wrap>"
+        table_wrap = etree.fromstring(xml_str)
+        self.assertEqual(
+            xml_pipe.determine_table_layout(table_wrap),
+            pdf_enum.SINGLE_COLUMN_PAGE_LABEL,
+        )
+
+    def test_determine_table_layout_moderately_long_cell_stays_double_column(self):
+        moderate_text = "x" * 150
+        xml_str = f"<table-wrap><table><tbody><tr><td>{moderate_text}</td></tr></tbody></table></table-wrap>"
+        table_wrap = etree.fromstring(xml_str)
+        self.assertEqual(
+            xml_pipe.determine_table_layout(table_wrap),
+            pdf_enum.DOUBLE_COLUMN_PAGE_LABEL,
+        )
 
 
 class TestExtractBodyDataTableDedup(unittest.TestCase):


### PR DESCRIPTION

## O que esse PR faz?

Adiciona um canal opcional pra forçar o layout (`single-column-layout`/`double-column-layout`) de uma tabela específica, por `@id`, sem depender da heurística automática de `determine_table_layout`. É o mesmo padrão já usado pra figura (`decide_figure_layout` checa um override antes de calcular), agora também disponível pra tabela.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, `determine_table_layout(table_wrap, override=None)`: checa o override antes de rodar a heurística. O parâmetro é encanado de `extract_table_data(table_wrap, override_layout=None)` até `extract_body_data(xml_tree, table_layout_overrides=None)` (dict `{table_id: layout}`) até `pipeline_docx(xml_tree, data)`, lendo `data.get('table_layout_overrides')`.

## Como este poderia ser testado manualmente?

```python
from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
from packtools.sps.utils import xml_utils

xml_tree = xml_utils.get_xml_tree("tests/fixtures/pdf/a1.xml")
data = {
    "base_layout": "tests/fixtures/pdf/layout.docx",
    "table_layout_overrides": {"t1": "single-column-layout"},
}
document = docx_pipe.pipeline_docx(xml_tree, data)
```

Testes novos em `test_xml.py`: override válido vence a heurística, override inválido cai pro comportamento padrão, e o encanamento ponta a ponta desde `extract_body_data` até o `layout` final da tabela.

## Algum cenário de contexto que queira dar?

Não corrige nenhum bug específico, é a peça de "customização mínima" identificada numa auditoria mais ampla do gerador de PDF: mesmo com a heurística automática melhor calibrada (PR #1318), tabelas dentro do mesmo artigo podem legitimamente precisar de tratamento diferente (confirmado olhando o ground truth real de artigos publicados), e não há como prever isso só a partir do conteúdo. Este PR não implementa nenhuma fonte externa de override (isso é trabalho futuro, ligado à Fase 2 da issue #1278 de config por periódico), só abre o canal pra quando essa fonte existir, e já deixa disponível pra quem quiser chamar a API diretamente.

## Screenshots

Não aplicável, é um parâmetro novo, sem mudança de comportamento quando não usado (confirmado: toda a suíte `tests/sps/formats/pdf/` continua passando sem alteração de saída pros casos que não passam override).

## Quais são os tickets relevantes?

Closes #1319.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (parâmetro interno opcional, sem novas dependências ou superfícies expostas)

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
