### PR TITLE
fix: limita nome do periódico a 2 linhas no cabeçalho do PDF

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -115,7 +115,7 @@ def docx_journal_title_pipe(docx, journal_title_text, style_name='SCL Journal Ti
     first_page_header = docx_renderer.section.get_first_page_header(docx)
     para = docx_renderer.text.get_first_paragraph(first_page_header)
 
-    left_run = para.add_run(journal_title_text.replace(' ', '\n'))
+    left_run = para.add_run(_format_journal_title_two_lines(journal_title_text))
     left_run.style = docx.styles[style_name]
 
     return para
@@ -354,7 +354,7 @@ def docx_second_header_pipe(
     para = header.add_paragraph()
     para.style = docx.styles[paragraph_header_style_name]
 
-    r1 = para.add_run(journal_title.replace(' ', '\n'))
+    r1 = para.add_run(_format_journal_title_two_lines(journal_title))
     r1.style = docx.styles[paragraph_title_style_name]
 
     r2 = para.add_run(f'\t{article_title}')
@@ -496,6 +496,18 @@ def docx_supplementary_material_pipe(docx, footer_data, supplementary_data, sect
 # -----------------
 # Private helpers
 # -----------------
+
+def _format_journal_title_two_lines(journal_title_text):
+    """
+    Break a journal title into at most two lines for the masthead: the first
+    word on its own line, and every remaining word joined onto the second
+    line. A one-word title stays on a single line.
+    """
+    words = journal_title_text.split(' ')
+    if len(words) <= 1:
+        return journal_title_text
+    return f"{words[0]}\n{' '.join(words[1:])}"
+
 
 def _body_column_count():
     """Number of columns configured for the body, from PAGE_ATTRIBUTES."""

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from docx import Document
+from docx.enum.style import WD_STYLE_TYPE
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
 from packtools.sps.formats.pdf import enum as pdf_enum
@@ -12,9 +13,57 @@ class TestPipelineDocx(unittest.TestCase):
     ...
 
 
-class TestJournalTitlePipe(unittest.TestLoader):
-    # TODO
-    ...
+class TestFormatJournalTitleTwoLines(unittest.TestCase):
+    """
+    Regression tests for issue #1301: journal titles with more than 2 words
+    used to get one word per line (unbounded), pushing the rest of the page-1
+    header down. The first word stays on its own line and every remaining
+    word is joined onto a single second line, capping the masthead at 2 lines
+    regardless of how many words the title has.
+    """
+
+    def test_single_word_title_stays_on_one_line(self):
+        self.assertEqual(docx_pipe._format_journal_title_two_lines('Biology'), 'Biology')
+
+    def test_two_word_title_keeps_one_word_per_line(self):
+        self.assertEqual(
+            docx_pipe._format_journal_title_two_lines('Acta Amazonica'),
+            'Acta\nAmazonica',
+        )
+
+    def test_four_word_title_is_capped_at_two_lines(self):
+        self.assertEqual(
+            docx_pipe._format_journal_title_two_lines('Brazilian Journal of Biology'),
+            'Brazilian\nJournal of Biology',
+        )
+
+    def test_five_word_title_is_capped_at_two_lines(self):
+        self.assertEqual(
+            docx_pipe._format_journal_title_two_lines('Urbe. Revista Brasileira de Gestão Urbana'),
+            'Urbe.\nRevista Brasileira de Gestão Urbana',
+        )
+
+    def test_empty_title_returns_empty_string(self):
+        self.assertEqual(docx_pipe._format_journal_title_two_lines(''), '')
+
+
+class TestJournalTitlePipe(unittest.TestCase):
+
+    def setUp(self):
+        self.docx = Document()
+        self.docx.styles.add_style('SCL Journal Title Char', WD_STYLE_TYPE.CHARACTER)
+
+    def test_two_word_title_keeps_one_word_per_line(self):
+        para = docx_pipe.docx_journal_title_pipe(self.docx, 'Acta Amazonica')
+        self.assertEqual(para.runs[0].text, 'Acta\nAmazonica')
+
+    def test_multi_word_title_is_capped_at_two_lines(self):
+        para = docx_pipe.docx_journal_title_pipe(self.docx, 'Brazilian Journal of Biology')
+        self.assertEqual(para.runs[0].text, 'Brazilian\nJournal of Biology')
+
+    def test_run_uses_the_given_style(self):
+        para = docx_pipe.docx_journal_title_pipe(self.docx, 'Acta Amazonica')
+        self.assertEqual(para.runs[0].style.name, 'SCL Journal Title Char')
 
 
 class TestDocxDoiPipe(unittest.TestCase):
@@ -63,8 +112,31 @@ class TestDocxCiteAsPipe(unittest.TestCase):
 
 
 class TestDocxSecondHeaderPipe(unittest.TestCase):
-    # TODO
-    ...
+
+    def setUp(self):
+        self.docx = Document()
+        self.docx.styles.add_style('SCL Header Paragraph', WD_STYLE_TYPE.PARAGRAPH)
+        self.docx.styles.add_style('SCL Header Paragraph Char', WD_STYLE_TYPE.CHARACTER)
+        self.docx.styles.add_style('SCL Journal Title Char', WD_STYLE_TYPE.CHARACTER)
+
+    def _second_header_paragraph(self):
+        header = docx_pipe.docx_renderer.section.get_default_header(self.docx)
+        return header.paragraphs[-1]
+
+    def test_two_word_title_keeps_one_word_per_line(self):
+        docx_pipe.docx_second_header_pipe(self.docx, 'Acta Amazonica', 'Some Article Title')
+        para = self._second_header_paragraph()
+        self.assertEqual(para.runs[0].text, 'Acta\nAmazonica')
+
+    def test_multi_word_title_is_capped_at_two_lines(self):
+        docx_pipe.docx_second_header_pipe(self.docx, 'Brazilian Journal of Biology', 'Some Article Title')
+        para = self._second_header_paragraph()
+        self.assertEqual(para.runs[0].text, 'Brazilian\nJournal of Biology')
+
+    def test_article_title_is_appended_after_a_tab(self):
+        docx_pipe.docx_second_header_pipe(self.docx, 'Acta Amazonica', 'Some Article Title')
+        para = self._second_header_paragraph()
+        self.assertEqual(para.runs[1].text, '\tSome Article Title')
 
 
 class TestDocxSecondFooterPipe(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1301: o nome do periódico no cabeçalho do PDF (página 1 e páginas seguintes) era quebrado em uma linha por palavra, sem limite. Periódicos com nome de 3+ palavras (ex.: "Brazilian Journal of Biology") geravam 4+ linhas empilhadas, aumentando a área reservada ao título e empurrando o resto do cabeçalho da página 1 para baixo.

A correção limita sempre a no máximo 2 linhas: a primeira palavra fica em sua própria linha, e todas as demais são unidas na segunda linha. O comportamento atual para títulos de 2 palavras (ex.: "Acta Amazonica") é preservado sem alteração.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/docx.py`, nova função `_format_journal_title_two_lines`, usada em `docx_journal_title_pipe` (cabeçalho da página 1) e `docx_second_header_pipe` (cabeçalho das páginas seguintes) — os dois pontos que antes faziam `journal_title_text.replace(' ', '\n')`.

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a4.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a4.pdf --libreoffice-binary libreoffice
```
Testado também com o artigo real citado na issue (nome de periódico "Brazilian Journal of Biology", 4 palavras): antes ocupava 4 linhas, depois ocupa 2 (ver screenshot).

Testes automatizados: `pytest tests/sps/formats/pdf/pipeline/test_docx.py` (ou `pytest tests/sps/formats/pdf`).

## Algum cenário de contexto que queira dar?

Confirmei que o parágrafo do cabeçalho ocupa a largura útil total da página (sem tabela/caixa estreita limitando o texto) — o efeito de "uma palavra por linha" era inteiramente proposital no código (masthead empilhado), não uma consequência de espaço insuficiente. Por isso a correção só precisou limitar a contagem de linhas, sem precisar lidar com quebra automática por largura.

Como efeito colateral, corrigi também `TestJournalTitlePipe` em `test_docx.py`, que herdava de `unittest.TestLoader` em vez de `unittest.TestCase` e por isso nunca era coletada pelo pytest (nenhum teste rodava).

## Screenshots

<img width="1654" height="1388" alt="a5_1301_before_after" src="https://github.com/user-attachments/assets/17fae982-068b-4622-9a94-b9a592dc3571" />

## Quais são os tickets relevantes?

Closes #1301.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado). Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim
