### PR TITLE
fix: adiciona espaço depois do parágrafo de Keywords/Palavras-chave

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -1,3 +1,5 @@
+from docx.shared import Pt
+
 from packtools.sps.formats.pdf import enum as pdf_enum
 from packtools.sps.formats.pdf.pipeline import xml as xml_pipe
 from packtools.sps.formats.pdf.renderer import docx as docx_renderer
@@ -279,6 +281,11 @@ def docx_keyworks_pipe(
     """
     para = docx.add_paragraph()
     para.style = docx.styles[keywords_paragraph_style_name]
+    # SCL Paragraph Keywords has no space-after of its own (issue #1322), so a
+    # section title immediately following it (before=0) would otherwise sit
+    # right on top of it. Pt(5.65) matches SCL Paragraph's own space-after
+    # (113 twentieths of a point), keeping the same rhythm as body text.
+    para.paragraph_format.space_after = Pt(5.65)
 
     r1 = para.add_run(f'{keywords_title} ')
     r1.style = docx.styles[keywords_header_character_style_name]

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from docx import Document
+from docx.enum.style import WD_STYLE_TYPE
 
 from packtools.sps.formats.pdf.pipeline import docx as docx_pipe
 from packtools.sps.formats.pdf import enum as pdf_enum
@@ -53,8 +54,28 @@ class TestDocxAbstractPipe(unittest.TestCase):
 
 
 class TestDocxKeyworksPipe(unittest.TestCase):
-    # TODO
-    ...
+    """
+    Regression tests for issue #1322: the Keywords/Palavras-chave paragraph
+    had no space-after of its own, so the section title immediately
+    following it (space-before=0) collapsed onto it with almost no gap.
+    """
+
+    def setUp(self):
+        self.docx = Document()
+        self.docx.styles.add_style('SCL Paragraph Keywords', WD_STYLE_TYPE.PARAGRAPH)
+        self.docx.styles.add_style('SCL Paragraph Keywords Header Char', WD_STYLE_TYPE.CHARACTER)
+        self.docx.styles.add_style('SCL Paragraph Keywords Char', WD_STYLE_TYPE.CHARACTER)
+
+    def test_paragraph_has_space_after(self):
+        docx_pipe.docx_keyworks_pipe(self.docx, 'Keywords:', 'one, two, three')
+        para = self.docx.paragraphs[-1]
+        self.assertGreater(para.paragraph_format.space_after.pt, 0)
+
+    def test_title_and_content_runs(self):
+        docx_pipe.docx_keyworks_pipe(self.docx, 'Keywords:', 'one, two, three')
+        para = self.docx.paragraphs[-1]
+        self.assertEqual(para.runs[0].text, 'Keywords: ')
+        self.assertEqual(para.runs[1].text, 'one, two, three')
 
 
 class TestDocxCiteAsPipe(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1322: a transição entre a última linha de Keywords/Palavras-chave e o primeiro título de seção do corpo do artigo (ex.: "1. INTRODUCTION") ficava praticamente colada, sem o respiro visual presente nas demais transições da página.

No template `layout.docx`, `SCL Section Title` (títulos de seção) tem `before=0` e depende do `after` do parágrafo anterior para ter espaçamento. `SCL Paragraph` (texto normal) tem `after=113` (~5,6pt), o que dá o respiro visto antes de títulos como "2. MATERIALS AND METHODS". `SCL Paragraph Keywords` (linha "Keywords:"/"Palavras-chave:") não definia `after` nenhum.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/docx.py`, função `docx_keyworks_pipe` — define `paragraph_format.space_after = Pt(5.65)` explicitamente no parágrafo de Keywords, em vez de editar o template binário `layout.docx`.

## Como este poderia ser testado manualmente?

```bash
python -m packtools.sps.formats.pdf_generator \
    -i tests/fixtures/pdf/a4.xml \
    -l tests/fixtures/pdf/layout.docx \
    -o /tmp/a4.pdf --libreoffice-binary libreoffice
```

Testado também com o artigo real citado na issue: gap entre "Palavras-chave:" e "1. INTRODUCTION" media ~1,6pt (via `pdftotext -bbox`), passou para ~7,3pt depois da correção (ver screenshot).

Testes automatizados: `pytest tests/sps/formats/pdf/pipeline/test_docx.py` (ou `pytest tests/sps/formats/pdf`).

## Algum cenário de contexto que queira dar?

Medido no corpus de 26 artigos reais: gap apertado nessa transição específica confirmado em pelo menos 18/26 artigos (os demais têm layout de página 1 diferente e não foram comparáveis pelo mesmo método) — o problema não é específico de um artigo, é sistemático sempre que há Keywords/Palavras-chave imediatamente antes do primeiro título de seção.

Optei por corrigir via `python-docx` (setar `space_after` explicitamente no código) em vez de editar `word/styles.xml` dentro do `layout.docx`, para manter a mudança revisável em texto/diff normal e testável, seguindo o padrão já usado em `renderer/docx/table.py` (`paragraph.paragraph_format.space_after = Pt(0)`).

## Screenshots

<img width="1654" height="378" alt="a5_1322_before_after" src="https://github.com/user-attachments/assets/37bb00a9-38dd-4d33-8c92-b2f3793c6eb5" />

**Nota**: o screenshot mostra a keyword "milho (," ainda truncada em ambos os lados (antes/depois) — isso é um problema separado (issue #1321), corrigido em #1324, fora do escopo deste PR. Aqui o que importa é o espaçamento antes de "1. INTRODUCTION", não o texto da keyword.

## Quais são os tickets relevantes?

Closes #1322.

## Referências

N/A

---

## Segurança da informação (NSI.04)

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim
- [x] Não aplicável a este PR (justifique): Trivy/SonarQube não estão configurados neste repositório (packtools é biblioteca Python, não serviço containerizado). Os gates automáticos reais deste repositório (Snyk e GitGuardian) rodam via CI neste PR.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim

