### PR TITLE
fix: não imprime afiliação duplicada não referenciada por nenhum contrib

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -112,6 +112,7 @@ def extract_contrib_data(xml_tree):
     contrib_group = xml_tree.find('.//contrib-group')
     if contrib_group is not None:
         aff_mapping = {}
+        referenced_aff_ids = set()
 
         for aff in xml_tree.findall('.//aff'):
             aff_id = aff.get('id')
@@ -140,12 +141,30 @@ def extract_contrib_data(xml_tree):
                                 full_name += label
                     full_name += corresp_mark
                     authors_names.append(full_name)
-        
-        for aff in xml_tree.findall('.//aff'):
+
+            for xref in contrib.findall('.//xref[@ref-type="aff"]'):
+                rid = xref.get('rid')
+                if rid:
+                    referenced_aff_ids.add(rid)
+
+        # Some SciELO packages carry duplicate/orphaned <aff> elements (seen
+        # in 7/26 of the real test corpus) that aren't referenced by any
+        # contributor's xref - e.g. a second, unused copy of the same
+        # affiliations under ids like aff1e/aff0100/aff1s, or (in one case)
+        # a full second set aff13-aff24 duplicating aff1-aff12. The id
+        # suffix convention isn't consistent enough to filter on, but none
+        # of these duplicates are ever cited, so restrict the printed list
+        # to affiliations actually referenced. Falls back to every <aff> if
+        # none are referenced at all (defensive; not seen in practice).
+        affs_to_print = xml_tree.findall('.//aff')
+        if referenced_aff_ids:
+            affs_to_print = [aff for aff in affs_to_print if aff.get('id') in referenced_aff_ids]
+
+        for aff in affs_to_print:
             label = aff.find('label').text if aff.find('label') is not None else ''
             institution = aff.find('institution[@content-type="original"]')
             institution_name = institution.text if institution is not None else ''
-            
+
             if institution_name:
                 aff_info = f"{label}[^] {institution_name}"
                 affiliations.append(aff_info)

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -109,12 +109,14 @@ def extract_contrib_data(xml_tree):
     affiliations = []
     corresponding_author = ''
 
-    contrib_group = xml_tree.find('.//contrib-group')
+    article_meta = xml_tree.find('./front/article-meta')
+    metadata_scope = article_meta if article_meta is not None else xml_tree
+    contrib_group = metadata_scope.find('.//contrib-group')
     if contrib_group is not None:
         aff_mapping = {}
-        referenced_aff_ids = set()
+        affs = metadata_scope.findall('.//aff')
 
-        for aff in xml_tree.findall('.//aff'):
+        for aff in affs:
             aff_id = aff.get('id')
             label = aff.find('label').text if aff.find('label') is not None else ''
             institution = aff.find('institution[@content-type="original"]')
@@ -142,25 +144,7 @@ def extract_contrib_data(xml_tree):
                     full_name += corresp_mark
                     authors_names.append(full_name)
 
-            for xref in contrib.findall('.//xref[@ref-type="aff"]'):
-                rid = xref.get('rid')
-                if rid:
-                    referenced_aff_ids.add(rid)
-
-        # Some SciELO packages carry duplicate/orphaned <aff> elements (seen
-        # in 7/26 of the real test corpus) that aren't referenced by any
-        # contributor's xref - e.g. a second, unused copy of the same
-        # affiliations under ids like aff1e/aff0100/aff1s, or (in one case)
-        # a full second set aff13-aff24 duplicating aff1-aff12. The id
-        # suffix convention isn't consistent enough to filter on, but none
-        # of these duplicates are ever cited, so restrict the printed list
-        # to affiliations actually referenced. Falls back to every <aff> if
-        # none are referenced at all (defensive; not seen in practice).
-        affs_to_print = xml_tree.findall('.//aff')
-        if referenced_aff_ids:
-            affs_to_print = [aff for aff in affs_to_print if aff.get('id') in referenced_aff_ids]
-
-        for aff in affs_to_print:
+        for aff in affs:
             label = aff.find('label').text if aff.find('label') is not None else ''
             institution = aff.find('institution[@content-type="original"]')
             institution_name = institution.text if institution is not None else ''

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -644,6 +644,99 @@ class TestExtractContribData(unittest.TestCase):
         self.assertEqual(result['authors_names'], ['John Smith[^]'])
         self.assertEqual(result['affiliations'], ['[^] University X'])
 
+    def test_unreferenced_duplicate_affiliation_is_not_printed(self):
+        # Regression: some SciELO packages carry a duplicate/orphaned <aff>
+        # that no contributor's xref points to (seen in a9.xml of the real
+        # test corpus: aff1e/aff2e duplicate aff1/aff2 under a different id
+        # suffix). findall('.//aff') picked up every <aff> in the document
+        # regardless of whether any contrib actually cited it, so the
+        # affiliation printed twice.
+        xml = etree.fromstring("""
+            <article>
+                <contrib-group>
+                    <contrib>
+                        <name>
+                            <surname>Smith</surname>
+                            <given-names>John</given-names>
+                        </name>
+                        <xref ref-type="aff" rid="aff1"/>
+                    </contrib>
+                </contrib-group>
+                <aff id="aff1">
+                    <label>I</label>
+                    <institution content-type="original">University A</institution>
+                </aff>
+                <aff id="aff1e">
+                    <label>I</label>
+                    <institution content-type="original">University A</institution>
+                </aff>
+            </article>
+        """)
+        result = xml_pipe.extract_contrib_data(xml)
+        self.assertEqual(result['affiliations'], ['I[^] University A'])
+
+    def test_all_referenced_affiliations_are_kept_regardless_of_id_pattern(self):
+        # The duplicate <aff>'s id doesn't follow one fixed naming
+        # convention across real packages (seen: aff1e, aff0100, aff1s, and
+        # a fully separate aff13-aff24 numbering) - the fix must not assume
+        # one, and must not drop a legitimately different affiliation that
+        # simply happens to use an unusual id.
+        xml = etree.fromstring("""
+            <article>
+                <contrib-group>
+                    <contrib>
+                        <name>
+                            <surname>Smith</surname>
+                            <given-names>John</given-names>
+                        </name>
+                        <xref ref-type="aff" rid="aff01"/>
+                    </contrib>
+                    <contrib>
+                        <name>
+                            <surname>Doe</surname>
+                            <given-names>Jane</given-names>
+                        </name>
+                        <xref ref-type="aff" rid="aff0100"/>
+                    </contrib>
+                </contrib-group>
+                <aff id="aff01">
+                    <label>1</label>
+                    <institution content-type="original">University A</institution>
+                </aff>
+                <aff id="aff0100">
+                    <label>2</label>
+                    <institution content-type="original">University B</institution>
+                </aff>
+            </article>
+        """)
+        result = xml_pipe.extract_contrib_data(xml)
+        self.assertEqual(
+            result['affiliations'],
+            ['1[^] University A', '2[^] University B'],
+        )
+
+    def test_falls_back_to_every_affiliation_when_none_are_referenced(self):
+        # Defensive: an article with no aff xrefs at all (not seen in the
+        # real corpus) must not end up with an empty affiliation list.
+        xml = etree.fromstring("""
+            <article>
+                <contrib-group>
+                    <contrib>
+                        <name>
+                            <surname>Smith</surname>
+                            <given-names>John</given-names>
+                        </name>
+                    </contrib>
+                </contrib-group>
+                <aff id="aff1">
+                    <label>1</label>
+                    <institution content-type="original">University A</institution>
+                </aff>
+            </article>
+        """)
+        result = xml_pipe.extract_contrib_data(xml)
+        self.assertEqual(result['affiliations'], ['1[^] University A'])
+
 
 class TestExtractDOI(unittest.TestCase):
 

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -688,38 +688,37 @@ class TestExtractContribData(unittest.TestCase):
         result = xml_pipe.extract_contrib_data(xml)
         self.assertEqual(result['affiliations'], ['I[^] University A'])
 
-    def test_all_referenced_affiliations_are_kept_regardless_of_id_pattern(self):
-        # The duplicate <aff>'s id doesn't follow one fixed naming
-        # convention across real packages (seen: aff1e, aff0100, aff1s, and
-        # a fully separate aff13-aff24 numbering) - the fix must not assume
-        # one, and must not drop a legitimately different affiliation that
-        # simply happens to use an unusual id.
+    def test_main_article_affiliations_are_kept_regardless_of_id_pattern(self):
         xml = etree.fromstring("""
             <article>
-                <contrib-group>
-                    <contrib>
-                        <name>
-                            <surname>Smith</surname>
-                            <given-names>John</given-names>
-                        </name>
-                        <xref ref-type="aff" rid="aff01"/>
-                    </contrib>
-                    <contrib>
-                        <name>
-                            <surname>Doe</surname>
-                            <given-names>Jane</given-names>
-                        </name>
-                        <xref ref-type="aff" rid="aff0100"/>
-                    </contrib>
-                </contrib-group>
-                <aff id="aff01">
-                    <label>1</label>
-                    <institution content-type="original">University A</institution>
-                </aff>
-                <aff id="aff0100">
-                    <label>2</label>
-                    <institution content-type="original">University B</institution>
-                </aff>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib>
+                                <name>
+                                    <surname>Smith</surname>
+                                    <given-names>John</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff01"/>
+                            </contrib>
+                            <contrib>
+                                <name>
+                                    <surname>Doe</surname>
+                                    <given-names>Jane</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff0100"/>
+                            </contrib>
+                        </contrib-group>
+                        <aff id="aff01">
+                            <label>1</label>
+                            <institution content-type="original">University A</institution>
+                        </aff>
+                        <aff id="aff0100">
+                            <label>2</label>
+                            <institution content-type="original">University B</institution>
+                        </aff>
+                    </article-meta>
+                </front>
             </article>
         """)
         result = xml_pipe.extract_contrib_data(xml)
@@ -728,23 +727,33 @@ class TestExtractContribData(unittest.TestCase):
             ['1[^] University A', '2[^] University B'],
         )
 
-    def test_falls_back_to_every_affiliation_when_none_are_referenced(self):
-        # Defensive: an article with no aff xrefs at all (not seen in the
-        # real corpus) must not end up with an empty affiliation list.
+    def test_main_article_affiliation_without_xref_is_printed(self):
         xml = etree.fromstring("""
             <article>
-                <contrib-group>
-                    <contrib>
-                        <name>
-                            <surname>Smith</surname>
-                            <given-names>John</given-names>
-                        </name>
-                    </contrib>
-                </contrib-group>
-                <aff id="aff1">
-                    <label>1</label>
-                    <institution content-type="original">University A</institution>
-                </aff>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib>
+                                <name>
+                                    <surname>Smith</surname>
+                                    <given-names>John</given-names>
+                                </name>
+                            </contrib>
+                        </contrib-group>
+                        <aff id="aff1">
+                            <label>1</label>
+                            <institution content-type="original">University A</institution>
+                        </aff>
+                    </article-meta>
+                </front>
+                <sub-article article-type="translation">
+                    <front-stub>
+                        <aff id="aff1e">
+                            <label>1</label>
+                            <institution content-type="original">Universidade A</institution>
+                        </aff>
+                    </front-stub>
+                </sub-article>
             </article>
         """)
         result = xml_pipe.extract_contrib_data(xml)

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -644,32 +644,45 @@ class TestExtractContribData(unittest.TestCase):
         self.assertEqual(result['authors_names'], ['John Smith[^]'])
         self.assertEqual(result['affiliations'], ['[^] University X'])
 
-    def test_unreferenced_duplicate_affiliation_is_not_printed(self):
-        # Regression: some SciELO packages carry a duplicate/orphaned <aff>
-        # that no contributor's xref points to (seen in a9.xml of the real
-        # test corpus: aff1e/aff2e duplicate aff1/aff2 under a different id
-        # suffix). findall('.//aff') picked up every <aff> in the document
-        # regardless of whether any contrib actually cited it, so the
-        # affiliation printed twice.
+    def test_subarticle_affiliation_is_not_printed(self):
+        # Regression: translated affiliations in a sub-article must not be
+        # included in the affiliation list of the main article.
         xml = etree.fromstring("""
             <article>
-                <contrib-group>
-                    <contrib>
-                        <name>
-                            <surname>Smith</surname>
-                            <given-names>John</given-names>
-                        </name>
-                        <xref ref-type="aff" rid="aff1"/>
-                    </contrib>
-                </contrib-group>
-                <aff id="aff1">
-                    <label>I</label>
-                    <institution content-type="original">University A</institution>
-                </aff>
-                <aff id="aff1e">
-                    <label>I</label>
-                    <institution content-type="original">University A</institution>
-                </aff>
+                <front>
+                    <article-meta>
+                        <contrib-group>
+                            <contrib>
+                                <name>
+                                    <surname>Smith</surname>
+                                    <given-names>John</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1"/>
+                            </contrib>
+                        </contrib-group>
+                        <aff id="aff1">
+                            <label>I</label>
+                            <institution content-type="original">University A</institution>
+                        </aff>
+                    </article-meta>
+                </front>
+                <sub-article article-type="translation">
+                    <front-stub>
+                        <contrib-group>
+                            <contrib>
+                                <name>
+                                    <surname>Smith</surname>
+                                    <given-names>John</given-names>
+                                </name>
+                                <xref ref-type="aff" rid="aff1e"/>
+                            </contrib>
+                        </contrib-group>
+                        <aff id="aff1e">
+                            <label>I</label>
+                            <institution content-type="original">Universidade A</institution>
+                        </aff>
+                    </front-stub>
+                </sub-article>
             </article>
         """)
         result = xml_pipe.extract_contrib_data(xml)


### PR DESCRIPTION
## O que esse PR faz?

Corrige a lista de afiliações de autores no PDF: alguns artigos imprimiam a mesma instituição duas vezes.

`extract_contrib_data` montava a lista de afiliações impressas com `findall('.//aff')`, pegando **todo** `<aff>` do documento. Alguns pacotes SciELO carregam uma cópia duplicada/órfã das afiliações que nenhum `xref` de contribuidor referencia. Confirmei em **7 dos 26 artigos do corpus real (27%)**, e o padrão de `id` da cópia duplicada varia bastante entre pacotes — não dá pra filtrar por convenção de nome:

| Artigo | ids "primários" | ids duplicados (nunca referenciados) |
|---|---|---|
| a9.xml | aff1, aff2 | aff1e, aff2e |
| a11.xml | aff01–aff04 | aff0100–aff0400 |
| a17.xml | aff01 | aff0100 |
| a20.xml | aff01 | aff0100 |
| a23.xml | aff1 | aff1001 |
| a28.xml | aff1, aff2 | aff1s, aff2s |
| a14.xml | aff1–aff12 | aff13–aff24 (bloco inteiro duplicado) |

Em todos os casos, porém, a cópia duplicada **nunca é referenciada** por nenhum `xref[@ref-type="aff"]` de contribuidor — só a cópia original é. A correção coleta os `rid` de todos os `xref` de afiliação de cada contribuidor (não só o primeiro) e restringe a lista impressa aos `<aff>` com id referenciado, em vez de listar todo `<aff>` do documento.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py` — `extract_contrib_data`. `aff_mapping` (usado para resolver o sobrescrito numérico/label de cada autor) fica inalterado, continua olhando todo `<aff>`; só a lista final impressa (`affiliations`) foi filtrada. Mantém um fallback para imprimir tudo se nenhum `<aff>` for referenciado (defensivo, não visto no corpus real).

## Como este poderia ser testado manualmente?

```
python -m packtools.sps.formats.pdf_generator \
  -i <artigo-com-afiliacao-duplicada>.xml \
  -l layout.docx \
  -o saida.pdf \
  --libreoffice-binary libreoffice
```
Conferir a lista de afiliações na página 1.

## Algum cenário de contexto que queira dar?

Achado revisando visualmente o corpus de teste de 26 artigos reais (`layout_examples_rafael/corpus/`), inicialmente só em `a9.xml`. Investigando o padrão de `id` antes de implementar (por pedido explícito de sempre checar o corpus completo antes de generalizar um fix), achei mais 6 casos com convenções de `id` completamente diferentes — o pior, `a14.xml`, tinha 24 afiliações impressas (12 duplicadas), ocupando quase uma página inteira sozinha.

## Screenshots

<img width="1594" height="1984" alt="itemE_before_after" src="https://github.com/user-attachments/assets/ef68d1ed-a391-49be-9a89-5813df9f68ed" />

## Quais são os tickets relevantes?

Nenhuma issue aberta associada; achado durante revisão visual do corpus de teste do gerador de PDF.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança isolada de extração de dados a partir do próprio XML do artigo, sem I/O externo ou entrada não confiável

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8r2LRJ3PGTT9vLaPtb373
