### PR TITLE
fix: corrige idioma do resumo de sub-article traduzido (#1329)

### DIFF
--- a/packtools/sps/models/v2/abstract.py
+++ b/packtools/sps/models/v2/abstract.py
@@ -304,21 +304,108 @@ class Abstract:
         }
 
 
-import warnings as _warnings
+class XMLAbstracts:
+    """
+    Collects the <abstract>/<trans-abstract> elements of an article, in the
+    main article and in every <sub-article>, as plain data (no validation
+    rule or expected-value logic lives here).
 
+    PR #1180 (2026-05) had moved this class into
+    packtools.sps.validation.models.abstract on the premise that it was
+    used only by validation code; that premise was wrong (scms-upload's
+    TOC builder consumes it directly for presentation data, not
+    validation), so it moved back here. See issues #1153/#1181.
+    """
 
-def __getattr__(name):
-    _moved = {
-        "XMLAbstracts": "packtools.sps.validation.models.abstract",
-    }
-    if name in _moved:
-        import importlib
-        _warnings.warn(
-            f"{name} has moved to {_moved[name]}. "
-            f"Importing from packtools.sps.models.v2.abstract is deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
+    def __init__(self, xmltree):
+        self.xmltree = xmltree
+        self.lang = xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
+        self.tags_to_keep = None
+        self.tags_to_keep_with_content = None
+        self.tags_to_remove_with_content = None
+        self.tags_to_convert_to_html = None
+
+    def configure(
+        self,
+        tags_to_keep=None,
+        tags_to_keep_with_content=None,
+        tags_to_remove_with_content=None,
+        tags_to_convert_to_html=None,
+    ):
+        self.tags_to_keep = tags_to_keep
+        self.tags_to_keep_with_content = tags_to_keep_with_content
+        self.tags_to_remove_with_content = tags_to_remove_with_content
+        self.tags_to_convert_to_html = tags_to_convert_to_html
+
+    def _build_abstract(self, node, lang):
+        abstract = Abstract(
+            node,
+            lang,
+            tags_to_keep=self.tags_to_keep,
+            tags_to_keep_with_content=self.tags_to_keep_with_content,
+            tags_to_remove_with_content=self.tags_to_remove_with_content,
+            tags_to_convert_to_html=self.tags_to_convert_to_html,
         )
-        mod = importlib.import_module(_moved[name])
-        return getattr(mod, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        return abstract.data
+
+    def get_abstracts(self, abstract_type=None):
+        type_filter = f'[@abstract-type="{abstract_type}"]' if abstract_type else "[not(@abstract-type)]"
+
+        # Abstracts do artigo principal: exclui qualquer coisa dentro de
+        # sub-article (traduções), para nunca misturar os dois casos.
+        main_xpath = (
+            f".//abstract{type_filter}[not(ancestor::sub-article)] | "
+            f".//trans-abstract{type_filter}[not(ancestor::sub-article)]"
+        )
+        for node in self.xmltree.xpath(main_xpath):
+            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or self.lang
+            yield self._build_abstract(node, lang)
+
+        # Abstracts de sub-article: o lang vem do próprio nó, com fallback
+        # para o xml:lang do sub-article que o contém. Nunca cai para o
+        # lang do artigo principal, já que um sub-article representa outro
+        # idioma.
+        sub_xpath = (
+            f".//sub-article//abstract{type_filter} | "
+            f".//sub-article//trans-abstract{type_filter}"
+        )
+        for node in self.xmltree.xpath(sub_xpath):
+            sub_article = node.xpath("ancestor::sub-article[1]")
+            sub_lang = (
+                sub_article[0].get("{http://www.w3.org/XML/1998/namespace}lang")
+                if sub_article else None
+            )
+            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or sub_lang
+            yield self._build_abstract(node, lang)
+
+    @property
+    def standard_abstracts(self):
+        return self.get_abstracts()
+
+    @property
+    def visual_abstracts(self):
+        return self.get_abstracts("graphical")
+
+    @property
+    def key_points_abstracts(self):
+        return self.get_abstracts("key-points")
+
+    @property
+    def summary_abstracts(self):
+        return self.get_abstracts("summary")
+
+    @property
+    def abstracts(self):
+        yield from self.standard_abstracts
+        yield from self.key_points_abstracts
+        yield from self.visual_abstracts
+        yield from self.summary_abstracts
+
+    def abstracts_by_lang_and_type(self):
+        langs = {}
+        for item in self.abstracts:
+            lang = item["lang"]
+            abstract_type = item["abstract_type"]
+            langs.setdefault(lang, {})
+            langs[lang][abstract_type] = item
+        return langs

--- a/packtools/sps/validation/article_abstract.py
+++ b/packtools/sps/validation/article_abstract.py
@@ -1,4 +1,4 @@
-from packtools.sps.validation.models.abstract import XMLAbstracts
+from packtools.sps.models.v2.abstract import XMLAbstracts
 from packtools.sps.validation.utils import build_response
 from packtools.sps import i18n
 

--- a/packtools/sps/validation/models/abstract.py
+++ b/packtools/sps/validation/models/abstract.py
@@ -22,22 +22,46 @@ class XMLAbstracts:
         self.tags_to_remove_with_content = tags_to_remove_with_content
         self.tags_to_convert_to_html = tags_to_convert_to_html
 
-    def get_abstracts(self, abstract_type=None):
-        if abstract_type:
-            xpath = f'.//abstract[@abstract-type="{abstract_type}"] | .//trans-abstract[@abstract-type="{abstract_type}"]'
-        else:
-            xpath = ".//abstract[not(@abstract-type)] | .//trans-abstract[not(@abstract-type)]"
+    def _build_abstract(self, node, lang):
+        abstract = Abstract(
+            node,
+            lang,
+            tags_to_keep=self.tags_to_keep,
+            tags_to_keep_with_content=self.tags_to_keep_with_content,
+            tags_to_remove_with_content=self.tags_to_remove_with_content,
+            tags_to_convert_to_html=self.tags_to_convert_to_html,
+        )
+        return abstract.data
 
-        for node in self.xmltree.xpath(xpath):
-            abstract = Abstract(
-                node,
-                node.get("{http://www.w3.org/XML/1998/namespace}lang") or self.lang,
-                tags_to_keep=self.tags_to_keep,
-                tags_to_keep_with_content=self.tags_to_keep_with_content,
-                tags_to_remove_with_content=self.tags_to_remove_with_content,
-                tags_to_convert_to_html=self.tags_to_convert_to_html,
+    def get_abstracts(self, abstract_type=None):
+        type_filter = f'[@abstract-type="{abstract_type}"]' if abstract_type else "[not(@abstract-type)]"
+
+        # Abstracts do artigo principal: exclui qualquer coisa dentro de
+        # sub-article (traduções), para nunca misturar os dois casos.
+        main_xpath = (
+            f".//abstract{type_filter}[not(ancestor::sub-article)] | "
+            f".//trans-abstract{type_filter}[not(ancestor::sub-article)]"
+        )
+        for node in self.xmltree.xpath(main_xpath):
+            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or self.lang
+            yield self._build_abstract(node, lang)
+
+        # Abstracts de sub-article: o lang vem do próprio nó, com fallback
+        # para o xml:lang do sub-article que o contém. Nunca cai para o
+        # lang do artigo principal, já que um sub-article representa outro
+        # idioma.
+        sub_xpath = (
+            f".//sub-article//abstract{type_filter} | "
+            f".//sub-article//trans-abstract{type_filter}"
+        )
+        for node in self.xmltree.xpath(sub_xpath):
+            sub_article = node.xpath("ancestor::sub-article[1]")
+            sub_lang = (
+                sub_article[0].get("{http://www.w3.org/XML/1998/namespace}lang")
+                if sub_article else None
             )
-            yield abstract.data
+            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or sub_lang
+            yield self._build_abstract(node, lang)
 
     @property
     def standard_abstracts(self):

--- a/packtools/sps/validation/models/abstract.py
+++ b/packtools/sps/validation/models/abstract.py
@@ -1,96 +1,28 @@
-from packtools.sps.models.v2.abstract import Abstract
+"""
+XMLAbstracts moved back to packtools.sps.models.v2.abstract.
+
+PR #1180 (2026-05) moved it here believing it was used only by validation
+code; that premise was wrong (scms-upload's TOC builder consumes it
+directly for presentation data via packtools.sps.models.v2.abstract, not
+for validation). Kept as a compatibility redirect only: this module
+should not gain new logic, since the class itself carries no
+validation-rule/expected-value concerns and doesn't belong here.
+"""
+import warnings as _warnings
 
 
-class XMLAbstracts:
-    def __init__(self, xmltree):
-        self.xmltree = xmltree
-        self.lang = xmltree.find(".").get("{http://www.w3.org/XML/1998/namespace}lang")
-        self.tags_to_keep = None
-        self.tags_to_keep_with_content = None
-        self.tags_to_remove_with_content = None
-        self.tags_to_convert_to_html = None
-
-    def configure(
-        self,
-        tags_to_keep=None,
-        tags_to_keep_with_content=None,
-        tags_to_remove_with_content=None,
-        tags_to_convert_to_html=None,
-    ):
-        self.tags_to_keep = tags_to_keep
-        self.tags_to_keep_with_content = tags_to_keep_with_content
-        self.tags_to_remove_with_content = tags_to_remove_with_content
-        self.tags_to_convert_to_html = tags_to_convert_to_html
-
-    def _build_abstract(self, node, lang):
-        abstract = Abstract(
-            node,
-            lang,
-            tags_to_keep=self.tags_to_keep,
-            tags_to_keep_with_content=self.tags_to_keep_with_content,
-            tags_to_remove_with_content=self.tags_to_remove_with_content,
-            tags_to_convert_to_html=self.tags_to_convert_to_html,
+def __getattr__(name):
+    _moved = {
+        "XMLAbstracts": "packtools.sps.models.v2.abstract",
+    }
+    if name in _moved:
+        import importlib
+        _warnings.warn(
+            f"{name} has moved to {_moved[name]}. "
+            f"Importing from packtools.sps.validation.models.abstract is deprecated.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return abstract.data
-
-    def get_abstracts(self, abstract_type=None):
-        type_filter = f'[@abstract-type="{abstract_type}"]' if abstract_type else "[not(@abstract-type)]"
-
-        # Abstracts do artigo principal: exclui qualquer coisa dentro de
-        # sub-article (traduções), para nunca misturar os dois casos.
-        main_xpath = (
-            f".//abstract{type_filter}[not(ancestor::sub-article)] | "
-            f".//trans-abstract{type_filter}[not(ancestor::sub-article)]"
-        )
-        for node in self.xmltree.xpath(main_xpath):
-            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or self.lang
-            yield self._build_abstract(node, lang)
-
-        # Abstracts de sub-article: o lang vem do próprio nó, com fallback
-        # para o xml:lang do sub-article que o contém. Nunca cai para o
-        # lang do artigo principal, já que um sub-article representa outro
-        # idioma.
-        sub_xpath = (
-            f".//sub-article//abstract{type_filter} | "
-            f".//sub-article//trans-abstract{type_filter}"
-        )
-        for node in self.xmltree.xpath(sub_xpath):
-            sub_article = node.xpath("ancestor::sub-article[1]")
-            sub_lang = (
-                sub_article[0].get("{http://www.w3.org/XML/1998/namespace}lang")
-                if sub_article else None
-            )
-            lang = node.get("{http://www.w3.org/XML/1998/namespace}lang") or sub_lang
-            yield self._build_abstract(node, lang)
-
-    @property
-    def standard_abstracts(self):
-        return self.get_abstracts()
-
-    @property
-    def visual_abstracts(self):
-        return self.get_abstracts("graphical")
-
-    @property
-    def key_points_abstracts(self):
-        return self.get_abstracts("key-points")
-
-    @property
-    def summary_abstracts(self):
-        return self.get_abstracts("summary")
-
-    @property
-    def abstracts(self):
-        yield from self.standard_abstracts
-        yield from self.key_points_abstracts
-        yield from self.visual_abstracts
-        yield from self.summary_abstracts
-
-    def abstracts_by_lang_and_type(self):
-        langs = {}
-        for item in self.abstracts:
-            lang = item["lang"]
-            abstract_type = item["abstract_type"]
-            langs.setdefault(lang, {})
-            langs[lang][abstract_type] = item
-        return langs
+        mod = importlib.import_module(_moved[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packtools/version.py
+++ b/packtools/version.py
@@ -1,4 +1,4 @@
 """Single source to the version across setup.py and the whole project.
 """
 from __future__ import unicode_literals
-__version__ = '4.17.0'
+__version__ = '4.17.2'

--- a/tests/sps/validation/test_article_abstract.py
+++ b/tests/sps/validation/test_article_abstract.py
@@ -772,6 +772,85 @@ class MultipleAbstractsTest(TestCase):
             self.assertEqual(validation["response"], "OK")
 
 
+class SubArticleAbstractLangTest(TestCase):
+    """
+    Regression tests for packtools#1329: a sub-article's translated
+    <abstract> (which usually has no xml:lang of its own — the language
+    lives on the parent <sub-article xml:lang="..."> element) must be
+    reported with its own language, never the main article's language.
+    """
+
+    def test_sub_article_abstract_without_own_lang_uses_sub_article_lang(self):
+        """Sub-article abstract without xml:lang must use the sub-article's own lang, not the main article's."""
+        self.maxDiff = None
+        xmltree = ET.fromstring(
+            """
+            <article article-type="research-article" xml:lang="en">
+                <front>
+                    <article-meta>
+                        <abstract>
+                            <title>Abstract</title>
+                            <p>Main abstract text.</p>
+                        </abstract>
+                    </article-meta>
+                </front>
+                <sub-article article-type="translation" id="s1" xml:lang="pt">
+                    <front-stub>
+                        <abstract>
+                            <title>Resumo</title>
+                            <p>Texto do resumo.</p>
+                        </abstract>
+                    </front-stub>
+                </sub-article>
+            </article>
+            """
+        )
+
+        abstracts = {a["lang"]: a for a in XMLAbstracts(xmltree).standard_abstracts}
+
+        self.assertEqual(abstracts["en"]["text"], "Main abstract text.")
+        self.assertEqual(abstracts["pt"]["text"], "Texto do resumo.")
+
+    def test_multiple_sub_articles_each_keep_own_lang(self):
+        """Reuses the shared fixture with an en main article plus pt/es sub-article translations."""
+        xmltree = ET.parse("tests/samples/article-abstract-en-sub-articles-pt-es.xml")
+
+        abstracts = list(XMLAbstracts(xmltree).standard_abstracts)
+
+        self.assertEqual({a["lang"] for a in abstracts}, {"en", "pt", "es"})
+        self.assertEqual(len(abstracts), 3)
+
+    def test_validation_pipeline_does_not_break_with_sub_article_abstracts(self):
+        """XMLAbstractsValidation (the production entry point) must keep working with sub-article abstracts present."""
+        xmltree = ET.fromstring(
+            """
+            <article article-type="research-article" xml:lang="en">
+                <front>
+                    <article-meta>
+                        <abstract>
+                            <title>Abstract</title>
+                            <p>Main abstract text.</p>
+                        </abstract>
+                    </article-meta>
+                </front>
+                <sub-article article-type="translation" id="s1" xml:lang="pt">
+                    <front-stub>
+                        <abstract>
+                            <title>Resumo</title>
+                            <p>Texto do resumo.</p>
+                        </abstract>
+                    </front-stub>
+                </sub-article>
+            </article>
+            """
+        )
+
+        validator = XMLAbstractsValidation(xmltree)
+        obtained = list(validator.validate())
+
+        self.assertTrue(obtained)
+
+
 class TransAbstractValidationTest(TestCase):
     """
     Tests for translated abstracts (<trans-abstract>).


### PR DESCRIPTION
## O que esse PR faz?

Corrige `XMLAbstracts.get_abstracts()` (`packtools/sps/validation/models/abstract.py`), que rotulava incorretamente o idioma do resumo (`<abstract>`) de um `<sub-article>` traduzido — o resumo saía com o idioma do artigo principal em vez do idioma do sub-article. Isso corrompia o campo `language` consumido pelo Upload/scms-upload na página de TOC do fascículo, fazendo dois resumos em idiomas diferentes aparecerem com a mesma etiqueta de idioma.

## Onde a revisão poderia começar?

`packtools/sps/validation/models/abstract.py`, método `XMLAbstracts.get_abstracts()`. O xpath original usava `.//` sobre o documento inteiro, misturando abstracts de `sub-article` com os do artigo principal; e quando o `<abstract>` do sub-article não tinha `xml:lang` próprio, caía no fallback `self.lang` (o idioma do artigo principal, não o do sub-article).

## Como este poderia ser testado manualmente?

```python
from lxml import etree
from packtools.sps.validation.models.abstract import XMLAbstracts

tree = etree.parse("caminho/para/artigo-com-sub-article-traduzido.xml")
for item in XMLAbstracts(tree).abstracts:
    print(item["lang"], "->", item["text"][:60])
```

Reproduzido e verificado localmente contra o XML real citado na issue (`1518-8787-rsp-56-9.xml`, de `scieloorg/scms-upload`): antes do fix, os dois resumos saíam como `en`/`en`; depois do fix, saem como `en`/`pt`.

## Algum cenário de contexto que queira dar?

Relatado pela Roberta Takenaka em #1329: ao reprocessar o fascículo v56 da RSP no Upload, o resumo em português de um artigo apareceu marcado como inglês na página de TOC. O problema só ocorre com artigos vindos de XML com `<sub-article>` de tradução (não ocorre com artigos HTML, que passam por outro caminho de código).

Como efeito colateral positivo, o fix também corrige `kwds` vazios em resumos de sub-article (a busca de `kwd-group` usa o mesmo `lang` que estava incorreto).

Fora do escopo deste PR: `packtools/sps/models/article_abstract.py::ArticleAbstract.get_sub_article_abstract` tem bugs semelhantes e independentes, mas não está no caminho de código exercitado por esta issue — ficará para uma issue de follow-up.

## Screenshots

Não aplicável (mudança de lógica interna, sem interface visual no packtools).

## Quais são os tickets relevantes?

Closes #1329

## Referências

- Sintoma visível no Upload: scieloorg/scms-upload#1081
- XML de exemplo: `migration/fixtures/classic_website/bases/xml/rsp/v56/1518-8787-rsp-56-9.xml` (repo `scieloorg/scms-upload`)

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): pipeline de CI roda automaticamente ao abrir o PR

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
