### PR TITLE
fix: espaçamento entre linhas mais compacto em legenda e referência

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -459,6 +459,11 @@ def docx_references_pipe(
     for reference in references:
         paragraph = docx.add_paragraph(reference)
         paragraph.style = docx.styles[paragraph_style_name]
+        # SCL Paragraph Reference has no line_spacing of its own and uses
+        # the same font size as body text, so a reference that wraps to
+        # multiple lines rendered with the same loose spacing as a body
+        # paragraph, with no visual distinction between entries.
+        paragraph.paragraph_format.line_spacing = 1.0
 
 def docx_acknowledgments_pipe(docx, acknowledgment_title, acknowledgement_paragraphs, paragraph_section_style_name='SCL Section Title'):
     """

--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -298,6 +298,12 @@ def _add_caption(docx, figure_data, header_style_name):
         r_cap = p.add_run(figure_data['caption'])
         r_cap.bold = False
 
+    # Single line spacing regardless of whether the named style resolves:
+    # SCL Table Heading has no line_spacing of its own, so a multi-line
+    # caption would otherwise fall back to the same loose spacing as body
+    # text (only the smaller caption font made it look tighter).
+    p.paragraph_format.line_spacing = 1.0
+
     try:
         p.style = docx.styles[header_style_name]
     except KeyError:

--- a/packtools/sps/formats/pdf/renderer/docx/table.py
+++ b/packtools/sps/formats/pdf/renderer/docx/table.py
@@ -177,13 +177,19 @@ def _add_caption_paragraph(docx, table_data, header_style_name):
 	if table_data.get('title'):
 		r = p.add_run(table_data['title'])
 		r.bold = False
-	
+
+	# Single line spacing regardless of whether the named style resolves:
+	# SCL Table Heading has no line_spacing of its own, so a multi-line
+	# caption would otherwise fall back to the same loose spacing as body
+	# text (only the smaller caption font made it look tighter).
+	p.paragraph_format.line_spacing = 1.0
+
 	try:
 		p.style = docx.styles[header_style_name]
 		p.paragraph_format.keep_with_next = True
 	except Exception:
 		pass
-	
+
 	return p
 
 def _add_table_foot_paragraphs(docx, table_data):

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -259,8 +259,19 @@ class TestDocxBodyPipe(unittest.TestCase):
 
 
 class TestDocxReferencesPipe(unittest.TestCase):
-    # TODO
-    ...
+    """
+    Regression: SCL Paragraph Reference uses the same font size as body
+    text and has no line_spacing of its own, so a reference wrapping to
+    multiple lines rendered with the same loose spacing as a body
+    paragraph. Line spacing is now set explicitly on each reference
+    paragraph.
+    """
+
+    def test_reference_has_single_line_spacing(self):
+        docx = _docx_with_layout_styles()
+        docx_pipe.docx_references_pipe(docx, references=['Author A. Title B. Journal C. 2020.'])
+        para = docx.paragraphs[-1]
+        self.assertEqual(para.paragraph_format.line_spacing, 1.0)
 
 
 class TestDocxAcknowledgmentsPipe(unittest.TestCase):

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -7,12 +7,37 @@ from docx.shared import Cm
 from PIL import Image
 
 from packtools.sps.formats.pdf.renderer.docx.figure import (
+    _add_caption,
     _infer_image_dpi,
     _natural_width_capped,
     add_figure,
     decide_figure_layout,
 )
 from packtools.sps.formats.pdf import enum as pdf_enum
+
+
+class TestAddCaption(unittest.TestCase):
+    """
+    Regression: the caption paragraph's own style (SCL Table Heading) has no
+    line_spacing, so it fell back to the same loose spacing as body text -
+    only the smaller caption font size made it look somewhat tighter. Line
+    spacing is now set explicitly, independent of whether the named style
+    resolves.
+    """
+
+    def test_caption_has_single_line_spacing(self):
+        docx = Document()
+        docx.add_paragraph()
+        _add_caption(docx, {'label': 'Figure 1', 'caption': 'A caption'}, 'SCL Table Heading')
+        p = docx.paragraphs[-1]
+        self.assertEqual(p.paragraph_format.line_spacing, 1.0)
+
+    def test_line_spacing_set_even_when_named_style_is_missing(self):
+        docx = Document()
+        docx.add_paragraph()
+        _add_caption(docx, {'label': 'Figure 1', 'caption': 'A caption'}, 'Does Not Exist')
+        p = docx.paragraphs[-1]
+        self.assertEqual(p.paragraph_format.line_spacing, 1.0)
 
 
 class TestDecideFigureLayoutUnits(unittest.TestCase):

--- a/tests/sps/formats/pdf/renderer/docx/test_table.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_table.py
@@ -3,7 +3,7 @@ import unittest
 from docx import Document
 from docx.shared import Cm
 
-from packtools.sps.formats.pdf.renderer.docx.table import _compute_table_width, add_table
+from packtools.sps.formats.pdf.renderer.docx.table import _compute_table_width, _add_caption_paragraph, add_table
 from packtools.sps.formats.pdf import enum as pdf_enum
 
 
@@ -47,6 +47,30 @@ class TestComputeTableWidth(unittest.TestCase):
         )
         self.assertEqual(table_width, content_width)
         self.assertEqual(layout, pdf_enum.SINGLE_COLUMN_PAGE_LABEL)
+
+
+class TestAddCaptionParagraph(unittest.TestCase):
+    """
+    Regression: the caption paragraph's own style (SCL Table Heading) has no
+    line_spacing, so it fell back to the same loose spacing as body text -
+    only the smaller caption font size made it look somewhat tighter. Line
+    spacing is now set explicitly, independent of whether the named style
+    resolves.
+    """
+
+    def test_caption_has_single_line_spacing(self):
+        docx = Document()
+        p = _add_caption_paragraph(
+            docx, {'label': 'Table 1', 'title': 'A caption'}, 'SCL Table Heading'
+        )
+        self.assertEqual(p.paragraph_format.line_spacing, 1.0)
+
+    def test_line_spacing_set_even_when_named_style_is_missing(self):
+        docx = Document()
+        p = _add_caption_paragraph(
+            docx, {'label': 'Table 1', 'title': 'A caption'}, 'Does Not Exist'
+        )
+        self.assertEqual(p.paragraph_format.line_spacing, 1.0)
 
 
 class TestAddTableFoot(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Reduz o espaçamento entre linhas de legendas (figuras e tabelas) e de cada referência bibliográfica no `pdf_generator`, para não ficarem tão "soltas" quanto o texto do corpo.

`SCL Table Heading` (usado nas legendas) e `SCL Paragraph Reference` não têm `line_spacing` próprio no template. A legenda só parecia um pouco mais compacta que o corpo por usar fonte 7pt (vs 8pt do corpo) — efeito proporcional da fonte, não espaçamento proposital. A referência usa a **mesma** fonte 8pt do corpo, então renderizava com espaçamento idêntico ao texto corrido, sem nenhuma diferenciação visual.

Medi em pixels (200dpi) contra o corpus real: a legenda da Figura 2 de `a13.xml` tinha ~29.5px de distância entre linhas, proporcionalmente igual ao corpo. `SCL Affiliation` (que já tem `line_spacing=1.0` explícito no template, de um fix anterior) mede ~26px. Apliquei `paragraph_format.line_spacing = 1.0` direto no código — mesmo padrão já usado em `table.py` para célula de tabela — na legenda de tabela, legenda de figura e em cada parágrafo de referência. Resultado: a legenda cai para ~25.5px, equivalente ao das afiliações.

## Onde a revisão poderia começar?

- `packtools/sps/formats/pdf/renderer/docx/table.py` — `_add_caption_paragraph`
- `packtools/sps/formats/pdf/renderer/docx/figure.py` — `_add_caption`
- `packtools/sps/formats/pdf/pipeline/docx.py` — `docx_references_pipe`

Em ambas as legendas, o `line_spacing` é setado **antes** do `try/except` que aplica o nome do estilo, para não depender de o estilo resolver.

## Como este poderia ser testado manualmente?

```
python -m packtools.sps.formats.pdf_generator \
  -i <artigo-com-legenda-ou-referencia-longa>.xml \
  -l layout.docx \
  -o saida.pdf \
  --libreoffice-binary libreoffice
```
Conferir uma legenda de figura/tabela com 2+ linhas e uma referência com 2+ linhas.

## Algum cenário de contexto que queira dar?

Achado revisando visualmente o corpus de teste de 26 artigos reais (`layout_examples_rafael/corpus/`). Ao investigar, descartei um terceiro item do mesmo lote (afiliação de autor): medi e confirmei que `SCL Affiliation` já tem `line_spacing=1.0` explícito no template, então já estava correto — o pitch medido (~26px) já é mais apertado do que a fonte 7pt sozinha explicaria.

## Screenshots

<img width="1532" height="886" alt="itemB_before_after" src="https://github.com/user-attachments/assets/cbef7d88-7b6b-4a86-a12f-0841ca52fde7" />

## Quais são os tickets relevantes?

Nenhuma issue aberta associada; achado durante revisão visual do corpus de teste do gerador de PDF.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança isolada de formatação de espaçamento (propriedade de parágrafo do python-docx), sem I/O externo ou entrada não confiável

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8r2LRJ3PGTT9vLaPtb373
