### PR TITLE
feat: preserva itálico/negrito/sobrescrito/subscrito no corpo do PDF (#1362)

### DIFF
--- a/packtools/sps/formats/pdf/pipeline/docx.py
+++ b/packtools/sps/formats/pdf/pipeline/docx.py
@@ -728,9 +728,9 @@ def _render_section_title(docx, title, style_name, level):
 
 
 def _render_paragraphs(docx, paragraphs):
-    """Render a list of paragraphs with the default formatting for body text."""
+    """Render a list of paragraphs (each a list of style-tagged segments) with the default formatting for body text."""
     for para in paragraphs:
-        docx_renderer.text.add_paragraph_with_formatting(docx, para)
+        docx_renderer.text.add_paragraph_with_segments(docx, para)
 
 
 def _add_single_column_section(docx):

--- a/packtools/sps/formats/pdf/pipeline/xml.py
+++ b/packtools/sps/formats/pdf/pipeline/xml.py
@@ -360,7 +360,7 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
         list: A list of dictionaries, where each dictionary represents a section in the body of the document. Each dictionary has the following keys:
             - 'level': The nesting level of the section.
             - 'title': The title of the section, if present.
-            - 'paragraphs': A list of the text content of each paragraph in the section, excluding paragraphs that contain table/figure references or wrappers.
+            - 'paragraphs': A list of paragraphs, each a list of style-tagged text segments (see xml_utils.get_segments_from_node) preserving inline <italic>/<bold>/<sup>/<sub> markup, excluding paragraphs that contain table/figure references or wrappers.
             - 'tables': A list of dictionaries representing the tables in the section, as returned by the `extract_table_data` function.
             - 'figures': A list of dictionaries representing figures in the section, as returned by the `extract_figure_data` function.
     """
@@ -385,9 +385,9 @@ def extract_body_data(xml_tree, table_layout_overrides=None):
         # whether the source had one there (e.g. "(<xref>...</xref>)" came
         # out as "( ... )", and "<xref/>; <xref/>" as "... ; ...").
         for para in document_section.findall('p'):
-            para_text = xml_utils.get_text_from_node(para, skip_tags={'fig', 'table-wrap'}).strip()
-            if para_text:
-                sec['paragraphs'].append(para_text)
+            para_segments = xml_utils.get_segments_from_node(para, skip_tags={'fig', 'table-wrap'})
+            if para_segments:
+                sec['paragraphs'].append(para_segments)
 
         for table_wrap in document_section.findall('.//table-wrap'):
             closest_sec = table_wrap.xpath('ancestor::sec[1]')

--- a/packtools/sps/formats/pdf/renderer/docx/text.py
+++ b/packtools/sps/formats/pdf/renderer/docx/text.py
@@ -17,6 +17,38 @@ def add_paragraph_with_formatting(docx, text, style_name='SCL Paragraph', elemen
     para.style = docx.styles[style_name]
     return para
 
+def add_paragraph_with_segments(docx, segments, style_name='SCL Paragraph'):
+    """
+    Add a paragraph built from style-tagged text segments (see
+    xml_utils.get_segments_from_node), emitting one run per segment with
+    the matching bold/italic/superscript/subscript formatting.
+
+    A flag set to False is applied as None rather than False: python-docx
+    treats an explicit False as forcing the property off even if the
+    paragraph's own style already turns it on, while None lets the run
+    inherit from the style - the same behavior a plain, unstyled run has
+    today.
+
+    superscript/subscript are mutually exclusive on purpose, not just as
+    a style choice: python-docx backs both with the same OOXML
+    w:vertAlign element, so setting one after the other (even to None)
+    overwrites/clears whichever was set first - assigning both
+    unconditionally on every run would silently drop superscript.
+    """
+    para = docx.add_paragraph()
+    para.style = docx.styles[style_name]
+
+    for seg in segments:
+        run = para.add_run(seg.get('text', ''))
+        run.bold = seg.get('bold') or None
+        run.italic = seg.get('italic') or None
+        if seg.get('superscript'):
+            run.font.superscript = True
+        elif seg.get('subscript'):
+            run.font.subscript = True
+
+    return para
+
 def add_authors_names_paragraph_with_formatting_sup(docx, authors_names, paragraph_style_name, character_style_name, sup_mark="[^]"):
     """Add a paragraph with authors' names, handling superscript markers for affiliations."""
     para = docx.add_paragraph()

--- a/packtools/sps/formats/pdf/utils/xml_utils.py
+++ b/packtools/sps/formats/pdf/utils/xml_utils.py
@@ -37,6 +37,100 @@ def get_text_from_node(node, skip_tags=None):
     text = _normalize_punctuation_spacing(text)
     return text
 
+_INLINE_STYLE_TAGS = {
+    'italic': 'italic',
+    'bold': 'bold',
+    'sup': 'superscript',
+    'sub': 'subscript',
+}
+
+
+def get_segments_from_node(node, skip_tags=None):
+    """
+    Extracts text from an XML node as a list of style-tagged segments
+    instead of a single flattened string, so inline markup
+    (<italic>/<bold>/<sup>/<sub>) can be rendered with the matching run
+    formatting instead of being discarded.
+
+    Preserves the same adjacency-preserving traversal as
+    get_text_from_node (including skip_tags), then merges adjacent
+    fragments that ended up with the same combination of active styles
+    before normalizing whitespace/punctuation per merged segment - doing
+    it per merged run rather than per raw fragment matters because a
+    stray space next to a paren/bracket/comma (e.g. "( <xref>...</xref>
+    )") always lands in the same text fragment as that punctuation, not
+    split across a style boundary.
+
+    Args:
+        node (ElementTree): The XML node to extract segments from.
+        skip_tags (set, optional): Child tag names to drop entirely from
+            the output; only their `.tail` is kept. Same semantics as
+            get_text_from_node.
+
+    Returns:
+        list[dict]: Segments in document order, each
+            {'type': 'text', 'text': str, 'italic': bool, 'bold': bool,
+            'superscript': bool, 'subscript': bool}. Empty after
+            whitespace normalization/leading-trailing strip are dropped.
+    """
+    skip_tags = skip_tags or set()
+    raw_segments = []
+    _collect_style_segments(node, skip_tags, frozenset(), raw_segments)
+
+    segments = []
+    for text, styles in _merge_adjacent_segments(raw_segments):
+        text = _remove_double_spaces(text)
+        text = _normalize_punctuation_spacing(text)
+        if text:
+            segments.append(_build_text_segment(text, styles))
+
+    if segments:
+        segments[0]['text'] = segments[0]['text'].lstrip()
+        segments[-1]['text'] = segments[-1]['text'].rstrip()
+        segments = [seg for seg in segments if seg['text']]
+
+    return segments
+
+
+def _collect_style_segments(node, skip_tags, active_styles, raw_segments):
+    """Recursively walk node, appending (text, active_styles) fragments to raw_segments."""
+    if node.text:
+        raw_segments.append((node.text, active_styles))
+
+    for child in node:
+        if child.tag in skip_tags:
+            pass
+        elif child.tag in _INLINE_STYLE_TAGS:
+            child_styles = active_styles | {_INLINE_STYLE_TAGS[child.tag]}
+            _collect_style_segments(child, skip_tags, child_styles, raw_segments)
+        else:
+            _collect_style_segments(child, skip_tags, active_styles, raw_segments)
+
+        if child.tail:
+            raw_segments.append((child.tail, active_styles))
+
+
+def _merge_adjacent_segments(raw_segments):
+    """Concatenate consecutive (text, styles) fragments that share the same styles."""
+    merged = []
+    for text, styles in raw_segments:
+        if merged and merged[-1][1] == styles:
+            merged[-1] = (merged[-1][0] + text, styles)
+        else:
+            merged.append((text, styles))
+    return merged
+
+
+def _build_text_segment(text, styles):
+    return {
+        'type': 'text',
+        'text': text,
+        'italic': 'italic' in styles,
+        'bold': 'bold' in styles,
+        'superscript': 'superscript' in styles,
+        'subscript': 'subscript' in styles,
+    }
+
 def get_node_level(element, root):
     """
     Determines the level or depth of an XML element within the document tree.

--- a/tests/sps/formats/pdf/pipeline/test_docx.py
+++ b/tests/sps/formats/pdf/pipeline/test_docx.py
@@ -383,8 +383,85 @@ class TestDocxPageVolIssueYearPipe(unittest.TestCase):
 
 
 class TestDocxBodyPipe(unittest.TestCase):
-    # TODO
-    ...
+    """
+    Item 04 of the pdf_generator backlog: a body paragraph is now a list
+    of style-tagged segments (see xml_utils.get_segments_from_node)
+    instead of a single string, and each segment must become its own
+    run with matching bold/italic/superscript/subscript formatting.
+    """
+
+    def _segment(self, text, **flags):
+        seg = {'type': 'text', 'text': text, 'italic': False, 'bold': False, 'superscript': False, 'subscript': False}
+        seg.update(flags)
+        return seg
+
+    def test_paragraph_emits_one_run_per_segment_with_matching_style(self):
+        docx = _docx_with_layout_styles()
+        body_data = [{
+            'level': 2,
+            'title': None,
+            'paragraphs': [[
+                self._segment('A '),
+                self._segment('Genus species', italic=True),
+                self._segment(' seen'),
+                self._segment('1', superscript=True),
+                self._segment('.'),
+            ]],
+            'tables': [],
+            'figures': [],
+        }]
+        docx_pipe.docx_body_pipe(docx, body_data)
+
+        para = docx.paragraphs[-1]
+        self.assertEqual([r.text for r in para.runs], ['A ', 'Genus species', ' seen', '1', '.'])
+        self.assertIsNone(para.runs[0].italic)
+        self.assertTrue(para.runs[1].italic)
+        self.assertIsNone(para.runs[2].italic)
+        self.assertTrue(para.runs[3].font.superscript)
+        self.assertIsNone(para.runs[4].font.superscript)
+
+    def test_superscript_and_subscript_segments_in_the_same_paragraph(self):
+        # Regression: python-docx backs superscript/subscript with the
+        # same OOXML w:vertAlign element, so unconditionally assigning
+        # both on every run (even the falsy one, as None) clears
+        # whichever was set first instead of leaving it alone.
+        docx = _docx_with_layout_styles()
+        body_data = [{
+            'level': 2,
+            'title': None,
+            'paragraphs': [[
+                self._segment('1', superscript=True),
+                self._segment(' and '),
+                self._segment('2', subscript=True),
+            ]],
+            'tables': [],
+            'figures': [],
+        }]
+        docx_pipe.docx_body_pipe(docx, body_data)
+
+        runs = docx.paragraphs[-1].runs
+        self.assertTrue(runs[0].font.superscript)
+        self.assertTrue(runs[2].font.subscript)
+
+    def test_unstyled_segment_does_not_force_run_bold_false(self):
+        # An explicit False on run.bold overrides the style's own default
+        # instead of inheriting it; a segment with no style must leave
+        # the run's bold/italic/superscript/subscript unset (None).
+        docx = _docx_with_layout_styles()
+        body_data = [{
+            'level': 2,
+            'title': None,
+            'paragraphs': [[self._segment('Plain text.')]],
+            'tables': [],
+            'figures': [],
+        }]
+        docx_pipe.docx_body_pipe(docx, body_data)
+
+        run = docx.paragraphs[-1].runs[0]
+        self.assertIsNone(run.bold)
+        self.assertIsNone(run.italic)
+        self.assertIsNone(run.font.superscript)
+        self.assertIsNone(run.font.subscript)
 
 
 class TestDocxReferencesPipe(unittest.TestCase):

--- a/tests/sps/formats/pdf/pipeline/test_xml.py
+++ b/tests/sps/formats/pdf/pipeline/test_xml.py
@@ -331,6 +331,11 @@ class TestExtractArticleType(unittest.TestCase):
         self.assertEqual(result, '')
 
 
+def _plain_para(text):
+    """A single-segment, unstyled paragraph, as extract_body_data now returns it."""
+    return [{'type': 'text', 'text': text, 'italic': False, 'bold': False, 'superscript': False, 'subscript': False}]
+
+
 class TestExtractBodyData(unittest.TestCase):
 
     def test_extract_body_data_basic(self):
@@ -347,7 +352,7 @@ class TestExtractBodyData(unittest.TestCase):
             {
                 'level': 1,
                 'title': 'Section 1',
-                'paragraphs': ['Paragraph 1', 'Paragraph 2'],
+                'paragraphs': [_plain_para('Paragraph 1'), _plain_para('Paragraph 2')],
                 'tables': [],
                 'figures': [],
             }
@@ -377,7 +382,7 @@ class TestExtractBodyData(unittest.TestCase):
             {
                 'level': 2,
                 'title': 'Introduction',
-                'paragraphs': ['Body text.'],
+                'paragraphs': [_plain_para('Body text.')],
                 'tables': [],
                 'figures': [],
             }
@@ -406,7 +411,7 @@ class TestExtractBodyData(unittest.TestCase):
             {
                 'level': 1,
                 'title': 'Section 1',
-                'paragraphs': ['Paragraph 1'],
+                'paragraphs': [_plain_para('Paragraph 1')],
                 'tables': [
                     {
                         'label': 'Table 1',
@@ -443,14 +448,14 @@ class TestExtractBodyData(unittest.TestCase):
             {
                 'level': 1,
                 'title': 'Section 1',
-                'paragraphs': ['Paragraph 1'],
+                'paragraphs': [_plain_para('Paragraph 1')],
                 'tables': [],
                 'figures': [],
             },
             {
                 'level': 2,
                 'title': 'Subsection 1.1',
-                'paragraphs': ['Paragraph 1.1'],
+                'paragraphs': [_plain_para('Paragraph 1.1')],
                 'tables': [],
                 'figures': [],
             }
@@ -479,7 +484,7 @@ class TestExtractBodyData(unittest.TestCase):
             {
                 'level': 1,
                 'title': 'Section 1',
-                'paragraphs': ['Paragraph with Table 1'],
+                'paragraphs': [_plain_para('Paragraph with Table 1')],
                 'tables': [
                     {
                         'label': 'Table 1',
@@ -515,7 +520,7 @@ class TestExtractBodyData(unittest.TestCase):
         result = xml_pipe.extract_body_data(xml)
         self.assertEqual(
             result[0]['paragraphs'],
-            ['Pressure is increasing (Lang and Barling, 2012; Ripple et al., 2019) worldwide.'],
+            [_plain_para('Pressure is increasing (Lang and Barling, 2012; Ripple et al., 2019) worldwide.')],
         )
 
     def test_embedded_fig_tail_whitespace_is_collapsed_not_left_raw(self):
@@ -532,7 +537,32 @@ class TestExtractBodyData(unittest.TestCase):
         result = xml_pipe.extract_body_data(xml)
         self.assertEqual(
             result[0]['paragraphs'],
-            ['See the figure below for details.'],
+            [_plain_para('See the figure below for details.')],
+        )
+
+    def test_extract_body_data_preserves_inline_formatting(self):
+        # Item 04 of the pdf_generator backlog: <italic>/<bold>/<sup>/<sub>
+        # inside a body paragraph used to be flattened to plain text by
+        # get_text_from_node. extract_body_data now keeps them as
+        # style-tagged segments instead of a single string.
+        xml = etree.fromstring(
+            '<article><sec><title>Results</title>'
+            '<p>The species <italic>Genus species</italic> was observed'
+            '<sup>1</sup> in <bold>high</bold> numbers.</p>'
+            '</sec></article>'
+        )
+        result = xml_pipe.extract_body_data(xml)
+        self.assertEqual(
+            result[0]['paragraphs'],
+            [[
+                {'type': 'text', 'text': 'The species ', 'italic': False, 'bold': False, 'superscript': False, 'subscript': False},
+                {'type': 'text', 'text': 'Genus species', 'italic': True, 'bold': False, 'superscript': False, 'subscript': False},
+                {'type': 'text', 'text': ' was observed', 'italic': False, 'bold': False, 'superscript': False, 'subscript': False},
+                {'type': 'text', 'text': '1', 'italic': False, 'bold': False, 'superscript': True, 'subscript': False},
+                {'type': 'text', 'text': ' in ', 'italic': False, 'bold': False, 'superscript': False, 'subscript': False},
+                {'type': 'text', 'text': 'high', 'italic': False, 'bold': True, 'superscript': False, 'subscript': False},
+                {'type': 'text', 'text': ' numbers.', 'italic': False, 'bold': False, 'superscript': False, 'subscript': False},
+            ]],
         )
 
 

--- a/tests/sps/formats/pdf/utils/test_xml_utils.py
+++ b/tests/sps/formats/pdf/utils/test_xml_utils.py
@@ -114,6 +114,100 @@ class TestGetTextFromNode(unittest.TestCase):
         )
 
 
+def _seg(text, italic=False, bold=False, superscript=False, subscript=False):
+    return {
+        'type': 'text',
+        'text': text,
+        'italic': italic,
+        'bold': bold,
+        'superscript': superscript,
+        'subscript': subscript,
+    }
+
+
+class TestGetSegmentsFromNode(unittest.TestCase):
+    """
+    Regression/coverage for get_segments_from_node (item 04 of the
+    pdf_generator backlog): unlike get_text_from_node, inline
+    <italic>/<bold>/<sup>/<sub> markup must be preserved as style flags
+    on each segment instead of being flattened away.
+    """
+
+    def test_plain_text_is_a_single_unstyled_segment(self):
+        xmltree = etree.fromstring('<p>Plain text only.</p>')
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [_seg('Plain text only.')])
+
+    def test_italic_segment_gets_its_own_run(self):
+        xmltree = etree.fromstring('<p>A <italic>Genus species</italic> name.</p>')
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [
+            _seg('A '),
+            _seg('Genus species', italic=True),
+            _seg(' name.'),
+        ])
+
+    def test_bold_sup_sub_segments(self):
+        xmltree = etree.fromstring('<p><bold>Bold</bold> and <sup>sup</sup> and <sub>sub</sub>.</p>')
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [
+            _seg('Bold', bold=True),
+            _seg(' and '),
+            _seg('sup', superscript=True),
+            _seg(' and '),
+            _seg('sub', subscript=True),
+            _seg('.'),
+        ])
+
+    def test_nested_styles_combine_regardless_of_order(self):
+        xmltree = etree.fromstring(
+            '<p>A <sup><italic>one</italic></sup> and <italic><sup>two</sup></italic> case.</p>'
+        )
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [
+            _seg('A '),
+            _seg('one', italic=True, superscript=True),
+            _seg(' and '),
+            _seg('two', italic=True, superscript=True),
+            _seg(' case.'),
+        ])
+
+    def test_adjacent_unstyled_fragments_merge_into_one_segment(self):
+        # <xref> carries no style of its own, so its text and tail merge
+        # with the surrounding plain text into a single segment rather
+        # than fragmenting the run needlessly.
+        xmltree = etree.fromstring(
+            '<p>Start <xref ref-type="bibr">Text</xref> end.</p>'
+        )
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [_seg('Start Text end.')])
+
+    def test_punctuation_spacing_normalized_like_get_text_from_node(self):
+        xmltree = etree.fromstring(
+            '<p>seen (<xref ref-type="bibr">Author, 2020</xref>; '
+            '<xref ref-type="bibr">Other, 2021</xref>) here</p>'
+        )
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [_seg('seen (Author, 2020; Other, 2021) here')])
+
+    def test_skip_tags_drops_content_but_keeps_tail(self):
+        xmltree = etree.fromstring(
+            '<p>Before <fig id="f1"><label>Figure 1</label></fig> after</p>'
+        )
+        result = xml_utils.get_segments_from_node(xmltree, skip_tags={'fig'})
+        self.assertEqual(result, [_seg('Before after')])
+
+    def test_leading_and_trailing_whitespace_stripped(self):
+        xmltree = etree.fromstring('<p>  padded text  </p>')
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [_seg('padded text')])
+
+    def test_empty_node_returns_no_segments(self):
+        xmltree = etree.fromstring('<p><italic></italic></p>')
+        result = xml_utils.get_segments_from_node(xmltree)
+        self.assertEqual(result, [])
+
+
 class TestGetTextFromMixedCitationNode(unittest.TestCase):
 
     def test_get_text_from_mixed_citation_node_with_simple_text(self):


### PR DESCRIPTION
## O que esse PR faz?

Corrige a issue #1362: `get_text_from_node` (`packtools/sps/formats/pdf/utils/xml_utils.py`), usada por `extract_body_data` para extrair o texto de cada `<p>` do corpo, achatava `<italic>`, `<bold>`, `<sup>` e `<sub>` numa string só, sem preservar nenhum estilo. `_render_paragraphs` (`pipeline/docx.py`) confirmava do lado da renderização: cada parágrafo virava um único `run`, sem como aplicar estilo a pedaços do texto. Resultado: nomes de espécie, termos em latim, números de citação sobrescritos e notação química/matemática perdiam toda formatação no PDF gerado.

Medido no corpus de 26 artigos de teste: **25/26 artigos (96%)** têm pelo menos um parágrafo do corpo com marcação inline; **38% de todos os parágrafos** (606 de 1577) carregam `<italic>` (1630 ocorrências), `<bold>` (95), `<sup>` (1089) ou `<sub>` (180).

Nova `get_segments_from_node` (`xml_utils.py`) percorre o mesmo caminho de `get_text_from_node`, mas devolve uma lista de segmentos tipados (texto + flags de estilo) em vez de uma string única, fundindo fragmentos adjacentes de mesmo estilo antes de normalizar espaço/pontuação por segmento (o que já existia por regex global, `_remove_double_spaces`/`_normalize_punctuation_spacing`, passa a rodar por segmento fundido, produzindo o mesmo resultado). `extract_body_data` passa a usar essa função; `sec['paragraphs']` muda de `list[str]` para `list[list[segment]]`.

`_render_paragraphs` e a nova `add_paragraph_with_segments` (`renderer/docx/text.py`) emitem um `run` por segmento, aplicando `bold`/`italic`/`superscript`/`subscript` - mesma técnica já usada em `add_authors_names_paragraph_with_formatting_sup`, generalizada de 1 marcador fixo pra 4 flags combináveis.

## Onde a revisão poderia começar?

`packtools/sps/formats/pdf/utils/xml_utils.py`, função `get_segments_from_node`, e `packtools/sps/formats/pdf/renderer/docx/text.py`, função `add_paragraph_with_segments`.

## Como este poderia ser testado manualmente?

1. Gerar o PDF de `a12.xml` do corpus de teste (`layout_examples_rafael/corpus/`), que tem `et al.` em itálico várias vezes na Introdução.
2. Antes: "Saadati et al., 2018" e "Baki et al., (2009)" aparecem sem itálico.
3. Depois: aparecem em itálico, igual ao XML fonte. Ver screenshot.
4. `pytest tests/sps/formats/pdf/utils/test_xml_utils.py -k GetSegmentsFromNode` cobre a extração (texto plano, itálico/negrito/sup/sub isolados, estilos aninhados combinando independente da ordem, fusão de fragmentos adjacentes sem estilo, normalização de espaço/pontuação, `skip_tags`, strip de borda, nó vazio).
5. `pytest tests/sps/formats/pdf/pipeline/test_docx.py -k TestDocxBodyPipe` cobre a renderização, incluindo a regressão descrita abaixo.

## Algum cenário de contexto que queira dar?

**Achado de arquitetura, decisivo pra esta implementação**: a issue #1353 (Fase 2 do plano de fórmulas, #1347) já planeja generalizar essa mesma estrutura de parágrafo (`list[str]` → segmentos) pra acomodar fórmula inline misturada a texto corrido. O modelo de segmento aqui já nasce com um campo `type` (`'text'` por enquanto) justamente pra que a Fase 2 só precise adicionar um segmento `type='formula'` ao mesmo container mais tarde, sem reabrir esse parser - decisão confirmada com o usuário antes de implementar, pra não duplicar o trabalho de generalização entre as duas tarefas.

**Bug real pego durante a implementação, pelo teste de integração (não pelo teste unitário da função de extração isolada, que não renderiza nada)**: `superscript` e `subscript` compartilham o mesmo elemento OOXML `w:vertAlign` no python-docx. Minha primeira versão atribuía os dois incondicionalmente em todo `run` (`run.font.superscript = seg['superscript'] or None`, depois `run.font.subscript = seg['subscript'] or None`), e como a segunda atribuição é `None` no caso comum, ela limpava o `superscript = True` que tinha acabado de ser setado - todo `<sup>` sumia silenciosamente. Corrigido com `if`/`elif` mutuamente exclusivo (também correto semanticamente: um run não pode ser sobrescrito e subscrito ao mesmo tempo). `bold`/`italic` não têm esse problema, são elementos OOXML independentes - confirmado em REPL antes de assumir que o mesmo padrão valeria pra tudo.

Escopo: só parágrafo de corpo (`extract_body_data`/`_render_paragraphs`). Abstract/trans-abstract usam a mesma extração de texto e teriam o mesmo ganho aplicando `get_segments_from_node`, mas ficam de fora deste PR pra manter o diff revisável - follow-up direto e de baixo custo depois que a função existir. Referências (`<mixed-citation>`) passam por um caminho de código diferente (`get_text_from_mixed_citation_node`), também fora do escopo.

Validado contra os 26 artigos do corpus: `extract_body_data` roda sem exceção em todos, contagem de seções/parágrafos idêntica a antes (mudança é só no formato interno do dado, não na quantidade de conteúdo extraído).

## Screenshots

<img width="1870" height="460" alt="a12_1362_before_after" src="https://github.com/user-attachments/assets/8816e1bf-b576-4380-8fdb-f7bf532e204f" />

<img width="900" height="360" alt="a14_bold_before_after" src="https://github.com/user-attachments/assets/f820c766-a3c4-4a8e-8e88-22912e135b1e" />

<img width="990" height="800" alt="a21_sub_before_after" src="https://github.com/user-attachments/assets/0c184a94-b7db-413a-8ffe-9f4ac6c39930" />


## Quais são os tickets relevantes?

Issue #1362

## Referências

N/A

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique): mudança de estrutura interna de dados e renderização de texto, sem alteração de infraestrutura, dependências ou pipeline.

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)
