### PR TITLE
fix: omite VOL./issue vazio no rodapé do PDF quando o XML não tem o dado

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -391,7 +391,7 @@ def docx_second_footer_pipe(docx, footer_data, paragraph_style_name='SCL Footer'
 
     docx_renderer.text.add_field_run(para, "PAGE \\* MERGEFORMAT")
 
-    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
+    para.add_run(f" | {_format_vol_issue_year(footer_data)}")
 
 def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL Footer'):
     """
@@ -416,7 +416,7 @@ def docx_page_vol_issue_year_pipe(docx, footer_data, paragraph_style_name='SCL F
 
     para.style = docx.styles[paragraph_style_name]
     docx_renderer.text.add_field_run(para, "PAGE \\* MERGEFORMAT")
-    para.add_run(f" | VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
+    para.add_run(f" | {_format_vol_issue_year(footer_data)}")
 
 def docx_body_pipe(docx, body_data):
     """
@@ -501,7 +501,7 @@ def docx_supplementary_material_pipe(docx, footer_data, supplementary_data, sect
 
     # No PAGE field is added here: supplementary material has its own
     # pagination, independent of the article body, so no leading " | " either.
-    para.add_run(f"VOL. {footer_data['volume']} ({footer_data['issue']}) {footer_data['year']}: {footer_data['location_label']}")
+    para.add_run(_format_vol_issue_year(footer_data))
 
     docx_renderer.section.setup_section_columns(section, 1, pdf_enum.TWO_COLUMNS_SPACING)
 
@@ -517,6 +517,20 @@ def docx_supplementary_material_pipe(docx, footer_data, supplementary_data, sect
 # -----------------
 # Private helpers
 # -----------------
+
+def _format_vol_issue_year(footer_data):
+    """
+    Format 'VOL. {volume} ({issue}) {year}: {location}', dropping the VOL.
+    segment or the issue parentheses when that value is missing from the
+    XML front matter (e.g. ahead-of-print articles carry no issue).
+    """
+    parts = []
+    if footer_data['volume']:
+        parts.append(f"VOL. {footer_data['volume']}")
+    if footer_data['issue']:
+        parts.append(f"({footer_data['issue']})")
+    parts.append(f"{footer_data['year']}: {footer_data['location_label']}")
+    return ' '.join(parts)
 
 def _format_journal_title_two_lines(journal_title_text):
     """

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -228,6 +228,17 @@ class TestDocxSecondFooterPipe(unittest.TestCase):
         self.assertIn('VOL. 33 (3) 2024: e282794', para.text)
         self.assertNotIn(': -', para.text)
 
+    def test_omits_issue_parentheses_when_issue_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '86', 'issue': '', 'year': '2026',
+                       'fpage': '', 'lpage': '', 'location_label': 'e301043'}
+        docx_pipe.docx_second_footer_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_second_footer(docx)
+        para = footer.paragraphs[0]
+        self.assertIn('VOL. 86 2026: e301043', para.text)
+        self.assertNotIn('()', para.text)
+
 
 class TestDocxPageVolIssueYearPipe(unittest.TestCase):
 
@@ -251,6 +262,17 @@ class TestDocxPageVolIssueYearPipe(unittest.TestCase):
         para = footer.paragraphs[-1]
         self.assertIn('VOL. 33 (3) 2024: e282794', para.text)
         self.assertNotIn(': -', para.text)
+
+    def test_omits_issue_parentheses_when_issue_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '86', 'issue': '', 'year': '2026',
+                       'fpage': '', 'lpage': '', 'location_label': 'e301043'}
+        docx_pipe.docx_page_vol_issue_year_pipe(docx, footer_data)
+
+        footer = docx_renderer.section.get_first_page_footer(docx)
+        para = footer.paragraphs[-1]
+        self.assertIn('VOL. 86 2026: e301043', para.text)
+        self.assertNotIn('()', para.text)
 
 
 class TestDocxBodyPipe(unittest.TestCase):
@@ -293,6 +315,33 @@ class TestDocxSupplementaryMaterialPipe(unittest.TestCase):
         footer = docx.sections[-1].footer
         para = footer.paragraphs[-1]
         self.assertEqual(para.text, 'VOL. 33 (3) 2024: e282794')
+
+    def test_omits_issue_parentheses_when_issue_is_absent(self):
+        docx = _docx_with_layout_styles()
+        footer_data = {'volume': '86', 'issue': '', 'year': '2026',
+                       'fpage': '', 'lpage': '', 'location_label': 'e301043'}
+        docx_pipe.docx_supplementary_material_pipe(
+            docx, footer_data, {'title': 'Supplementary Material', 'elements': []}
+        )
+
+        footer = docx.sections[-1].footer
+        para = footer.paragraphs[-1]
+        self.assertEqual(para.text, 'VOL. 86 2026: e301043')
+
+
+class TestFormatVolIssueYear(unittest.TestCase):
+
+    def test_keeps_both_when_present(self):
+        footer_data = {'volume': '10', 'issue': '2', 'year': '2023', 'location_label': '123-130'}
+        self.assertEqual(docx_pipe._format_vol_issue_year(footer_data), 'VOL. 10 (2) 2023: 123-130')
+
+    def test_omits_issue_parentheses_when_issue_is_absent(self):
+        footer_data = {'volume': '86', 'issue': '', 'year': '2026', 'location_label': 'e301043'}
+        self.assertEqual(docx_pipe._format_vol_issue_year(footer_data), 'VOL. 86 2026: e301043')
+
+    def test_omits_vol_label_when_volume_is_absent(self):
+        footer_data = {'volume': '', 'issue': '67', 'year': '2023', 'location_label': 'e236720'}
+        self.assertEqual(docx_pipe._format_vol_issue_year(footer_data), '(67) 2023: e236720')
 
 
 class TestBodyColumnConfiguration(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige o rodapé de páginas geradas pelo `pdf_generator`: quando o artigo não tem `<volume>` ou `<issue>` no XML (comum em artigos ahead-of-print/continuous publication), o rodapé imprimia o campo vazio mesmo assim — `VOL. 86 () 2026: e301043` (parênteses vazios, sem issue) ou `VOL.  (67) 2023: e236720` (espaço duplo, sem volume).

`docx_second_footer_pipe`, `docx_page_vol_issue_year_pipe` e `docx_supplementary_material_pipe` montavam essa string com o mesmo f-string fixo em três lugares. Extraí um helper `_format_vol_issue_year(footer_data)` que omite o rótulo `VOL.` quando falta volume e os parênteses quando falta issue, e passei a reutilizá-lo nos três pontos.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/docx.py` — a função `_format_vol_issue_year` (helpers privados, final do arquivo) e os três pontos que passaram a chamá-la.

## Como este poderia ser testado manualmente?

```
python -m packtools.sps.formats.pdf_generator \
  -i <artigo-sem-issue-ou-volume>.xml \
  -l layout.docx \
  -o saida.pdf \
  --libreoffice-binary libreoffice
```
Conferir o rodapé da página 1 e das páginas internas.

## Algum cenário de contexto que queira dar?

Encontrado revisando visualmente o corpus de teste de 26 artigos reais (`layout_examples_rafael/corpus/`): `a5.xml` (Brazilian Journal of Biology) não tem `<issue>` no front matter; `a18.xml` (Cadernos Pagu) não tem `<volume>`. Os dois casos reais de dado ausente que motivaram a correção.

## Screenshots

<img width="941" height="656" alt="item2_before_after" src="https://github.com/user-attachments/assets/28553a7e-c73a-4105-8d21-227e849c6faf" />

## Quais são os tickets relevantes?

Nenhuma issue aberta associada; achado durante revisão visual do corpus de teste do gerador de PDF.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança isolada de formatação de string, sem I/O externo ou entrada não confiável

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8r2LRJ3PGTT9vLaPtb373
