### PR TITLE
fix: corrige resolução invertida de caminho local de imagem (#1360)

### DIFF
--- a/packtools/sps/formats/pdf/renderer/docx/figure.py
+++ b/packtools/sps/formats/pdf/renderer/docx/figure.py
@@ -192,11 +192,8 @@ def _extract_figure_meta(figure_data):
 
 def _resolve_image_path(href, context):
     """Resolve the image path, handling local paths and remote URLs."""
-    if not href:
-        assets_dir = context.get('assets_dir')
-        img_path = resolve_asset_path(href, assets_dir=assets_dir)
-    else:
-        img_path = href
+    assets_dir = context.get('assets_dir')
+    img_path = resolve_asset_path(href, assets_dir=assets_dir)
 
     if isinstance(img_path, str) and (img_path.startswith('http://') or img_path.startswith('https://')):
         downloaded = download_remote_asset(img_path, context)

--- a/tests/sps/formats/pdf/renderer/docx/test_figure.py
+++ b/tests/sps/formats/pdf/renderer/docx/test_figure.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from docx import Document
 from docx.shared import Cm
@@ -10,10 +11,53 @@ from packtools.sps.formats.pdf.renderer.docx.figure import (
     _add_caption,
     _infer_image_dpi,
     _natural_width_capped,
+    _resolve_image_path,
     add_figure,
     decide_figure_layout,
 )
 from packtools.sps.formats.pdf import enum as pdf_enum
+
+
+class TestResolveImagePath(unittest.TestCase):
+    """
+    Regression: the condition was inverted - resolve_asset_path (which
+    joins assets_dir + href for a local relative path) was only called
+    when href was empty, a case it always resolves to None anyway. When
+    href was actually present (the normal case), it was used unchanged,
+    so a relative local path never got joined with assets_dir and never
+    resolved to a real, existing file.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_relative_local_path_resolves_against_assets_dir(self):
+        img_path = os.path.join(self.tmpdir.name, 'fig1.png')
+        with open(img_path, 'wb') as f:
+            f.write(b'fake')
+
+        result = _resolve_image_path('fig1.png', {'assets_dir': self.tmpdir.name})
+        self.assertEqual(result, img_path)
+
+    def test_empty_href_returns_none(self):
+        result = _resolve_image_path('', {'assets_dir': self.tmpdir.name})
+        self.assertIsNone(result)
+
+    def test_absolute_local_path_returned_unchanged(self):
+        img_path = os.path.join(self.tmpdir.name, 'fig1.png')
+        with open(img_path, 'wb') as f:
+            f.write(b'fake')
+
+        result = _resolve_image_path(img_path, {'assets_dir': '/some/other/dir'})
+        self.assertEqual(result, img_path)
+
+    @patch('packtools.sps.formats.pdf.renderer.docx.figure.download_remote_asset')
+    def test_remote_url_is_downloaded(self, mock_download):
+        mock_download.return_value = '/cache/fig1.png'
+        result = _resolve_image_path('https://example.org/fig1.png', {})
+        mock_download.assert_called_once_with('https://example.org/fig1.png', {})
+        self.assertEqual(result, '/cache/fig1.png')
 
 
 class TestAddCaption(unittest.TestCase):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1360: `_resolve_image_path` (`packtools/sps/formats/pdf/renderer/docx/figure.py`) tinha a condição de resolução de caminho invertida. Só chamava `resolve_asset_path` (que junta `assets_dir` com `href` para caminhos locais relativos) quando `href` estava vazio, caso em que `resolve_asset_path` sempre retorna `None` de qualquer forma. Quando `href` existia (o caso normal), o código usava `href` sem alteração, então um caminho local relativo nunca era resolvido contra `assets_dir` e nunca existia de fato no disco. A figura então nunca era inserida no PDF, caindo silenciosamente para o texto alternativo.

`resolve_asset_path` já trata todos os casos corretamente por conta própria (URL `http(s)://` absoluta, caminho absoluto, caminho relativo com `assets_dir` fornecido, fallback quando o arquivo não existe). O fix faz `_resolve_image_path` delegar sempre a ela, removendo a ramificação `if/else` que pulava justamente o caso mais comum.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/renderer/docx/figure.py`, função `_resolve_image_path`.

## Como este poderia ser testado manualmente?

1. Criar um diretório com um arquivo de imagem, ex. `fig1.png`.
2. Chamar `_resolve_image_path('fig1.png', {'assets_dir': '<esse diretório>'})`.
3. Antes: retorna `'fig1.png'` sem alteração; `os.path.exists('fig1.png')` é `False` a menos que o diretório de trabalho do processo coincida por acaso com `assets_dir`.
4. Depois: retorna o caminho absoluto real do arquivo; `os.path.exists(...)` é `True`.
5. `pytest tests/sps/formats/pdf/renderer/docx/test_figure.py -k ResolveImagePath` cobre os 4 casos (caminho relativo + assets_dir, href vazio, caminho absoluto, URL remota delegando para `download_remote_asset`).

## Algum cenário de contexto que queira dar?

Achado incidentalmente ao construir a demonstração do PR #1300, nunca teve issue própria até agora. Não afeta os artigos do corpus de teste usados nas demais issues/PRs do gerador de PDF (todos referenciam imagens por URL `https://` absoluta), mas afeta o caso de entrada padrão de um pacote SciELO real (XML + imagens num mesmo diretório, referenciadas por caminho relativo). Sem exemplo real disponível no corpus para gerar um PDF antes/depois; a evidência é a reprodução direta da função (passos acima) e os testes de regressão novos.

Independente de #1348, #1350, #1356 e #1358 (arquivo, função e casos totalmente diferentes).

## Screenshots

N/A. Bug reproduzido diretamente na função (sem interface visual), ver seção de testes manuais acima.

## Quais são os tickets relevantes?

Issue #1360

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): correção pontual de resolução de caminho de arquivo local já existente no projeto, sem alteração de infraestrutura, dependências ou pipeline.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
