### PR TITLE
fix: aumenta espaçamento entre legenda de figura e seção seguinte (#1346)

### DIFF
--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -2,7 +2,7 @@ import os
 
 from PIL import Image
 from docx.enum.text import WD_ALIGN_PARAGRAPH
-from docx.shared import Cm
+from docx.shared import Cm, Pt
 
 from packtools.sps.formats.pdf import enum as pdf_enum
 from packtools.sps.formats.pdf.utils.request_utils import download_remote_asset
@@ -303,6 +303,12 @@ def _add_caption(docx, figure_data, header_style_name):
     # caption would otherwise fall back to the same loose spacing as body
     # text (only the smaller caption font made it look tighter).
     p.paragraph_format.line_spacing = 1.0
+    # SCL Table Heading also has no space_after of its own (issue #1346),
+    # so a section title immediately following a figure caption (whose
+    # own space_before is 0 for a top-level "SCL Section Title") sits
+    # right on top of it. Pt(5.65) matches SCL Paragraph's own space-after,
+    # same fix already applied to docx_keywords_pipe for issue #1322.
+    p.paragraph_format.space_after = Pt(5.65)
 
     try:
         p.style = docx.styles[header_style_name]

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 
 from docx import Document
-from docx.shared import Cm
+from docx.shared import Cm, Pt
 from PIL import Image
 
 from packtools.sps.formats.pdf.renderer.docx.figure import (
@@ -38,6 +38,33 @@ class TestAddCaption(unittest.TestCase):
         _add_caption(docx, {'label': 'Figure 1', 'caption': 'A caption'}, 'Does Not Exist')
         p = docx.paragraphs[-1]
         self.assertEqual(p.paragraph_format.line_spacing, 1.0)
+
+
+class TestAddCaptionSpaceAfter(unittest.TestCase):
+    """
+    Regression for issue #1346: the caption paragraph's own style (SCL
+    Table Heading) has no space_after, so a section title immediately
+    following a figure (space_before=0 for a top-level section) sat right
+    on top of the caption, with visibly less breathing room than other
+    transitions in the document (e.g. body paragraph -> section title,
+    which gets 5.65pt from the paragraph's own space_after). space_after
+    is now set explicitly on the caption, same fix already applied to
+    docx_keywords_pipe for issue #1322.
+    """
+
+    def test_caption_has_space_after_matching_body_paragraph(self):
+        docx = Document()
+        docx.add_paragraph()
+        _add_caption(docx, {'label': 'Figure 1', 'caption': 'A caption'}, 'SCL Table Heading')
+        p = docx.paragraphs[-1]
+        self.assertEqual(p.paragraph_format.space_after, Pt(5.65))
+
+    def test_space_after_set_even_when_named_style_is_missing(self):
+        docx = Document()
+        docx.add_paragraph()
+        _add_caption(docx, {'label': 'Figure 1', 'caption': 'A caption'}, 'Does Not Exist')
+        p = docx.paragraphs[-1]
+        self.assertEqual(p.paragraph_format.space_after, Pt(5.65))
 
 
 class TestDecideFigureLayoutUnits(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1346: quando uma figura é o último conteúdo de uma seção do corpo, a transição para a legenda dessa figura e o título da seção seguinte fica com pouco respiro visual, menor do que outras transições do documento.

Confirmei a causa raiz lendo os estilos de `tests/fixtures/pdf/layout.docx` via `python-docx`. O respiro entre dois blocos é a soma do `space_after` do bloco anterior com o `space_before` do bloco seguinte:

| Estilo | usado em | `space_before` | `space_after` |
|---|---|---|---|
| `SCL Table Heading` | legenda de figura | 0pt | **0pt** |
| `SCL Paragraph` | parágrafo de corpo normal | 0pt | 5.65pt |
| `SCL Section Title` (nível 2) | título de seção de 1º nível | **0pt** | 0pt |

Parágrafo de texto seguido de um título de seção de 1º nível soma `5.65 + 0 = 5.65pt`. Figura seguida do mesmo tipo de título soma `0 + 0 = 0pt`, exatamente o problema relatado.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py`, função `_add_caption`.

## Como este poderia ser testado manualmente?

1. Gerar o PDF de `a11.xml` do corpus de teste (`layout_examples_rafael/corpus/`), onde a seção RESULTADOS termina com "Figura 1. Fluxograma da triagem dos artigos" e a próxima seção é DISCUSSÃO.
2. Antes: a legenda da figura fica praticamente colada no título DISCUSSÃO.
3. Depois: o mesmo respiro visual usado nas demais transições do documento aparece entre a legenda e o título. Ver screenshot.
4. `pytest tests/sps/formats/pdf/renderer/docx/test_figure.py` cobre a regressão (`TestAddCaptionSpaceAfter`, incluindo o caso do estilo nomeado não existir no documento).

## Algum cenário de contexto que queira dar?

Achado por `pitangainnovare` numa revisão do PR #1328 (fora daquele escopo, por isso virou issue própria: https://github.com/scieloorg/packtools/pull/1328#issuecomment-5553663607).

Esse é o mesmo padrão de bug já corrigido uma vez para outra transição: issue #1322/PR #1325, em `docx_keywords_pipe` (`pipeline/docx.py:330-335`), onde `SCL Paragraph Keywords` também tinha `space_after` zerado. A correção aqui usa exatamente a mesma técnica (`paragraph_format.space_after = Pt(5.65)`, mesmo valor, mesma justificativa).

Escopo: só a legenda de figura. A legenda de tabela usa o mesmo estilo `SCL Table Heading`, mas fica antes da tabela, não depois, então não é afetada por este bug (o conteúdo que fica depois de uma tabela é o `table-wrap-foot` ou a última linha da tabela, não essa legenda). Não investiguei se uma tabela sem `table-wrap-foot` imediatamente seguida de uma seção tem um problema parecido, fica fora do escopo desta issue.

Validado contra os 26 artigos do corpus: todos têm pelo menos uma seção com figura seguida de outra seção, então o problema não é raro.

## Screenshots

**a11.xml, transição RESULTADOS -> DISCUSSÃO (página 6):**

<img width="1750" height="410" alt="a11_1346_before_after" src="https://github.com/user-attachments/assets/47e96f5d-f7db-4201-8afe-189207bf4f8b" />


## Quais são os tickets relevantes?

Issue #1346

## Referências

Comentário original de `@pitangainnovare`: https://github.com/scieloorg/packtools/pull/1328#issuecomment-5553663607

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): ajuste pontual de espaçamento de parágrafo (python-docx), sem alteração de infraestrutura, dependências ou pipeline.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
