### PR TITLE
fix: extrai parágrafos de resumo estruturado (sec por subseção)

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -164,14 +164,20 @@ def extract_contrib_data(xml_tree):
 def extract_abstract_data(xml_tree):
     """
     Extracts the title and content of the abstract from the given XML tree.
-    
+
+    Handles both a plain abstract (<p> direct children of <abstract>) and a
+    structured one (subsections wrapped in <sec>, e.g. Introduction/Methods/
+    Results, each with its own <title> and <p>) - see _extract_abstract_paragraphs.
+
     Args:
         xml_tree (ElementTree): The XML tree to extract the abstract from.
-    
+
     Returns:
         dict: A dictionary containing the following keys:
             - 'title': The text content of the abstract title element, or an empty string if not found.
-            - 'content': The text content of the abstract paragraphs, concatenated into a single string.
+            - 'content': The text content of the abstract paragraphs (and, for a
+              structured abstract, each subsection's title), concatenated into a
+              single string.
     """
     data = {'title': '', 'content': ''}
 
@@ -182,22 +188,22 @@ def extract_abstract_data(xml_tree):
         if node_title is not None:
             data['title'] = ''.join(node_title.itertext()).strip()
 
-        abstract = []
-        for p in node_abstract.findall('p'):
-            if p is not None:
-                abstract.append(''.join(p.itertext()).strip())
-        data['content'] = ' '.join(abstract)
+        data['content'] = ' '.join(_extract_abstract_paragraphs(node_abstract))
 
     return data
 
 def extract_trans_abstract_data(xml_tree, namespaces={'xml': 'http://www.w3.org/XML/1998/namespace'}):
     """
     Extracts the title and content of translated abstracts from the given XML tree.
-    
+
+    Handles both a plain and a structured trans-abstract (subsections wrapped
+    in <sec>) the same way extract_abstract_data does - see
+    _extract_abstract_paragraphs.
+
     Args:
         xml_tree (ElementTree): The XML tree to extract the translated abstracts from.
         namespaces (dict, optional): A dictionary of XML namespaces to use in the XPath expressions.
-    
+
     Returns:
         list: A list of dictionaries, where each dictionary contains the following keys:
             - 'lang': The language of the translated abstract.
@@ -217,11 +223,7 @@ def extract_trans_abstract_data(xml_tree, namespaces={'xml': 'http://www.w3.org/
 
         item['lang'] = node.attrib.get(lang_attrib_name)
 
-        abstract = []
-        for p in node.findall('p'):
-            if p is not None:
-                abstract.append(''.join(p.itertext()).strip())
-        item['content'] = ' '.join(abstract)
+        item['content'] = ' '.join(_extract_abstract_paragraphs(node))
 
         data.append(item)
     
@@ -796,6 +798,39 @@ def get_table_column_info(headers, rows):
 # -----------------
 # Private helpers
 # -----------------
+
+def _extract_abstract_paragraphs(node):
+    """
+    Collects an abstract's readable text as a list of strings, one per
+    <p> found at any depth. A structured abstract wraps each subsection
+    in its own <sec> (e.g. <sec><title>Methods:</title><p>...</p></sec>),
+    so a plain `node.findall('p')` (direct children only) misses every
+    paragraph and returns an empty abstract. Recursing into <sec> finds
+    them, and including each <sec>'s own <title> (already carries the
+    subsection label and its own trailing colon, e.g. "Methods:")
+    preserves the abstract's structure in the flattened output instead
+    of silently merging distinct subsections together.
+
+    Args:
+        node (ElementTree): The <abstract> or <trans-abstract> element
+            (or a <sec> within one, for the recursive call).
+
+    Returns:
+        list: Text fragments in document order - <sec> titles and <p> content.
+    """
+    parts = []
+    for child in node:
+        if child.tag == 'p':
+            parts.append(''.join(child.itertext()).strip())
+        elif child.tag == 'sec':
+            sec_title = child.find('title')
+            if sec_title is not None:
+                title_text = ''.join(sec_title.itertext()).strip()
+                if title_text:
+                    parts.append(title_text)
+            parts.extend(_extract_abstract_paragraphs(child))
+    return parts
+
 
 def _extract_table_rows_with_merged_cells(table_section, cell_tag):
     """

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -342,6 +342,11 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
     """
     Extracts the body data from an XML tree, including section titles, paragraphs, and tables.
 
+    Excludes any <sec> nested inside <abstract> or <trans-abstract> - those
+    are structured-abstract subsections handled by extract_abstract_data /
+    extract_trans_abstract_data, and would otherwise be picked up twice by
+    a plain './/sec' search.
+
     Args:
         xml_tree (ElementTree): The XML tree to extract the body data from.
         table_layout_overrides (dict, optional): Maps a table-wrap @id to a forced
@@ -359,7 +364,10 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
     data = []
     seen_fig_keys = set()
 
-    for document_section in xml_tree.findall('.//sec'):
+    body_sections = xml_tree.xpath(
+        './/sec[not(ancestor::abstract) and not(ancestor::trans-abstract)]'
+    )
+    for document_section in body_sections:
         sec = {'paragraphs': [], 'tables': [], 'figures': []}
         sec['level'] = xml_utils.get_node_level(document_section, xml_tree)
         sec['title'] = document_section.find('title')
@@ -806,10 +814,12 @@ def _extract_abstract_paragraphs(node):
     in its own <sec> (e.g. <sec><title>Methods:</title><p>...</p></sec>),
     so a plain `node.findall('p')` (direct children only) misses every
     paragraph and returns an empty abstract. Recursing into <sec> finds
-    them, and including each <sec>'s own <title> (already carries the
-    subsection label and its own trailing colon, e.g. "Methods:")
-    preserves the abstract's structure in the flattened output instead
-    of silently merging distinct subsections together.
+    them, and including each <sec>'s own <title> in the flattened output
+    preserves the abstract's structure instead of silently merging
+    distinct subsections together. Some XMLs already carry a trailing
+    colon in the title (e.g. "Methods:"), others don't (e.g. "Methods");
+    a colon is appended only when the title lacks its own closing
+    punctuation, so it never gets duplicated.
 
     Args:
         node (ElementTree): The <abstract> or <trans-abstract> element
@@ -827,6 +837,8 @@ def _extract_abstract_paragraphs(node):
             if sec_title is not None:
                 title_text = ''.join(sec_title.itertext()).strip()
                 if title_text:
+                    if title_text[-1] not in ':.!?;':
+                        title_text = f'{title_text}:'
                     parts.append(title_text)
             parts.extend(_extract_abstract_paragraphs(child))
     return parts

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -83,6 +83,45 @@ class TestExtractAbstractData(unittest.TestCase):
         result = xml_pipe.extract_abstract_data(xml)
         self.assertEqual(result, expected)
 
+    def test_extract_abstract_data_structured_with_sections(self):
+        # Regression for issue #1332: a structured abstract wraps
+        # each subsection in its own <sec>, so a plain findall('p') (direct
+        # children only) found nothing and returned an empty content.
+        xml = etree.fromstring(
+            '<article><abstract>'
+            '<title>Abstract</title>'
+            '<sec><title>Introduction:</title><p>Some introduction text.</p></sec>'
+            '<sec><title>Methods:</title><p>Some methods text.</p></sec>'
+            '</abstract></article>'
+        )
+        expected = {
+            'title': 'Abstract',
+            'content': 'Introduction: Some introduction text. Methods: Some methods text.',
+        }
+        result = xml_pipe.extract_abstract_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_abstract_data_structured_section_without_title(self):
+        xml = etree.fromstring(
+            '<article><abstract>'
+            '<sec><p>Untitled section text.</p></sec>'
+            '</abstract></article>'
+        )
+        expected = {'title': '', 'content': 'Untitled section text.'}
+        result = xml_pipe.extract_abstract_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_abstract_data_mixed_direct_and_sectioned_paragraphs(self):
+        xml = etree.fromstring(
+            '<article><abstract>'
+            '<p>Lead paragraph.</p>'
+            '<sec><title>Conclusion:</title><p>Final remarks.</p></sec>'
+            '</abstract></article>'
+        )
+        expected = {'title': '', 'content': 'Lead paragraph. Conclusion: Final remarks.'}
+        result = xml_pipe.extract_abstract_data(xml)
+        self.assertEqual(result, expected)
+
 
 class TestExtractAcknowledgmentData(unittest.TestCase):
 
@@ -1572,6 +1611,30 @@ class TestExtractTransAbstractData(unittest.TestCase):
         )
         result = xml_pipe.extract_trans_abstract_data(xml)
         self.assertEqual(result[0]['title'], 'Resumo*')
+
+    def test_extract_trans_abstract_data_structured_with_sections(self):
+        # Regression for issue #1332: same bug as extract_abstract_data,
+        # a structured trans-abstract's <p> nested in <sec> was invisible
+        # to a plain findall('p'), so the translated abstract's content
+        # came out empty (e.g. a10.xml's RESUMO in the real test corpus).
+        xml = etree.fromstring(
+            '<article>'
+            '<trans-abstract xml:lang="pt">'
+            '<title>Resumo</title>'
+            '<sec><title>Contexto:</title><p>Texto de contexto.</p></sec>'
+            '<sec><title>Métodos:</title><p>Texto de métodos.</p></sec>'
+            '</trans-abstract>'
+            '</article>'
+        )
+        expected = [
+            {
+                'lang': 'pt',
+                'title': 'Resumo',
+                'content': 'Contexto: Texto de contexto. Métodos: Texto de métodos.',
+            }
+        ]
+        result = xml_pipe.extract_trans_abstract_data(xml)
+        self.assertEqual(result, expected)
 
 
 class TestExtractFigureData(unittest.TestCase):

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -101,6 +101,19 @@ class TestExtractAbstractData(unittest.TestCase):
         result = xml_pipe.extract_abstract_data(xml)
         self.assertEqual(result, expected)
 
+    def test_extract_abstract_data_structured_section_title_without_punctuation(self):
+        # Some XMLs don't carry a trailing colon in the <sec><title>, unlike
+        # the "Methods:" style above - a colon must be added so the title
+        # doesn't run into the paragraph text (e.g. "Objetivodescrever...").
+        xml = etree.fromstring(
+            '<article><abstract>'
+            '<sec><title>Objetivo</title><p>Descrever o metodo.</p></sec>'
+            '</abstract></article>'
+        )
+        expected = {'title': '', 'content': 'Objetivo: Descrever o metodo.'}
+        result = xml_pipe.extract_abstract_data(xml)
+        self.assertEqual(result, expected)
+
     def test_extract_abstract_data_structured_section_without_title(self):
         xml = etree.fromstring(
             '<article><abstract>'
@@ -335,6 +348,36 @@ class TestExtractBodyData(unittest.TestCase):
                 'level': 1,
                 'title': 'Section 1',
                 'paragraphs': ['Paragraph 1', 'Paragraph 2'],
+                'tables': [],
+                'figures': [],
+            }
+        ]
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_body_data_excludes_abstract_and_trans_abstract_sections(self):
+        # Regression: a structured abstract/trans-abstract wraps each
+        # subsection in its own <sec> (see extract_abstract_data), which a
+        # plain './/sec' search would also pick up as a body section,
+        # duplicating the same content in both the abstract and the body.
+        xml = etree.fromstring(
+            '<article>'
+            '<abstract>'
+            '<sec><title>Background:</title><p>Abstract text.</p></sec>'
+            '</abstract>'
+            '<trans-abstract>'
+            '<sec><title>Contexto:</title><p>Texto do resumo.</p></sec>'
+            '</trans-abstract>'
+            '<body>'
+            '<sec><title>Introduction</title><p>Body text.</p></sec>'
+            '</body>'
+            '</article>'
+        )
+        expected = [
+            {
+                'level': 2,
+                'title': 'Introduction',
+                'paragraphs': ['Body text.'],
                 'tables': [],
                 'figures': [],
             }


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1332: quando um artigo tem **resumo estruturado** (subseções tipo Introduction/Methods/Results, cada uma dentro de sua própria `<sec>`), o resumo saía **vazio** no PDF gerado — só o cabeçalho "ABSTRACT"/"RESUMO" aparecia, indo direto para "Keywords".

`extract_abstract_data` e `extract_trans_abstract_data` (`packtools/sps/formats/pdf/pipeline/xml.py`) usavam `node.findall('p')`, que só localiza `<p>` **filho direto** do elemento `<abstract>`/`<trans-abstract>`. Num resumo estruturado, os `<p>` ficam um nível mais fundo (dentro de `<sec>`), então a extração retornava lista vazia.

Adiciona `_extract_abstract_paragraphs(node)`, um helper recursivo que percorre `<p>` e `<sec>` em qualquer profundidade, incluindo o `<title>` de cada `<sec>` como rótulo (o texto fonte já vem com o `:`, ex. `"Methods:"`) — preserva a estrutura do resumo no texto final em vez de apagar a divisão entre subseções. Reaproveitado nas duas funções, que tinham exatamente o mesmo bug.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py` — `_extract_abstract_paragraphs` (helpers privados) e os dois pontos que passaram a chamá-la: `extract_abstract_data` e `extract_trans_abstract_data`.

## Como este poderia ser testado manualmente?

```
python -m packtools.sps.formats.pdf_generator \
  -i <artigo-com-resumo-estruturado>.xml \
  -l layout.docx \
  -o saida.pdf \
  --libreoffice-binary libreoffice
```
Conferir o RESUMO/ABSTRACT na página 1.

## Algum cenário de contexto que queira dar?

Achado por acaso revisando visualmente o corpus de teste de 26 artigos reais (`layout_examples_rafael/corpus/`), enquanto validava outro fix (afiliação duplicada). Confirmei a causa raiz e a abrangência antes de abrir a issue #1332: **6 de 26 artigos (23%)** tinham resumo vazio por esse motivo — `a10.xml` (RESUMO em português também vazio), `a11.xml`, `a14.xml`, `a17.xml`, `a20.xml`, `a28.xml`. Não é um caso raro nem exclusivo de uma área (saúde e administração/negócios ambos afetados).

## Screenshots

<img width="1594" height="892" alt="issue1332_before_after" src="https://github.com/user-attachments/assets/07acbd8a-e18c-4602-b2fc-4ec46b223ec4" />

## Quais são os tickets relevantes?

Corrige #1332.

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa:
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança isolada de extração de texto a partir do próprio XML do artigo, sem I/O externo ou entrada não confiável

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8r2LRJ3PGTT9vLaPtb373
