### PR TITLE
fix: não descarta corpo do artigo sem <sec> (#1351)

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -350,6 +350,13 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
     extract_trans_abstract_data, and would otherwise be picked up twice by
     a plain './/sec' search.
 
+    Falls back to treating <body> itself as an extra, untitled section when
+    <body> has no <sec> of its own (valid JATS pattern for unsectioned
+    short communications/brief reports) - otherwise its content would be
+    silently dropped even though an unrelated <sec> elsewhere in the
+    document (e.g. a data-availability statement under <back>) keeps the
+    section search from returning empty.
+
     Args:
         xml_tree (ElementTree): The XML tree to extract the body data from.
         table_layout_overrides (dict, optional): Maps a table-wrap @id to a forced
@@ -370,6 +377,10 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
     body_sections = xml_tree.xpath(
         './/sec[not(ancestor::abstract) and not(ancestor::trans-abstract)]'
     )
+    body = xml_tree.find('.//body')
+    if body is not None and body.find('.//sec') is None:
+        body_sections = [body] + body_sections
+
     for document_section in body_sections:
         sec = {'paragraphs': [], 'tables': [], 'figures': []}
         sec['level'] = xml_utils.get_node_level(document_section, xml_tree)

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -535,6 +535,98 @@ class TestExtractBodyData(unittest.TestCase):
             ['See the figure below for details.'],
         )
 
+    def test_extract_body_data_falls_back_to_body_when_no_sec_exists(self):
+        # Regression for issue #1351: a <body> with <p> as direct children
+        # and no <sec> at all (valid JATS pattern for unsectioned short
+        # communications/brief reports) used to disappear entirely, since
+        # the section search only ever looked for <sec>.
+        xml = etree.fromstring(
+            '<article><body>'
+            '<p>Paragraph 1</p>'
+            '<p>Paragraph 2</p>'
+            '</body></article>'
+        )
+        expected = [
+            {
+                'level': 1,
+                'title': None,
+                'paragraphs': ['Paragraph 1', 'Paragraph 2'],
+                'tables': [],
+                'figures': [],
+            }
+        ]
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_body_data_falls_back_to_body_with_table_and_figure(self):
+        xml = etree.fromstring(
+            '<article><body>'
+            '<p>Intro paragraph.</p>'
+            '<p>Figure 1<fig id="f1"><label>Figure 1</label></fig></p>'
+            '<p>Table 1'
+            '<table-wrap id="t1">'
+            '<label>Table 1</label>'
+            '<title>Sample Table</title>'
+            '<table>'
+            '<thead><tr><th>Header</th></tr></thead>'
+            '<tbody><tr><td>Data</td></tr></tbody>'
+            '</table>'
+            '</table-wrap>'
+            '</p>'
+            '</body></article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(len(result), 1)
+        self.assertIsNone(result[0]['title'])
+        self.assertEqual(len(result[0]['tables']), 1)
+        self.assertEqual(len(result[0]['figures']), 1)
+
+    def test_extract_body_data_does_not_fall_back_when_sec_exists(self):
+        # Regression: the fallback must not kick in for a normally
+        # sectioned article, even one with just a single <sec>.
+        xml = etree.fromstring(
+            '<article><body>'
+            '<sec><title>Introduction</title><p>Body text.</p></sec>'
+            '</body></article>'
+        )
+        expected = [
+            {
+                'level': 2,
+                'title': 'Introduction',
+                'paragraphs': ['Body text.'],
+                'tables': [],
+                'figures': [],
+            }
+        ]
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(result, expected)
+
+    def test_extract_body_data_falls_back_even_when_an_unrelated_sec_exists_outside_body(self):
+        # Regression for issue #1351, reproduced against the real corpus
+        # sample a8.xml: <body> has no <sec> of its own, but a <sec
+        # sec-type="data-availability"> lives under <back>. A naive
+        # "any <sec> found anywhere -> skip the fallback" check would
+        # wrongly treat body as already covered by that unrelated sec and
+        # keep discarding body's own content.
+        xml = etree.fromstring(
+            '<article>'
+            '<body>'
+            '<p>Body paragraph.</p>'
+            '</body>'
+            '<back>'
+            '<sec sec-type="data-availability">'
+            '<label>Data availability</label>'
+            '<p>Data statement.</p>'
+            '</sec>'
+            '</back>'
+            '</article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['title'], None)
+        self.assertEqual(result[0]['paragraphs'], ['Body paragraph.'])
+        self.assertEqual(result[1]['paragraphs'], ['Data statement.'])
+
 
 class TestExtractCategory(unittest.TestCase):
 


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1351: `extract_body_data` (`packtools/sps/formats/pdf/pipeline/xml.py`) só buscava `<sec>` no documento inteiro para montar o corpo do PDF. Quando um artigo é uma comunicação curta/relato breve sem nenhuma seção (`<body>` com `<p>` como filhos diretos, padrão JATS válido), essa busca não encontrava conteúdo do corpo e o artigo inteiro (introdução, métodos, resultados, discussão, tabelas e figuras) desaparecia silenciosamente do PDF gerado.

A correção trata o próprio `<body>` como uma seção extra sem título sempre que ele não tem nenhum `<sec>` próprio, reaproveitando o mesmo bloco de extração de parágrafos/tabelas/figuras já usado para seções reais, sem duplicar lógica.

**Detalhe que exigiu uma segunda volta**: minha primeira versão checava apenas "existe algum `<sec>` em todo o documento?". Isso falhou contra o `a8.xml` real do corpus de teste, que tem um `<sec sec-type="data-availability">` solto em `<back>` (declaração de disponibilidade de dados), irrelevante ao corpo, mas suficiente para a busca global não retornar vazia, então o corpo continuava sendo descartado. Corrigido checando especificamente se **o `<body>`** tem algum `<sec>` (`body.find('.//sec') is None`), o que preserva esse `<sec>` de `<back>` como uma seção adicional (comportamento já existente hoje) em vez de substituí-lo pelo fallback.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/pipeline/xml.py`, função `extract_body_data`.

## Como este poderia ser testado manualmente?

1. Gerar o PDF de `a8.xml` do corpus de teste (`layout_examples_rafael/corpus/`), o único dos 26 artigos cujo `<body>` não tem nenhum `<sec>`.
2. Antes: o PDF salta do Abstract/RESUMEN direto para "Data availability"/ACKNOWLEDGMENTS/REFERENCES (2 páginas no total).
3. Depois: introdução, métodos, resultados, discussão, Tabela 1 e Figuras 1-3 aparecem entre o Abstract e "Data availability" (7 páginas no total). Ver screenshot.
4. `pytest tests/sps/formats/pdf/pipeline/test_xml.py -k extract_body_data` cobre os casos (body sem `<sec>` puro; body sem `<sec>` com tabela/figura embutida; body com `<sec>` real não deve disparar o fallback; body sem `<sec>` + `<sec>` não relacionado em `<back>`, replicando o `a8.xml`).

## Algum cenário de contexto que queira dar?

Achado ao investigar a lista de possíveis problemas do gerador de PDF fora dos PRs #1348/#1350 (em revisão). Confirmado que `a8.xml` é o único dos 26 artigos do corpus com esse padrão de `<body>` sem `<sec>`. Não há caso real no corpus de conteúdo "solto" intercalado *entre* seções reais, então o fallback foi escopado deliberadamente para o caso confirmado (body inteiramente sem `<sec>`), não para intercalação geral.

Validado contra os 26 artigos do corpus: `extract_body_data` roda sem exceção em todos, e os outros 25 (já sectionados) ficam com a mesma contagem de seções/parágrafos/tabelas/figuras de antes. A condição só muda comportamento quando `<body>` não tem `<sec>` próprio.

## Screenshots

<img width="3328" height="1337" alt="a8_1351_before_after" src="https://github.com/user-attachments/assets/9625b1a6-d14f-4d8e-85d9-e0767767dc65" />

## Quais são os tickets relevantes?

Issue #1351

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança pontual de extração de dados do corpo do artigo (troca da condição de fallback em `extract_body_data`), sem alteração de infraestrutura, dependências ou pipeline.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

