### PR TITLE
fix: extrai RESUMO e keywords traduzidos completos, mesmo com marcação inline

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -213,14 +213,14 @@ def extract_trans_abstract_data(xml_tree, namespaces={'xml': 'http://www.w3.org/
 
         node_title = node.find('title')
         if node_title is not None:
-            item['title'] = node_title.text or ''
+            item['title'] = ''.join(node_title.itertext()).strip()
 
         item['lang'] = node.attrib.get(lang_attrib_name)
 
         abstract = []
         for p in node.findall('p'):
             if p is not None:
-                abstract.append(p.text or '')
+                abstract.append(''.join(p.itertext()).strip())
         item['content'] = ' '.join(abstract)
 
         data.append(item)
@@ -248,9 +248,11 @@ def extract_keywords_data(xml_tree, lang='en', namespaces={'xml': 'http://www.w3
     if kwd_group is not None:
         node_title = kwd_group.find('title')
         if node_title is not None:
-            data['title'] = node_title.text
+            data['title'] = ''.join(node_title.itertext()).strip()
 
-        data['keywords'] = ', '.join([kwd.text for kwd in kwd_group.findall('kwd')])
+        data['keywords'] = ', '.join(
+            ''.join(kwd.itertext()).strip() for kwd in kwd_group.findall('kwd')
+        )
 
     return data
 

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -864,6 +864,40 @@ class TestExtractKeywordsData(unittest.TestCase):
         result = xml_pipe.extract_keywords_data(xml)
         self.assertEqual(result, expected)
 
+    def test_extract_keywords_data_keyword_with_inline_markup(self):
+        """
+        Regression test for issue #1321: a <kwd> containing inline markup
+        (e.g. <italic>) used to be truncated at kwd.text, dropping the
+        italic text and everything after it within that keyword.
+        """
+        xml = etree.fromstring(
+            '<article>'
+            '<kwd-group xml:lang="en">'
+            '<title>Keywords</title>'
+            '<kwd>maize (<italic>Zea mays</italic> L.)</kwd>'
+            '<kwd>growth stimulation</kwd>'
+            '</kwd-group>'
+            '</article>'
+        )
+        expected = {
+            'title': 'Keywords',
+            'keywords': 'maize (Zea mays L.), growth stimulation'
+        }
+        result = xml_pipe.extract_keywords_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_keywords_data_title_with_inline_markup(self):
+        xml = etree.fromstring(
+            '<article>'
+            '<kwd-group xml:lang="en">'
+            '<title>Keywords<italic>*</italic></title>'
+            '<kwd>Keyword1</kwd>'
+            '</kwd-group>'
+            '</article>'
+        )
+        result = xml_pipe.extract_keywords_data(xml)
+        self.assertEqual(result['title'], 'Keywords*')
+
 
 class TestExtractReferencesData(unittest.TestCase):
 
@@ -1242,6 +1276,42 @@ class TestExtractTransAbstractData(unittest.TestCase):
             namespaces={'xml': 'http://custom.namespace'}
         )
         self.assertEqual(result, expected)
+
+    def test_extract_trans_abstract_data_paragraph_with_inline_markup(self):
+        """
+        Regression test for issue #1321: a <p> containing inline markup
+        (e.g. <italic>) used to be truncated at p.text, dropping the italic
+        text and everything after it in that paragraph.
+        """
+        xml = etree.fromstring(
+            '<article>'
+            '<trans-abstract xml:lang="pt">'
+            '<title>Resumo</title>'
+            '<p>Efeito do milho (<italic>Zea mays</italic> L.) na produtividade.</p>'
+            '</trans-abstract>'
+            '</article>'
+        )
+        expected = [
+            {
+                'lang': 'pt',
+                'title': 'Resumo',
+                'content': 'Efeito do milho (Zea mays L.) na produtividade.'
+            }
+        ]
+        result = xml_pipe.extract_trans_abstract_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_trans_abstract_data_title_with_inline_markup(self):
+        xml = etree.fromstring(
+            '<article>'
+            '<trans-abstract xml:lang="pt">'
+            '<title>Resumo<italic>*</italic></title>'
+            '<p>Texto.</p>'
+            '</trans-abstract>'
+            '</article>'
+        )
+        result = xml_pipe.extract_trans_abstract_data(xml)
+        self.assertEqual(result[0]['title'], 'Resumo*')
 
 
 class TestExtractFigureData(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1321: `<trans-abstract>` (RESUMO) e `<kwd>` (palavras-chave) eram truncados no primeiro elemento inline (ex.: `<italic>`) que aparecesse no meio do texto, descartando silenciosamente tudo depois dele.

`extract_trans_abstract_data` e `extract_keywords_data` (`packtools/sps/formats/pdf/pipeline/xml.py`) usavam `.text` diretamente (`p.text`, `kwd.text`, `node_title.text`), que no lxml só retorna o texto até o primeiro filho. A função irmã `extract_abstract_data` (mesmo arquivo) já tratava isso corretamente com `''.join(node.itertext()).strip()`.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, funções `extract_trans_abstract_data` e `extract_keywords_data` — ambas alinhadas ao padrão já usado por `extract_abstract_data`.

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a4.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a4.pdf --libreoffice-binary libreoffice
```

Testado também com o artigo real citado na issue (RESUMO e keyword com `<italic>` no meio): antes o RESUMO parava em "...biomassa do milho (" e a keyword virava "maize (", depois ambos aparecem completos (ver screenshot).

Testes automatizados: `pytest tests/sps/formats/pdf/pipeline/test_xml.py` (ou `pytest tests/sps/formats/pdf`).

## Algum cenário de contexto que queira dar?

Levantado a partir do corpus de teste de 26 artigos reais: RESUMO truncado em 3/26 artigos (perda de mais de 80% do parágrafo em pelo menos um caso), keyword truncada em 1/26 (afeta `en` e `pt`, já que é a mesma função por idioma).

## Screenshots

<img width="1654" height="1102" alt="a5_1321_before_after" src="https://github.com/user-attachments/assets/80a570a0-c714-4720-b028-d1ac16d91904" />

**Nota**: o screenshot acima também mostra o gap apertado entre "Palavras-chave:" e "1. INTRODUCTION" — isso é um problema separado (issue #1322), corrigido em #1325, fora do escopo deste PR. Aqui o que importa é o texto completo do RESUMO/Keywords, não o espaçamento ao redor.

## Quais são os tickets relevantes?

Closes #1321.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado). Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim

