### PR TITLE
fix: não descarta disp-formula irmã de p em extract_body_data

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -366,7 +366,9 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
               section, excluding paragraphs that contain table/figure
               references or wrappers.
             - 'tables': A list of dictionaries representing the tables in the section, as returned by the `extract_table_data` function.
-            - 'figures': A list of dictionaries representing figures in the section, as returned by the `extract_figure_data` function.
+            - 'figures': A list of dictionaries representing figures in the section, as returned by the `extract_figure_data` function
+              (also includes any <disp-formula> that is a graphic rather than
+              MathML/text, since there's nothing to flatten into a paragraph).
     """
     data = []
     seen_fig_keys = set()
@@ -400,6 +402,20 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
                 para_text = xml_utils.get_text_from_node(child, skip_tags={'fig', 'table-wrap'}).strip()
             elif child.tag == 'disp-formula':
                 para_text = xml_utils.get_text_from_node(child).strip()
+                if not para_text and child.find('graphic') is not None:
+                    # A formula rendered as an image (no MathML, no flattenable
+                    # text) has nothing for get_text_from_node to return - it
+                    # was silently dropped entirely. extract_figure_data reads
+                    # the same label/caption/graphic shape <fig> has, so a
+                    # <disp-formula> with a <graphic> can reuse it as-is and
+                    # render like any other figure instead of vanishing.
+                    formula_fig = extract_figure_data(child)
+                    formula_key = child.get('id') or formula_fig.get('href') or ''
+                    if not formula_key or formula_key not in seen_fig_keys:
+                        sec['figures'].append(formula_fig)
+                        if formula_key:
+                            seen_fig_keys.add(formula_key)
+                    continue
             else:
                 continue
             if para_text:

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -360,7 +360,11 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
         list: A list of dictionaries, where each dictionary represents a section in the body of the document. Each dictionary has the following keys:
             - 'level': The nesting level of the section.
             - 'title': The title of the section, if present.
-            - 'paragraphs': A list of the text content of each paragraph in the section, excluding paragraphs that contain table/figure references or wrappers.
+            - 'paragraphs': A list of the text content of each paragraph (and
+              of any <disp-formula> found as a direct sibling of a <p>, since
+              a structured formula isn't always wrapped in one) in the
+              section, excluding paragraphs that contain table/figure
+              references or wrappers.
             - 'tables': A list of dictionaries representing the tables in the section, as returned by the `extract_table_data` function.
             - 'figures': A list of dictionaries representing figures in the section, as returned by the `extract_figure_data` function.
     """
@@ -384,8 +388,20 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
         # artificial space between every text-node fragment regardless of
         # whether the source had one there (e.g. "(<xref>...</xref>)" came
         # out as "( ... )", and "<xref/>; <xref/>" as "... ; ...").
-        for para in document_section.findall('p'):
-            para_text = xml_utils.get_text_from_node(para, skip_tags={'fig', 'table-wrap'}).strip()
+        #
+        # <disp-formula> isn't always nested inside a <p> - it's often a
+        # direct sibling of one - so a plain `findall('p')` silently drops
+        # it. Walking direct children instead of just `<p>` catches that
+        # case too. This still only flattens the formula's text (no
+        # MathML->OMML conversion yet, see issue #1347's phased plan), but
+        # flattened-and-present beats silently missing.
+        for child in document_section:
+            if child.tag == 'p':
+                para_text = xml_utils.get_text_from_node(child, skip_tags={'fig', 'table-wrap'}).strip()
+            elif child.tag == 'disp-formula':
+                para_text = xml_utils.get_text_from_node(child).strip()
+            else:
+                continue
             if para_text:
                 sec['paragraphs'].append(para_text)
 

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -385,6 +385,40 @@ class TestExtractBodyData(unittest.TestCase):
         result = xml_pipe.extract_body_data(xml)
         self.assertEqual(result, expected)
 
+    def test_extract_body_data_includes_disp_formula_as_sibling_of_p(self):
+        # Regression for issue #1347: <disp-formula> is often a direct
+        # sibling of <p>, not nested inside one - a plain findall('p') never
+        # visits it, so the formula silently vanished from the output. No
+        # MathML->OMML conversion yet (see #1347's phased plan), just
+        # flattened text, but present beats missing.
+        xml = etree.fromstring(
+            '<article xmlns:mml="http://www.w3.org/1998/Math/MathML">'
+            '<sec>'
+            '<title>Section 1</title>'
+            '<p>See the formula below.</p>'
+            '<disp-formula id="e01">'
+            '<mml:math><mml:mi>Y</mml:mi><mml:mo>=</mml:mo><mml:mn>1</mml:mn></mml:math>'
+            '</disp-formula>'
+            '<p>Where Y is the result.</p>'
+            '</sec>'
+            '</article>'
+        )
+        expected = [
+            {
+                'level': 1,
+                'title': 'Section 1',
+                'paragraphs': [
+                    'See the formula below.',
+                    'Y=1',
+                    'Where Y is the result.',
+                ],
+                'tables': [],
+                'figures': [],
+            }
+        ]
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(result, expected)
+
     def test_extract_body_data_with_tables(self):
         xml = etree.fromstring(
             '<article>'

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -419,6 +419,42 @@ class TestExtractBodyData(unittest.TestCase):
         result = xml_pipe.extract_body_data(xml)
         self.assertEqual(result, expected)
 
+    def test_extract_body_data_includes_graphic_disp_formula_as_figure(self):
+        # Regression for issue #1347: a <disp-formula> rendered as an image
+        # (<graphic>, no MathML) has no text for get_text_from_node to
+        # flatten, so it was silently dropped even after the fix for the
+        # MathML/text case above. extract_figure_data reads the same
+        # label/caption/graphic shape <fig> has, so the formula is rendered
+        # as a figure instead of vanishing.
+        xml = etree.fromstring(
+            '<article>'
+            '<sec>'
+            '<title>Section 1</title>'
+            '<p>See the formula below.</p>'
+            '<disp-formula id="e01">'
+            '<graphic xlink:href="e01.tif" xmlns:xlink="http://www.w3.org/1999/xlink"/>'
+            '</disp-formula>'
+            '<p>Where Y is the result.</p>'
+            '</sec>'
+            '</article>'
+        )
+        expected = [
+            {
+                'level': 1,
+                'title': 'Section 1',
+                'paragraphs': [
+                    'See the formula below.',
+                    'Where Y is the result.',
+                ],
+                'tables': [],
+                'figures': [
+                    {'label': '', 'caption': '', 'href': 'e01.tif', 'alt': ''},
+                ],
+            }
+        ]
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(result, expected)
+
     def test_extract_body_data_with_tables(self):
         xml = etree.fromstring(
             '<article>'


### PR DESCRIPTION
## O que esse PR faz?

Corrige a Fase 0 da issue #1347 em duas partes:

1. `<disp-formula>` costuma ser irmã de `<p>` dentro de `<sec>`, não filha dele. `extract_body_data` só coletava `document_section.findall('p')` (filhos diretos `<p>`), então a fórmula nunca era visitada e desaparecia do corpo do PDF sem deixar rastro (confirmado em a5/a6/a13/a15/a25/a26.xml do corpus de teste).
2. Uma fórmula renderizada como imagem (`<disp-formula><graphic/></disp-formula>`, sem MathML) continuava desaparecendo mesmo após o item 1, porque não há texto para `get_text_from_node` achatar (apontado na revisão - obrigado pela pegada, `@pitangainnovare`). `extract_figure_data` lê a mesma estrutura de `label`/`caption`/`graphic` que `<fig>` tem, então esse caso passa a ser tratado como figura em vez de descartado.

A correção passa a percorrer os filhos diretos da seção tratando `p` e `disp-formula` juntos, preservando a ordem original. O texto da fórmula com MathML ainda sai achatado (sem conversão MathML->OMML - isso é a Fase 1 do plano, tratada em issue futura); a fórmula-imagem é inserida como figura (com dimensionamento/layout de coluna reaproveitados de `_render_figures`, sem código novo de renderização). Nos dois casos, o objetivo desta fase é só parar a perda silenciosa de conteúdo.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, função `extract_body_data` (o loop que antes era `for para in document_section.findall('p')`).

## Como este poderia ser testado manualmente?

1. Gerar o PDF de `a6.xml` do corpus de teste (`layout_examples_rafael/corpus/`), que tem `<disp-formula>` filho direto de `<sec>`.
2. Antes: o texto "...soil weight per hectare Formula 1 presented by Muguruza (2024)." é seguido diretamente por "Formula for arable layer weight." sem a fórmula em si.
3. Depois: a fórmula aparece entre as duas frases (achatada, ex: `[W . h a] = [(D e p t h) (A D) (H a)] (1)`).
4. Para o caso de fórmula-imagem: `tests/samples/0034-8910-rsp-48-2-0232.xml` tem `<disp-formula><graphic/></disp-formula>` filho direto de `<sec>` na seção MÉTODOS/METHODS. Rodando `extract_body_data` nesse XML, a fórmula agora aparece em `sec['figures']` (antes: descartada, sem nenhum rastro em `paragraphs` nem `figures`). Não há asset de imagem versionado para esse fixture, então não é possível gerar um PDF completo a partir dele - a verificação foi feita direto no dado estruturado retornado por `extract_body_data`.
5. `pytest tests/sps/formats/pdf/pipeline/test_xml.py` cobre os dois casos com testes de regressão (`test_extract_body_data_includes_disp_formula_as_sibling_of_p` e `test_extract_body_data_includes_graphic_disp_formula_as_figure`).

## Algum cenário de contexto que queira dar?

Esta é a Fase 0 de um plano de correção em 4 fases para o tratamento de fórmulas matemáticas no gerador de PDF (ver issue #1347). As Fases 1-3 (conversão real MathML->OMML, fórmula inline em texto corrido, fórmula em célula de tabela) ficam para issues futuras - esta trata só de parar a perda silenciosa de conteúdo.

Validado contra as 26 amostras do corpus de teste: as **6** afetadas pelo caso "irmã de `<p>`" são **a5, a6, a13, a15, a25 e a26** (a lista anterior desta descrição estava incompleta - faltavam a5 e a25, obrigado pela revisão). As outras 20 não mudam. Nenhuma das 26 amostras do corpus tem fórmula-imagem (`<disp-formula><graphic/></disp-formula>`); esse segundo caso foi validado contra a fixture já versionada `tests/samples/0034-8910-rsp-48-2-0232.xml`. Suíte completa de `tests/sps/formats/pdf/` (229 testes) passa.

## Screenshots

**a6.xml (página 3):**

<img width="1664" height="430" alt="a6_before_after_comparison" src="https://github.com/user-attachments/assets/fcd68566-c18d-4968-820f-d3d18a45e695" />

**a26.xml (página 2):**

<img width="1664" height="360" alt="a26_before_after_comparison" src="https://github.com/user-attachments/assets/7976de5e-2748-4a76-bf9d-2d8b5b78af3c" />

## Quais são os tickets relevantes?

Issue #1347 (Fase 0)

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança pontual de extração de texto (troca de `findall('p')` por iteração de filhos diretos), sem alteração de infraestrutura, dependências ou pipeline.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V829P3TiVHWnnde6tumABq
